### PR TITLE
feat(runtime): runtime-mutable RUST_MCP_MODE + A2A_MODE via admin API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -248,10 +248,12 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # RUST_MCP_MODE=full   -> edge + Rust session/event-store/resume/live-stream/affinity cores
 #
 # Runtime override (in-memory only; restart re-reads RUST_MCP_MODE / RUST_A2A_MODE):
-# When the boot mode is shadow or edge an authorized caller (admin.system_config)
-# can flip shadow <-> edge live via:
-# (off and full boot modes are not flippable — off has no Rust sidecar; full
-#  would require live migration of Rust-owned session/event-store cores.)
+# When the boot mode is edge an authorized caller (admin.system_config) can
+# flip shadow <-> edge live via:
+# (off, shadow, and full boot modes are not flippable — off has no Rust
+#  sidecar; shadow did not opt into session-auth-reuse / delegate-enabled
+#  so an edge override cannot safely route traffic; full would require
+#  live migration of Rust-owned session/event-store cores.)
 #   curl -X PATCH .../admin/runtime/mcp-mode -d '{"mode": "shadow"}'
 #   curl -X PATCH .../admin/runtime/a2a-mode -d '{"mode": "edge"}'
 # If REDIS_URL is configured the override propagates to all pods; otherwise the

--- a/.env.example
+++ b/.env.example
@@ -247,6 +247,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # RUST_MCP_MODE=edge   -> direct public /mcp on Rust with managed UDS sidecar defaults
 # RUST_MCP_MODE=full   -> edge + Rust session/event-store/resume/live-stream/affinity cores
 #
+# Runtime override (in-memory only; restart re-reads RUST_MCP_MODE / RUST_A2A_MODE):
+# When the boot mode is shadow or edge an authorized caller (admin.system_config)
+# can flip shadow <-> edge live via:
+# (off and full boot modes are not flippable — off has no Rust sidecar; full
+#  would require live migration of Rust-owned session/event-store cores.)
+#   curl -X PATCH .../admin/runtime/mcp-mode -d '{"mode": "shadow"}'
+#   curl -X PATCH .../admin/runtime/a2a-mode -d '{"mode": "edge"}'
+# If REDIS_URL is configured the override propagates to all pods; otherwise the
+# override is local to the pod that received the PATCH (visible via /health
+# under mcp_runtime.cluster_propagation).
+#
 # Advanced Rust MCP overrides
 # RUST_MCP_SESSION_AUTH_REUSE=false         # advanced override for the fast direct public Rust session-auth path; prefer RUST_MCP_MODE presets above
 # EXPERIMENTAL_RUST_MCP_RUNTIME_ENABLED=

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-18T14:32:19Z",
+  "generated_at": "2026-04-18T15:32:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-18T06:40:01Z",
+  "generated_at": "2026-04-18T07:08:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-18T07:08:52Z",
+  "generated_at": "2026-04-18T09:14:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4888,7 +4888,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2264,
+        "line_number": 2281,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9336,7 +9336,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2604,
+        "line_number": 2625,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9344,7 +9344,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2892,
+        "line_number": 2913,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-17T16:42:19Z",
+  "generated_at": "2026-04-18T06:40:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 522,
+        "line_number": 535,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 730,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 986,
+        "line_number": 999,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1012,
+        "line_number": 1025,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1092,
+        "line_number": 1105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1097,
+        "line_number": 1110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1102,
+        "line_number": 1115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1108,
+        "line_number": 1121,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1120,
+        "line_number": 1133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1138,
+        "line_number": 1151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1199,
+        "line_number": 1212,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -954,7 +954,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 255,
+        "line_number": 265,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -962,7 +962,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 349,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -970,7 +970,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -978,7 +978,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 387,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -986,7 +986,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 405,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +994,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 933,
+        "line_number": 943,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1030,
+        "line_number": 1040,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1091,
+        "line_number": 1101,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1136,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1665,
+        "line_number": 1675,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1742,
+        "line_number": 1752,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2054,
+        "line_number": 2064,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2511,
+        "line_number": 2521,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2511,
+        "line_number": 2521,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2524,
+        "line_number": 2534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2669,
+        "line_number": 2679,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2690,
+        "line_number": 2700,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2698,
+        "line_number": 2708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2703,
+        "line_number": 2713,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2668,7 +2668,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 595,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5502,7 +5502,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 576,
+        "line_number": 849,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5510,7 +5510,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 638,
+        "line_number": 911,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9336,7 +9336,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2439,
+        "line_number": 2604,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9344,7 +9344,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2727,
+        "line_number": 2892,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline|package-lock.json|Cargo.lock|scripts/sign_image.sh|scripts/zap|sonar-project.properties|uv.lock|go.sum|mcpgateway/sri_hashes.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-18T09:14:49Z",
+  "generated_at": "2026-04-18T14:32:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4888,7 +4888,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2281,
+        "line_number": 2282,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9336,7 +9336,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2625,
+        "line_number": 2667,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9344,7 +9344,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2913,
+        "line_number": 2955,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/crates/mcp_runtime/README.md
+++ b/crates/mcp_runtime/README.md
@@ -39,10 +39,11 @@ Important nuance:
   compatibility input translated by [docker-entrypoint.sh](../../docker-entrypoint.sh).
   Prefer `RUST_MCP_MODE` unless you are intentionally testing a specific
   override path.
-- When the boot mode is `shadow` or `edge` an authorized admin can flip the
-  public `/mcp` ingress between `shadow` and `edge` at runtime via
-  `PATCH /admin/runtime/mcp-mode` (and `/admin/runtime/a2a-mode` for A2A) —
-  `off` and `full` are not flippable; see the architecture doc —
+- When the boot mode is `edge` an authorized admin can flip the public
+  `/mcp` ingress between `shadow` and `edge` at runtime via
+  `PATCH /admin/runtime/mcp-mode` (and `/admin/runtime/a2a-mode` for A2A).
+  `off`, `shadow`, and `full` are not flippable — `shadow` did not opt
+  into the session-auth-reuse safety invariant; see the architecture doc.
   see [docs/docs/architecture/rust-mcp-runtime.md](../../docs/docs/architecture/rust-mcp-runtime.md#runtime-mode-override)
   for the full operator contract and cluster propagation behavior.
 

--- a/crates/mcp_runtime/README.md
+++ b/crates/mcp_runtime/README.md
@@ -39,6 +39,12 @@ Important nuance:
   compatibility input translated by [docker-entrypoint.sh](../../docker-entrypoint.sh).
   Prefer `RUST_MCP_MODE` unless you are intentionally testing a specific
   override path.
+- When the boot mode is `shadow` or `edge` an authorized admin can flip the
+  public `/mcp` ingress between `shadow` and `edge` at runtime via
+  `PATCH /admin/runtime/mcp-mode` (and `/admin/runtime/a2a-mode` for A2A) —
+  `off` and `full` are not flippable; see the architecture doc —
+  see [docs/docs/architecture/rust-mcp-runtime.md](../../docs/docs/architecture/rust-mcp-runtime.md#runtime-mode-override)
+  for the full operator contract and cluster propagation behavior.
 
 ## Quick reference
 

--- a/crates/mcp_runtime/STATUS.md
+++ b/crates/mcp_runtime/STATUS.md
@@ -22,10 +22,12 @@ Current meaning:
 - `full`: `edge` plus Rust session/event-store/resume/live-stream/affinity
   cores
 
-Boot modes `shadow` and `edge` additionally support an in-memory runtime
-override (`shadow ↔ edge`) via `PATCH /admin/runtime/mcp-mode` and
-`PATCH /admin/runtime/a2a-mode`. `off` and `full` are not flippable at
-runtime — `off` has no Rust sidecar to swap to, and `full` would require
+Boot mode `edge` additionally supports an in-memory runtime override
+(`shadow ↔ edge`) via `PATCH /admin/runtime/mcp-mode` and
+`PATCH /admin/runtime/a2a-mode`. `off`, `shadow`, and `full` are not
+flippable at runtime — `off` has no Rust sidecar to swap to, `shadow` did
+not opt into the session-auth-reuse / delegate-enabled safety invariant
+that routing public traffic to Rust requires, and `full` would require
 live migration of Rust-owned MCP session/event-store cores. When Redis is
 available the override propagates to the whole cluster; otherwise it stays
 local to the pod that received the PATCH.

--- a/crates/mcp_runtime/STATUS.md
+++ b/crates/mcp_runtime/STATUS.md
@@ -22,6 +22,14 @@ Current meaning:
 - `full`: `edge` plus Rust session/event-store/resume/live-stream/affinity
   cores
 
+Boot modes `shadow` and `edge` additionally support an in-memory runtime
+override (`shadow ↔ edge`) via `PATCH /admin/runtime/mcp-mode` and
+`PATCH /admin/runtime/a2a-mode`. `off` and `full` are not flippable at
+runtime — `off` has no Rust sidecar to swap to, and `full` would require
+live migration of Rust-owned MCP session/event-store cores. When Redis is
+available the override propagates to the whole cluster; otherwise it stays
+local to the pod that received the PATCH.
+
 Python still remains the authority for:
 
 - authentication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,11 +160,13 @@ services:
       #   RUST_MCP_MODE=shadow -> Rust sidecar is present, but public /mcp stays on Python for safe fallback
       #   RUST_MCP_MODE=edge   -> direct public /mcp on Rust with managed UDS sidecar defaults
       #   RUST_MCP_MODE=full   -> edge + Rust session/event-store/resume/live-stream/affinity cores
-      # When the boot mode is shadow or edge an authorized admin can flip
-      # the public /mcp ingress between shadow and edge at runtime via
+      # When the boot mode is edge an authorized admin can flip the public
+      # /mcp ingress between shadow and edge at runtime via
       # PATCH /admin/runtime/mcp-mode (and /admin/runtime/a2a-mode for A2A).
-      # (off and full boot modes are NOT flippable at runtime — off has no
-      # Rust sidecar; full would require live migration of Rust-owned cores.)
+      # (off, shadow, and full boot modes are NOT flippable at runtime —
+      # off has no Rust sidecar; shadow did not opt into session-auth-reuse
+      # so an edge override cannot safely route public traffic; full would
+      # require live migration of Rust-owned cores.)
       # The override is in-memory only; restarts re-read RUST_MCP_MODE/RUST_A2A_MODE.
       # If REDIS_URL is set the override propagates to all pods; otherwise it is
       # local to the pod that received the PATCH.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,14 @@ services:
       #   RUST_MCP_MODE=shadow -> Rust sidecar is present, but public /mcp stays on Python for safe fallback
       #   RUST_MCP_MODE=edge   -> direct public /mcp on Rust with managed UDS sidecar defaults
       #   RUST_MCP_MODE=full   -> edge + Rust session/event-store/resume/live-stream/affinity cores
+      # When the boot mode is shadow or edge an authorized admin can flip
+      # the public /mcp ingress between shadow and edge at runtime via
+      # PATCH /admin/runtime/mcp-mode (and /admin/runtime/a2a-mode for A2A).
+      # (off and full boot modes are NOT flippable at runtime — off has no
+      # Rust sidecar; full would require live migration of Rust-owned cores.)
+      # The override is in-memory only; restarts re-read RUST_MCP_MODE/RUST_A2A_MODE.
+      # If REDIS_URL is set the override propagates to all pods; otherwise it is
+      # local to the pod that received the PATCH.
       # Advanced EXPERIMENTAL_/MCP_RUST_* env vars below still work as explicit overrides.
       - RUST_MCP_MODE=${RUST_MCP_MODE:-off}
       - RUST_MCP_LOG=${RUST_MCP_LOG:-warn}

--- a/docs/docs/architecture/adr/043-rust-mcp-runtime-sidecar-mode-model.md
+++ b/docs/docs/architecture/adr/043-rust-mcp-runtime-sidecar-mode-model.md
@@ -197,9 +197,12 @@ We additionally allow an authenticated admin to flip the public `/mcp` ingress
 runtime via `PATCH /admin/runtime/mcp-mode` and
 `PATCH /admin/runtime/a2a-mode` (`admin.system_config` permission). The
 override is in-memory only — there is no new Postgres persistence surface,
-and a process restart re-reads `RUST_MCP_MODE` / `RUST_A2A_MODE`. `off` and
-`full` boot modes are intentionally not flippable (`off` lacks the Rust
-sidecar; `full` would require live session/event-store/resume migration).
+and a process restart re-reads `RUST_MCP_MODE` / `RUST_A2A_MODE`. Flips
+require `boot_mode=edge` so that the existing session-auth-reuse /
+delegate-enabled safety invariant is met; `off`, `shadow`, and `full` boot
+modes are intentionally not flippable (`off` has no sidecar; `shadow` did
+not opt into the safety flags; `full` would require live session/
+event-store/resume migration).
 
 When Redis is configured the override propagates cluster-wide via the
 `contextforge:runtime:mode` pub/sub channel with a per-runtime monotonic

--- a/docs/docs/architecture/adr/043-rust-mcp-runtime-sidecar-mode-model.md
+++ b/docs/docs/architecture/adr/043-rust-mcp-runtime-sidecar-mode-model.md
@@ -190,6 +190,29 @@ the documented operator model is the high-level mode switch above.
 | Expose only low-level `EXPERIMENTAL_RUST_MCP_*` flags | Too hard for operators to reason about safely |
 | Keep public `/mcp` permanently on Python and use Rust only behind Python | Leaves the Python ingress hop in the hot path and limits the performance gain |
 
+## Addendum (2026-04): Runtime mode override
+
+We additionally allow an authenticated admin to flip the public `/mcp` ingress
+(and the registered-A2A invocation path) between `shadow` and `edge` at
+runtime via `PATCH /admin/runtime/mcp-mode` and
+`PATCH /admin/runtime/a2a-mode` (`admin.system_config` permission). The
+override is in-memory only — there is no new Postgres persistence surface,
+and a process restart re-reads `RUST_MCP_MODE` / `RUST_A2A_MODE`. `off` and
+`full` boot modes are intentionally not flippable (`off` lacks the Rust
+sidecar; `full` would require live session/event-store/resume migration).
+
+When Redis is configured the override propagates cluster-wide via the
+`contextforge:runtime:mode` pub/sub channel with a per-runtime monotonic
+version (allocated via `INCR`); each pod also persists a short-lived hint
+key (`contextforge:runtime:mode_state:{runtime}`, TTL 24h) so a freshly
+started pod reconciles to the cluster's current desired override on boot.
+Without Redis the override is per-pod and operators see
+`cluster_propagation: "disabled"` on `/health` and the admin response.
+
+This is a deliberate operability tradeoff: the override survives pod-level
+churn (via Redis) but not full cluster restarts (no DB persistence), keeping
+the env-var contract authoritative for "what does this deployment boot as."
+
 ## References
 
 - [Rust MCP Runtime Architecture](../rust-mcp-runtime.md)

--- a/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
+++ b/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
@@ -1,0 +1,198 @@
+# ADR-050: Defer Generic Cluster-Wide Settings Propagation Framework
+
+- *Status:* Accepted
+- *Date:* 2026-04-18
+- *Deciders:* Platform Team
+- *Related:* [ADR-043: Rust MCP Runtime Sidecar with Mode-Based Rollout](043-rust-mcp-runtime-sidecar-mode-model.md), [Issue #4273: Runtime-mutable RUST_MCP_MODE](https://github.com/IBM/mcp-context-forge/issues/4273)
+
+## Context
+
+Issue #4273 introduced the first runtime-mutable cluster-wide setting in
+ContextForge: an authenticated admin can now flip the public `/mcp` ingress
+(and the registered-A2A invocation path) between `shadow` and `edge` at
+runtime, with the change propagating across all pods via Redis. The
+implementation lives in `mcpgateway/runtime_state.py` and exposes:
+
+- `RuntimeStateCoordinator` — Redis pub/sub on
+  `contextforge:runtime:mode`, with a `LISTEN_LOOP_DEGRADE_THRESHOLD` for
+  fault tolerance and a `cluster_propagation` status surfaced via `/health`
+- A monotonic per-runtime version counter via `INCR contextforge:runtime:mode_version:{runtime}`
+  that prevents two pods from silently overwriting each other's flips
+- A short-lived per-runtime hint key
+  (`contextforge:runtime:mode_state:{runtime}`, TTL 24h) so a freshly
+  started pod reconciles to the cluster's current desired override on boot
+- A compatibility gate (`version.deployment_allows_override_mode` →
+  `MoveCompatibility` enum) that prevents stranded overrides on deployments
+  whose boot-time flags can't safely honor the requested mode
+- `BootReconcileStatus` (`OK` / `REDIS_UNAVAILABLE` / `MALFORMED_HINT` /
+  `INCOMPATIBLE_NO_DISPATCHER` / `INCOMPATIBLE_BOOT_FULL` /
+  `INCOMPATIBLE_SAFETY_FLAG` / `PUBSUB_UNAVAILABLE` / `COORDINATOR_OFFLINE`)
+  for granular operator visibility
+- Audit trail integration via `SecurityLogger.log_data_access`
+- A reverse-proxy detection WARN that surfaces the proxy-doesn't-follow-the-flip
+  gap (tracked in [#4278](https://github.com/IBM/mcp-context-forge/issues/4278))
+
+The natural follow-up question: **other runtime-mutable settings will
+appear** (feature flags, log levels, plugin enable/disable, traffic-shaping
+knobs, etc.). Should we extract this propagation machinery into a generic
+framework now, before the second consumer arrives?
+
+## Decision
+
+**We do NOT extract a generic framework today.** The current implementation
+stays purpose-built for MCP / A2A runtime mode overrides. When a second
+genuine cluster-wide-mutable-setting use case lands, we revisit with
+concrete requirements from both consumers in hand.
+
+This ADR records the decision, the alternative we analyzed, and the
+trigger conditions for revisiting — so the next contributor doesn't have
+to re-derive the same trade-off from scratch.
+
+## Rationale
+
+1. **N=1 is the wrong moment to abstract.** CLAUDE.md is explicit:
+   > Three similar lines is better than a premature abstraction.
+
+   We have exactly one concrete consumer (with two sub-kinds, MCP and A2A,
+   that already share most of the implementation). The shape of the right
+   abstraction is hard to see from a single instance — what looks generic
+   in one consumer often turns out to be policy-specific in the second.
+
+2. **The current code is the most-reviewed code on the branch.** Six
+   stop-time review iterations from Codex caught real bugs (safety-invariant
+   bypass, stranded overrides, listen-loop false-recovery, self-contradicting
+   409 messages, etc.). Pulling the propagation primitives into a separate
+   framework now would either lose that hardening or require porting all
+   the regression tests across an additional API boundary. Either path is
+   net-negative for reliability.
+
+3. **The current factoring already supports a second consumer cheaply.**
+   `MoveCompatibility`, `BootReconcileStatus`, and the per-runtime keying
+   scheme were intentionally kept generic-shaped. A second consumer can
+   copy-modify `runtime_state.py` and `runtime_admin_router.py` (≈900 LOC
+   together) and the diff against this ADR's design will be the basis for
+   the eventual abstraction. That diff is more reliable design input than
+   any framework we'd guess at now.
+
+## The alternative we considered
+
+A `ClusterStatePrimitive` (or `RuntimeSettingsCoordinator`) that owns the
+operational shell, with each consumer plugging in its policy. Sketch:
+
+```python
+class ClusterStatePrimitive:
+    """Generic Redis-backed cluster-wide propagation for in-memory settings."""
+
+    def __init__(
+        self,
+        *,
+        channel: str,                       # e.g. "contextforge:runtime:mode"
+        hint_key_prefix: str,               # e.g. "contextforge:runtime:mode_state"
+        version_key_prefix: str,            # e.g. "contextforge:runtime:mode_version"
+        hint_ttl_seconds: int = 24 * 60 * 60,
+        listen_loop_degrade_threshold: int = 5,
+    ) -> None: ...
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def next_version(self, key: str, current_version: int) -> int: ...
+    async def publish(self, payload: dict) -> bool: ...
+    def register_consumer(
+        self,
+        kind: str,
+        *,
+        compat_check: Callable[[Any, Any], CompatibilityResult],
+        apply_callback: Callable[[ChangeEvent], Awaitable[None]],
+        status_setter: Callable[[BootStatus], None],
+    ) -> None: ...
+```
+
+Each consumer (MCP modes, log levels, feature flags, …) would register
+itself and supply:
+
+- a **serializer** for its value type
+- a **`compat_check`** that returns a structured rejection reason or `OK`
+  (today's `MoveCompatibility` becomes one realization)
+- an **`apply_callback`** invoked when a remote change lands in local state
+- a **`status_setter`** so per-consumer boot reconcile status surfaces on
+  `/health` independently
+
+What stays per-consumer (intentionally):
+
+- The compatibility-rejection enum (today's `MoveCompatibility`) is
+  policy-specific and shouldn't be generalized; it just has to satisfy a
+  protocol shape (`OK` vs. structured-reason).
+- The admin router endpoints (URL shape, RBAC permission, audit
+  resource\_type) stay one-per-feature.
+- The transport-layer wiring that observes the override (today's
+  `MCPStreamableHTTPModeDispatcher`) is consumer-specific by definition.
+
+What the framework would own:
+
+- Pub/sub channel lifecycle, subscriber backoff, `degraded` status
+- Monotonic version allocation (`INCR` discipline)
+- Boot hint reconciliation (read + compatibility-gated apply)
+- Listen-loop with the same compatibility gate on remote messages
+- Per-consumer `cluster_propagation` and `boot_reconcile_status` surfaces
+- A single set of operational dashboards / alert rules
+
+## When to revisit
+
+Build the framework when **any one** of the following becomes true:
+
+1. A second concrete cluster-wide-mutable-setting use case is in flight,
+   not hypothetical. At that point, build both consumers side-by-side and
+   let the framework fall out of the diff.
+2. A third, independently-tracked use case is on the horizon. Two
+   consumers may still be close enough that a framework is premature; three
+   makes the case unambiguous.
+3. We need cross-consumer coordination (e.g. atomic multi-setting flips,
+   global per-cluster freeze, or a "config version" that pins multiple
+   settings together). That's a feature the framework enables; the
+   purpose-built coordinator can't deliver it without significant rework.
+
+Until one of those conditions hits, the right move is to copy-modify
+`runtime_state.py` for the second consumer and treat the resulting two-file
+diff as the design input for ADR-051 (or whichever number lands).
+
+## Consequences
+
+### Positive
+
+- The current implementation stays exactly as the six review rounds shaped
+  it — no risk of regression from porting the hardened logic across a new
+  API boundary.
+- The next contributor adding a runtime-mutable setting has a working,
+  well-tested template to copy and a clear ADR explaining why the framework
+  doesn't exist yet.
+- Operational tooling (alerts, dashboards, runbooks) for MCP/A2A overrides
+  can be built and refined without worrying about a framework refactor
+  invalidating them.
+
+### Negative
+
+- Two near-identical consumers will exist in the codebase between when the
+  second use case lands and when the framework is built. That's the
+  expected cost of waiting for the right shape.
+- A second contributor might miss a subtle defense (e.g. the listen-loop
+  compatibility gate, the discarded-hint-stays-in-Redis trade-off, the
+  reverse-proxy WARN) when copy-modifying. **Mitigation:** before the
+  second consumer ships, capture the non-obvious defenses as a checklist in
+  this ADR's "When to revisit" section so the copy-modify diff is reviewed
+  against them.
+
+### Neutral
+
+- ADR-043 (Rust MCP Runtime Sidecar with Mode-Based Rollout) and the
+  Modular Runtime Architecture work continue independently. Nothing in
+  this ADR forecloses or accelerates either.
+
+## References
+
+- Implementation: `mcpgateway/runtime_state.py`,
+  `mcpgateway/routers/runtime_admin_router.py`,
+  `mcpgateway/version.py` (the `_should_mount_public_rust_transport` /
+  `_should_delegate_a2a_to_rust` / `_deployment_allows_override_mode`
+  helpers)
+- Architecture overview: [Rust MCP Runtime — Runtime Mode Override](../rust-mcp-runtime.md#runtime-mode-override)
+- Reverse-proxy follow-up: [#4278](https://github.com/IBM/mcp-context-forge/issues/4278)

--- a/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
+++ b/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
@@ -11,16 +11,20 @@ Issue #4273 introduced the first runtime-mutable cluster-wide setting in
 ContextForge: an authenticated admin can now flip the public `/mcp` ingress
 (and the registered-A2A invocation path) between `shadow` and `edge` at
 runtime, with the change propagating across all pods via Redis. The
-implementation lives in `mcpgateway/runtime_state.py` and exposes:
+implementation lives across `mcpgateway/runtime_state.py` and
+`mcpgateway/routers/runtime_admin_router.py` and exposes:
 
-- `RuntimeStateCoordinator` — Redis pub/sub on
-  `contextforge:runtime:mode`, with a `LISTEN_LOOP_DEGRADE_THRESHOLD` for
-  fault tolerance and a `cluster_propagation` status surfaced via `/health`
-- A monotonic per-runtime version counter via `INCR contextforge:runtime:mode_version:{runtime}`
-  that prevents two pods from silently overwriting each other's flips
+- `RuntimeStateCoordinator` (`runtime_state.py`) — Redis pub/sub on
+  `contextforge:runtime:mode`, with `LISTEN_LOOP_DEGRADE_THRESHOLD = 5`
+  for fault tolerance and a `cluster_propagation` status surfaced via
+  `/health`
+- A monotonic per-runtime version counter via
+  `INCR contextforge:runtime:mode_version:{runtime}` that prevents two
+  pods from silently overwriting each other's flips
 - A short-lived per-runtime hint key
-  (`contextforge:runtime:mode_state:{runtime}`, TTL 24h) so a freshly
-  started pod reconciles to the cluster's current desired override on boot
+  (`contextforge:runtime:mode_state:{runtime}`,
+  `RUNTIME_STATE_HINT_TTL_SECONDS = 24 * 60 * 60`) so a freshly started
+  pod reconciles to the cluster's current desired override on boot
 - A compatibility gate (`version.deployment_allows_override_mode` →
   `MoveCompatibility` enum) that prevents stranded overrides on deployments
   whose boot-time flags can't safely honor the requested mode
@@ -29,8 +33,10 @@ implementation lives in `mcpgateway/runtime_state.py` and exposes:
   `INCOMPATIBLE_SAFETY_FLAG` / `PUBSUB_UNAVAILABLE` / `COORDINATOR_OFFLINE`)
   for granular operator visibility
 - Audit trail integration via `SecurityLogger.log_data_access`
-- A reverse-proxy detection WARN that surfaces the proxy-doesn't-follow-the-flip
-  gap (tracked in [#4278](https://github.com/IBM/mcp-context-forge/issues/4278))
+  (called from `runtime_admin_router.py`)
+- A reverse-proxy detection WARN in `runtime_admin_router.py` that
+  surfaces the proxy-doesn't-follow-the-flip gap (tracked in
+  [#4278](https://github.com/IBM/mcp-context-forge/issues/4278))
 
 The natural follow-up question: **other runtime-mutable settings will
 appear** (feature flags, log levels, plugin enable/disable, traffic-shaping
@@ -50,34 +56,41 @@ to re-derive the same trade-off from scratch.
 
 ## Rationale
 
-1. **N=1 is the wrong moment to abstract.** Repo convention is explicit:
-   three similar lines beats a premature abstraction.
+1. **N=1 is the wrong moment to abstract.** We have exactly one concrete
+   consumer (with two sub-kinds, MCP and A2A, that already share most of
+   the implementation). The shape of the right abstraction is hard to see
+   from a single instance — what looks generic in one consumer often turns
+   out to be policy-specific in the second. Building the framework on a
+   single example would force guesses we can't validate.
 
-   We have exactly one concrete consumer (with two sub-kinds, MCP and A2A,
-   that already share most of the implementation). The shape of the right
-   abstraction is hard to see from a single instance — what looks generic
-   in one consumer often turns out to be policy-specific in the second.
-
-2. **The current code is the most-reviewed code on the branch.** Six
-   stop-time review iterations caught real bugs during development
-   (safety-invariant bypass, stranded overrides, listen-loop
-   false-recovery, self-contradicting 409 messages, etc.). Pulling the
-   propagation primitives into a separate framework now would either lose
-   that hardening or require porting all the regression tests across an
-   additional API boundary. Either path is net-negative for reliability.
+2. **The current code received unusually heavy review during initial
+   development.** Five follow-up `fix(runtime):` commits on top of the
+   initial `feat(runtime):` caught real bugs: safety-invariant bypass,
+   stranded overrides on incompatible boots, listen-loop false-recovery
+   under `None` returns, self-contradicting 409 guidance, and others.
+   Pulling the propagation primitives into a separate framework now would
+   either lose that hardening or require porting all the regression tests
+   across an additional API boundary. Either path is net-negative for
+   reliability.
 
 3. **The current factoring already supports a second consumer cheaply.**
    `MoveCompatibility`, `BootReconcileStatus`, and the per-runtime keying
    scheme were intentionally kept generic-shaped. A second consumer can
-   copy-modify `runtime_state.py` and `runtime_admin_router.py` (≈900 LOC
+   copy-modify `runtime_state.py` and `runtime_admin_router.py` (~1.5 kLOC
    together) and the diff against this ADR's design will be the basis for
-   the eventual abstraction. That diff is more reliable design input than
-   any framework we'd guess at now.
+   the eventual abstraction — copy-modify first, then extract the
+   framework from the resulting diff (see "When to revisit" below). That
+   diff is more reliable design input than any framework we'd guess at now.
 
 ## The alternative we considered
 
 A `ClusterStatePrimitive` (or `RuntimeSettingsCoordinator`) that owns the
-operational shell, with each consumer plugging in its policy. Sketch:
+operational shell, with each consumer plugging in its policy.
+
+> *The class below is a **hypothetical sketch** — no such class exists in
+> the codebase today. Reproduced here so a future ADR-052 (or whichever
+> number lands) author can push against concrete shape rather than start
+> from a blank page.*
 
 ```python
 class ClusterStatePrimitive:
@@ -141,27 +154,79 @@ What the framework would own:
 Build the framework when **any one** of the following becomes true:
 
 1. A second concrete cluster-wide-mutable-setting use case is in flight,
-   not hypothetical. At that point, build both consumers side-by-side and
-   let the framework fall out of the diff.
+   not hypothetical. The path is: **copy-modify** `runtime_state.py` and
+   `runtime_admin_router.py` for the second consumer first (don't try to
+   abstract on the way), then **extract the framework from the resulting
+   two-implementation diff**. The shape that survives both consumers is
+   the shape worth abstracting.
 2. A third, independently-tracked use case is on the horizon. Two
-   consumers may still be close enough that a framework is premature; three
-   makes the case unambiguous.
+   consumers may still be close enough that a framework is premature;
+   three makes the case unambiguous.
 3. We need cross-consumer coordination (e.g. atomic multi-setting flips,
    global per-cluster freeze, or a "config version" that pins multiple
    settings together). That's a feature the framework enables; the
    purpose-built coordinator can't deliver it without significant rework.
 
-Until one of those conditions hits, the right move is to copy-modify
-`runtime_state.py` for the second consumer and treat the resulting two-file
-diff as the design input for ADR-051 (or whichever number lands).
+### Defenses checklist for the copy-modify path
+
+A second consumer that copy-modifies `runtime_state.py` /
+`runtime_admin_router.py` MUST preserve every defense below. Each line
+came from a real bug caught during this PR's review iterations; missing
+any of them re-introduces a bug class the original code already paid for.
+
+- [ ] **Safety-invariant check on every read site.** The transport layer
+  must never trust an override blindly. Today: `_should_mount_public_rust_transport`
+  and `_should_delegate_a2a_to_rust` re-derive the safety predicate from
+  raw settings even when an override is in state.
+- [ ] **Compatibility gate on `_reconcile_from_hint`.** A persisted hint
+  whose target mode can't safely take effect on this deployment must be
+  discarded with `BootReconcileStatus.INCOMPATIBLE_*`, not silently
+  applied.
+- [ ] **Compatibility gate on `_listen_loop`'s remote messages too.**
+  Symmetric to the boot path — a remote pod's published flip can be
+  incompatible with the receiving pod's deployment, and the gate must
+  catch it before `apply_remote`.
+- [ ] **Discarded hint key stays in Redis.** Don't `DEL` an incompatible
+  hint — a future compatible-boot pod must still be able to read it. TTL
+  handles natural expiry; operators get a manual `DEL` escape hatch.
+- [ ] **Listen-loop recovery requires a real message.** Re-promote from
+  `DEGRADED` to `REDIS` only when `message is not None`, not on any
+  non-exception return. A pubsub returning `None` reliably without
+  raising would otherwise falsely recover.
+- [ ] **`next_version` raises rather than falling back to local
+  allocation.** Local fallback can collide with a concurrent PATCH on a
+  peer pod and silently drop one of the two flips at peer dedup time.
+  Raise `RuntimeStateError` → router maps to 503 → operator retries.
+- [ ] **Audit fail-open with a broad catch.** Audit-write failures
+  (network sink, DB outage, misconfigured logger) must NOT roll back the
+  override after `apply_local` has already mutated state. Catch broadly,
+  log at ERROR, surface `audit_persisted: false` in the response.
+- [ ] **Race-loser PATCH still writes an audit row.** When
+  `apply_local` returns `None` (concurrent newer change won), record the
+  intent with `success=False` and `additional_context.outcome="superseded"`
+  so postmortems can see the attempt.
+- [ ] **Per-target-mode 409 gating** in the router. Don't gate on boot
+  mode label alone; gate on whether the target mode can take effect.
+  `mode=shadow` is the escape hatch from any dispatcher-mounted boot;
+  `mode=edge` requires the safety invariant.
+- [ ] **9-message audit trail entry uses authenticated identity, not
+  body-supplied fields.** The router pulls `email` / `ip_address` /
+  `user_agent` from the user context only, never from the request body.
+- [ ] **Reverse-proxy WARN on PATCH** when `X-Forwarded-For` /
+  `Forwarded` headers are present, pointing at the proxy-doesn't-follow
+  gap (currently #4278).
+- [ ] **`_apply_mode_change` ordering**: validate → reverse-proxy WARN →
+  allocate version → mutate state → audit → publish. Reordering breaks
+  several of the above defenses (e.g. logging proxy WARN before the 409
+  check would log unsafe PATCHes as proxy-fronted).
 
 ## Consequences
 
 ### Positive
 
-- The current implementation stays exactly as the six review rounds shaped
-  it — no risk of regression from porting the hardened logic across a new
-  API boundary.
+- The current implementation stays exactly as the iterative review rounds
+  shaped it — no risk of regression from porting the hardened logic
+  across a new API boundary.
 - The next contributor adding a runtime-mutable setting has a working,
   well-tested template to copy and a clear ADR explaining why the framework
   doesn't exist yet.
@@ -174,12 +239,12 @@ diff as the design input for ADR-051 (or whichever number lands).
 - Two near-identical consumers will exist in the codebase between when the
   second use case lands and when the framework is built. That's the
   expected cost of waiting for the right shape.
-- A second contributor might miss a subtle defense (e.g. the listen-loop
+- A second contributor might miss a subtle defense (the listen-loop
   compatibility gate, the discarded-hint-stays-in-Redis trade-off, the
-  reverse-proxy WARN) when copy-modifying. **Mitigation:** before the
-  second consumer ships, capture the non-obvious defenses as a checklist in
-  this ADR's "When to revisit" section so the copy-modify diff is reviewed
-  against them.
+  reverse-proxy WARN, etc.) when copy-modifying. **Mitigation:** the
+  "Defenses checklist for the copy-modify path" subsection above
+  enumerates every defense the original code paid for; the PR that adds
+  the second consumer must walk through it line by line.
 
 ### Neutral
 

--- a/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
+++ b/docs/docs/architecture/adr/050-defer-generic-cluster-settings-propagation-framework.md
@@ -50,8 +50,8 @@ to re-derive the same trade-off from scratch.
 
 ## Rationale
 
-1. **N=1 is the wrong moment to abstract.** CLAUDE.md is explicit:
-   > Three similar lines is better than a premature abstraction.
+1. **N=1 is the wrong moment to abstract.** Repo convention is explicit:
+   three similar lines beats a premature abstraction.
 
    We have exactly one concrete consumer (with two sub-kinds, MCP and A2A,
    that already share most of the implementation). The shape of the right
@@ -59,12 +59,12 @@ to re-derive the same trade-off from scratch.
    in one consumer often turns out to be policy-specific in the second.
 
 2. **The current code is the most-reviewed code on the branch.** Six
-   stop-time review iterations from Codex caught real bugs (safety-invariant
-   bypass, stranded overrides, listen-loop false-recovery, self-contradicting
-   409 messages, etc.). Pulling the propagation primitives into a separate
-   framework now would either lose that hardening or require porting all
-   the regression tests across an additional API boundary. Either path is
-   net-negative for reliability.
+   stop-time review iterations caught real bugs during development
+   (safety-invariant bypass, stranded overrides, listen-loop
+   false-recovery, self-contradicting 409 messages, etc.). Pulling the
+   propagation primitives into a separate framework now would either lose
+   that hardening or require porting all the regression tests across an
+   additional API boundary. Either path is net-negative for reliability.
 
 3. **The current factoring already supports a second consumer cheaply.**
    `MoveCompatibility`, `BootReconcileStatus`, and the per-runtime keying

--- a/docs/docs/architecture/adr/051-swappable-mcp-ingress-mount.md
+++ b/docs/docs/architecture/adr/051-swappable-mcp-ingress-mount.md
@@ -1,0 +1,228 @@
+# ADR-051: Swappable MCP Ingress Mount
+
+- *Status:* Accepted
+- *Date:* 2026-04-18
+- *Deciders:* Platform Team
+- *Related:* [ADR-043: Rust MCP Runtime Sidecar with Mode-Based Rollout](043-rust-mcp-runtime-sidecar-mode-model.md), [ADR-050: Defer Generic Cluster-Wide Settings Propagation Framework](050-defer-generic-cluster-settings-propagation-framework.md), [Issue #4273: Runtime-mutable RUST_MCP_MODE](https://github.com/IBM/mcp-context-forge/issues/4273), [Issue #4278: Propagate runtime MCP mode override into the public reverse proxy](https://github.com/IBM/mcp-context-forge/issues/4278)
+
+## Context
+
+Issue #4273 introduced the runtime-mutable MCP mode override. The original
+implementation mounted an `MCPStreamableHTTPModeDispatcher` at `/mcp` that
+held two hard-coded transports — `MCPRuntimeHeaderTransportWrapper`
+(Python) and `RustMCPRuntimeProxy` (the trusted Python→Rust forwarder over
+`MCP_RUST_LISTEN_HTTP` / UDS) — and chose between them per request based
+on `_should_mount_public_rust_transport()`. That worked for the two
+transports we had at the time but pinned the dispatcher to a closed set
+and embedded the selection policy inside the dispatch method.
+
+Two near-term needs surfaced that the dispatcher couldn't accommodate
+cleanly:
+
+1. **An nginx-style reverse proxy to the Rust public listener.** In a
+   single-process / no-nginx deployment, edge mode still routes through
+   Python's `RustMCPRuntimeProxy` over the trusted-internal listener
+   (`MCP_RUST_LISTEN_HTTP`). For deployments without nginx in front, the
+   gateway can also play the nginx role itself by reverse-proxying to
+   the Rust public listener at `MCP_RUST_PUBLIC_LISTEN_HTTP`. This is a
+   third ingress kind, not a different way of using the existing two.
+
+2. **Future ingresses we don't yet have specs for.** Shadow-comparison
+   (run both transports, compare results), percentage traffic split,
+   per-method routing (POST → Rust direct, GET SSE → Python), header-based
+   A/B canaries — each is a distinct ingress shape, not a tweak to the
+   selection policy. Adding them under the closed dispatcher requires
+   either growing its constructor signature with each new transport or
+   subclassing repeatedly.
+
+ADR-050 deferred the broader cluster-wide settings framework on the
+grounds that N=1 is too few examples to abstract. The MCP ingress case is
+different: we're already moving from N=2 to N=3 ingresses inside the same
+mount, and the future N is plausibly larger. The abstraction sweet spot
+is here.
+
+## Decision
+
+We replace `MCPStreamableHTTPModeDispatcher` with `MCPIngressMount`: a
+thin ASGI indirection that holds a registry of named ASGI ingresses and a
+swappable selector function. The mount itself owns no policy.
+
+Implementation:
+
+- **`mcpgateway/transports/mcp_ingress_mount.py`** — `MCPIngressMount`
+  class. `register(name, app)` adds an ingress; `set_selector(fn)` swaps
+  the policy; `dispatch(scope, receive, send)` is the ASGI entry point.
+  Selector receives the ASGI scope so policies can inspect
+  method/path/headers without changing the mount API.
+
+- **`mcpgateway/transports/rust_mcp_public_proxy.py`** —
+  `RustMCPPublicProxyApp`, an ASGI app that does nginx-style reverse-proxy
+  to `MCP_RUST_PUBLIC_LISTEN_HTTP`. Adds `X-Forwarded-{For,Proto,Host}`,
+  RFC 7239 `Forwarded`, and `X-Real-IP` so the Rust public listener's
+  `/_internal/mcp/authenticate` callback sees the original client info.
+  Streams both directions; preserves `Authorization` / `Cookie` (this is
+  a public hop, not trusted-internal); does NOT inject any trust-marker
+  headers. Built via `build_rust_public_proxy_app()` factory.
+
+- **`mcpgateway/main.py`** — `_select_mcp_ingress(scope)` is the single
+  selection policy. `_build_mcp_transport_app()` constructs the mount,
+  registers `python` + `rust-internal` (always for boot=shadow/edge) and
+  `rust-public` (only for boot=edge — shadow doesn't bind the Rust public
+  listener). The mount is exposed under the legacy `mcp_transport_app`
+  module attribute and aliases `dispatch` as `handle_streamable_http` so
+  the `app.mount("/mcp", app=mcp_transport_app.handle_streamable_http)`
+  line stays unchanged.
+
+- **`mcpgateway/config.py`** — two new settings:
+  - `mcp_rust_ingress: str = "internal"` — selector input, picks between
+    the two Rust ingress shapes (`"internal"` or `"public"`).
+  - `mcp_rust_public_proxy_upstream: str = "http://127.0.0.1:8787"` —
+    default upstream for `RustMCPPublicProxyApp`, matching
+    `docker-entrypoint.sh`'s `MCP_RUST_PUBLIC_LISTEN_HTTP=0.0.0.0:8787`
+    accessed via loopback inside the same pod.
+
+The selection policy in `_select_mcp_ingress` preserves all the existing
+safety invariants:
+
+- `_should_mount_public_rust_transport()` is consulted first — same
+  function the runtime-mode override coordinator already gates on, so
+  shadow override / edge boot / safety-flag check / boot=full all behave
+  identically to the prior dispatcher.
+- Within the Rust branch, the `mcp_rust_ingress` setting selects between
+  the two shapes. Default is `"internal"` to preserve the prior behavior
+  bit-for-bit; operators opt into the public-proxy shape with a single
+  setting change.
+- For boot=full, the mount isn't used at all — the plain
+  `RustMCPRuntimeProxy` is mounted directly per the prior code, since
+  full-boot has no dispatcher (flipping `full` would orphan Rust-held
+  session/event-store state per ADR-043).
+
+## Why this isn't the framework ADR-050 deferred
+
+ADR-050 deferred a generic cluster-wide settings propagation framework.
+This ADR is scoped to the single mount point that serves `/mcp` and the
+ingress shapes that mount can hold. It doesn't introduce a registry of
+runtime settings, a propagation channel, or a coordinator — those remain
+purpose-built in `runtime_state.py`. The MoveCompatibility/safety
+invariant gate, the boot reconcile status surfacing, the audit pipeline
+all stay exactly where they are; the new mount just consumes
+`should_mount_public_rust_transport()` and `settings.mcp_rust_ingress`
+the same way the prior dispatcher consumed the same predicates.
+
+## Consequences
+
+### Positive
+
+- **Adding a new ingress is one `register()` call.** No conditional in
+  the dispatch hot path, no class hierarchy churn. Future shapes
+  (shadow-comparison, percentage traffic split, per-method routing) plug
+  in without touching the mount class or the existing ingresses.
+- **Each ingress is a plain ASGI 3.0 callable.** Testable in isolation
+  by calling `await ingress(scope, receive, send)` with a mock — see
+  `tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py`.
+- **Selector swap is atomic.** `set_selector(fn)` replaces the policy
+  without rebuilding the mount or touching ingress registrations. In
+  practice the selector is set once at boot and the runtime-mode
+  override coordinator drives behavior changes through the predicates
+  the selector reads — but the mechanism for hot-swapping the policy
+  itself is now there.
+- **Operator-facing 503 names the missing ingress.** When a deployment
+  is misconfigured (selector returns an ingress name not registered for
+  this build) the response body reads, e.g., `MCP ingress 'rust-public'
+  is not registered for this build; available: ['python', 'rust-internal']`.
+- **The nginx-style public proxy is now a usable production option.**
+  Single-process / no-proxy edge deployments can set
+  `mcp_rust_ingress=public` and route directly to Rust's public listener
+  without nginx in the picture — partially closing the gap tracked in
+  #4278 for non-nginx topologies.
+- **Drain semantics preserved.** Per-request selection means in-flight
+  requests on a deselected ingress complete on their original handler;
+  only newly-accepted requests follow the new selection. Same property
+  the prior dispatcher had — tested at
+  `tests/unit/mcpgateway/test_main_extended.py::test_mcp_ingress_mount_in_flight_request_finishes_on_original_ingress`.
+
+### Negative
+
+- **One more abstraction to learn.** Contributors wanting to understand
+  the `/mcp` mount now read three modules
+  (`mcp_ingress_mount.py`, the ingress implementations, the selector in
+  `main.py`) instead of one dispatcher class. The mount is intentionally
+  ~140 LOC including docstrings, and `_select_mcp_ingress` is one screen
+  of code, so the additional cognitive load is small.
+- **The legacy `handle_streamable_http` alias is a wart.** The mount
+  exposes `dispatch` as the natural ASGI entry point but the
+  `app.mount("/mcp", app=mcp_transport_app.handle_streamable_http)` line
+  in `main.py` predates the rename. Aliasing one to the other keeps the
+  mount line unchanged; a follow-up could change the mount line and drop
+  the alias.
+- **Public-listener proxy shares a port with the internal listener.**
+  `MCP_RUST_LISTEN_HTTP=127.0.0.1:8787` and
+  `MCP_RUST_PUBLIC_LISTEN_HTTP=0.0.0.0:8787` are the same port on
+  different bind addresses. Operators who want to run both listeners
+  from outside the default `docker-entrypoint.sh` flow need to be aware
+  that the Rust binary picks one or the other based on env at startup —
+  this isn't something the new ingress shape can change.
+
+### Neutral
+
+- The runtime-mode override admin API (`PATCH /admin/runtime/mcp-mode`)
+  is unchanged. It still reads/writes `RuntimeState`; the selector picks
+  it up via `_should_mount_public_rust_transport()` on the next request.
+- Docs at `docs/docs/architecture/rust-mcp-runtime.md` and the operator
+  guidance in `.env.example` / `docker-compose.yml` continue to describe
+  shadow ↔ edge as the user-visible toggle. The internal/public ingress
+  choice is a deployment-shape setting separate from the runtime override.
+
+## Migration from MCPStreamableHTTPModeDispatcher
+
+Code consumers:
+
+- `mcp_transport_app: MCPStreamableHTTPModeDispatcher` →
+  `mcp_transport_app: MCPIngressMount` for boot=shadow/edge. Same
+  attribute on the module, different class.
+- `dispatcher._python_transport` / `_rust_transport` →
+  `mount._ingresses["python"]` / `mount._ingresses["rust-internal"]`
+  (or `mount.names()` for the registered set).
+- `dispatcher.handle_streamable_http(scope, receive, send)` →
+  `mount.dispatch(scope, receive, send)`. The `handle_streamable_http`
+  alias is preserved on the mount so the existing `app.mount(...)` line
+  works unchanged.
+
+Tests:
+
+- `MCPStreamableHTTPModeDispatcher` references in
+  `test_main_extended.py:245,261,277` and the two dispatcher-behavior
+  tests have been migrated to assert against `MCPIngressMount` /
+  `_select_mcp_ingress` instead. Behavior assertions (per-request
+  routing, in-flight drain) are preserved.
+- New focused tests for the mount itself live at
+  `tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py`.
+
+## When to revisit
+
+Build the next layer of abstraction (e.g., a registry-based ingress
+plugin system that auto-registers from setup.cfg entry points) when:
+
+1. A second non-Rust ingress shape appears that benefits from registration
+   outside `main.py` — e.g., a third-party plugin shipping its own MCP
+   ingress.
+2. The selector grows past ~50 LOC of policy. At that point the right
+   move is to extract policy into composable predicates rather than to
+   change the mount.
+
+Until then, registration in `main.py` is the simplest thing that works
+and keeps the available ingress set auditable from one location.
+
+## References
+
+- Implementation:
+  - `mcpgateway/transports/mcp_ingress_mount.py`
+  - `mcpgateway/transports/rust_mcp_public_proxy.py`
+  - `mcpgateway/main.py` (`_build_mcp_transport_app`, `_select_mcp_ingress`)
+  - `mcpgateway/config.py` (`mcp_rust_ingress`, `mcp_rust_public_proxy_upstream`)
+- Tests:
+  - `tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py`
+  - `tests/unit/mcpgateway/test_main_extended.py` (the two
+    `test_mcp_ingress_mount_*` tests + the three `test_import_*` tests)
+- Architecture overview: [Rust MCP Runtime](../rust-mcp-runtime.md)
+- Reverse-proxy follow-up: [#4278](https://github.com/IBM/mcp-context-forge/issues/4278)

--- a/docs/docs/architecture/adr/051-swappable-mcp-ingress-mount.md
+++ b/docs/docs/architecture/adr/051-swappable-mcp-ingress-mount.md
@@ -138,8 +138,8 @@ the same way the prior dispatcher consumed the same predicates.
 - **Drain semantics preserved.** Per-request selection means in-flight
   requests on a deselected ingress complete on their original handler;
   only newly-accepted requests follow the new selection. Same property
-  the prior dispatcher had — tested at
-  `tests/unit/mcpgateway/test_main_extended.py::test_mcp_ingress_mount_in_flight_request_finishes_on_original_ingress`.
+  the prior dispatcher had — see the in-flight drain test in
+  `tests/unit/mcpgateway/test_main_extended.py`.
 
 ### Negative
 
@@ -190,13 +190,18 @@ Code consumers:
 
 Tests:
 
-- `MCPStreamableHTTPModeDispatcher` references in
-  `test_main_extended.py:245,261,277` and the two dispatcher-behavior
-  tests have been migrated to assert against `MCPIngressMount` /
-  `_select_mcp_ingress` instead. Behavior assertions (per-request
-  routing, in-flight drain) are preserved.
+- The dispatcher-behavior tests in `tests/unit/mcpgateway/test_main_extended.py`
+  (the `TestConditionalPaths::test_import_*` group plus the two
+  `test_mcp_ingress_mount_*` async tests) now assert against
+  `MCPIngressMount` / `_select_mcp_ingress` instead of the prior
+  dispatcher class. Behavior assertions (per-request routing, in-flight
+  drain) are preserved.
 - New focused tests for the mount itself live at
   `tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py`.
+- New focused tests for the public-listener proxy (header forwarding,
+  XFF spoof rejection, hop-by-hop stripping, error mapping, streaming
+  close-on-exit) live at
+  `tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py`.
 
 ## When to revisit
 

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -53,5 +53,6 @@ This page tracks all significant design decisions made for ContextForge project,
 | 0048  | Extract Rust-Backed Plugins First and Preserve Python Examples Separately | Accepted | Architecture | 2026-04-10 |
 | 0049  | Multi-Protocol Virtual Servers                       | Accepted | Architecture | 2026-04-16 |
 | 0050  | Defer Generic Cluster-Wide Settings Propagation Framework | Accepted | Architecture | 2026-04-18 |
+| 0051  | Swappable MCP Ingress Mount                          | Accepted | Architecture | 2026-04-18 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -51,5 +51,6 @@ This page tracks all significant design decisions made for ContextForge project,
 | 0046  | Shared-Nothing Between Protocol Modules              | Proposed | Architecture  | 2026-03-15 |
 | 0047  | Incremental Migration Over Rewrite                   | Proposed | Architecture  | 2026-03-15 |
 | 0048  | Extract Rust-Backed Plugins First and Preserve Python Examples Separately | Accepted | Architecture | 2026-04-10 |
+| 0050  | Defer Generic Cluster-Wide Settings Propagation Framework | Accepted | Architecture | 2026-04-18 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -51,6 +51,7 @@ This page tracks all significant design decisions made for ContextForge project,
 | 0046  | Shared-Nothing Between Protocol Modules              | Proposed | Architecture  | 2026-03-15 |
 | 0047  | Incremental Migration Over Rewrite                   | Proposed | Architecture  | 2026-03-15 |
 | 0048  | Extract Rust-Backed Plugins First and Preserve Python Examples Separately | Accepted | Architecture | 2026-04-10 |
+| 0049  | Multi-Protocol Virtual Servers                       | Accepted | Architecture | 2026-04-16 |
 | 0050  | Defer Generic Cluster-Wide Settings Propagation Framework | Accepted | Architecture | 2026-04-18 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.

--- a/docs/docs/architecture/rust-mcp-runtime.md
+++ b/docs/docs/architecture/rust-mcp-runtime.md
@@ -64,15 +64,22 @@ Behavior:
   `RUST_A2A_MODE`; there is no new persistence surface in Postgres.
 - Drain semantics are natural: in-flight requests complete on their original
   transport and only newly-accepted requests follow the flip.
-- Runtime flips are scoped to `shadow ↔ edge` **from `boot_mode=edge` only**.
-  `off`, `shadow`, and `full` boot modes all return `409 Conflict`:
-  - `off` has no Rust sidecar to swap to.
-  - `shadow` did not opt into session-auth-reuse / delegate-enabled at boot,
-    so an override to `edge` cannot safely route public traffic to Rust
-    (see the safety invariant above).
-  - `full` keeps Rust as the owner of MCP session/event-store/resume/
-    live-stream cores, and flipping to shadow would orphan that Rust-held
-    session state.
+- Runtime flip gating is per-target-mode:
+  - `mode=shadow` is accepted from any boot that has a dispatcher mounted
+    (`shadow` or `edge`). This is the **escape hatch** — it lets admins
+    clear a stale `override=edge` that landed via a Redis hint inherited
+    from a prior edge-boot deploy, without needing to flush Redis by hand.
+  - `mode=edge` is accepted only from `boot_mode=edge`, which is the only
+    configuration where the session-auth-reuse / delegate-enabled safety
+    invariant is met.
+  - `off` and `full` boot modes return `409` for every PATCH: `off` has no
+    Rust sidecar, `full` mounts a plain Rust proxy with no dispatcher so
+    an override can't take effect.
+- The coordinator's boot reconciliation discards persisted hints whose mode
+  cannot safely take effect on the current deployment (e.g. a hint written
+  by a former edge-boot pod replayed on a shadow-boot deploy). Discarded
+  hints surface via `/health` under `mcp_runtime.boot_reconcile_status` as
+  `incompatible_hint`.
 - Each successful flip writes a `runtime_config` audit trail entry via the
   existing `SecurityLogger.log_data_access` pathway. Audit-write failures
   caused by transient DB issues do not roll back the flip — the response
@@ -106,11 +113,12 @@ behavior-changing** at the public ingress until the proxy is reconfigured.
 Two deployment shapes:
 
 1. **Single-process / no proxy** (FastAPI on `:4444` is the only public
-   ingress). Runtime flips are end-to-end functional **only for
-   `boot_mode=edge`**. The `/mcp` mount is the per-request
+   ingress). Runtime flips are end-to-end functional **for `boot_mode=edge`**;
+   `boot_mode=shadow` accepts `mode=shadow` PATCHes as a clearance
+   escape hatch but cannot be promoted to `mode=edge` (see the 409
+   contract above). The `/mcp` mount is the per-request
    `MCPStreamableHTTPModeDispatcher`, which reads the override on every
-   request. Boot modes `off`, `shadow`, and `full` are not flippable — see
-   the 409 contract above.
+   request. Boot modes `off` and `full` are not flippable at all.
 
 2. **Reverse-proxy in front** (e.g. nginx routing public `GET/POST/DELETE
    /mcp` either to `gateway:4444` for Python or directly to the Rust public

--- a/docs/docs/architecture/rust-mcp-runtime.md
+++ b/docs/docs/architecture/rust-mcp-runtime.md
@@ -76,10 +76,18 @@ Behavior:
     Rust sidecar, `full` mounts a plain Rust proxy with no dispatcher so
     an override can't take effect.
 - The coordinator's boot reconciliation discards persisted hints whose mode
-  cannot safely take effect on the current deployment (e.g. a hint written
-  by a former edge-boot pod replayed on a shadow-boot deploy). Discarded
-  hints surface via `/health` under `mcp_runtime.boot_reconcile_status` as
-  `incompatible_hint`.
+  cannot safely take effect on the current deployment. This covers three
+  cases:
+  - Edge hint replayed on a shadow-boot deploy (safety invariant unmet).
+  - Any hint replayed on an off-boot deploy (no Rust sidecar, no mechanism
+    to honor the override).
+  - Any hint replayed on a full-boot deploy (plain Rust proxy mounted with
+    no dispatcher; the override would strand in state with the transport
+    layer ignoring it, and the router 409s for any PATCH on full-boot so
+    operators would have no path to clear the stale override).
+
+  Discarded hints surface via `/health` under
+  `mcp_runtime.boot_reconcile_status` as `incompatible_hint`.
 - Each successful flip writes a `runtime_config` audit trail entry via the
   existing `SecurityLogger.log_data_access` pathway. Audit-write failures
   caused by transient DB issues do not roll back the flip — the response

--- a/docs/docs/architecture/rust-mcp-runtime.md
+++ b/docs/docs/architecture/rust-mcp-runtime.md
@@ -36,9 +36,20 @@ make testing-rebuild-rust-full
 ## Runtime Mode Override
 
 The boot env vars `RUST_MCP_MODE` and `RUST_A2A_MODE` still pick the initial
-mode. When the boot mode is `shadow` or `edge` an authorized admin can flip
-the public `/mcp` ingress (and the registered-A2A invocation path) between
-`shadow` and `edge` at runtime, without a restart.
+mode. When the boot mode is `edge` an authorized admin can flip the public
+`/mcp` ingress (and the registered-A2A invocation path) between `shadow` and
+`edge` at runtime, without a restart.
+
+**Why only `edge`?** The repo's safety invariant for routing public traffic
+to Rust requires BOTH `experimental_rust_mcp_runtime_enabled` and
+`experimental_rust_mcp_session_auth_reuse_enabled` (and the analogous
+`experimental_rust_a2a_runtime_delegate_enabled` for A2A). Only `edge` boot
+sets both flags. A `shadow`-booted deployment has the Rust sidecar present
+but session-auth-reuse disabled, so an override to `edge` cannot safely
+route public traffic — the API rejects such PATCHes with 409. Operators who
+want runtime flippability must boot with `edge`; from there they can flip
+to `shadow` (forces Python path) and back to `edge` (restores default)
+freely.
 
 | Method | Path | Body | Permission |
 |---|---|---|---|
@@ -53,13 +64,15 @@ Behavior:
   `RUST_A2A_MODE`; there is no new persistence surface in Postgres.
 - Drain semantics are natural: in-flight requests complete on their original
   transport and only newly-accepted requests follow the flip.
-- Runtime flips are scoped to `shadow ↔ edge`. `off` and `full` boot modes
-  cannot be flipped at runtime; the endpoint returns `409 Conflict`:
+- Runtime flips are scoped to `shadow ↔ edge` **from `boot_mode=edge` only**.
+  `off`, `shadow`, and `full` boot modes all return `409 Conflict`:
   - `off` has no Rust sidecar to swap to.
+  - `shadow` did not opt into session-auth-reuse / delegate-enabled at boot,
+    so an override to `edge` cannot safely route public traffic to Rust
+    (see the safety invariant above).
   - `full` keeps Rust as the owner of MCP session/event-store/resume/
     live-stream cores, and flipping to shadow would orphan that Rust-held
-    session state. Operators who want runtime flippability should boot the
-    deployment as `shadow` or `edge`.
+    session state.
 - Each successful flip writes a `runtime_config` audit trail entry via the
   existing `SecurityLogger.log_data_access` pathway. Audit-write failures
   caused by transient DB issues do not roll back the flip — the response
@@ -93,11 +106,11 @@ behavior-changing** at the public ingress until the proxy is reconfigured.
 Two deployment shapes:
 
 1. **Single-process / no proxy** (FastAPI on `:4444` is the only public
-   ingress). Runtime flips are end-to-end functional **for boot modes
-   `shadow` and `edge`**. The `/mcp` mount is the per-request
+   ingress). Runtime flips are end-to-end functional **only for
+   `boot_mode=edge`**. The `/mcp` mount is the per-request
    `MCPStreamableHTTPModeDispatcher`, which reads the override on every
-   request. Boot modes `off` and `full` are not flippable — see the 409
-   contract above.
+   request. Boot modes `off`, `shadow`, and `full` are not flippable — see
+   the 409 contract above.
 
 2. **Reverse-proxy in front** (e.g. nginx routing public `GET/POST/DELETE
    /mcp` either to `gateway:4444` for Python or directly to the Rust public

--- a/docs/docs/architecture/rust-mcp-runtime.md
+++ b/docs/docs/architecture/rust-mcp-runtime.md
@@ -33,6 +33,146 @@ make testing-rebuild-rust
 make testing-rebuild-rust-full
 ```
 
+## Runtime Mode Override
+
+The boot env vars `RUST_MCP_MODE` and `RUST_A2A_MODE` still pick the initial
+mode. When the boot mode is `shadow` or `edge` an authorized admin can flip
+the public `/mcp` ingress (and the registered-A2A invocation path) between
+`shadow` and `edge` at runtime, without a restart.
+
+| Method | Path | Body | Permission |
+|---|---|---|---|
+| GET | `/admin/runtime/mcp-mode` | — | `admin.system_config` |
+| PATCH | `/admin/runtime/mcp-mode` | `{"mode": "shadow" \| "edge"}` | `admin.system_config` |
+| GET | `/admin/runtime/a2a-mode` | — | `admin.system_config` |
+| PATCH | `/admin/runtime/a2a-mode` | `{"mode": "shadow" \| "edge"}` | `admin.system_config` |
+
+Behavior:
+
+- The override lives in process memory. A restart re-reads `RUST_MCP_MODE` /
+  `RUST_A2A_MODE`; there is no new persistence surface in Postgres.
+- Drain semantics are natural: in-flight requests complete on their original
+  transport and only newly-accepted requests follow the flip.
+- Runtime flips are scoped to `shadow ↔ edge`. `off` and `full` boot modes
+  cannot be flipped at runtime; the endpoint returns `409 Conflict`:
+  - `off` has no Rust sidecar to swap to.
+  - `full` keeps Rust as the owner of MCP session/event-store/resume/
+    live-stream cores, and flipping to shadow would orphan that Rust-held
+    session state. Operators who want runtime flippability should boot the
+    deployment as `shadow` or `edge`.
+- Each successful flip writes a `runtime_config` audit trail entry via the
+  existing `SecurityLogger.log_data_access` pathway. Audit-write failures
+  caused by transient DB issues do not roll back the flip — the response
+  body reports `audit_persisted: false` so the caller knows the audit gap.
+- When Redis is attached but the version counter cannot be safely allocated
+  (`INCR` fails or returns a value not greater than the local floor), the
+  PATCH returns `503 Service Unavailable`. Falling back to a local version
+  could collide with a concurrent PATCH on a peer pod and silently lose one
+  of the two flips at peer dedup time.
+- The PATCH response includes:
+  - `publish_status: "propagated" | "local-only" | "failed" | "superseded"`
+    so the caller knows whether peers received the flip.
+  - `audit_persisted: bool`.
+- The currently effective mode and propagation status surface on `/health`
+  under `mcp_runtime` and `a2a_runtime` (`boot_mode`, `effective_mode`,
+  `override_active`, `cluster_propagation`, `last_change`).
+- `cluster_propagation` is one of:
+  - `"redis"` — coordinator is publishing/subscribing successfully.
+  - `"disabled"` — Redis is intentionally not configured for this deployment.
+  - `"degraded"` — Redis is configured but the coordinator failed to attach;
+    operators should treat this as alertable (e.g. fail readiness or page).
+
+### Reverse-proxy deployments — important caveat
+
+The override updates the Python gateway's in-process state (and propagates
+across pods via Redis), but the public `/mcp` ingress is sometimes terminated
+by an upstream reverse proxy (typically nginx) before reaching the Python
+gateway. In that topology a runtime flip is **observable but not
+behavior-changing** at the public ingress until the proxy is reconfigured.
+
+Two deployment shapes:
+
+1. **Single-process / no proxy** (FastAPI on `:4444` is the only public
+   ingress). Runtime flips are end-to-end functional **for boot modes
+   `shadow` and `edge`**. The `/mcp` mount is the per-request
+   `MCPStreamableHTTPModeDispatcher`, which reads the override on every
+   request. Boot modes `off` and `full` are not flippable — see the 409
+   contract above.
+
+2. **Reverse-proxy in front** (e.g. nginx routing public `GET/POST/DELETE
+   /mcp` either to `gateway:4444` for Python or directly to the Rust public
+   listener at `gateway:8787` for edge/full). The nginx config is decided
+   at deploy time from `RUST_MCP_MODE`. **The proxy is not aware of the
+   runtime override.** Symptoms:
+
+   - `edge` → `shadow` flip: the gateway's Python path is now ready to
+     serve `/mcp`, but nginx is still routing to `:8787`. Public traffic
+     continues to land on Rust until nginx is updated.
+   - `shadow` → `edge` flip: FastAPI on `:4444` is now configured to proxy
+     to Rust, but nginx is still routing all public `/mcp` to `:4444`.
+     Traffic does not reach the Rust public listener directly. (Note:
+     because the Python proxy still forwards to the Rust sidecar over the
+     internal UDS/loopback URL, requests still execute against Rust — but
+     the latency benefit of bypassing Python is not realized.)
+
+Until the proxy can follow the override, treat the API as a **single-pod
+control surface**: useful for CI / compliance harnesses that talk straight
+to FastAPI, and for incident-rollback scenarios where you also have a
+mechanism to update the proxy. For production reverse-proxy deployments,
+plan to either:
+
+- Update the proxy config alongside the API call (e.g. write the new mode
+  to a shared store the proxy consults, or run a configuration-management
+  step that rewrites nginx and reloads it), or
+- Use the API only for the single-pod / single-process scenarios above.
+
+Tracking issue for an nginx-side mechanism (e.g. an OpenResty lua module
+that consults the Redis hint key) is
+[#4278](https://github.com/IBM/mcp-context-forge/issues/4278).
+
+### Cluster-wide propagation
+
+When `REDIS_URL` is configured, every pod runs a `RuntimeStateCoordinator`
+that subscribes to the `contextforge:runtime:mode` pub/sub channel. A
+successful PATCH on any pod publishes a versioned message; every other pod
+applies it under monotonic versioning (last writer wins, ties impossible
+because the version is allocated via `INCR` on a per-runtime Redis counter).
+
+A short-lived hint key per runtime (`contextforge:runtime:mode_state:mcp` and
+`contextforge:runtime:mode_state:a2a`, TTL 24h) lets a freshly started pod
+reconcile to the cluster's current desired override on boot.
+
+When Redis is unavailable, the coordinator degrades to per-pod scope; the
+endpoint still works on the pod that received the PATCH and the response
+payload reports `cluster_propagation: "disabled"` so operators know to flip
+each pod individually.
+
+To revert the cluster to env-var defaults, delete the hint keys and restart
+the pods:
+
+```bash
+redis-cli DEL contextforge:runtime:mode_state:mcp contextforge:runtime:mode_state:a2a
+```
+
+### Quick-start examples
+
+```bash
+# Inspect current mode (any pod)
+curl -H "Authorization: Bearer $JWT" .../admin/runtime/mcp-mode
+
+# Flip the public /mcp ingress back to Python (incident rollback)
+curl -X PATCH -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     -d '{"mode": "shadow"}' \
+     .../admin/runtime/mcp-mode
+
+# Flip A2A delegate back to Rust
+curl -X PATCH -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     -d '{"mode": "edge"}' \
+     .../admin/runtime/a2a-mode
+```
+
 ## Request Flows
 
 ### `off` and `shadow`

--- a/docs/docs/architecture/rust-mcp-runtime.md
+++ b/docs/docs/architecture/rust-mcp-runtime.md
@@ -75,19 +75,26 @@ Behavior:
   - `off` and `full` boot modes return `409` for every PATCH: `off` has no
     Rust sidecar, `full` mounts a plain Rust proxy with no dispatcher so
     an override can't take effect.
-- The coordinator's boot reconciliation discards persisted hints whose mode
-  cannot safely take effect on the current deployment. This covers three
-  cases:
-  - Edge hint replayed on a shadow-boot deploy (safety invariant unmet).
-  - Any hint replayed on an off-boot deploy (no Rust sidecar, no mechanism
-    to honor the override).
-  - Any hint replayed on a full-boot deploy (plain Rust proxy mounted with
-    no dispatcher; the override would strand in state with the transport
-    layer ignoring it, and the router 409s for any PATCH on full-boot so
-    operators would have no path to clear the stale override).
+- The coordinator's boot reconciliation (and the live pub/sub listener)
+  discards messages whose mode cannot safely take effect on the current
+  deployment. The reason surfaces via `/health` under
+  `mcp_runtime.boot_reconcile_status` as one of:
+  - `incompatible_no_dispatcher`: any hint on a `boot=off` deploy (no Rust
+    sidecar, no mechanism to honor the override).
+  - `incompatible_boot_full`: any hint on a `boot=full` deploy (plain Rust
+    proxy mounted with no dispatcher; the override would strand).
+  - `incompatible_safety_flag`: an `edge` hint on a `boot=shadow` deploy
+    (the session-auth-reuse / delegate-enabled safety invariant is unmet).
 
-  Discarded hints surface via `/health` under
-  `mcp_runtime.boot_reconcile_status` as `incompatible_hint`.
+  The Redis hint key is intentionally NOT deleted on discard — a future
+  compatible-boot pod must still be able to read it, and stale hints
+  expire on their own via the 24h TTL set at publish time. An operator
+  who wants to clear immediately can `DEL contextforge:runtime:mode_state:{runtime}`.
+
+  The same compatibility check runs on every live pub/sub message: a
+  remote pod's flip that the local deployment can't safely honor is
+  discarded with a WARN log (no INCOMPATIBLE_* state is recorded for live
+  discards because they don't represent boot state — only a log line).
 - Each successful flip writes a `runtime_config` audit trail entry via the
   existing `SecurityLogger.log_data_access` pathway. Audit-write failures
   caused by transient DB issues do not roll back the flip — the response

--- a/docs/docs/manage/rbac.md
+++ b/docs/docs/manage/rbac.md
@@ -363,6 +363,8 @@ These checks are aligned with equivalent REST endpoints.
 | JSON-RPC `logging/setLevel` (`POST /rpc`) | `admin.system_config` | Same permission as `POST /logging/setLevel` |
 | Utility SSE (`GET /sse`) | `tools.execute` | Canonical tool execution permission |
 | Utility message relay (`POST /message`) | `tools.execute` | Canonical tool execution permission |
+| `GET`/`PATCH /admin/runtime/mcp-mode` | `admin.system_config` | Runtime override of public `/mcp` ingress (`shadow ↔ edge`); see [Rust MCP Runtime](../architecture/rust-mcp-runtime.md#runtime-mode-override). |
+| `GET`/`PATCH /admin/runtime/a2a-mode` | `admin.system_config` | Runtime override of registered-A2A invocation path (`shadow ↔ edge`). |
 
 ---
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -279,6 +279,23 @@ class Settings(BaseSettings):
         default=False,
         description="Enable the experimental Rust-owned MCP session-bound auth-context reuse path for direct public /mcp ingress.",
     )
+    mcp_rust_ingress: str = Field(
+        default="internal",
+        description=(
+            "Selects which Rust MCP ingress shape MCPIngressMount uses when boot mode is "
+            "edge or full and no shadow override is in effect. 'internal' (default) uses "
+            "the trusted Python→Rust forwarder (RustMCPRuntimeProxy) over the internal "
+            "listener at MCP_RUST_LISTEN_HTTP/UDS; 'public' uses an nginx-style reverse "
+            "proxy to the Rust public listener at MCP_RUST_PUBLIC_LISTEN_HTTP — useful "
+            "for single-process deployments without nginx in front."
+        ),
+    )
+    mcp_rust_public_proxy_upstream: str = Field(
+        default="http://127.0.0.1:8787",
+        description=(
+            "Upstream URL the 'public' MCP ingress shape forwards to. Defaults to the " "loopback address that matches docker-entrypoint.sh's " "MCP_RUST_PUBLIC_LISTEN_HTTP=0.0.0.0:8787 default."
+        ),
+    )
     experimental_rust_a2a_runtime_enabled: bool = Field(
         default=False,
         description="Enable the experimental Rust A2A runtime sidecar for registered A2A agent invocations.",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -279,7 +279,7 @@ class Settings(BaseSettings):
         default=False,
         description="Enable the experimental Rust-owned MCP session-bound auth-context reuse path for direct public /mcp ingress.",
     )
-    mcp_rust_ingress: str = Field(
+    mcp_rust_ingress: Literal["internal", "public"] = Field(
         default="internal",
         description=(
             "Selects which Rust MCP ingress shape MCPIngressMount uses when boot mode is "
@@ -287,7 +287,8 @@ class Settings(BaseSettings):
             "the trusted Python→Rust forwarder (RustMCPRuntimeProxy) over the internal "
             "listener at MCP_RUST_LISTEN_HTTP/UDS; 'public' uses an nginx-style reverse "
             "proxy to the Rust public listener at MCP_RUST_PUBLIC_LISTEN_HTTP — useful "
-            "for single-process deployments without nginx in front."
+            "for single-process deployments without nginx in front. Pydantic rejects "
+            "any other value at config load."
         ),
     )
     mcp_rust_public_proxy_upstream: str = Field(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1884,6 +1884,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         cache_invalidation_subscriber = get_cache_invalidation_subscriber()
         await cache_invalidation_subscriber.start()
 
+        # Start runtime-mode coordinator for cluster-wide override propagation
+        # First-Party
+        from mcpgateway.runtime_state import get_runtime_state_coordinator  # pylint: disable=import-outside-toplevel
+
+        runtime_state_coordinator = get_runtime_state_coordinator()
+        await runtime_state_coordinator.start()
+
         # Reconfigure uvicorn loggers after startup to capture access logs in dual output
         logging_service.configure_uvicorn_after_startup()
 
@@ -1975,6 +1982,15 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             await cache_invalidation_subscriber.stop()
         except Exception as e:
             logger.debug(f"Error stopping cache invalidation subscriber: {e}")
+
+        # Stop runtime-mode coordinator
+        try:
+            # First-Party
+            from mcpgateway.runtime_state import get_runtime_state_coordinator  # pylint: disable=import-outside-toplevel
+
+            await get_runtime_state_coordinator().stop()
+        except Exception as e:
+            logger.debug(f"Error stopping runtime-mode coordinator: {e}")
 
         logger.info("Shutting down ContextForge services")
         # await stop_streamablehttp()
@@ -11850,6 +11866,12 @@ if ADMIN_API_ENABLED:
 
     # Validate section-to-permission mapping consistency at startup
     validate_section_permissions(admin_router)
+
+    # Runtime-mode admin endpoints (GET/PATCH /admin/runtime/{mcp,a2a}-mode).
+    # First-Party
+    from mcpgateway.routers.runtime_admin_router import runtime_admin_router  # pylint: disable=import-outside-toplevel
+
+    app.include_router(runtime_admin_router, prefix="/admin/runtime", tags=["Runtime Admin"])
 else:
     logger.warning("Admin API routes not mounted - Admin API disabled via MCPGATEWAY_ADMIN_API_ENABLED=False")
 
@@ -11911,12 +11933,66 @@ class MCPRuntimeHeaderTransportWrapper:
         await self.transport_app.handle_streamable_http(scope, receive, _send_with_runtime_header)
 
 
+class MCPStreamableHTTPModeDispatcher:
+    """Per-request dispatcher that flips between Python and Rust public ``/mcp`` ingress.
+
+    The dispatcher holds both streamable-HTTP transports and routes each
+    incoming request to whichever one matches the currently effective MCP
+    mode. This gives natural drain semantics: a runtime flip affects only new
+    requests because the target is selected before the inbound ``await``;
+    in-flight requests already past that point finish on their original
+    transport. Used only for boot modes ``shadow`` and ``edge`` where
+    runtime flipping is supported. Boot mode ``off`` has no Rust transport
+    to dispatch to; boot mode ``full`` mounts the plain Rust proxy directly
+    because flipping ``full`` would orphan Rust-held session/event-store
+    state — admin PATCHes against ``off``/``full`` boots return ``409``.
+    """
+
+    def __init__(self, *, python_transport, rust_transport) -> None:
+        """Initialize the dispatcher with both pre-built transport apps.
+
+        Args:
+            python_transport: Python-owned MCP streamable-HTTP transport app.
+            rust_transport: Rust-proxy MCP streamable-HTTP transport app.
+        """
+        self._python_transport = python_transport
+        self._rust_transport = rust_transport
+
+    async def handle_streamable_http(self, scope, receive, send):
+        """Dispatch the incoming MCP request to the transport selected by the current mode.
+
+        Args:
+            scope: Incoming ASGI scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        target = self._rust_transport if _should_mount_public_rust_transport() else self._python_transport
+        await target.handle_streamable_http(scope, receive, send)
+
+
 def _build_mcp_transport_app():
     """Choose the MCP transport app for the mounted /mcp path.
 
     Returns:
         Transport app object that should be mounted at the public ``/mcp`` path.
     """
+    boot_mode = version_module.boot_mcp_runtime_mode()
+    python_transport = MCPRuntimeHeaderTransportWrapper(streamable_http_session, runtime_name="python")
+
+    if boot_mode in ("shadow", "edge"):
+        # First-Party
+        from mcpgateway.transports.rust_mcp_runtime_proxy import RustMCPRuntimeProxy  # pylint: disable=import-outside-toplevel
+
+        rust_transport = RustMCPRuntimeProxy(streamable_http_session.handle_streamable_http)
+        logger.warning(
+            "MCP runtime mode: %s (boot=%s). Public /mcp dispatches per-request between Python and Rust (uds=%s, url=%s). Runtime override may flip via PATCH /admin/runtime/mcp-mode.",
+            _current_mcp_runtime_mode(),
+            boot_mode,
+            settings.experimental_rust_mcp_runtime_uds,
+            settings.experimental_rust_mcp_runtime_url,
+        )
+        return MCPStreamableHTTPModeDispatcher(python_transport=python_transport, rust_transport=rust_transport)
+
     if _should_mount_public_rust_transport():
         logger.warning(
             "MCP runtime mode: %s. GET/POST/DELETE /mcp requests will be proxied to %s. MCP session core mode: %s. MCP replay/resume core mode: %s. MCP live stream core mode: %s. MCP affinity core mode: %s. MCP session auth reuse mode: %s.",
@@ -11933,18 +12009,6 @@ def _build_mcp_transport_app():
 
         return RustMCPRuntimeProxy(streamable_http_session.handle_streamable_http)
 
-    if settings.experimental_rust_mcp_runtime_enabled:
-        logger.warning(
-            "MCP runtime mode: %s. Rust sidecar remains enabled, but public /mcp stays on the Python transport because MCP session auth reuse is disabled. MCP session core mode: %s. MCP replay/resume core mode: %s. MCP live stream core mode: %s. MCP affinity core mode: %s. MCP session auth reuse mode: %s.",
-            _current_mcp_runtime_mode(),
-            _current_mcp_session_core_mode(),
-            _current_mcp_resume_core_mode(),
-            _current_mcp_live_stream_core_mode(),
-            _current_mcp_affinity_core_mode(),
-            _current_mcp_session_auth_reuse_mode(),
-        )
-        return MCPRuntimeHeaderTransportWrapper(streamable_http_session, runtime_name="python")
-
     if _rust_build_included():
         logger.warning(
             "MCP runtime mode: %s. Rust MCP artifacts are present in this image, but EXPERIMENTAL_RUST_MCP_RUNTIME_ENABLED=false so /mcp remains on the Python transport. Set RUST_MCP_MODE=edge or RUST_MCP_MODE=full to activate the Rust runtime with the simple env flow.",
@@ -11953,7 +12017,7 @@ def _build_mcp_transport_app():
     else:
         logger.info("MCP runtime mode: %s. /mcp is mounted on the Python transport.", _current_mcp_runtime_mode())
 
-    return MCPRuntimeHeaderTransportWrapper(streamable_http_session, runtime_name="python")
+    return python_transport
 
 
 class InternalTrustedMCPTransportBridge:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11948,6 +11948,13 @@ def _select_mcp_ingress(_scope: dict) -> str:
     - Override forces ``shadow``, OR safety invariant is unmet: route to
       the Python transport (the always-safe fallback).
 
+    The ``"rust-public"`` ingress is only registered on ``boot=edge``
+    (the public listener isn't bound on shadow boot per the entrypoint
+    flow). On any other boot mode the selector transparently downgrades
+    a configured ``"public"`` choice to ``"rust-internal"`` to avoid
+    routing to an unregistered name; the misconfig itself is surfaced
+    as a boot-time error in ``_build_mcp_transport_app``.
+
     Args:
         _scope: ASGI scope (unused today; reserved so future selectors
             can route by method/path/headers without changing the
@@ -11956,9 +11963,11 @@ def _select_mcp_ingress(_scope: dict) -> str:
     Returns:
         The ingress name to look up in the mount's registry.
     """
-    if _should_mount_public_rust_transport():
-        return "rust-public" if settings.mcp_rust_ingress == "public" else "rust-internal"
-    return "python"
+    if not _should_mount_public_rust_transport():
+        return "python"
+    if settings.mcp_rust_ingress == "public" and version_module.boot_mcp_runtime_mode() == "edge":
+        return "rust-public"
+    return "rust-internal"
 
 
 def _build_mcp_transport_app():
@@ -11999,6 +12008,18 @@ def _build_mcp_transport_app():
             from mcpgateway.transports.rust_mcp_public_proxy import build_rust_public_proxy_app  # pylint: disable=import-outside-toplevel
 
             ingress.register("rust-public", build_rust_public_proxy_app())
+        elif settings.mcp_rust_ingress == "public":
+            # boot=shadow with mcp_rust_ingress=public is a misconfig: the
+            # Rust public listener isn't bound on shadow boot, so the
+            # selector deliberately downgrades to "rust-internal". Logged
+            # at error severity so it survives the default LOG_LEVEL=ERROR
+            # — a warning here would be invisible in most production
+            # deployments and the operator would never know their setting
+            # is being silently overridden.
+            logger.error(
+                "mcp_rust_ingress=public is set on boot=shadow; the Rust public listener isn't bound on shadow boot. "
+                "Selector will route to rust-internal instead. Switch boot mode to edge to honor the public ingress.",
+            )
 
         logger.warning(
             "MCP runtime mode: %s (boot=%s). Public /mcp dispatches via MCPIngressMount; ingresses=%s; current=%s. Runtime override may flip via PATCH /admin/runtime/mcp-mode.",

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -11933,49 +11933,51 @@ class MCPRuntimeHeaderTransportWrapper:
         await self.transport_app.handle_streamable_http(scope, receive, _send_with_runtime_header)
 
 
-class MCPStreamableHTTPModeDispatcher:
-    """Per-request dispatcher that flips between Python and Rust public ``/mcp`` ingress.
+def _select_mcp_ingress(_scope: dict) -> str:
+    """Pick the registered MCPIngressMount ingress to serve a request.
 
-    The dispatcher holds both streamable-HTTP transports and routes each
-    incoming request to whichever one matches the currently effective MCP
-    mode. This gives natural drain semantics: a runtime flip affects only new
-    requests because the target is selected before the inbound ``await``;
-    in-flight requests already past that point finish on their original
-    transport. Used only for boot modes ``shadow`` and ``edge`` where
-    runtime flipping is supported. Boot mode ``off`` has no Rust transport
-    to dispatch to; boot mode ``full`` mounts the plain Rust proxy directly
-    because flipping ``full`` would orphan Rust-held session/event-store
-    state — admin PATCHes against ``off``/``full`` boots return ``409``.
+    Single source of truth for the dispatch policy:
+
+    - Boot ``off`` / ``full`` (no dispatcher today): the mount isn't used;
+      the Python transport or the plain Rust proxy is mounted directly
+      from ``_build_mcp_transport_app``.
+    - Boot ``shadow`` / ``edge`` with no override OR an ``edge`` override
+      that satisfies the safety invariant: route to the Rust ingress
+      shape selected by ``settings.mcp_rust_ingress`` (``"public"`` for
+      nginx-style or ``"internal"`` for trusted Python→Rust forwarding).
+    - Override forces ``shadow``, OR safety invariant is unmet: route to
+      the Python transport (the always-safe fallback).
+
+    Args:
+        _scope: ASGI scope (unused today; reserved so future selectors
+            can route by method/path/headers without changing the
+            mount's API).
+
+    Returns:
+        The ingress name to look up in the mount's registry.
     """
-
-    def __init__(self, *, python_transport, rust_transport) -> None:
-        """Initialize the dispatcher with both pre-built transport apps.
-
-        Args:
-            python_transport: Python-owned MCP streamable-HTTP transport app.
-            rust_transport: Rust-proxy MCP streamable-HTTP transport app.
-        """
-        self._python_transport = python_transport
-        self._rust_transport = rust_transport
-
-    async def handle_streamable_http(self, scope, receive, send):
-        """Dispatch the incoming MCP request to the transport selected by the current mode.
-
-        Args:
-            scope: Incoming ASGI scope.
-            receive: ASGI receive callable.
-            send: ASGI send callable.
-        """
-        target = self._rust_transport if _should_mount_public_rust_transport() else self._python_transport
-        await target.handle_streamable_http(scope, receive, send)
+    if _should_mount_public_rust_transport():
+        return "rust-public" if settings.mcp_rust_ingress == "public" else "rust-internal"
+    return "python"
 
 
 def _build_mcp_transport_app():
-    """Choose the MCP transport app for the mounted /mcp path.
+    """Build the ASGI app to mount at public ``/mcp``.
 
     Returns:
-        Transport app object that should be mounted at the public ``/mcp`` path.
+        For boot modes ``shadow``/``edge``: an :class:`MCPIngressMount`
+        with the Python transport, the trusted-internal Rust proxy, and
+        (when supported) the nginx-style Rust public proxy registered.
+        For boot ``full``: the plain trusted-internal Rust proxy mounted
+        directly (no dispatcher — flipping ``full`` would orphan
+        Rust-held session/event-store state). For boot ``off``: the
+        Python transport. The ``/mcp`` mount calls
+        ``returned_app.handle_streamable_http`` (legacy interface kept
+        for backward compatibility with the existing mount line).
     """
+    # First-Party
+    from mcpgateway.transports.mcp_ingress_mount import MCPIngressMount  # pylint: disable=import-outside-toplevel
+
     boot_mode = version_module.boot_mcp_runtime_mode()
     python_transport = MCPRuntimeHeaderTransportWrapper(streamable_http_session, runtime_name="python")
 
@@ -11983,15 +11985,33 @@ def _build_mcp_transport_app():
         # First-Party
         from mcpgateway.transports.rust_mcp_runtime_proxy import RustMCPRuntimeProxy  # pylint: disable=import-outside-toplevel
 
-        rust_transport = RustMCPRuntimeProxy(streamable_http_session.handle_streamable_http)
+        rust_internal = RustMCPRuntimeProxy(streamable_http_session.handle_streamable_http)
+        ingress = MCPIngressMount(selector=_select_mcp_ingress, fallback=python_transport.handle_streamable_http)
+        ingress.register("python", python_transport.handle_streamable_http)
+        ingress.register("rust-internal", rust_internal.handle_streamable_http)
+
+        # Public-listener proxy is only meaningful when the safety invariant
+        # is met (i.e. boot=edge); shadow boot doesn't bind the public
+        # listener. Register it on edge so an operator can flip
+        # `settings.mcp_rust_ingress = "public"` without a restart.
+        if boot_mode == "edge":
+            # First-Party
+            from mcpgateway.transports.rust_mcp_public_proxy import build_rust_public_proxy_app  # pylint: disable=import-outside-toplevel
+
+            ingress.register("rust-public", build_rust_public_proxy_app())
+
         logger.warning(
-            "MCP runtime mode: %s (boot=%s). Public /mcp dispatches per-request between Python and Rust (uds=%s, url=%s). Runtime override may flip via PATCH /admin/runtime/mcp-mode.",
+            "MCP runtime mode: %s (boot=%s). Public /mcp dispatches via MCPIngressMount; ingresses=%s; current=%s. Runtime override may flip via PATCH /admin/runtime/mcp-mode.",
             _current_mcp_runtime_mode(),
             boot_mode,
-            settings.experimental_rust_mcp_runtime_uds,
-            settings.experimental_rust_mcp_runtime_url,
+            ingress.names(),
+            _select_mcp_ingress({}),
         )
-        return MCPStreamableHTTPModeDispatcher(python_transport=python_transport, rust_transport=rust_transport)
+        # The legacy mount line calls .handle_streamable_http on the returned
+        # app; expose that name on a tiny shim so the mount line can stay
+        # unchanged. (.dispatch is the modern ASGI 3.0 callable.)
+        ingress.handle_streamable_http = ingress.dispatch  # type: ignore[attr-defined]
+        return ingress
 
     if _should_mount_public_rust_transport():
         logger.warning(

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
 from mcpgateway.runtime_state import (
+    MoveCompatibility,
     OverrideMode,
     PublishStatus,
     RuntimeKind,
@@ -49,23 +50,49 @@ logger = logging_service.get_logger(__name__)
 
 runtime_admin_router = APIRouter()
 
-# Boot modes that have a dispatcher mounted at all (i.e. any PATCH could
-# conceivably take effect). ``off`` has no Rust sidecar; ``full`` mounts a
-# plain Rust proxy with no dispatcher, so an override could not be honored
-# by the transport layer.
-_DISPATCHER_BOOT_MODES: frozenset[str] = frozenset({"shadow", "edge"})
-
-# Boot modes where a runtime override to ``edge`` can safely take effect.
-# This is gated by the same session-auth-reuse / delegate-enabled safety
-# invariant that ``_should_mount_public_rust_transport`` and
-# ``_should_delegate_a2a_to_rust`` enforce — only ``edge`` boot satisfies it.
-_EDGE_OVERRIDE_BOOT_MODES: frozenset[str] = frozenset({"edge"})
-
 # Headers commonly added by reverse proxies. When any are present we know the
 # gateway is fronted by an L7 proxy that won't follow runtime flips by itself
 # (see issue #4278), and we emit a one-line WARN so operators don't expect the
 # override to change public traffic on that hop.
 _REVERSE_PROXY_HEADER_NAMES: frozenset[str] = frozenset({"x-forwarded-for", "forwarded", "x-forwarded-host", "x-forwarded-proto"})
+
+
+def _move_compat_to_409_detail(runtime: RuntimeKind, mode: OverrideMode, boot_mode: str, compat: MoveCompatibility) -> str:
+    """Translate a ``MoveCompatibility`` rejection into an operator-actionable 409 detail.
+
+    Args:
+        runtime: Runtime kind being changed.
+        mode: Requested target mode.
+        boot_mode: Boot-time mode label, included for operator context.
+        compat: The ``MoveCompatibility`` rejection reason.
+
+    Returns:
+        Detail string naming the exact env var or flag to flip, suitable for
+        an HTTPException 409 response body.
+    """
+    runtime_label = runtime.value.upper()
+    if compat == MoveCompatibility.NO_DISPATCHER:
+        return (
+            f"{runtime_label} runtime cannot accept overrides when boot_mode={boot_mode!r}. "
+            "The Rust sidecar is not enabled for this runtime, so there is no mechanism to honor an override. "
+            f"Boot with RUST_{runtime.value.upper()}_MODE='shadow' or 'edge' (or 'full' for MCP) to enable overrides."
+        )
+    if compat == MoveCompatibility.BOOT_FULL_STRANDS:
+        return (
+            f"{runtime_label} runtime cannot accept overrides when boot_mode={boot_mode!r}. "
+            "Full-boot mounts a plain Rust proxy with no dispatcher, so an override could not be honored. "
+            "Boot with RUST_MCP_MODE='edge' to enable overrides without giving up the Rust ingress."
+        )
+    if compat == MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG:
+        flag = "experimental_rust_mcp_session_auth_reuse_enabled" if runtime == RuntimeKind.MCP else "experimental_rust_a2a_runtime_delegate_enabled"
+        return (
+            f"{runtime_label} runtime cannot be flipped to 'edge' when boot_mode={boot_mode!r}. "
+            f"The edge override requires the {flag} safety flag, which only boot_mode='edge' deployments set. "
+            f"Boot with RUST_{runtime.value.upper()}_MODE='edge' to enable edge overrides. "
+            "(mode='shadow' is always accepted as an escape hatch to clear a stale override.)"
+        )
+    # OK shouldn't reach here; defensive default.
+    return f"{runtime_label} runtime cannot accept this override on boot_mode={boot_mode!r} (reason={compat.value})."
 
 
 class RuntimeModeUpdate(BaseModel):
@@ -157,35 +184,15 @@ async def _apply_mode_change(
             Redis-backed version cannot be allocated (would risk a silent
             collision with a concurrent PATCH on a peer pod).
     """
-    if boot_mode not in _DISPATCHER_BOOT_MODES:
+    # Single source of truth for "can this deployment honor the override?":
+    # the same helper the coordinator uses for hint reconciliation. Returning
+    # the structured ``MoveCompatibility`` reason lets us produce a 409 detail
+    # that names the exact env var the operator needs to flip.
+    compat = version_module.deployment_allows_override_mode(runtime, new_mode)
+    if compat != MoveCompatibility.OK:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"{runtime.value.upper()} runtime cannot accept overrides when boot_mode={boot_mode!r}. "
-                "'off' has no Rust sidecar to route to; 'full' mounts a plain Rust proxy with no dispatcher so "
-                "an override could not be honored. Boot with RUST_MCP_MODE='shadow' or 'edge' "
-                "(or RUST_A2A_MODE='shadow' or 'edge') to enable runtime overrides."
-            ),
-        )
-    if new_mode == OverrideMode.EDGE and boot_mode not in _EDGE_OVERRIDE_BOOT_MODES:
-        # Edge override requires the safety invariant (session-auth-reuse for
-        # MCP, delegate-enabled for A2A). Shadow-boot deployments did NOT opt
-        # into the invariant; accepting an edge override here would leave
-        # state claiming "edge" while the transport layer refuses to honor it
-        # — misleading diagnostics + no functional effect. 409 is cleaner.
-        # mode=shadow is always allowed as an escape hatch (see below): it
-        # clears any stale override and falls back to boot behavior, which
-        # shadow-boot deployments already serve on Python.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                f"{runtime.value.upper()} runtime cannot be flipped to 'edge' when boot_mode={boot_mode!r}. "
-                "The edge override requires the session-auth-reuse / delegate-enabled safety invariant, "
-                "which only boot_mode='edge' deployments satisfy. "
-                "Boot with RUST_MCP_MODE='edge' or RUST_A2A_MODE='edge' to enable edge overrides. "
-                "(Note: 'mode=shadow' is always accepted as an escape hatch to clear a stale override, "
-                "including on this shadow-boot deployment.)"
-            ),
+            detail=_move_compat_to_409_detail(runtime, new_mode, boot_mode, compat),
         )
 
     if request is not None:

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -95,8 +95,8 @@ def _move_compat_to_409_detail(runtime: RuntimeKind, mode: OverrideMode, boot_mo
             f"Boot with RUST_{runtime.value.upper()}_MODE='edge' to enable edge overrides. "
             "(mode='shadow' is always accepted as an escape hatch to clear a stale override.)"
         )
-    # OK shouldn't reach here; defensive default.
-    return f"{runtime_label} runtime cannot accept this override on boot_mode={boot_mode!r} (reason={compat.value})."
+    # OK shouldn't reach here; defensive default for any future MoveCompatibility variant.
+    return f"{runtime_label} runtime cannot accept this override on boot_mode={boot_mode!r} (reason={compat.value})."  # pragma: no cover
 
 
 class RuntimeModeUpdate(BaseModel):

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -49,22 +49,17 @@ logger = logging_service.get_logger(__name__)
 
 runtime_admin_router = APIRouter()
 
-# A deployment can be flipped between shadow and edge at runtime only when it
-# booted with the safety-invariant flags enabled — i.e. boot_mode == "edge".
-#
-# - ``off``: no Rust sidecar to swap to.
-# - ``shadow``: Rust sidecar is running but the session-auth-reuse /
-#   delegate-enabled flag is OFF; flipping to "edge" cannot safely route
-#   public traffic to Rust because the repo's documented safety invariant
-#   (see ``_should_mount_public_rust_transport`` and
-#   ``_should_delegate_a2a_to_rust``) requires BOTH flags. Operators who
-#   want runtime flippability must boot with ``edge``.
-# - ``full``: keeps Rust as the owner of MCP session/event-store/resume/
-#   live-stream cores; flipping to shadow would orphan that Rust-held state.
-#
-# Issue #4273 deliberately scopes runtime flips to ``shadow ↔ edge`` and both
-# user stories assume a gateway booted with ``edge`` as the starting point.
-_FLIPPABLE_BOOT_MODES: frozenset[str] = frozenset({"edge"})
+# Boot modes that have a dispatcher mounted at all (i.e. any PATCH could
+# conceivably take effect). ``off`` has no Rust sidecar; ``full`` mounts a
+# plain Rust proxy with no dispatcher, so an override could not be honored
+# by the transport layer.
+_DISPATCHER_BOOT_MODES: frozenset[str] = frozenset({"shadow", "edge"})
+
+# Boot modes where a runtime override to ``edge`` can safely take effect.
+# This is gated by the same session-auth-reuse / delegate-enabled safety
+# invariant that ``_should_mount_public_rust_transport`` and
+# ``_should_delegate_a2a_to_rust`` enforce — only ``edge`` boot satisfies it.
+_EDGE_OVERRIDE_BOOT_MODES: frozenset[str] = frozenset({"edge"})
 
 # Headers commonly added by reverse proxies. When any are present we know the
 # gateway is fronted by an L7 proxy that won't follow runtime flips by itself
@@ -162,17 +157,34 @@ async def _apply_mode_change(
             Redis-backed version cannot be allocated (would risk a silent
             collision with a concurrent PATCH on a peer pod).
     """
-    if boot_mode not in _FLIPPABLE_BOOT_MODES:
+    if boot_mode not in _DISPATCHER_BOOT_MODES:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                f"{runtime.value.upper()} runtime cannot be flipped at runtime when boot_mode={boot_mode!r}. "
-                "Runtime flips (shadow ↔ edge) are supported only from boot_mode='edge', which is the only "
-                "configuration where the session-auth-reuse / delegate-enabled safety invariant is met. "
-                "'off' has no Rust sidecar; 'shadow' did not opt into session-auth-reuse so an edge override "
-                "would not safely route public traffic to Rust; 'full' keeps Rust as the owner of session "
-                "state, which cannot be migrated live. Boot with RUST_MCP_MODE='edge' or RUST_A2A_MODE='edge' "
-                "to enable runtime flips."
+                f"{runtime.value.upper()} runtime cannot accept overrides when boot_mode={boot_mode!r}. "
+                "'off' has no Rust sidecar to route to; 'full' mounts a plain Rust proxy with no dispatcher so "
+                "an override could not be honored. Boot with RUST_MCP_MODE='shadow' or 'edge' "
+                "(or RUST_A2A_MODE='shadow' or 'edge') to enable runtime overrides."
+            ),
+        )
+    if new_mode == OverrideMode.EDGE and boot_mode not in _EDGE_OVERRIDE_BOOT_MODES:
+        # Edge override requires the safety invariant (session-auth-reuse for
+        # MCP, delegate-enabled for A2A). Shadow-boot deployments did NOT opt
+        # into the invariant; accepting an edge override here would leave
+        # state claiming "edge" while the transport layer refuses to honor it
+        # — misleading diagnostics + no functional effect. 409 is cleaner.
+        # mode=shadow is always allowed as an escape hatch (see below): it
+        # clears any stale override and falls back to boot behavior, which
+        # shadow-boot deployments already serve on Python.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"{runtime.value.upper()} runtime cannot be flipped to 'edge' when boot_mode={boot_mode!r}. "
+                "The edge override requires the session-auth-reuse / delegate-enabled safety invariant, "
+                "which only boot_mode='edge' deployments satisfy. "
+                "Boot with RUST_MCP_MODE='edge' or RUST_A2A_MODE='edge' to enable edge overrides. "
+                "(Note: 'mode=shadow' is always accepted as an escape hatch to clear a stale override, "
+                "including on this shadow-boot deployment.)"
             ),
         )
 

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -50,12 +50,21 @@ logger = logging_service.get_logger(__name__)
 runtime_admin_router = APIRouter()
 
 # A deployment can be flipped between shadow and edge at runtime only when it
-# booted into one of those two modes. ``off`` has no Rust sidecar to swap to;
-# ``full`` keeps Rust as the owner of MCP session/event-store/resume/live-stream
-# cores, and flipping to shadow would orphan that Rust-held session state — the
-# issue (#4273) deliberately scopes runtime flips to shadow ↔ edge to avoid
-# live session-state migration.
-_FLIPPABLE_BOOT_MODES: frozenset[str] = frozenset({"shadow", "edge"})
+# booted with the safety-invariant flags enabled — i.e. boot_mode == "edge".
+#
+# - ``off``: no Rust sidecar to swap to.
+# - ``shadow``: Rust sidecar is running but the session-auth-reuse /
+#   delegate-enabled flag is OFF; flipping to "edge" cannot safely route
+#   public traffic to Rust because the repo's documented safety invariant
+#   (see ``_should_mount_public_rust_transport`` and
+#   ``_should_delegate_a2a_to_rust``) requires BOTH flags. Operators who
+#   want runtime flippability must boot with ``edge``.
+# - ``full``: keeps Rust as the owner of MCP session/event-store/resume/
+#   live-stream cores; flipping to shadow would orphan that Rust-held state.
+#
+# Issue #4273 deliberately scopes runtime flips to ``shadow ↔ edge`` and both
+# user stories assume a gateway booted with ``edge`` as the starting point.
+_FLIPPABLE_BOOT_MODES: frozenset[str] = frozenset({"edge"})
 
 # Headers commonly added by reverse proxies. When any are present we know the
 # gateway is fronted by an L7 proxy that won't follow runtime flips by itself
@@ -158,9 +167,12 @@ async def _apply_mode_change(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
                 f"{runtime.value.upper()} runtime cannot be flipped at runtime when boot_mode={boot_mode!r}. "
-                "Runtime flips are scoped to shadow ↔ edge only: 'off' has no Rust sidecar to swap to, "
-                "and 'full' would require live migration of Rust-owned session/event-store/resume cores. "
-                "Set RUST_MCP_MODE or RUST_A2A_MODE to 'shadow' or 'edge' to enable runtime flips."
+                "Runtime flips (shadow ↔ edge) are supported only from boot_mode='edge', which is the only "
+                "configuration where the session-auth-reuse / delegate-enabled safety invariant is met. "
+                "'off' has no Rust sidecar; 'shadow' did not opt into session-auth-reuse so an edge override "
+                "would not safely route public traffic to Rust; 'full' keeps Rust as the owner of session "
+                "state, which cannot be migrated live. Boot with RUST_MCP_MODE='edge' or RUST_A2A_MODE='edge' "
+                "to enable runtime flips."
             ),
         )
 

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -1,0 +1,454 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/runtime_admin_router.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Runtime-mode admin router.
+
+Exposes ``GET`` / ``PATCH /admin/runtime/mcp-mode`` and
+``GET`` / ``PATCH /admin/runtime/a2a-mode`` for flipping the public ``/mcp``
+ingress and the registered-A2A invocation path between ``shadow`` (Python) and
+``edge`` (Rust) at runtime. Boot env vars (``RUST_MCP_MODE`` /
+``RUST_A2A_MODE``) still pick the initial mode; overrides are in-memory only.
+
+Each endpoint requires the ``admin.system_config`` permission (the same
+permission used by sibling admin routers such as ``llm_admin_router`` and
+``observability``). Successful flips emit a ``runtime_config`` audit event via
+``SecurityLogger.log_data_access`` and, when Redis is available, propagate to
+all pods via the ``RuntimeStateCoordinator``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, get_db, require_permission
+from mcpgateway.runtime_state import (
+    OverrideMode,
+    PublishStatus,
+    RuntimeKind,
+    RuntimeStateError,
+    get_runtime_state,
+    get_runtime_state_coordinator,
+)
+from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.security_logger import get_security_logger
+from mcpgateway import version as version_module
+
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+runtime_admin_router = APIRouter()
+
+# A deployment can be flipped between shadow and edge at runtime only when it
+# booted into one of those two modes. ``off`` has no Rust sidecar to swap to;
+# ``full`` keeps Rust as the owner of MCP session/event-store/resume/live-stream
+# cores, and flipping to shadow would orphan that Rust-held session state — the
+# issue (#4273) deliberately scopes runtime flips to shadow ↔ edge to avoid
+# live session-state migration.
+_FLIPPABLE_BOOT_MODES: frozenset[str] = frozenset({"shadow", "edge"})
+
+# Headers commonly added by reverse proxies. When any are present we know the
+# gateway is fronted by an L7 proxy that won't follow runtime flips by itself
+# (see issue #4278), and we emit a one-line WARN so operators don't expect the
+# override to change public traffic on that hop.
+_REVERSE_PROXY_HEADER_NAMES: frozenset[str] = frozenset({"x-forwarded-for", "forwarded", "x-forwarded-host", "x-forwarded-proto"})
+
+
+class RuntimeModeUpdate(BaseModel):
+    """Request body for ``PATCH /admin/runtime/{runtime}-mode``."""
+
+    mode: OverrideMode = Field(description="Target override mode. Only shadow and edge are supported at runtime.")
+
+
+@dataclass(frozen=True)
+class ApplyModeResult:
+    """Outcome of an admin-initiated mode change.
+
+    Returned by ``_apply_mode_change`` and consumed by the PATCH handlers to
+    populate ``publish_status`` and ``audit_persisted`` on the response.
+    """
+
+    publish_status: PublishStatus
+    audit_persisted: bool
+
+
+def _build_state_payload(runtime: RuntimeKind, *, boot_mode: str, mounted: Optional[str] = None, invoke_mode: Optional[str] = None) -> Dict[str, Any]:
+    """Build the response payload describing the current override state for ``runtime``.
+
+    Args:
+        runtime: Runtime kind (``RuntimeKind.MCP`` or ``RuntimeKind.A2A``).
+        boot_mode: Boot-time mode label derived from settings.
+        mounted: For MCP, the active transport mount label (``"rust"`` or ``"python"``).
+        invoke_mode: For A2A, the active invocation runtime label (``"rust"`` or ``"python"``).
+
+    Returns:
+        Response body for the GET / PATCH endpoints.
+    """
+    state = get_runtime_state()
+    override = state.override_mode(runtime)
+    last_change = state.last_change(runtime)
+    payload: Dict[str, Any] = {
+        "runtime": runtime.value,
+        "boot_mode": boot_mode,
+        "effective_mode": (override or boot_mode),
+        "override_active": override is not None,
+        "override_version": state.version(runtime),
+        "cluster_propagation": state.cluster_propagation.value,
+        "boot_reconcile_status": state.boot_reconcile_status(runtime).value,
+        "pod_id": state.pod_id,
+        "supported_override_modes": sorted(m.value for m in OverrideMode),
+    }
+    if mounted is not None:
+        payload["mounted"] = mounted
+    if invoke_mode is not None:
+        payload["invoke_mode"] = invoke_mode
+    if last_change is not None:
+        payload["last_change"] = {
+            "version": last_change.version,
+            "mode": last_change.mode.value,
+            "initiator_user": last_change.initiator_user,
+            "initiator_pod": last_change.initiator_pod,
+            "timestamp": last_change.timestamp,
+        }
+    return payload
+
+
+async def _apply_mode_change(
+    *,
+    runtime: RuntimeKind,
+    new_mode: OverrideMode,
+    user: Dict[str, Any],
+    db: Session,
+    boot_mode: str,
+    resource_label: str,
+    request: Optional[Any] = None,
+) -> ApplyModeResult:
+    """Validate and apply a runtime-mode override, emit audit event, and publish.
+
+    Args:
+        runtime: Runtime kind being changed.
+        new_mode: Requested override mode (already validated by Pydantic).
+        user: Authenticated user context from ``get_current_user_with_permissions``.
+        db: Request-scoped DB session for the audit write.
+        boot_mode: Boot-time mode label, used for the 409 check and audit context.
+        resource_label: Audit ``resource_id`` (e.g. ``"mcp_mode"``).
+        request: Optional FastAPI Request used for reverse-proxy detection.
+
+    Returns:
+        An ``ApplyModeResult`` with ``publish_status`` (``PublishStatus``) and
+        ``audit_persisted`` (bool).
+
+    Raises:
+        HTTPException: 409 when boot mode does not support flips, 503 when a
+            Redis-backed version cannot be allocated (would risk a silent
+            collision with a concurrent PATCH on a peer pod).
+    """
+    if boot_mode not in _FLIPPABLE_BOOT_MODES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"{runtime.value.upper()} runtime cannot be flipped at runtime when boot_mode={boot_mode!r}. "
+                "Runtime flips are scoped to shadow ↔ edge only: 'off' has no Rust sidecar to swap to, "
+                "and 'full' would require live migration of Rust-owned session/event-store/resume cores. "
+                "Set RUST_MCP_MODE or RUST_A2A_MODE to 'shadow' or 'edge' to enable runtime flips."
+            ),
+        )
+
+    if request is not None:
+        _warn_if_behind_reverse_proxy(request, runtime=runtime)
+
+    state = get_runtime_state()
+    coordinator = get_runtime_state_coordinator()
+    previous_override = state.override_mode(runtime)
+
+    try:
+        next_version = await coordinator.next_version(runtime, state.version(runtime))
+    except RuntimeStateError as exc:
+        # Refusing to allocate a colliding version is preferable to silently
+        # losing one of two concurrent flips at peer dedup time.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Cannot safely allocate a runtime-mode version: {exc}",
+        ) from exc
+
+    change = await state.apply_local(runtime, new_mode, initiator_user=user.get("email"), version=next_version)
+    if change is None:
+        # A concurrent newer change won the race on this pod. Surface this as
+        # a soft success — current state already reflects an authorized flip
+        # — but record the intent in the audit trail so postmortems can see
+        # the superseded request.
+        winning_version = state.version(runtime)
+        winning_override = state.override_mode(runtime)
+        winning_mode = winning_override.value if winning_override is not None else boot_mode
+        audit_persisted = _write_audit_event(
+            user=user,
+            db=db,
+            runtime=runtime,
+            resource_label=resource_label,
+            success=False,
+            old_values={"mode": (previous_override.value if previous_override is not None else boot_mode), "override_active": previous_override is not None},
+            new_values={"mode": new_mode.value, "override_active": True, "version": next_version, "applied": False},
+            additional_context={
+                "runtime": runtime.value,
+                "boot_mode": boot_mode,
+                "initiator_pod": state.pod_id,
+                "outcome": "superseded",
+                "attempted_version": next_version,
+                "superseded_by_version": winning_version,
+                "superseded_by_mode": winning_mode,
+            },
+        )
+        return ApplyModeResult(publish_status=PublishStatus.SUPERSEDED, audit_persisted=audit_persisted)
+
+    audit_persisted = _write_audit_event(
+        user=user,
+        db=db,
+        runtime=runtime,
+        resource_label=resource_label,
+        success=True,
+        old_values={"mode": (previous_override.value if previous_override is not None else boot_mode), "override_active": previous_override is not None},
+        new_values={"mode": new_mode.value, "override_active": True, "version": change.version},
+        additional_context={
+            "runtime": runtime.value,
+            "boot_mode": boot_mode,
+            "initiator_pod": change.initiator_pod,
+            "outcome": "applied",
+        },
+    )
+
+    publish_ok = await coordinator.publish(change)
+    if publish_ok:
+        publish_status = PublishStatus.PROPAGATED if coordinator.cluster_propagation_enabled else PublishStatus.LOCAL_ONLY
+    else:
+        publish_status = PublishStatus.FAILED
+    logger.info(
+        "Runtime override applied: runtime=%s new=%s previous=%s version=%d initiator=%s publish=%s audit=%s",
+        runtime.value,
+        new_mode.value,
+        previous_override,
+        change.version,
+        user.get("email"),
+        publish_status.value,
+        audit_persisted,
+    )
+    return ApplyModeResult(publish_status=publish_status, audit_persisted=audit_persisted)
+
+
+def _warn_if_behind_reverse_proxy(request: Any, *, runtime: RuntimeKind) -> None:
+    """Emit a one-line WARNING when reverse-proxy headers are present on a PATCH.
+
+    A reverse proxy fronting the gateway is configured at deploy time and does
+    not follow the runtime override (see issue #4278). The local override still
+    takes effect on this pod, but public ingress traffic that lands at the
+    proxy will continue to follow whatever upstream the proxy was configured
+    with. Surfacing this on every PATCH gives operators a chance to notice
+    before they assume the flip is end-to-end.
+
+    Args:
+        request: FastAPI request whose headers we inspect.
+        runtime: Runtime kind being changed.
+    """
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return
+    detected = sorted(name for name in _REVERSE_PROXY_HEADER_NAMES if name in headers)
+    if not detected:
+        return
+    logger.warning(
+        "Runtime-mode PATCH for %s arrived through a reverse proxy (headers: %s). The local override is applied, but "
+        "the proxy is configured at deploy time and will not follow the override unless explicitly reconfigured. "
+        "See https://github.com/IBM/mcp-context-forge/issues/4278 for the proxy-side mechanism follow-up.",
+        runtime.value,
+        detected,
+    )
+
+
+def _write_audit_event(
+    *,
+    user: Dict[str, Any],
+    db: Session,
+    runtime: RuntimeKind,
+    resource_label: str,
+    success: bool,
+    old_values: Dict[str, Any],
+    new_values: Dict[str, Any],
+    additional_context: Dict[str, Any],
+) -> bool:
+    """Write a runtime_config audit trail entry; report whether the write persisted.
+
+    Audit-write failures must NOT roll back a runtime-mode change. Operators
+    rely on this endpoint as an incident-rollback lever, and a failed audit
+    write (DB outage, sink unreachable, misconfigured logger) is strictly
+    less harmful than a failed flip. Catch broadly, log at ERROR with full
+    context so the audit gap is visible, and let the caller surface
+    ``audit_persisted: False`` in the response.
+
+    Args:
+        user: Authenticated user context.
+        db: Request-scoped DB session.
+        runtime: Runtime kind being changed.
+        resource_label: Audit ``resource_id`` (e.g. ``"mcp_mode"``).
+        success: ``True`` for an applied change, ``False`` for a superseded one.
+        old_values: Snapshot of state before the attempted change.
+        new_values: Snapshot of the requested change (and ``applied`` flag for the superseded path).
+        additional_context: Free-form context dict surfaced in the audit row.
+
+    Returns:
+        ``True`` when the audit write succeeded, ``False`` when it failed.
+    """
+    try:
+        get_security_logger().log_data_access(
+            action="update",
+            resource_type="runtime_config",
+            resource_id=resource_label,
+            resource_name=f"{runtime.value}_runtime_mode",
+            user_id=user.get("email") or "unknown",
+            user_email=user.get("email"),
+            team_id=None,
+            client_ip=user.get("ip_address"),
+            user_agent=user.get("user_agent"),
+            success=success,
+            old_values=old_values,
+            new_values=new_values,
+            additional_context=additional_context,
+            db=db,
+        )
+        return True
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.error(
+            "Runtime-mode audit trail failed to persist for %s outcome=%s (override action still proceeded): %s",
+            runtime.value,
+            additional_context.get("outcome", "unknown"),
+            exc,
+        )
+        return False
+
+
+@runtime_admin_router.get("/mcp-mode")
+@require_permission("admin.system_config")
+async def get_mcp_mode(
+    user: Dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> Dict[str, Any]:
+    """Return the current MCP runtime mode and override state.
+
+    Args:
+        user: Authenticated user context (must have ``admin.system_config``).
+
+    Returns:
+        State payload describing boot mode, effective mode, override state, and propagation status.
+    """
+    del user  # consumed by the @require_permission decorator
+    return _build_state_payload(
+        RuntimeKind.MCP,
+        boot_mode=version_module.boot_mcp_runtime_mode(),
+        mounted=version_module.current_mcp_transport_mount(),
+    )
+
+
+@runtime_admin_router.patch("/mcp-mode")
+@require_permission("admin.system_config")
+async def patch_mcp_mode(
+    body: RuntimeModeUpdate,
+    request: Request,
+    user: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Flip the public ``/mcp`` ingress between ``shadow`` and ``edge``.
+
+    Args:
+        body: Request body containing the target mode.
+        request: FastAPI request (used for reverse-proxy header detection).
+        user: Authenticated user context (must have ``admin.system_config``).
+        db: Request-scoped DB session for the audit write.
+
+    Returns:
+        Updated state payload after the flip is applied locally and published.
+    """
+    boot_mode = version_module.boot_mcp_runtime_mode()
+    result = await _apply_mode_change(
+        runtime=RuntimeKind.MCP,
+        new_mode=body.mode,
+        user=user,
+        db=db,
+        boot_mode=boot_mode,
+        resource_label="mcp_mode",
+        request=request,
+    )
+    payload = _build_state_payload(
+        RuntimeKind.MCP,
+        boot_mode=boot_mode,
+        mounted=version_module.current_mcp_transport_mount(),
+    )
+    payload["publish_status"] = result.publish_status.value
+    payload["audit_persisted"] = result.audit_persisted
+    return payload
+
+
+@runtime_admin_router.get("/a2a-mode")
+@require_permission("admin.system_config")
+async def get_a2a_mode(
+    user: Dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> Dict[str, Any]:
+    """Return the current A2A runtime mode and override state.
+
+    Args:
+        user: Authenticated user context (must have ``admin.system_config``).
+
+    Returns:
+        State payload describing boot mode, effective mode, override state, and propagation status.
+    """
+    del user
+    return _build_state_payload(
+        RuntimeKind.A2A,
+        boot_mode=version_module.boot_a2a_runtime_mode(),
+        invoke_mode="rust" if version_module.should_delegate_a2a_to_rust() else "python",
+    )
+
+
+@runtime_admin_router.patch("/a2a-mode")
+@require_permission("admin.system_config")
+async def patch_a2a_mode(
+    body: RuntimeModeUpdate,
+    request: Request,
+    user: Dict[str, Any] = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Flip the registered-A2A invocation path between Python and the Rust runtime.
+
+    Args:
+        body: Request body containing the target mode.
+        request: FastAPI request (used for reverse-proxy header detection).
+        user: Authenticated user context (must have ``admin.system_config``).
+        db: Request-scoped DB session for the audit write.
+
+    Returns:
+        Updated state payload after the flip is applied locally and published.
+    """
+    boot_mode = version_module.boot_a2a_runtime_mode()
+    result = await _apply_mode_change(
+        runtime=RuntimeKind.A2A,
+        new_mode=body.mode,
+        user=user,
+        db=db,
+        boot_mode=boot_mode,
+        resource_label="a2a_mode",
+        request=request,
+    )
+    payload = _build_state_payload(
+        RuntimeKind.A2A,
+        boot_mode=boot_mode,
+        invoke_mode="rust" if version_module.should_delegate_a2a_to_rust() else "python",
+    )
+    payload["publish_status"] = result.publish_status.value
+    payload["audit_persisted"] = result.audit_persisted
+    return payload

--- a/mcpgateway/routers/runtime_admin_router.py
+++ b/mcpgateway/routers/runtime_admin_router.py
@@ -72,10 +72,14 @@ def _move_compat_to_409_detail(runtime: RuntimeKind, mode: OverrideMode, boot_mo
     """
     runtime_label = runtime.value.upper()
     if compat == MoveCompatibility.NO_DISPATCHER:
+        # Note: boot='full' is intentionally NOT recommended here — it returns
+        # BOOT_FULL_STRANDS for the same reason (no dispatcher mounted). Only
+        # 'shadow' and 'edge' boot deployments mount the dispatcher that
+        # observes overrides.
         return (
             f"{runtime_label} runtime cannot accept overrides when boot_mode={boot_mode!r}. "
             "The Rust sidecar is not enabled for this runtime, so there is no mechanism to honor an override. "
-            f"Boot with RUST_{runtime.value.upper()}_MODE='shadow' or 'edge' (or 'full' for MCP) to enable overrides."
+            f"Boot with RUST_{runtime.value.upper()}_MODE='shadow' or 'edge' to enable overrides."
         )
     if compat == MoveCompatibility.BOOT_FULL_STRANDS:
         return (

--- a/mcpgateway/runtime_state.py
+++ b/mcpgateway/runtime_state.py
@@ -160,7 +160,7 @@ def _move_compat_to_reconcile_status(compat: "MoveCompatibility") -> "BootReconc
     Returns:
         The matching ``BootReconcileStatus``. ``OK`` maps to ``OK`` for symmetry.
     """
-    if compat == MoveCompatibility.OK:
+    if compat == MoveCompatibility.OK:  # pragma: no cover — caller filters OK upstream
         return BootReconcileStatus.OK
     if compat == MoveCompatibility.NO_DISPATCHER:
         return BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER
@@ -168,7 +168,7 @@ def _move_compat_to_reconcile_status(compat: "MoveCompatibility") -> "BootReconc
         return BootReconcileStatus.INCOMPATIBLE_BOOT_FULL
     if compat == MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG:
         return BootReconcileStatus.INCOMPATIBLE_SAFETY_FLAG
-    return BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER  # defensive default
+    return BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER  # pragma: no cover — defensive default for future MoveCompatibility variants
 
 
 # Backward-compat aliases for callers that consume the bare string set or the
@@ -802,7 +802,7 @@ class RuntimeStateCoordinator:
             hint_mode = None
         if hint_mode is not None:
             # First-Party: lazy to avoid the version <-> runtime_state import cycle.
-            from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel
+            from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel,cyclic-import
 
             compat = _deployment_allows_override_mode(kind, hint_mode)
             if compat != MoveCompatibility.OK:
@@ -839,99 +839,99 @@ class RuntimeStateCoordinator:
         """
         consecutive_errors = 0
         state = get_runtime_state()
-        try:
-            while self._started and not (self._stop_event and self._stop_event.is_set()):
-                if self._pubsub is None:
-                    break
-                try:
-                    message = await asyncio.wait_for(
-                        self._pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
-                        timeout=2.0,
-                    )
-                except asyncio.TimeoutError:
-                    # Idle timeout is the normal path when no messages arrive;
-                    # treat it as evidence the subscriber is alive.
-                    if consecutive_errors > 0:
-                        consecutive_errors = 0
-                        if state.cluster_propagation == PROPAGATION_DEGRADED:
-                            state.set_cluster_propagation(PROPAGATION_REDIS)
-                            logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
-                    continue
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    consecutive_errors += 1
-                    if consecutive_errors == LISTEN_LOOP_DEGRADE_THRESHOLD:
-                        state.set_cluster_propagation(PROPAGATION_DEGRADED)
-                        logger.error(
-                            "RuntimeStateCoordinator: %d consecutive pub/sub receive failures; cluster_propagation downgraded to %s. Last error: %s",
-                            consecutive_errors,
-                            PROPAGATION_DEGRADED,
-                            exc,
-                        )
-                    else:
-                        logger.debug("RuntimeStateCoordinator: receive error (%d consecutive): %s", consecutive_errors, exc)
-                    await asyncio.sleep(0.1)
-                    continue
-                # A non-exception return without a real message (e.g. ``None`` from
-                # a pubsub that's broken in a way that doesn't raise) is NOT
-                # evidence the subscriber is alive — the idle-timeout branch above
-                # handles the legit silence case. Only count real messages as
-                # "subscriber is healthy" for the recovery promotion.
-                if not message or message.get("type") != "message":
-                    continue
+        # asyncio.CancelledError is BaseException in 3.8+ — the inner
+        # ``except Exception`` won't swallow a task cancel; it propagates
+        # naturally out of this coroutine.
+        while self._started and not (self._stop_event and self._stop_event.is_set()):
+            if self._pubsub is None:
+                break
+            try:
+                message = await asyncio.wait_for(
+                    self._pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                    timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                # Idle timeout is the normal path when no messages arrive;
+                # treat it as evidence the subscriber is alive.
                 if consecutive_errors > 0:
                     consecutive_errors = 0
                     if state.cluster_propagation == PROPAGATION_DEGRADED:
                         state.set_cluster_propagation(PROPAGATION_REDIS)
                         logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
-                data = message.get("data")
-                if isinstance(data, bytes):
-                    data = data.decode("utf-8", errors="replace")
-                if not data:
-                    continue
-                try:
-                    payload = orjson.loads(data)
-                except orjson.JSONDecodeError as exc:
-                    logger.warning("RuntimeStateCoordinator: discarding malformed pub/sub payload: %s", exc)
-                    continue
-                # Mirror _reconcile_from_hint's compatibility check: a remote pod
-                # may publish a flip that this pod cannot safely honor (e.g. an
-                # edge-boot pod publishes ``edge`` and a shadow-boot peer
-                # receives it). Without this guard the override would land in
-                # local state, the transport layer would refuse to honor it,
-                # and diagnostics would lie. Discard with a WARN.
-                try:
-                    remote_mode = _coerce_mode(payload.get("mode", ""))
-                    remote_runtime = _coerce_runtime(payload.get("runtime", ""))
-                except ValueError:
-                    # apply_remote will log the malformed payload; let it run.
-                    remote_mode = None
-                    remote_runtime = None
-                if remote_mode is not None and remote_runtime is not None:
-                    # First-Party: lazy to avoid the version <-> runtime_state import cycle.
-                    from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel
-
-                    remote_compat = _deployment_allows_override_mode(remote_runtime, remote_mode)
-                    if remote_compat != MoveCompatibility.OK:
-                        logger.warning(
-                            "RuntimeStateCoordinator: discarding incompatible remote override for %s (mode=%s) from pod=%s; "
-                            "reason=%s. The publishing pod's flags allow this mode but this pod's do not.",
-                            remote_runtime.value,
-                            remote_mode.value,
-                            payload.get("initiator_pod", "unknown"),
-                            remote_compat.value,
-                        )
-                        continue
-                applied = await get_runtime_state().apply_remote(payload)
-                if applied is not None:
-                    logger.info(
-                        "RuntimeStateCoordinator: applied remote %s override mode=%s version=%d from pod=%s",
-                        applied.runtime,
-                        applied.mode,
-                        applied.version,
-                        applied.initiator_pod,
+                continue
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                consecutive_errors += 1
+                if consecutive_errors == LISTEN_LOOP_DEGRADE_THRESHOLD:
+                    state.set_cluster_propagation(PROPAGATION_DEGRADED)
+                    logger.error(
+                        "RuntimeStateCoordinator: %d consecutive pub/sub receive failures; cluster_propagation downgraded to %s. Last error: %s",
+                        consecutive_errors,
+                        PROPAGATION_DEGRADED,
+                        exc,
                     )
-        except asyncio.CancelledError:
-            raise
+                else:
+                    logger.debug("RuntimeStateCoordinator: receive error (%d consecutive): %s", consecutive_errors, exc)
+                await asyncio.sleep(0.1)
+                continue
+            # A non-exception return without a real message (e.g. ``None`` from
+            # a pubsub that's broken in a way that doesn't raise) is NOT
+            # evidence the subscriber is alive — the idle-timeout branch above
+            # handles the legit silence case. Only count real messages as
+            # "subscriber is healthy" for the recovery promotion.
+            if not message or message.get("type") != "message":
+                continue
+            if consecutive_errors > 0:
+                consecutive_errors = 0
+                if state.cluster_propagation == PROPAGATION_DEGRADED:
+                    state.set_cluster_propagation(PROPAGATION_REDIS)
+                    logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
+            data = message.get("data")
+            if isinstance(data, bytes):
+                data = data.decode("utf-8", errors="replace")
+            if not data:
+                continue
+            try:
+                payload = orjson.loads(data)
+            except orjson.JSONDecodeError as exc:
+                logger.warning("RuntimeStateCoordinator: discarding malformed pub/sub payload: %s", exc)
+                continue
+            # Mirror _reconcile_from_hint's compatibility check: a remote pod
+            # may publish a flip that this pod cannot safely honor (e.g. an
+            # edge-boot pod publishes ``edge`` and a shadow-boot peer
+            # receives it). Without this guard the override would land in
+            # local state, the transport layer would refuse to honor it,
+            # and diagnostics would lie. Discard with a WARN.
+            try:
+                remote_mode = _coerce_mode(payload.get("mode", ""))
+                remote_runtime = _coerce_runtime(payload.get("runtime", ""))
+            except ValueError:
+                # apply_remote will log the malformed payload; let it run.
+                remote_mode = None
+                remote_runtime = None
+            if remote_mode is not None and remote_runtime is not None:
+                # First-Party: lazy to avoid the version <-> runtime_state import cycle.
+                from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel,cyclic-import
+
+                remote_compat = _deployment_allows_override_mode(remote_runtime, remote_mode)
+                if remote_compat != MoveCompatibility.OK:
+                    logger.warning(
+                        "RuntimeStateCoordinator: discarding incompatible remote override for %s (mode=%s) from pod=%s; "
+                        "reason=%s. The publishing pod's flags allow this mode but this pod's do not.",
+                        remote_runtime.value,
+                        remote_mode.value,
+                        payload.get("initiator_pod", "unknown"),
+                        remote_compat.value,
+                    )
+                    continue
+            applied = await get_runtime_state().apply_remote(payload)
+            if applied is not None:
+                logger.info(
+                    "RuntimeStateCoordinator: applied remote %s override mode=%s version=%d from pod=%s",
+                    applied.runtime,
+                    applied.mode,
+                    applied.version,
+                    applied.initiator_pod,
+                )
 
     async def _cleanup_pubsub(self) -> None:
         """Unsubscribe and close the pubsub connection if open."""

--- a/mcpgateway/runtime_state.py
+++ b/mcpgateway/runtime_state.py
@@ -1,0 +1,858 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/runtime_state.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Runtime-mutable mode state for the public ``/mcp`` and A2A ingress paths.
+
+Boot-time env vars (``RUST_MCP_MODE``, ``RUST_A2A_MODE``) still select the
+initial transport at process start. This module layers an optional in-memory
+override on top so an authorized admin can flip ``shadow ↔ edge`` for either
+runtime without restarting the process.
+
+Each runtime kind (``mcp``, ``a2a``) has its own override slot, monotonic
+version counter, and last-change record. Overrides are not persisted to the
+database. When Redis is available, overrides are propagated cluster-wide via
+pub/sub on a single channel (each message carries a ``runtime`` field) plus a
+short-lived per-runtime hint key so a freshly started pod reconciles to the
+cluster's current desired override on boot. Without Redis the override is
+local to the pod that received the PATCH; this is surfaced via the
+``cluster_propagation`` field on the admin and ``/health`` responses.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from enum import StrEnum
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Union
+
+# Third-Party
+import orjson
+
+logger = logging.getLogger(__name__)
+
+RUNTIME_STATE_CHANNEL = "contextforge:runtime:mode"
+RUNTIME_STATE_HINT_KEY_PREFIX = "contextforge:runtime:mode_state"
+RUNTIME_STATE_VERSION_KEY_PREFIX = "contextforge:runtime:mode_version"
+RUNTIME_STATE_HINT_TTL_SECONDS = 24 * 60 * 60
+
+# Consecutive ``get_message`` failures before the listen loop downgrades
+# ``cluster_propagation`` from ``"redis"`` to ``"degraded"`` so /health and
+# admin responses reflect that pub/sub is no longer healthy. A single
+# successful receive re-promotes back to ``"redis"``.
+LISTEN_LOOP_DEGRADE_THRESHOLD = 5
+
+
+class RuntimeKind(StrEnum):
+    """Runtime kinds whose public-ingress mode can be flipped at runtime.
+
+    StrEnum members are ``str`` subclasses, so existing callers that compare
+    against the literal strings (``"mcp"``, ``"a2a"``) continue to work
+    transparently. The constructor (``RuntimeKind("mcp")``) doubles as a
+    validator and raises ``ValueError`` on unknown values.
+    """
+
+    MCP = "mcp"
+    A2A = "a2a"
+
+
+class OverrideMode(StrEnum):
+    """Modes that the runtime override can flip between at runtime."""
+
+    SHADOW = "shadow"
+    EDGE = "edge"
+
+
+class ClusterPropagation(StrEnum):
+    """Cluster-propagation status surfaced via /health and admin payloads.
+
+    - ``REDIS``: coordinator is publishing/subscribing successfully.
+    - ``DISABLED``: Redis is intentionally not configured for this deployment.
+    - ``DEGRADED``: Redis is configured but the coordinator failed to attach
+      (or pub/sub broke after startup, or boot reconciliation failed).
+    """
+
+    REDIS = "redis"
+    DISABLED = "disabled"
+    DEGRADED = "degraded"
+
+
+class PublishStatus(StrEnum):
+    """Outcomes reported by the admin PATCH endpoints.
+
+    - ``PROPAGATED``: local override applied and pub/sub publish succeeded.
+    - ``LOCAL_ONLY``: local override applied; coordinator not attached to Redis.
+    - ``FAILED``: local override applied but the pub/sub publish failed
+      (peers may not have received the change).
+    - ``SUPERSEDED``: a concurrent newer change won the race; local state
+      already reflects an authorized flip and this PATCH was a no-op.
+    """
+
+    PROPAGATED = "propagated"
+    LOCAL_ONLY = "local-only"
+    FAILED = "failed"
+    SUPERSEDED = "superseded"
+
+
+class BootReconcileStatus(StrEnum):
+    """Per-runtime outcome of the coordinator's boot-time reconciliation.
+
+    - ``OK``: hint either absent or applied successfully.
+    - ``REDIS_UNAVAILABLE``: Redis read failed; pod boots with stale settings.
+    - ``MALFORMED_HINT``: hint key existed but contained invalid JSON.
+    - ``PUBSUB_UNAVAILABLE``: pub/sub subscribe failed during start; this pod
+      will not receive remote overrides until restart.
+    - ``COORDINATOR_OFFLINE``: coordinator was never started (e.g. test mode
+      or a deployment that runs without the coordinator).
+    """
+
+    OK = "ok"
+    REDIS_UNAVAILABLE = "redis_unavailable"
+    MALFORMED_HINT = "malformed_hint"
+    PUBSUB_UNAVAILABLE = "pubsub_unavailable"
+    COORDINATOR_OFFLINE = "coordinator_offline"
+
+
+# Backward-compat aliases for callers that consume the bare string set or the
+# string constants. Built from the enums so they cannot drift.
+SUPPORTED_OVERRIDE_MODES: frozenset[str] = frozenset(OverrideMode)
+RUNTIME_KINDS: frozenset[str] = frozenset(RuntimeKind)
+PROPAGATION_REDIS: str = ClusterPropagation.REDIS.value
+PROPAGATION_DISABLED: str = ClusterPropagation.DISABLED.value
+PROPAGATION_DEGRADED: str = ClusterPropagation.DEGRADED.value
+
+
+class RuntimeStateError(Exception):
+    """Raised when a runtime-mode change cannot be safely applied or propagated."""
+
+
+def _coerce_runtime(value: Union[str, RuntimeKind]) -> RuntimeKind:
+    """Coerce a string or RuntimeKind into a canonical RuntimeKind.
+
+    Args:
+        value: Either the bare string (``"mcp"``/``"a2a"``) or a ``RuntimeKind`` member.
+
+    Returns:
+        The matching ``RuntimeKind`` member.
+
+    Raises:
+        ValueError: If ``value`` is not a recognized runtime kind.
+    """
+    return value if isinstance(value, RuntimeKind) else RuntimeKind(value)
+
+
+def _coerce_mode(value: Union[str, OverrideMode]) -> OverrideMode:
+    """Coerce a string or OverrideMode into a canonical OverrideMode.
+
+    Args:
+        value: Either the bare string (``"shadow"``/``"edge"``) or an ``OverrideMode`` member.
+
+    Returns:
+        The matching ``OverrideMode`` member.
+
+    Raises:
+        ValueError: If ``value`` is not a supported override mode.
+    """
+    return value if isinstance(value, OverrideMode) else OverrideMode(value)
+
+
+def _hint_key(runtime: Union[str, RuntimeKind]) -> str:
+    """Return the Redis hint key for a runtime kind.
+
+    Args:
+        runtime: Runtime kind.
+
+    Returns:
+        Fully qualified Redis key for the per-runtime override hint.
+    """
+    return f"{RUNTIME_STATE_HINT_KEY_PREFIX}:{_coerce_runtime(runtime).value}"
+
+
+def _version_key(runtime: Union[str, RuntimeKind]) -> str:
+    """Return the Redis monotonic version counter key for a runtime kind.
+
+    Args:
+        runtime: Runtime kind.
+
+    Returns:
+        Fully qualified Redis key for the per-runtime version counter.
+    """
+    return f"{RUNTIME_STATE_VERSION_KEY_PREFIX}:{_coerce_runtime(runtime).value}"
+
+
+@dataclass(frozen=True)
+class ModeChange:
+    """Snapshot of the most recent mode change applied locally for one runtime."""
+
+    runtime: RuntimeKind
+    version: int
+    mode: OverrideMode
+    initiator_user: Optional[str]
+    initiator_pod: str
+    timestamp: float
+
+    def __post_init__(self) -> None:
+        """Coerce string inputs to canonical enum members and validate.
+
+        Raises:
+            ValueError: If ``runtime`` is not one of ``RuntimeKind`` or ``mode``
+                is not one of ``OverrideMode``.
+        """
+        if not isinstance(self.runtime, RuntimeKind):
+            object.__setattr__(self, "runtime", _coerce_runtime(self.runtime))
+        if not isinstance(self.mode, OverrideMode):
+            object.__setattr__(self, "mode", _coerce_mode(self.mode))
+
+
+class RuntimeState:
+    """In-memory snapshot of runtime-mutable mode overrides for one process.
+
+    Reads happen on every public-ingress request, so they must stay lock-free.
+    Writes (local PATCH or remote pub/sub) take per-runtime locks and enforce
+    monotonic versioning.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty runtime state with no active overrides."""
+        self._locks: Dict[RuntimeKind, asyncio.Lock] = {kind: asyncio.Lock() for kind in RuntimeKind}
+        self._override: Dict[RuntimeKind, Optional[OverrideMode]] = {kind: None for kind in RuntimeKind}
+        self._version: Dict[RuntimeKind, int] = {kind: 0 for kind in RuntimeKind}
+        self._last_change: Dict[RuntimeKind, Optional[ModeChange]] = {kind: None for kind in RuntimeKind}
+        self._pod_id = os.environ.get("HOSTNAME") or uuid.uuid4().hex
+        self._cluster_propagation: ClusterPropagation = ClusterPropagation.DISABLED
+        self._boot_reconcile_status: Dict[RuntimeKind, BootReconcileStatus] = {kind: BootReconcileStatus.COORDINATOR_OFFLINE for kind in RuntimeKind}
+
+    @property
+    def pod_id(self) -> str:
+        """Stable identifier for this pod, used to dedupe self-published events.
+
+        Returns:
+            Stable pod identifier (HOSTNAME if set, otherwise a random UUID).
+        """
+        return self._pod_id
+
+    @property
+    def cluster_propagation(self) -> ClusterPropagation:
+        """Current cluster-propagation status.
+
+        Returns:
+            A ``ClusterPropagation`` enum member. Because the enum is a
+            ``StrEnum``, callers may continue to compare against the literal
+            strings (``"redis"``/``"disabled"``/``"degraded"``).
+        """
+        return self._cluster_propagation
+
+    def set_cluster_propagation(self, status: Union[str, ClusterPropagation]) -> None:
+        """Update the cluster-propagation status surfaced via diagnostics.
+
+        ``RuntimeState`` owns the storage so a freshly-constructed instance
+        (used in unit tests without a coordinator) has a sensible default,
+        but the only legitimate production writer is
+        ``RuntimeStateCoordinator``. ``cluster_propagation_enabled`` derives
+        from this value, so the status is the single source of truth for
+        "is propagation healthy?" decisions.
+
+        Args:
+            status: A ``ClusterPropagation`` member or matching string.
+
+        Raises:
+            ValueError: If ``status`` is not a recognized ClusterPropagation value.
+        """
+        self._cluster_propagation = status if isinstance(status, ClusterPropagation) else ClusterPropagation(status)
+
+    def boot_reconcile_status(self, runtime: Union[str, RuntimeKind]) -> BootReconcileStatus:
+        """Return the boot-time reconciliation outcome for ``runtime``.
+
+        Args:
+            runtime: Runtime kind.
+
+        Returns:
+            A ``BootReconcileStatus`` member; ``COORDINATOR_OFFLINE`` when no
+            coordinator has run, ``OK`` when the coordinator started cleanly
+            (with or without a hint), or one of the failure values when boot
+            reconciliation hit an issue that left the pod with stale settings.
+        """
+        try:
+            kind = _coerce_runtime(runtime)
+        except ValueError:
+            return BootReconcileStatus.COORDINATOR_OFFLINE
+        return self._boot_reconcile_status[kind]
+
+    def set_boot_reconcile_status(self, runtime: Union[str, RuntimeKind], status: Union[str, BootReconcileStatus]) -> None:
+        """Update the boot-reconciliation status for ``runtime``.
+
+        Like ``set_cluster_propagation``, ``RuntimeState`` owns storage but the
+        only legitimate writer is ``RuntimeStateCoordinator``.
+
+        Args:
+            runtime: Runtime kind.
+            status: A ``BootReconcileStatus`` member or matching string.
+
+        Raises:
+            ValueError: If ``runtime`` or ``status`` is not recognized.
+        """
+        kind = _coerce_runtime(runtime)
+        self._boot_reconcile_status[kind] = status if isinstance(status, BootReconcileStatus) else BootReconcileStatus(status)
+
+    def override_mode(self, runtime: Union[str, RuntimeKind]) -> Optional[OverrideMode]:
+        """Return the active override for ``runtime``, or ``None`` if no override is set.
+
+        Args:
+            runtime: Runtime kind.
+
+        Returns:
+            ``OverrideMode.SHADOW``/``OverrideMode.EDGE`` when an override is
+            active, else ``None``. Result compares equal to its string literal.
+        """
+        try:
+            kind = _coerce_runtime(runtime)
+        except ValueError:
+            return None
+        return self._override[kind]
+
+    def version(self, runtime: Union[str, RuntimeKind]) -> int:
+        """Return the monotonic version of the most recent applied override.
+
+        Args:
+            runtime: Runtime kind.
+
+        Returns:
+            The current monotonic version (``0`` when no override has been applied).
+        """
+        try:
+            kind = _coerce_runtime(runtime)
+        except ValueError:
+            return 0
+        return self._version[kind]
+
+    def last_change(self, runtime: Union[str, RuntimeKind]) -> Optional[ModeChange]:
+        """Return the most recent applied mode change for ``runtime``, if any.
+
+        Args:
+            runtime: Runtime kind.
+
+        Returns:
+            A ``ModeChange`` describing the last applied override, else ``None``.
+        """
+        try:
+            kind = _coerce_runtime(runtime)
+        except ValueError:
+            return None
+        return self._last_change[kind]
+
+    async def apply_local(
+        self,
+        runtime: Union[str, RuntimeKind],
+        mode: Union[str, OverrideMode],
+        *,
+        initiator_user: Optional[str],
+        version: int,
+    ) -> Optional[ModeChange]:
+        """Apply an override originating from this pod.
+
+        Args:
+            runtime: Runtime kind.
+            mode: Target override mode.
+            initiator_user: Authenticated user email that requested the change.
+            version: Monotonic version for the change (must be strictly greater than the current version).
+
+        Returns:
+            A ``ModeChange`` describing the applied override, or ``None`` if a
+            concurrent newer change has already been applied (rare race when
+            two PATCHes on the same pod allocate adjacent versions and land
+            out of order).
+
+        Raises:
+            ValueError: If ``runtime`` is unknown or ``mode`` is not a supported override mode.
+        """
+        kind = _coerce_runtime(runtime)
+        target_mode = _coerce_mode(mode)
+        async with self._locks[kind]:
+            if version <= self._version[kind]:
+                return None
+            self._override[kind] = target_mode
+            self._version[kind] = version
+            change = ModeChange(
+                runtime=kind,
+                version=version,
+                mode=target_mode,
+                initiator_user=initiator_user,
+                initiator_pod=self._pod_id,
+                timestamp=time.time(),
+            )
+            self._last_change[kind] = change
+            return change
+
+    async def apply_remote(self, payload: Dict[str, Any]) -> Optional[ModeChange]:
+        """Apply an override message received from another pod.
+
+        Args:
+            payload: Decoded pub/sub payload.
+
+        Returns:
+            The applied ``ModeChange`` when the message advanced local state,
+            otherwise ``None`` (stale, self-originated, or invalid).
+        """
+        try:
+            kind = _coerce_runtime(payload["runtime"])
+            target_mode = _coerce_mode(payload["mode"])
+            version = int(payload["version"])
+            initiator_pod = str(payload.get("initiator_pod", "unknown"))
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("RuntimeState: discarding malformed or invalid runtime-mode payload (%s): %r", exc, payload)
+            return None
+
+        if initiator_pod == self._pod_id:
+            return None
+
+        async with self._locks[kind]:
+            if version <= self._version[kind]:
+                return None
+            self._override[kind] = target_mode
+            self._version[kind] = version
+            change = ModeChange(
+                runtime=kind,
+                version=version,
+                mode=target_mode,
+                initiator_user=payload.get("initiator_user"),
+                initiator_pod=initiator_pod,
+                timestamp=float(payload.get("timestamp", time.time())),
+            )
+            self._last_change[kind] = change
+            return change
+
+
+_runtime_state: Optional[RuntimeState] = None
+
+
+def get_runtime_state() -> RuntimeState:
+    """Return the process-wide ``RuntimeState`` singleton, creating it if needed.
+
+    Returns:
+        The shared ``RuntimeState`` instance for this process.
+    """
+    global _runtime_state
+    if _runtime_state is None:
+        _runtime_state = RuntimeState()
+    return _runtime_state
+
+
+def reset_runtime_state_for_tests() -> None:
+    """Clear the runtime state singleton. Tests only.
+
+    Production code must not call this — it intentionally drops any active
+    override and leaks the prior coordinator's pubsub task if one is running.
+    """
+    global _runtime_state
+    _runtime_state = None
+
+
+class RuntimeStateCoordinator:
+    """Cluster-wide propagation for runtime-mutable mode overrides.
+
+    On startup the coordinator reads any persisted per-runtime override hint
+    from Redis and reconciles local state. It then subscribes to a single
+    pub/sub channel and applies remote overrides as they arrive (each message
+    carries a ``runtime`` field).
+
+    When Redis is unavailable the coordinator degrades to single-pod scope:
+    local overrides still apply on the pod that received the PATCH, but the
+    rest of the cluster is unaware. This is surfaced via ``cluster_propagation``
+    on ``/health`` and admin responses.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an inactive coordinator. Call :meth:`start` to activate."""
+        self._task: Optional[asyncio.Task[None]] = None
+        self._stop_event: Optional[asyncio.Event] = None
+        self._pubsub: Optional[Any] = None
+        self._redis: Optional[Any] = None
+        self._started = False
+
+    @property
+    def started(self) -> bool:
+        """Whether the coordinator's listener task is running.
+
+        Returns:
+            ``True`` after a successful :meth:`start`, else ``False``.
+        """
+        return self._started
+
+    @property
+    def cluster_propagation_enabled(self) -> bool:
+        """Whether cluster-wide propagation is currently healthy.
+
+        Derived from ``RuntimeState.cluster_propagation`` (the single source of
+        truth) so that a permanent pub/sub failure that downgraded the status
+        to ``degraded`` is correctly reported as "not enabled" — even though
+        the ``_pubsub`` handle is still bound waiting for ``stop()``.
+
+        Returns:
+            ``True`` only when the propagation status is ``REDIS``.
+        """
+        return get_runtime_state().cluster_propagation == ClusterPropagation.REDIS
+
+    async def start(self) -> None:
+        """Subscribe to the runtime-mode pub/sub channel and reconcile boot state.
+
+        Sets ``cluster_propagation`` to one of:
+
+        - ``"redis"`` — pub/sub attached and listener running.
+        - ``"disabled"`` — Redis is intentionally not configured for this deployment.
+        - ``"degraded"`` — Redis is configured but the coordinator failed to attach;
+          the pod will still serve PATCH locally, but operators should treat
+          ``"degraded"`` as an alertable condition (e.g. fail readiness or page).
+        """
+        if self._started:
+            return
+
+        state = get_runtime_state()
+        # If Redis is not configured for this deployment, propagation is
+        # intentionally off — distinct from "configured but broken".
+        try:
+            # First-Party
+            from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+            redis = await get_redis_client()
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("RuntimeStateCoordinator: Redis client raised at startup; cluster propagation is degraded: %s", exc)
+            state.set_cluster_propagation(PROPAGATION_DEGRADED)
+            for kind in RuntimeKind:
+                state.set_boot_reconcile_status(kind, BootReconcileStatus.REDIS_UNAVAILABLE)
+            self._started = True
+            return
+
+        if redis is None:
+            logger.info("RuntimeStateCoordinator: Redis disabled, runtime mode override is per-pod only")
+            state.set_cluster_propagation(PROPAGATION_DISABLED)
+            for kind in RuntimeKind:
+                state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
+            self._started = True
+            return
+
+        self._redis = redis
+        try:
+            for kind in RuntimeKind:
+                await self._reconcile_from_hint(kind)
+            self._stop_event = asyncio.Event()
+            self._pubsub = redis.pubsub()
+            await self._pubsub.subscribe(RUNTIME_STATE_CHANNEL)
+            self._task = asyncio.create_task(self._listen_loop())
+            # Only promote to "redis" if the per-runtime reconciliation didn't
+            # already mark us "degraded" (e.g. malformed hint, Redis read fail).
+            if state.cluster_propagation != PROPAGATION_DEGRADED:
+                state.set_cluster_propagation(PROPAGATION_REDIS)
+            self._started = True
+            logger.info("RuntimeStateCoordinator subscribed to %s", RUNTIME_STATE_CHANNEL)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("RuntimeStateCoordinator failed to attach pub/sub; cluster propagation is degraded: %s", exc)
+            await self._cleanup_pubsub()
+            state.set_cluster_propagation(PROPAGATION_DEGRADED)
+            for kind in RuntimeKind:
+                # Reconcile-specific failures (REDIS_UNAVAILABLE, MALFORMED_HINT)
+                # are more specific than "pub/sub down" — keep them. Otherwise
+                # mark PUBSUB_UNAVAILABLE so /health distinguishes "we attached
+                # to Redis but the listener is dead" from "Redis is intentionally
+                # off" or "the hint read failed".
+                if state.boot_reconcile_status(kind) in (BootReconcileStatus.OK, BootReconcileStatus.COORDINATOR_OFFLINE):
+                    state.set_boot_reconcile_status(kind, BootReconcileStatus.PUBSUB_UNAVAILABLE)
+            self._started = True
+
+    async def stop(self) -> None:
+        """Unsubscribe and cancel the listener task."""
+        if not self._started:
+            return
+        self._started = False
+
+        if self._stop_event is not None:
+            self._stop_event.set()
+
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await asyncio.wait_for(self._task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            self._task = None
+
+        await self._cleanup_pubsub()
+        self._redis = None
+        get_runtime_state().set_cluster_propagation(PROPAGATION_DISABLED)
+
+    async def publish(self, change: ModeChange) -> bool:
+        """Publish a local override to the cluster.
+
+        The local override is already applied before this is called. We report
+        whether the publish (and hint persistence) succeeded so the admin
+        endpoint can surface a per-PATCH propagation status — without a
+        successful publish, peer pods will silently keep the previous mode.
+
+        Args:
+            change: ``ModeChange`` produced by ``RuntimeState.apply_local``.
+
+        Returns:
+            ``True`` when both the pub/sub publish and the hint write succeeded
+            (or when the coordinator is not attached to Redis, in which case
+            propagation was never expected). ``False`` when Redis was
+            attached but the publish or hint write failed.
+        """
+        if self._redis is None:
+            return True
+        payload = {
+            "runtime": change.runtime,
+            "mode": change.mode,
+            "version": change.version,
+            "initiator_user": change.initiator_user,
+            "initiator_pod": change.initiator_pod,
+            "timestamp": change.timestamp,
+        }
+        encoded = orjson.dumps(payload)
+        try:
+            await self._redis.publish(RUNTIME_STATE_CHANNEL, encoded)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error(
+                "RuntimeStateCoordinator: publish failed for %s mode=%s version=%d (local override still applied; peers may not have received the change): %s",
+                change.runtime,
+                change.mode,
+                change.version,
+                exc,
+            )
+            return False
+
+        try:
+            await self._redis.set(_hint_key(change.runtime), encoded, ex=RUNTIME_STATE_HINT_TTL_SECONDS)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error(
+                "RuntimeStateCoordinator: failed to persist override hint for %s (peers received the pub/sub message, but newly started pods will not reconcile): %s",
+                change.runtime,
+                exc,
+            )
+            return False
+        return True
+
+    async def next_version(self, runtime: str, current_version: int) -> int:
+        """Allocate the next monotonic version for ``runtime``.
+
+        When Redis is attached we ``INCR`` a per-runtime counter — this gives
+        the only guarantee that two pods racing on PATCH allocate distinct
+        versions. When Redis is intentionally not configured we fall back to
+        the local floor; that's safe per-pod because there is only one pod's
+        worth of state to track.
+
+        Args:
+            runtime: Runtime kind (``"mcp"`` or ``"a2a"``).
+            current_version: The local pod's current version, used as the floor when Redis is not configured.
+
+        Returns:
+            A version strictly greater than both the Redis counter (if attached) and ``current_version``.
+
+        Raises:
+            RuntimeStateError: When Redis is attached but ``INCR`` fails. We
+                deliberately do not fall back to ``current_version + 1`` here:
+                a local fallback can collide with a concurrent PATCH on
+                another pod and silently lose one of the two flips at peer
+                dedup time.
+        """
+        if self._redis is not None:
+            try:
+                value = await self._redis.incr(_version_key(runtime))
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                raise RuntimeStateError(
+                    f"Redis INCR failed for {_version_key(runtime)} ({exc!r}); refusing to allocate a local version that could collide with a concurrent PATCH on another pod. "
+                    "Check Redis connectivity (REDIS_URL, network reachability, auth) before retrying."
+                ) from exc
+            if int(value) > current_version:
+                return int(value)
+            # Redis counter was reset/deleted while pods were live; raise so
+            # the operator sees the inconsistency rather than silently
+            # publishing a version that peers will dedup as stale.
+            raise RuntimeStateError(
+                f"Redis counter at {_version_key(runtime)}={value} is not greater than local version {current_version}; "
+                "the counter may have been deleted, rolled back, or rotated under live pods. "
+                "Restart the coordinator or restore the counter manually (e.g. SET the key to a value greater than the local floor); "
+                "if Redis itself is unhealthy, also check connectivity (REDIS_URL, network reachability, auth)."
+            )
+        return current_version + 1
+
+    async def _reconcile_from_hint(self, runtime: Union[str, RuntimeKind]) -> None:
+        """Read the persisted override hint for ``runtime`` and apply it locally if newer.
+
+        A failed reconciliation is operationally significant: the pod will boot
+        with stale settings and continue serving the boot mode until the next
+        published flip corrects it. We log at ERROR, mark the per-runtime
+        ``boot_reconcile_status`` so ``/health`` records the cause, and
+        downgrade ``cluster_propagation`` to ``"degraded"`` so dashboards key
+        on a single field.
+
+        Args:
+            runtime: Runtime kind (``"mcp"`` or ``"a2a"``).
+        """
+        kind = _coerce_runtime(runtime)
+        state = get_runtime_state()
+        if self._redis is None:
+            state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
+            return
+        try:
+            raw = await self._redis.get(_hint_key(kind))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error(
+                "RuntimeStateCoordinator: failed to read boot hint for %s on pod %s; pod will boot with stale settings until a new override is published: %s",
+                kind.value,
+                state.pod_id,
+                exc,
+            )
+            state.set_cluster_propagation(PROPAGATION_DEGRADED)
+            state.set_boot_reconcile_status(kind, BootReconcileStatus.REDIS_UNAVAILABLE)
+            return
+        if not raw:
+            state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
+            return
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8", errors="replace")
+        try:
+            payload = orjson.loads(raw)
+        except orjson.JSONDecodeError as exc:
+            logger.error(
+                "RuntimeStateCoordinator: discarding malformed boot hint for %s on pod %s; pod will boot with stale settings until a new override is published: %s",
+                kind.value,
+                state.pod_id,
+                exc,
+            )
+            state.set_cluster_propagation(PROPAGATION_DEGRADED)
+            state.set_boot_reconcile_status(kind, BootReconcileStatus.MALFORMED_HINT)
+            return
+        # Hints persisted before this code knew about per-runtime keys may
+        # omit the "runtime" field — fill it in based on the key we read.
+        payload.setdefault("runtime", kind.value)
+        applied = await state.apply_remote(payload)
+        state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
+        if applied is not None:
+            logger.info(
+                "RuntimeStateCoordinator: reconciled %s boot state to %s (version=%d, initiator_pod=%s)",
+                applied.runtime.value,
+                applied.mode.value,
+                applied.version,
+                applied.initiator_pod,
+            )
+
+    async def _listen_loop(self) -> None:
+        """Background loop that applies remote runtime-mode messages.
+
+        Tracks consecutive ``get_message`` failures so that a permanent pub/sub
+        outage (Redis restart, network partition, auth lapse) is reflected in
+        ``cluster_propagation`` rather than silently busy-spinning while admin
+        responses keep advertising healthy propagation.
+        """
+        consecutive_errors = 0
+        state = get_runtime_state()
+        try:
+            while self._started and not (self._stop_event and self._stop_event.is_set()):
+                if self._pubsub is None:
+                    break
+                try:
+                    message = await asyncio.wait_for(
+                        self._pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0),
+                        timeout=2.0,
+                    )
+                except asyncio.TimeoutError:
+                    # Idle timeout is the normal path when no messages arrive;
+                    # treat it as evidence the subscriber is alive.
+                    if consecutive_errors > 0:
+                        consecutive_errors = 0
+                        if state.cluster_propagation == PROPAGATION_DEGRADED:
+                            state.set_cluster_propagation(PROPAGATION_REDIS)
+                            logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
+                    continue
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    consecutive_errors += 1
+                    if consecutive_errors == LISTEN_LOOP_DEGRADE_THRESHOLD:
+                        state.set_cluster_propagation(PROPAGATION_DEGRADED)
+                        logger.error(
+                            "RuntimeStateCoordinator: %d consecutive pub/sub receive failures; cluster_propagation downgraded to %s. Last error: %s",
+                            consecutive_errors,
+                            PROPAGATION_DEGRADED,
+                            exc,
+                        )
+                    else:
+                        logger.debug("RuntimeStateCoordinator: receive error (%d consecutive): %s", consecutive_errors, exc)
+                    await asyncio.sleep(0.1)
+                    continue
+                # Successful receive — clear failure counter and re-promote if needed.
+                if consecutive_errors > 0:
+                    consecutive_errors = 0
+                    if state.cluster_propagation == PROPAGATION_DEGRADED:
+                        state.set_cluster_propagation(PROPAGATION_REDIS)
+                        logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
+                if not message or message.get("type") != "message":
+                    continue
+                data = message.get("data")
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8", errors="replace")
+                if not data:
+                    continue
+                try:
+                    payload = orjson.loads(data)
+                except orjson.JSONDecodeError as exc:
+                    logger.warning("RuntimeStateCoordinator: discarding malformed pub/sub payload: %s", exc)
+                    continue
+                applied = await get_runtime_state().apply_remote(payload)
+                if applied is not None:
+                    logger.info(
+                        "RuntimeStateCoordinator: applied remote %s override mode=%s version=%d from pod=%s",
+                        applied.runtime,
+                        applied.mode,
+                        applied.version,
+                        applied.initiator_pod,
+                    )
+        except asyncio.CancelledError:
+            raise
+
+    async def _cleanup_pubsub(self) -> None:
+        """Unsubscribe and close the pubsub connection if open."""
+        if self._pubsub is None:
+            return
+        try:
+            try:
+                await asyncio.wait_for(self._pubsub.unsubscribe(RUNTIME_STATE_CHANNEL), timeout=2.0)
+            except asyncio.TimeoutError:
+                logger.debug("RuntimeStateCoordinator: unsubscribe timed out")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("RuntimeStateCoordinator: error during unsubscribe: %s", exc)
+        try:
+            try:
+                await asyncio.wait_for(self._pubsub.aclose(), timeout=2.0)
+            except AttributeError:
+                await asyncio.wait_for(self._pubsub.close(), timeout=2.0)
+        except asyncio.TimeoutError:
+            logger.debug("RuntimeStateCoordinator: pubsub close timed out")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("RuntimeStateCoordinator: error closing pubsub: %s", exc)
+        self._pubsub = None
+
+
+_coordinator: Optional[RuntimeStateCoordinator] = None
+
+
+def get_runtime_state_coordinator() -> RuntimeStateCoordinator:
+    """Return the process-wide ``RuntimeStateCoordinator`` singleton.
+
+    Returns:
+        The shared ``RuntimeStateCoordinator`` for this process.
+    """
+    global _coordinator
+    if _coordinator is None:
+        _coordinator = RuntimeStateCoordinator()
+    return _coordinator
+
+
+def reset_runtime_state_coordinator_for_tests() -> None:
+    """Clear the coordinator singleton. Tests only."""
+    global _coordinator
+    _coordinator = None

--- a/mcpgateway/runtime_state.py
+++ b/mcpgateway/runtime_state.py
@@ -107,6 +107,10 @@ class BootReconcileStatus(StrEnum):
     - ``OK``: hint either absent or applied successfully.
     - ``REDIS_UNAVAILABLE``: Redis read failed; pod boots with stale settings.
     - ``MALFORMED_HINT``: hint key existed but contained invalid JSON.
+    - ``INCOMPATIBLE_HINT``: hint key existed and was well-formed, but its
+      target mode cannot safely take effect on this deployment (e.g. a
+      hint written by an edge-boot pod was inherited by a later shadow-boot
+      deploy). The hint is discarded so diagnostics match reality.
     - ``PUBSUB_UNAVAILABLE``: pub/sub subscribe failed during start; this pod
       will not receive remote overrides until restart.
     - ``COORDINATOR_OFFLINE``: coordinator was never started (e.g. test mode
@@ -116,6 +120,7 @@ class BootReconcileStatus(StrEnum):
     OK = "ok"
     REDIS_UNAVAILABLE = "redis_unavailable"
     MALFORMED_HINT = "malformed_hint"
+    INCOMPATIBLE_HINT = "incompatible_hint"
     PUBSUB_UNAVAILABLE = "pubsub_unavailable"
     COORDINATOR_OFFLINE = "coordinator_offline"
 
@@ -131,6 +136,34 @@ PROPAGATION_DEGRADED: str = ClusterPropagation.DEGRADED.value
 
 class RuntimeStateError(Exception):
     """Raised when a runtime-mode change cannot be safely applied or propagated."""
+
+
+def _deployment_allows_mode(runtime: RuntimeKind, mode: OverrideMode) -> bool:
+    """Return whether ``mode`` can safely take effect for ``runtime`` on this deployment.
+
+    Mirrors the safety invariant in ``version._should_mount_public_rust_transport``
+    and ``version._should_delegate_a2a_to_rust``: edge requires BOTH the Rust
+    runtime enabled AND the session-auth-reuse (MCP) / delegate-enabled (A2A)
+    flag. shadow is always achievable (it is the Python-default state).
+
+    Args:
+        runtime: Runtime kind being evaluated.
+        mode: Target override mode to check.
+
+    Returns:
+        ``True`` when the deployment's boot-time flags allow ``mode`` to
+        actually change transport behavior; ``False`` otherwise.
+    """
+    if mode == OverrideMode.SHADOW:
+        return True
+    # First-Party: lazy to avoid import cycles with mcpgateway.config consumers.
+    from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+    if runtime == RuntimeKind.MCP:
+        return bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled)
+    if runtime == RuntimeKind.A2A:
+        return bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled)
+    return False
 
 
 def _coerce_runtime(value: Union[str, RuntimeKind]) -> RuntimeKind:
@@ -731,6 +764,29 @@ class RuntimeStateCoordinator:
         # Hints persisted before this code knew about per-runtime keys may
         # omit the "runtime" field — fill it in based on the key we read.
         payload.setdefault("runtime", kind.value)
+
+        # Discard hints whose target mode cannot safely take effect on this
+        # deployment. Without this guard, a hint written by a former
+        # edge-boot pod would linger in Redis and be applied on every
+        # shadow-boot pod that starts up — state would claim "edge" while
+        # the transport layer refuses to honor it, and the admin API would
+        # not be able to clear state on the new deployment's terms.
+        try:
+            hint_mode = _coerce_mode(payload.get("mode", ""))
+        except ValueError:
+            hint_mode = None
+        if hint_mode is not None and not _deployment_allows_mode(kind, hint_mode):
+            logger.warning(
+                "RuntimeStateCoordinator: discarding incompatible boot hint for %s (mode=%s) on pod %s; "
+                "this deployment's safety flags do not allow that mode to take effect, so the hint would "
+                "mislead diagnostics. A new PATCH is required to update cluster state.",
+                kind.value,
+                hint_mode.value,
+                state.pod_id,
+            )
+            state.set_boot_reconcile_status(kind, BootReconcileStatus.INCOMPATIBLE_HINT)
+            return
+
         applied = await state.apply_remote(payload)
         state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
         if applied is not None:

--- a/mcpgateway/runtime_state.py
+++ b/mcpgateway/runtime_state.py
@@ -141,28 +141,61 @@ class RuntimeStateError(Exception):
 def _deployment_allows_mode(runtime: RuntimeKind, mode: OverrideMode) -> bool:
     """Return whether ``mode`` can safely take effect for ``runtime`` on this deployment.
 
-    Mirrors the safety invariant in ``version._should_mount_public_rust_transport``
-    and ``version._should_delegate_a2a_to_rust``: edge requires BOTH the Rust
-    runtime enabled AND the session-auth-reuse (MCP) / delegate-enabled (A2A)
-    flag. shadow is always achievable (it is the Python-default state).
+    Matches the router's admit/reject logic so a reconciled hint only lands
+    in state when the router would have accepted the equivalent PATCH.
+    Two concerns compose:
+
+    1. **Is there a mechanism that could honor the override?** For MCP, an
+       override is observed only by the ``MCPStreamableHTTPModeDispatcher``,
+       which is mounted for ``boot=shadow`` and ``boot=edge`` only —
+       ``boot=off`` has no Rust sidecar and ``boot=full`` mounts a plain
+       Rust proxy with no dispatcher, so any override on those is stranded.
+       For A2A, overrides are observed per-invocation by
+       ``_should_delegate_a2a_to_rust``, which requires the A2A runtime to
+       be enabled at boot (i.e. not ``boot=off``).
+    2. **Does the target mode satisfy the safety invariant?** An ``edge``
+       override additionally requires the session-auth-reuse (MCP) or
+       delegate-enabled (A2A) flag; without it, routing public traffic to
+       Rust would be unsafe. See ``version._should_mount_public_rust_transport``
+       and ``version._should_delegate_a2a_to_rust``.
 
     Args:
         runtime: Runtime kind being evaluated.
         mode: Target override mode to check.
 
     Returns:
-        ``True`` when the deployment's boot-time flags allow ``mode`` to
-        actually change transport behavior; ``False`` otherwise.
+        ``True`` when the deployment's boot-time configuration can both
+        observe AND safely honor ``mode``; ``False`` otherwise.
     """
-    if mode == OverrideMode.SHADOW:
-        return True
     # First-Party: lazy to avoid import cycles with mcpgateway.config consumers.
     from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
 
     if runtime == RuntimeKind.MCP:
-        return bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled)
+        if not settings.experimental_rust_mcp_runtime_enabled:
+            return False  # boot=off: no sidecar, no dispatcher, no mechanism
+        # boot=full: all Rust-owned cores enabled → no dispatcher is mounted,
+        # so an override (even shadow) would strand in state.
+        is_full_boot = bool(
+            settings.experimental_rust_mcp_session_auth_reuse_enabled
+            and settings.experimental_rust_mcp_session_core_enabled
+            and settings.experimental_rust_mcp_event_store_enabled
+            and settings.experimental_rust_mcp_resume_core_enabled
+            and settings.experimental_rust_mcp_live_stream_core_enabled
+            and settings.experimental_rust_mcp_affinity_core_enabled
+        )
+        if is_full_boot:
+            return False
+        # boot=shadow or boot=edge: dispatcher is mounted, so shadow always works.
+        if mode == OverrideMode.SHADOW:
+            return True
+        # mode == OverrideMode.EDGE: safety invariant requires session-auth-reuse.
+        return bool(settings.experimental_rust_mcp_session_auth_reuse_enabled)
     if runtime == RuntimeKind.A2A:
-        return bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled)
+        if not settings.experimental_rust_a2a_runtime_enabled:
+            return False  # A2A boot=off: runtime disabled, override cannot apply
+        if mode == OverrideMode.SHADOW:
+            return True
+        return bool(settings.experimental_rust_a2a_runtime_delegate_enabled)
     return False
 
 

--- a/mcpgateway/runtime_state.py
+++ b/mcpgateway/runtime_state.py
@@ -107,10 +107,18 @@ class BootReconcileStatus(StrEnum):
     - ``OK``: hint either absent or applied successfully.
     - ``REDIS_UNAVAILABLE``: Redis read failed; pod boots with stale settings.
     - ``MALFORMED_HINT``: hint key existed but contained invalid JSON.
-    - ``INCOMPATIBLE_HINT``: hint key existed and was well-formed, but its
-      target mode cannot safely take effect on this deployment (e.g. a
-      hint written by an edge-boot pod was inherited by a later shadow-boot
-      deploy). The hint is discarded so diagnostics match reality.
+    - ``INCOMPATIBLE_NO_DISPATCHER``: hint targeted a runtime that has no
+      dispatcher mounted on this deployment (e.g. ``boot=off`` for either
+      runtime). The hint is discarded; the operator must boot with the
+      runtime enabled for the hint to take effect.
+    - ``INCOMPATIBLE_BOOT_FULL``: hint targeted MCP on a ``boot=full`` pod.
+      Full-boot mounts a plain Rust proxy with no dispatcher, so the
+      override would strand. Operator action: boot with ``RUST_MCP_MODE=edge``.
+    - ``INCOMPATIBLE_SAFETY_FLAG``: hint requested ``edge`` but the
+      deployment did not opt into the session-auth-reuse (MCP) or
+      delegate-enabled (A2A) safety flag at boot. Operator action:
+      enable the corresponding flag (typically by booting with
+      ``RUST_MCP_MODE=edge`` / ``RUST_A2A_MODE=edge``).
     - ``PUBSUB_UNAVAILABLE``: pub/sub subscribe failed during start; this pod
       will not receive remote overrides until restart.
     - ``COORDINATOR_OFFLINE``: coordinator was never started (e.g. test mode
@@ -120,9 +128,47 @@ class BootReconcileStatus(StrEnum):
     OK = "ok"
     REDIS_UNAVAILABLE = "redis_unavailable"
     MALFORMED_HINT = "malformed_hint"
-    INCOMPATIBLE_HINT = "incompatible_hint"
+    INCOMPATIBLE_NO_DISPATCHER = "incompatible_no_dispatcher"
+    INCOMPATIBLE_BOOT_FULL = "incompatible_boot_full"
+    INCOMPATIBLE_SAFETY_FLAG = "incompatible_safety_flag"
     PUBSUB_UNAVAILABLE = "pubsub_unavailable"
     COORDINATOR_OFFLINE = "coordinator_offline"
+
+
+class MoveCompatibility(StrEnum):
+    """Why a runtime override is or is not safely applicable on this deployment.
+
+    Returned by ``version.deployment_allows_override_mode`` and consumed both
+    by the boot-hint reconciliation path and the admin router. Carrying the
+    structured reason (instead of a bare bool) lets the coordinator surface
+    a granular ``BootReconcileStatus`` and the router emit operator-actionable
+    409 details that name the exact env var or flag to flip.
+    """
+
+    OK = "ok"
+    NO_DISPATCHER = "no_dispatcher"
+    BOOT_FULL_STRANDS = "boot_full_strands"
+    EDGE_NEEDS_SAFETY_FLAG = "edge_needs_safety_flag"
+
+
+def _move_compat_to_reconcile_status(compat: "MoveCompatibility") -> "BootReconcileStatus":
+    """Map a ``MoveCompatibility`` rejection reason to its ``BootReconcileStatus`` peer.
+
+    Args:
+        compat: A non-OK ``MoveCompatibility`` value.
+
+    Returns:
+        The matching ``BootReconcileStatus``. ``OK`` maps to ``OK`` for symmetry.
+    """
+    if compat == MoveCompatibility.OK:
+        return BootReconcileStatus.OK
+    if compat == MoveCompatibility.NO_DISPATCHER:
+        return BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER
+    if compat == MoveCompatibility.BOOT_FULL_STRANDS:
+        return BootReconcileStatus.INCOMPATIBLE_BOOT_FULL
+    if compat == MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG:
+        return BootReconcileStatus.INCOMPATIBLE_SAFETY_FLAG
+    return BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER  # defensive default
 
 
 # Backward-compat aliases for callers that consume the bare string set or the
@@ -136,67 +182,6 @@ PROPAGATION_DEGRADED: str = ClusterPropagation.DEGRADED.value
 
 class RuntimeStateError(Exception):
     """Raised when a runtime-mode change cannot be safely applied or propagated."""
-
-
-def _deployment_allows_mode(runtime: RuntimeKind, mode: OverrideMode) -> bool:
-    """Return whether ``mode`` can safely take effect for ``runtime`` on this deployment.
-
-    Matches the router's admit/reject logic so a reconciled hint only lands
-    in state when the router would have accepted the equivalent PATCH.
-    Two concerns compose:
-
-    1. **Is there a mechanism that could honor the override?** For MCP, an
-       override is observed only by the ``MCPStreamableHTTPModeDispatcher``,
-       which is mounted for ``boot=shadow`` and ``boot=edge`` only —
-       ``boot=off`` has no Rust sidecar and ``boot=full`` mounts a plain
-       Rust proxy with no dispatcher, so any override on those is stranded.
-       For A2A, overrides are observed per-invocation by
-       ``_should_delegate_a2a_to_rust``, which requires the A2A runtime to
-       be enabled at boot (i.e. not ``boot=off``).
-    2. **Does the target mode satisfy the safety invariant?** An ``edge``
-       override additionally requires the session-auth-reuse (MCP) or
-       delegate-enabled (A2A) flag; without it, routing public traffic to
-       Rust would be unsafe. See ``version._should_mount_public_rust_transport``
-       and ``version._should_delegate_a2a_to_rust``.
-
-    Args:
-        runtime: Runtime kind being evaluated.
-        mode: Target override mode to check.
-
-    Returns:
-        ``True`` when the deployment's boot-time configuration can both
-        observe AND safely honor ``mode``; ``False`` otherwise.
-    """
-    # First-Party: lazy to avoid import cycles with mcpgateway.config consumers.
-    from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
-
-    if runtime == RuntimeKind.MCP:
-        if not settings.experimental_rust_mcp_runtime_enabled:
-            return False  # boot=off: no sidecar, no dispatcher, no mechanism
-        # boot=full: all Rust-owned cores enabled → no dispatcher is mounted,
-        # so an override (even shadow) would strand in state.
-        is_full_boot = bool(
-            settings.experimental_rust_mcp_session_auth_reuse_enabled
-            and settings.experimental_rust_mcp_session_core_enabled
-            and settings.experimental_rust_mcp_event_store_enabled
-            and settings.experimental_rust_mcp_resume_core_enabled
-            and settings.experimental_rust_mcp_live_stream_core_enabled
-            and settings.experimental_rust_mcp_affinity_core_enabled
-        )
-        if is_full_boot:
-            return False
-        # boot=shadow or boot=edge: dispatcher is mounted, so shadow always works.
-        if mode == OverrideMode.SHADOW:
-            return True
-        # mode == OverrideMode.EDGE: safety invariant requires session-auth-reuse.
-        return bool(settings.experimental_rust_mcp_session_auth_reuse_enabled)
-    if runtime == RuntimeKind.A2A:
-        if not settings.experimental_rust_a2a_runtime_enabled:
-            return False  # A2A boot=off: runtime disabled, override cannot apply
-        if mode == OverrideMode.SHADOW:
-            return True
-        return bool(settings.experimental_rust_a2a_runtime_delegate_enabled)
-    return False
 
 
 def _coerce_runtime(value: Union[str, RuntimeKind]) -> RuntimeKind:
@@ -804,21 +789,34 @@ class RuntimeStateCoordinator:
         # shadow-boot pod that starts up — state would claim "edge" while
         # the transport layer refuses to honor it, and the admin API would
         # not be able to clear state on the new deployment's terms.
+        #
+        # The Redis hint key is intentionally NOT deleted here: a future
+        # compatible-boot pod (e.g. the operator restores RUST_MCP_MODE=edge
+        # in a later deploy) must still be able to read it for boot
+        # reconciliation. Stale hints expire on their own via the 24h TTL
+        # set at publish time; an operator who wants to clear immediately
+        # can DEL the contextforge:runtime:mode_state:{runtime} key.
         try:
             hint_mode = _coerce_mode(payload.get("mode", ""))
         except ValueError:
             hint_mode = None
-        if hint_mode is not None and not _deployment_allows_mode(kind, hint_mode):
-            logger.warning(
-                "RuntimeStateCoordinator: discarding incompatible boot hint for %s (mode=%s) on pod %s; "
-                "this deployment's safety flags do not allow that mode to take effect, so the hint would "
-                "mislead diagnostics. A new PATCH is required to update cluster state.",
-                kind.value,
-                hint_mode.value,
-                state.pod_id,
-            )
-            state.set_boot_reconcile_status(kind, BootReconcileStatus.INCOMPATIBLE_HINT)
-            return
+        if hint_mode is not None:
+            # First-Party: lazy to avoid the version <-> runtime_state import cycle.
+            from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel
+
+            compat = _deployment_allows_override_mode(kind, hint_mode)
+            if compat != MoveCompatibility.OK:
+                logger.warning(
+                    "RuntimeStateCoordinator: discarding incompatible boot hint for %s (mode=%s) on pod %s; "
+                    "reason=%s. Hint key is left in Redis for future compatible-boot pods; an operator can "
+                    "DEL the hint key to force-clear cluster state.",
+                    kind.value,
+                    hint_mode.value,
+                    state.pod_id,
+                    compat.value,
+                )
+                state.set_boot_reconcile_status(kind, _move_compat_to_reconcile_status(compat))
+                return
 
         applied = await state.apply_remote(payload)
         state.set_boot_reconcile_status(kind, BootReconcileStatus.OK)
@@ -873,14 +871,18 @@ class RuntimeStateCoordinator:
                         logger.debug("RuntimeStateCoordinator: receive error (%d consecutive): %s", consecutive_errors, exc)
                     await asyncio.sleep(0.1)
                     continue
-                # Successful receive — clear failure counter and re-promote if needed.
+                # A non-exception return without a real message (e.g. ``None`` from
+                # a pubsub that's broken in a way that doesn't raise) is NOT
+                # evidence the subscriber is alive — the idle-timeout branch above
+                # handles the legit silence case. Only count real messages as
+                # "subscriber is healthy" for the recovery promotion.
+                if not message or message.get("type") != "message":
+                    continue
                 if consecutive_errors > 0:
                     consecutive_errors = 0
                     if state.cluster_propagation == PROPAGATION_DEGRADED:
                         state.set_cluster_propagation(PROPAGATION_REDIS)
                         logger.info("RuntimeStateCoordinator: pub/sub recovered, cluster_propagation back to %s", PROPAGATION_REDIS)
-                if not message or message.get("type") != "message":
-                    continue
                 data = message.get("data")
                 if isinstance(data, bytes):
                     data = data.decode("utf-8", errors="replace")
@@ -891,6 +893,34 @@ class RuntimeStateCoordinator:
                 except orjson.JSONDecodeError as exc:
                     logger.warning("RuntimeStateCoordinator: discarding malformed pub/sub payload: %s", exc)
                     continue
+                # Mirror _reconcile_from_hint's compatibility check: a remote pod
+                # may publish a flip that this pod cannot safely honor (e.g. an
+                # edge-boot pod publishes ``edge`` and a shadow-boot peer
+                # receives it). Without this guard the override would land in
+                # local state, the transport layer would refuse to honor it,
+                # and diagnostics would lie. Discard with a WARN.
+                try:
+                    remote_mode = _coerce_mode(payload.get("mode", ""))
+                    remote_runtime = _coerce_runtime(payload.get("runtime", ""))
+                except ValueError:
+                    # apply_remote will log the malformed payload; let it run.
+                    remote_mode = None
+                    remote_runtime = None
+                if remote_mode is not None and remote_runtime is not None:
+                    # First-Party: lazy to avoid the version <-> runtime_state import cycle.
+                    from mcpgateway.version import _deployment_allows_override_mode  # pylint: disable=import-outside-toplevel
+
+                    remote_compat = _deployment_allows_override_mode(remote_runtime, remote_mode)
+                    if remote_compat != MoveCompatibility.OK:
+                        logger.warning(
+                            "RuntimeStateCoordinator: discarding incompatible remote override for %s (mode=%s) from pod=%s; "
+                            "reason=%s. The publishing pod's flags allow this mode but this pod's do not.",
+                            remote_runtime.value,
+                            remote_mode.value,
+                            payload.get("initiator_pod", "unknown"),
+                            remote_compat.value,
+                        )
+                        continue
                 applied = await get_runtime_state().apply_remote(payload)
                 if applied is not None:
                     logger.info(

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -53,6 +53,21 @@ _REGISTRY_CACHE = None
 _TOOL_LOOKUP_CACHE = None
 
 
+def _should_delegate_a2a_to_rust() -> bool:
+    """Return whether A2A invocations should be delegated to the Rust runtime.
+
+    Lazy import of ``mcpgateway.version`` avoids the circular import between
+    ``mcpgateway.services`` package init and ``mcpgateway.version``.
+
+    Returns:
+        ``True`` when the Rust A2A runtime should service invocations.
+    """
+    # First-Party
+    from mcpgateway.version import should_delegate_a2a_to_rust  # pylint: disable=import-outside-toplevel
+
+    return should_delegate_a2a_to_rust()
+
+
 def _get_registry_cache():
     """Get registry cache singleton lazily.
 
@@ -1693,11 +1708,11 @@ class A2AAgentService(BaseService):
                         "endpoint_url": prepared.sanitized_endpoint_url,
                         "interaction_type": interaction_type,
                         "protocol_version": agent_protocol_version,
-                        "runtime": "rust" if settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled else "python",
+                        "runtime": "rust" if _should_delegate_a2a_to_rust() else "python",
                     },
                 )
 
-                if settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled:
+                if _should_delegate_a2a_to_rust():
                     runtime_response = await get_rust_a2a_runtime_client().invoke(
                         prepared,
                         timeout_seconds=int(settings.mcpgateway_a2a_default_timeout),
@@ -1790,7 +1805,7 @@ class A2AAgentService(BaseService):
                     # delegate mode (experimental_rust_a2a_runtime_delegate_enabled=true)
                     # for full Rust-path execution.
                     # ═══════════════════════════════════════════════════════════════════════════
-                    if settings.experimental_rust_a2a_runtime_enabled and not settings.experimental_rust_a2a_runtime_delegate_enabled:
+                    if settings.experimental_rust_a2a_runtime_enabled and not _should_delegate_a2a_to_rust():
                         structured_logger.log(
                             level="INFO",
                             message=f"A2A shadow mode active (observe-only): {agent_name}",

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5470,7 +5470,10 @@ class ToolService(BaseService):
                         logger.info(f"Calling A2A agent '{a2a_agent_name}' at {prepared.sanitized_endpoint_url}")
                         a2a_start_time = time.time()
                         try:
-                            if settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled:
+                            # First-Party
+                            from mcpgateway.version import should_delegate_a2a_to_rust  # pylint: disable=import-outside-toplevel
+
+                            if should_delegate_a2a_to_rust():
                                 runtime_response = await get_rust_a2a_runtime_client().invoke(prepared, timeout_seconds=int(max(1, effective_timeout)))
                                 status_code = int(runtime_response.get("status_code", 200))
                                 response_data = runtime_response.get("json")
@@ -6651,7 +6654,10 @@ class ToolService(BaseService):
         )
         logger.info(f"invoke tool request_data prepared: {prepared.request_data}")
 
-        if settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled:
+        # First-Party
+        from mcpgateway.version import should_delegate_a2a_to_rust  # pylint: disable=import-outside-toplevel
+
+        if should_delegate_a2a_to_rust():
             runtime_response = await get_rust_a2a_runtime_client().invoke(
                 prepared,
                 timeout_seconds=int(settings.mcpgateway_a2a_default_timeout),

--- a/mcpgateway/transports/mcp_ingress_mount.py
+++ b/mcpgateway/transports/mcp_ingress_mount.py
@@ -14,8 +14,9 @@ shadow-comparison, percentage-traffic-split, …) is a one-line
 This replaces the role of the prior ``MCPStreamableHTTPModeDispatcher``
 (which was hard-coded to a Python transport plus a single Rust transport,
 with the per-request choice baked into its ``handle_streamable_http``
-method). See ``docs/docs/architecture/adr/051-...md`` for the design
-decision and migration notes.
+method). See
+``docs/docs/architecture/adr/051-swappable-mcp-ingress-mount.md`` for
+the design decision and migration notes.
 """
 
 # Future
@@ -156,10 +157,24 @@ class MCPIngressMount:
         name = self._selector(scope)
         app = self._ingresses.get(name)
         if app is None:
+            # Selector miss is an invariant violation — the registered set
+            # and the policy are out of sync. Either path (fallback or
+            # 503) deserves a warning, not debug, so a misconfigured
+            # selector doesn't silently route auth-sensitive traffic to
+            # the wrong handler.
             if self._fallback is None:
+                logger.warning(
+                    "MCPIngressMount: selector returned %r but no ingress is registered under that name; available=%s. Returning 503.",
+                    name,
+                    self.names(),
+                )
                 await self._send_503(send, name)
                 return
-            logger.debug("MCPIngressMount: ingress %r not registered, using fallback", name)
+            logger.warning(
+                "MCPIngressMount: selector returned %r which is not registered; available=%s. Falling back to the configured fallback app.",
+                name,
+                self.names(),
+            )
             app = self._fallback
         await app(scope, receive, send)
 

--- a/mcpgateway/transports/mcp_ingress_mount.py
+++ b/mcpgateway/transports/mcp_ingress_mount.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/transports/mcp_ingress_mount.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Swappable mount point for the public ``/mcp`` ingress.
+
+The mount itself owns no routing policy. It holds a registry of named
+ingress ASGI apps and a callable that returns the name of whichever one
+should serve the current request. Adding a new ingress (rust-public-proxy,
+shadow-comparison, percentage-traffic-split, …) is a one-line
+``register()`` call; selection policy is one function.
+
+This replaces the role of the prior ``MCPStreamableHTTPModeDispatcher``
+(which was hard-coded to a Python transport plus a single Rust transport,
+with the per-request choice baked into its ``handle_streamable_http``
+method). See ``docs/docs/architecture/adr/051-...md`` for the design
+decision and migration notes.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Awaitable, Callable, Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class ASGIApp(Protocol):
+    """ASGI 3.0 callable. Any ingress registered with the mount must satisfy this."""
+
+    async def __call__(self, scope: dict, receive: Callable[[], Awaitable[dict]], send: Callable[[dict], Awaitable[None]]) -> None:
+        """ASGI 3.0 entry point. Implementations consume ``receive`` and emit via ``send``."""
+        ...
+
+
+# An ``IngressSelector`` returns the registered ingress name to serve THIS
+# request. It receives the ASGI scope so policies can inspect method, path,
+# headers, query — useful for routing GET /mcp (SSE) differently from POST.
+IngressSelector = Callable[[dict], str]
+
+
+class MCPIngressMount:
+    """Indirection at /mcp that delegates to a swappable inner ASGI app.
+
+    Lifecycle:
+      1. Construct with a selector and (optionally) a fallback ingress.
+      2. Register every ingress this build supports.
+      3. Mount once at /mcp via ``app.mount("/mcp", mount.dispatch)``.
+      4. Add/replace ingresses or swap the selector at runtime; the mount
+         picks them up on the next request.
+
+    Concurrency: ingress lookup is a single dict read on the request hot
+    path, no locks. Registration writes are not synchronized — the
+    assumption is that ingresses are registered at startup and changed
+    only via admin actions that already go through their own coordination
+    (e.g. the runtime override coordinator). If you need atomic policy
+    swaps mid-flight, swap the selector via :meth:`set_selector` rather
+    than rewriting registrations.
+
+    Drain semantics: an ingress that owns long-lived connections (SSE,
+    chunked POST) keeps serving them even after it is unregistered or
+    selected away from. The next request just routes to the new ingress.
+    This matches the prior dispatcher's "natural drain" property.
+    """
+
+    def __init__(
+        self,
+        *,
+        selector: IngressSelector,
+        fallback: Optional[ASGIApp] = None,
+    ) -> None:
+        """Initialize the mount with a selection policy and optional fallback.
+
+        Args:
+            selector: Function that returns the registered ingress name to
+                serve a given ASGI scope.
+            fallback: ASGI app used when the selector returns a name that
+                isn't registered. ``None`` means "send a 503 naming the
+                missing ingress" — useful in dev to fail loudly; production
+                deployments typically pass the Python transport here.
+        """
+        self._ingresses: Dict[str, ASGIApp] = {}
+        self._selector = selector
+        self._fallback = fallback
+
+    # ── registry -----------------------------------------------------------
+
+    def register(self, name: str, app: ASGIApp) -> None:
+        """Register an ingress under ``name``.
+
+        Idempotent — calling ``register("x", app1)`` then
+        ``register("x", app2)`` replaces ``app1``.
+
+        Args:
+            name: Identifier the selector will return to pick this app.
+            app: ASGI 3.0 callable.
+        """
+        self._ingresses[name] = app
+
+    def unregister(self, name: str) -> Optional[ASGIApp]:
+        """Remove an ingress; returns the prior app for graceful shutdown.
+
+        Args:
+            name: Ingress identifier.
+
+        Returns:
+            The previously-registered ASGI app, or ``None`` if the name
+            wasn't registered. Caller is responsible for any drain or
+            cleanup on the returned app.
+        """
+        return self._ingresses.pop(name, None)
+
+    def names(self) -> List[str]:
+        """Return the sorted list of currently-registered ingress names.
+
+        Returns:
+            Sorted list of ingress names. Useful for diagnostics, /health,
+            and the 503 body when a selector returns an unknown name.
+        """
+        return sorted(self._ingresses)
+
+    # ── policy ------------------------------------------------------------
+
+    def set_selector(self, selector: IngressSelector) -> None:
+        """Atomically swap the selection policy.
+
+        Args:
+            selector: New selector function. Takes effect on the next
+                request — in-flight requests already inside an ingress
+                continue under the old selection.
+        """
+        self._selector = selector
+
+    def set_fallback(self, app: Optional[ASGIApp]) -> None:
+        """Update the fallback app used when the selector misses.
+
+        Args:
+            app: New fallback ASGI app, or ``None`` to restore the
+                503-on-miss behavior.
+        """
+        self._fallback = app
+
+    # ── ASGI app ---------------------------------------------------------
+
+    async def dispatch(self, scope: dict, receive: Callable, send: Callable) -> None:
+        """ASGI entry point. Picks an ingress per request and delegates.
+
+        Args:
+            scope: ASGI scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        name = self._selector(scope)
+        app = self._ingresses.get(name)
+        if app is None:
+            if self._fallback is None:
+                await self._send_503(send, name)
+                return
+            logger.debug("MCPIngressMount: ingress %r not registered, using fallback", name)
+            app = self._fallback
+        await app(scope, receive, send)
+
+    async def _send_503(self, send: Callable, missing_name: str) -> None:
+        """Emit a 503 response naming the missing ingress.
+
+        Args:
+            send: ASGI send callable.
+            missing_name: The ingress name the selector returned.
+        """
+        body = (f"MCP ingress {missing_name!r} is not registered for this build; " f"available: {self.names() or '[]'}").encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 503,
+                "headers": [
+                    (b"content-type", b"text/plain; charset=utf-8"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/mcpgateway/transports/mcp_ingress_mount.py
+++ b/mcpgateway/transports/mcp_ingress_mount.py
@@ -34,7 +34,6 @@ class ASGIApp(Protocol):
 
     async def __call__(self, scope: dict, receive: Callable[[], Awaitable[dict]], send: Callable[[dict], Awaitable[None]]) -> None:
         """ASGI 3.0 entry point. Implementations consume ``receive`` and emit via ``send``."""
-        ...
 
 
 # An ``IngressSelector`` returns the registered ingress name to serve THIS

--- a/mcpgateway/transports/rust_mcp_public_proxy.py
+++ b/mcpgateway/transports/rust_mcp_public_proxy.py
@@ -34,6 +34,7 @@ the selector picks it when ``settings.mcp_rust_ingress == "public"``.
 from __future__ import annotations
 
 # Standard
+import asyncio
 import logging
 from typing import Awaitable, Callable, Optional
 
@@ -75,14 +76,61 @@ _HOP_BY_HOP_RESPONSE = frozenset(
         "upgrade",
     }
 )
+# Forwarded-chain headers are dropped from the inbound request and
+# re-set unconditionally below. This is the no-nginx-in-front case: the
+# immediate hop is the client, so we cannot trust any value they
+# pre-populate. The set is intentionally a superset of the
+# trusted-internal proxy's forwarded-chain set (it additionally drops
+# ``x-real-ip`` because we re-derive it from the ASGI client info).
+_FORWARDED_CHAIN_HEADERS = frozenset(
+    {
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-port",
+        "x-forwarded-proto",
+        "x-real-ip",
+    }
+)
+
+
+def _format_forwarded_for(host: Optional[str], port: int) -> str:
+    """Format an RFC 7239 ``for=`` directive value.
+
+    Args:
+        host: Client host (may be IPv4, IPv6, or ``None``).
+        port: Client port; ``0`` is treated as "no port" because
+            Starlette synthesizes ``0`` when ``request.client`` is
+            unavailable, which is not a valid port number to advertise.
+
+    Returns:
+        A token suitable as the value of ``for=`` — ``unknown`` for
+        absent clients, otherwise a quoted ``"ip[:port]"`` (with IPv6
+        addresses bracketed per RFC 3986).
+    """
+    if not host:
+        return "unknown"
+    # IPv6 addresses contain colons and must be bracketed per RFC 3986;
+    # detect already-bracketed input so a caller passing "[::1]" doesn't
+    # end up with "[[::1]]".
+    if ":" in host and not (host.startswith("[") and host.endswith("]")):
+        address = f"[{host}]"
+    else:
+        address = host
+    return f'"{address}:{port}"' if port else f'"{address}"'
 
 
 def _build_forwarded_headers(request: Request) -> dict:
     """Construct the request headers Rust's public listener will see.
 
-    Strips hop-by-hop headers, preserves auth / cookies / content-type /
-    MCP session headers, and adds nginx-style forwarded metadata so
-    Rust's auth callback sees the original client.
+    Strips hop-by-hop and forwarded-chain headers from the inbound
+    request, preserves auth / cookies / content-type / MCP session
+    headers, then adds nginx-style forwarded metadata derived from the
+    trusted ASGI ``request.client`` info. The forwarded-chain strip is
+    a security control: this proxy is the first hop in the
+    no-nginx-in-front deployment, so any client-supplied
+    ``X-Forwarded-*`` or ``Forwarded`` value would let the caller spoof
+    their own source IP to Rust's auth callback.
 
     Args:
         request: Incoming Starlette request.
@@ -92,19 +140,20 @@ def _build_forwarded_headers(request: Request) -> dict:
     """
     forwarded: dict = {}
     for name, value in request.headers.items():
-        if name.lower() in _HOP_BY_HOP_REQUEST:
+        lowered = name.lower()
+        if lowered in _HOP_BY_HOP_REQUEST or lowered in _FORWARDED_CHAIN_HEADERS:
             continue
         forwarded[name] = value
 
-    client_host = request.client.host if request.client else "unknown"
+    client_host = request.client.host if request.client else None
     client_port = request.client.port if request.client else 0
+    host_header = request.headers.get("host", "")
 
-    existing_xff = request.headers.get("x-forwarded-for", "")
-    forwarded["X-Forwarded-For"] = f"{existing_xff}, {client_host}".lstrip(", ") if existing_xff else client_host
+    forwarded["X-Forwarded-For"] = client_host or "unknown"
     forwarded["X-Forwarded-Proto"] = request.url.scheme
-    forwarded["X-Forwarded-Host"] = request.headers.get("host", "")
-    forwarded["X-Real-IP"] = client_host
-    forwarded["Forwarded"] = f'for="{client_host}:{client_port}";' f"proto={request.url.scheme};" f'host={request.headers.get("host", "")}'
+    forwarded["X-Forwarded-Host"] = host_header
+    forwarded["X-Real-IP"] = client_host or "unknown"
+    forwarded["Forwarded"] = f'for={_format_forwarded_for(client_host, client_port)};proto={request.url.scheme};host="{host_header}"'
     return forwarded
 
 
@@ -171,21 +220,32 @@ class RustMCPPublicProxyApp:
             return
 
         request = Request(scope, receive)
-        client = await self._get_client()
         upstream_path = scope.get("path", "/")
-        headers = _build_forwarded_headers(request)
+        method = request.method
 
         try:
+            client = await self._get_client()
+            headers = _build_forwarded_headers(request)
             upstream_request = client.build_request(
-                method=request.method,
+                method=method,
                 url=upstream_path,
                 headers=headers,
                 params=request.query_params,
                 content=request.stream(),
             )
             upstream_response = await client.send(upstream_request, stream=True)
+        except asyncio.CancelledError:
+            # Client disconnected before upstream replied — let asyncio
+            # propagate the cancel rather than swallowing it.
+            raise
         except httpx.HTTPError as exc:
-            logger.error("rust-public ingress: upstream request to %s failed: %s", upstream_path, exc)
+            logger.error(
+                "rust-public ingress: upstream %s %s failed (%s): %s",
+                method,
+                upstream_path,
+                type(exc).__name__,
+                exc,
+            )
             error_response = Response(
                 status_code=502,
                 content=b"Rust MCP public ingress unavailable",
@@ -193,14 +253,64 @@ class RustMCPPublicProxyApp:
             )
             await error_response(scope, receive, send)
             return
+        except Exception:  # pylint: disable=broad-except
+            # Defensive catch-all: anything else (RuntimeError, SSLError
+            # subclasses outside HTTPError, etc.) becomes a 500 with a
+            # logged stack trace, so silent 500s never reach the client
+            # without a server-side breadcrumb.
+            logger.exception(
+                "rust-public ingress: unexpected error preparing upstream %s %s",
+                method,
+                upstream_path,
+            )
+            error_response = Response(
+                status_code=500,
+                content=b"Rust MCP public ingress error",
+                media_type="text/plain",
+            )
+            await error_response(scope, receive, send)
+            return
+
+        # Auth-relevant or server-error upstream statuses get a warning so
+        # ops can spot a flood of 401s after a credential rotation, or a
+        # cascading 503, without raising the log level globally.
+        if upstream_response.status_code >= 500 or upstream_response.status_code in (401, 403):
+            logger.warning(
+                "rust-public ingress: upstream %s %s returned %d",
+                method,
+                upstream_path,
+                upstream_response.status_code,
+            )
 
         response_headers = {name: value for name, value in upstream_response.headers.items() if name.lower() not in _HOP_BY_HOP_RESPONSE}
 
         async def _body_iter():
-            """Stream the upstream response body chunk-by-chunk and close on exit."""
+            """Stream the upstream response body and close the upstream connection on exit.
+
+            The ``finally`` returns the connection to the pool whether
+            iteration completes normally, the client disconnects
+            (``CancelledError``), or upstream errors mid-stream. Errors
+            other than cancellation are logged with the upstream context
+            so a mid-SSE Rust crash leaves a breadcrumb instead of just
+            a generic Starlette 500.
+            """
             try:
                 async for chunk in upstream_response.aiter_raw():
                     yield chunk
+            except asyncio.CancelledError:
+                logger.debug(
+                    "rust-public ingress: client disconnected mid-stream from upstream %s %s",
+                    method,
+                    upstream_path,
+                )
+                raise
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "rust-public ingress: error streaming body from upstream %s %s",
+                    method,
+                    upstream_path,
+                )
+                raise
             finally:
                 await upstream_response.aclose()
 

--- a/mcpgateway/transports/rust_mcp_public_proxy.py
+++ b/mcpgateway/transports/rust_mcp_public_proxy.py
@@ -223,6 +223,9 @@ class RustMCPPublicProxyApp:
         upstream_path = scope.get("path", "/")
         method = request.method
 
+        # asyncio.CancelledError is BaseException in 3.8+ — neither the
+        # httpx.HTTPError nor the bare ``Exception`` arms below will swallow
+        # a client-disconnect cancel; it propagates out naturally.
         try:
             client = await self._get_client()
             headers = _build_forwarded_headers(request)
@@ -234,10 +237,6 @@ class RustMCPPublicProxyApp:
                 content=request.stream(),
             )
             upstream_response = await client.send(upstream_request, stream=True)
-        except asyncio.CancelledError:
-            # Client disconnected before upstream replied — let asyncio
-            # propagate the cancel rather than swallowing it.
-            raise
         except httpx.HTTPError as exc:
             logger.error(
                 "rust-public ingress: upstream %s %s failed (%s): %s",

--- a/mcpgateway/transports/rust_mcp_public_proxy.py
+++ b/mcpgateway/transports/rust_mcp_public_proxy.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/transports/rust_mcp_public_proxy.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+nginx-style reverse proxy to the Rust MCP public listener.
+
+Use this when the gateway is the only public ingress (no nginx in front)
+but you still want public ``/mcp`` traffic to bypass Python's transport
+on the hot path. Routes to ``MCP_RUST_PUBLIC_LISTEN_HTTP`` (Rust's
+authenticated public endpoint), not the trusted-internal
+``MCP_RUST_LISTEN_HTTP`` that ``RustMCPRuntimeProxy`` uses.
+
+Differences from ``RustMCPRuntimeProxy``
+(``mcpgateway/transports/rust_mcp_runtime_proxy.py``):
+
+- Forwards to the **public** listener (Rust calls back into Python for
+  auth via ``/_internal/mcp/authenticate``), not the trusted-internal
+  listener that assumes Python pre-authenticated.
+- Adds ``X-Forwarded-{For,Proto,Host}``, RFC 7239 ``Forwarded``, and
+  ``X-Real-IP`` — nginx-style — so Rust's auth path sees the original
+  client info instead of ``127.0.0.1``.
+- Preserves ``Authorization``, ``Cookie``, MCP session headers — this is
+  a public hop, not a trusted-internal one.
+- Does NOT inject ``x-contextforge-mcp-runtime``,
+  ``X-ContextForge-Auth-Context``, or any other trust-marker headers.
+- Streams both directions without buffering (SSE-friendly).
+
+Registered with ``MCPIngressMount`` under the name ``"rust-public"``;
+the selector picks it when ``settings.mcp_rust_ingress == "public"``.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Awaitable, Callable, Optional
+
+# Third-Party
+import httpx
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+
+# First-Party
+from mcpgateway.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Hop-by-hop headers per RFC 7230 §6.1 — must not be forwarded by an
+# intermediary. nginx strips these by default.
+_HOP_BY_HOP_REQUEST = frozenset(
+    {
+        "host",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "content-length",
+    }
+)
+_HOP_BY_HOP_RESPONSE = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def _build_forwarded_headers(request: Request) -> dict:
+    """Construct the request headers Rust's public listener will see.
+
+    Strips hop-by-hop headers, preserves auth / cookies / content-type /
+    MCP session headers, and adds nginx-style forwarded metadata so
+    Rust's auth callback sees the original client.
+
+    Args:
+        request: Incoming Starlette request.
+
+    Returns:
+        Dict of headers to send upstream.
+    """
+    forwarded: dict = {}
+    for name, value in request.headers.items():
+        if name.lower() in _HOP_BY_HOP_REQUEST:
+            continue
+        forwarded[name] = value
+
+    client_host = request.client.host if request.client else "unknown"
+    client_port = request.client.port if request.client else 0
+
+    existing_xff = request.headers.get("x-forwarded-for", "")
+    forwarded["X-Forwarded-For"] = f"{existing_xff}, {client_host}".lstrip(", ") if existing_xff else client_host
+    forwarded["X-Forwarded-Proto"] = request.url.scheme
+    forwarded["X-Forwarded-Host"] = request.headers.get("host", "")
+    forwarded["X-Real-IP"] = client_host
+    forwarded["Forwarded"] = f'for="{client_host}:{client_port}";' f"proto={request.url.scheme};" f'host={request.headers.get("host", "")}'
+    return forwarded
+
+
+class RustMCPPublicProxyApp:
+    """ASGI app that reverse-proxies public MCP requests to Rust's public listener.
+
+    Holds a single long-lived ``httpx.AsyncClient`` per app instance for
+    connection pooling; constructed lazily on first request so module
+    import doesn't trigger any I/O.
+    """
+
+    def __init__(self, *, upstream_url: Optional[str] = None) -> None:
+        """Initialize the proxy.
+
+        Args:
+            upstream_url: Base URL for the Rust public listener. Defaults
+                to ``settings.mcp_rust_public_proxy_upstream``
+                (default ``http://127.0.0.1:8787``, matching
+                ``MCP_RUST_PUBLIC_LISTEN_HTTP=0.0.0.0:8787`` from
+                ``docker-entrypoint.sh``).
+        """
+        self._upstream_url = upstream_url or settings.mcp_rust_public_proxy_upstream
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Lazily build the long-lived ``httpx.AsyncClient`` for upstream forwarding.
+
+        Returns:
+            The cached client (constructed on first call).
+        """
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._upstream_url,
+                timeout=httpx.Timeout(
+                    connect=5.0,
+                    read=None,  # SSE streams are long-lived; no read timeout
+                    write=30.0,
+                    pool=5.0,
+                ),
+                limits=httpx.Limits(
+                    max_keepalive_connections=64,
+                    max_connections=256,
+                    keepalive_expiry=30.0,
+                ),
+                follow_redirects=False,
+                http2=False,  # Rust public listener is HTTP/1.1
+            )
+        return self._client
+
+    async def __call__(self, scope: dict, receive: Callable[[], Awaitable[dict]], send: Callable[[dict], Awaitable[None]]) -> None:
+        """ASGI entry point.
+
+        Args:
+            scope: ASGI scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        if scope.get("type") != "http":
+            # Non-HTTP scopes (lifespan, websocket) aren't handled here.
+            # MCP uses streamable HTTP today; if a future version adds
+            # WebSocket-on-/mcp, route those through a different ingress.
+            response = Response(status_code=404, content=b"Not found", media_type="text/plain")
+            await response(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+        client = await self._get_client()
+        upstream_path = scope.get("path", "/")
+        headers = _build_forwarded_headers(request)
+
+        try:
+            upstream_request = client.build_request(
+                method=request.method,
+                url=upstream_path,
+                headers=headers,
+                params=request.query_params,
+                content=request.stream(),
+            )
+            upstream_response = await client.send(upstream_request, stream=True)
+        except httpx.HTTPError as exc:
+            logger.error("rust-public ingress: upstream request to %s failed: %s", upstream_path, exc)
+            error_response = Response(
+                status_code=502,
+                content=b"Rust MCP public ingress unavailable",
+                media_type="text/plain",
+            )
+            await error_response(scope, receive, send)
+            return
+
+        response_headers = {name: value for name, value in upstream_response.headers.items() if name.lower() not in _HOP_BY_HOP_RESPONSE}
+
+        async def _body_iter():
+            """Stream the upstream response body chunk-by-chunk and close on exit."""
+            try:
+                async for chunk in upstream_response.aiter_raw():
+                    yield chunk
+            finally:
+                await upstream_response.aclose()
+
+        streaming_response = StreamingResponse(
+            _body_iter(),
+            status_code=upstream_response.status_code,
+            headers=response_headers,
+            media_type=upstream_response.headers.get("content-type"),
+        )
+        await streaming_response(scope, receive, send)
+
+
+def build_rust_public_proxy_app(*, upstream_url: Optional[str] = None) -> RustMCPPublicProxyApp:
+    """Factory for the public-listener ingress app.
+
+    Args:
+        upstream_url: Optional override for the Rust public listener URL.
+            If ``None``, reads ``settings.mcp_rust_public_proxy_upstream``.
+
+    Returns:
+        A :class:`RustMCPPublicProxyApp` ready to register with
+        :class:`MCPIngressMount` under the name ``"rust-public"``.
+    """
+    return RustMCPPublicProxyApp(upstream_url=upstream_url)

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -205,15 +205,29 @@ def _should_mount_public_rust_transport() -> bool:
 
     Returns:
         ``True`` only when the Rust runtime is enabled and Rust can safely own
-        steady-state public MCP session traffic. Honors the runtime override
-        (``shadow`` forces Python, ``edge`` forces Rust) when one is active.
+        steady-state public MCP session traffic.
+
+    **Safety invariant (must remain invariant under runtime override):**
+    Rust public ingress requires BOTH ``experimental_rust_mcp_runtime_enabled``
+    AND ``experimental_rust_mcp_session_auth_reuse_enabled``. The
+    session-auth-reuse flag is what makes Rust's handling of public MCP
+    session traffic safe (dedicated isolation coverage lives in
+    ``crates/mcp_runtime/TESTING-DESIGN.md``). A runtime override can toggle
+    between the two modes the invariant permits (``shadow`` forces Python;
+    ``edge`` matches the default), but it cannot loosen the invariant — an
+    override to ``edge`` on a deployment that did not opt into
+    session-auth-reuse at boot stays on Python.
     """
+    rust_safe_for_public = bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled)
     override = _runtime_override_mode("mcp")
     if override == "shadow":
         return False
-    if override == "edge":
-        return bool(settings.experimental_rust_mcp_runtime_enabled)
-    return bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled)
+    # override == "edge" or override is None (default): both honor the
+    # safety invariant. This means a boot=shadow deployment with an
+    # admin-issued override=edge still returns False here (the router
+    # rejects such a PATCH with 409 at the API boundary — this is the
+    # belt to the router's braces).
+    return rust_safe_for_public
 
 
 def _should_use_rust_public_session_stack() -> bool:
@@ -402,18 +416,23 @@ def _boot_a2a_runtime_mode() -> str:
 def _should_delegate_a2a_to_rust() -> bool:
     """Return whether registered A2A invocations should be delegated to the Rust runtime.
 
-    Honors the runtime override (``shadow`` forces Python, ``edge`` forces Rust)
-    when one is active and the Rust A2A runtime is enabled at boot.
-
     Returns:
         ``True`` when the Rust A2A runtime should service invocations.
+
+    **Safety invariant (must remain invariant under runtime override):**
+    A2A delegation requires BOTH ``experimental_rust_a2a_runtime_enabled``
+    AND ``experimental_rust_a2a_runtime_delegate_enabled``. Mirroring the
+    MCP contract: a runtime override can toggle between the two modes the
+    invariant permits (``shadow`` forces Python; ``edge`` matches the
+    default), but cannot loosen the invariant — an override to ``edge`` on
+    a deployment that did not opt into delegate mode at boot stays on
+    Python. The router rejects such PATCHes at the API boundary.
     """
+    a2a_safe_for_delegate = bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled)
     override = _runtime_override_mode("a2a")
     if override == "shadow":
         return False
-    if override == "edge":
-        return bool(settings.experimental_rust_a2a_runtime_enabled)
-    return bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled)
+    return a2a_safe_for_delegate
 
 
 def _current_a2a_invoke_mode() -> str:

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -444,12 +444,12 @@ def _deployment_allows_override_mode(runtime, mode):
     compose:
 
     1. **Is there a mechanism that could honor the override?** For MCP, an
-       override is observed only by the ``MCPStreamableHTTPModeDispatcher``,
-       which is mounted for ``boot=shadow`` and ``boot=edge`` only. ``boot=off``
-       has no Rust sidecar (``NO_DISPATCHER``); ``boot=full`` mounts a plain
-       Rust proxy with no dispatcher (``BOOT_FULL_STRANDS``). For A2A,
-       overrides are observed per-invocation, requiring the A2A runtime to be
-       enabled at boot — ``boot=off`` returns ``NO_DISPATCHER``.
+       override is observed only by the ``MCPIngressMount`` mounted for
+       ``boot=shadow`` and ``boot=edge``. ``boot=off`` has no Rust sidecar
+       (``NO_DISPATCHER``); ``boot=full`` mounts a plain Rust proxy with no
+       dispatcher (``BOOT_FULL_STRANDS``). For A2A, overrides are observed
+       per-invocation, requiring the A2A runtime to be enabled at boot —
+       ``boot=off`` returns ``NO_DISPATCHER``.
     2. **Does the target mode satisfy the safety invariant?** An ``edge``
        override additionally requires the session-auth-reuse (MCP) or
        delegate-enabled (A2A) flag; without it, routing public traffic to

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -146,6 +146,51 @@ def _rust_a2a_runtime_managed() -> bool:
     return _env_flag("EXPERIMENTAL_RUST_A2A_RUNTIME_MANAGED", default=True)
 
 
+def _runtime_override_mode(runtime: str) -> Optional[str]:
+    """Return the active override for ``runtime`` (``shadow`` or ``edge``) when one is set.
+
+    Args:
+        runtime: Runtime kind (``"mcp"`` or ``"a2a"``).
+
+    Returns:
+        ``"shadow"`` or ``"edge"`` when an admin override is in effect, else ``None``.
+    """
+    # First-Party
+    from mcpgateway.runtime_state import get_runtime_state  # pylint: disable=import-outside-toplevel
+
+    return get_runtime_state().override_mode(runtime)
+
+
+def _boot_mcp_transport_mount() -> str:
+    """Return the transport mount selected by boot-time settings (no override applied).
+
+    Returns:
+        ``"rust"`` when boot settings select Rust ingress, otherwise ``"python"``.
+    """
+    return "rust" if bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled) else "python"
+
+
+def _boot_mcp_runtime_mode() -> str:
+    """Return the boot-time runtime mode label derived from settings.
+
+    Returns:
+        One of ``"off"``, ``"shadow"``, ``"edge"``, or ``"full"``.
+    """
+    if not settings.experimental_rust_mcp_runtime_enabled:
+        return "off"
+    if not settings.experimental_rust_mcp_session_auth_reuse_enabled:
+        return "shadow"
+    if (
+        settings.experimental_rust_mcp_session_core_enabled
+        and settings.experimental_rust_mcp_event_store_enabled
+        and settings.experimental_rust_mcp_resume_core_enabled
+        and settings.experimental_rust_mcp_live_stream_core_enabled
+        and settings.experimental_rust_mcp_affinity_core_enabled
+    ):
+        return "full"
+    return "edge"
+
+
 def _current_mcp_transport_mount() -> str:
     """Return which public ``/mcp`` transport is currently mounted.
 
@@ -160,8 +205,14 @@ def _should_mount_public_rust_transport() -> bool:
 
     Returns:
         ``True`` only when the Rust runtime is enabled and Rust can safely own
-        steady-state public MCP session traffic.
+        steady-state public MCP session traffic. Honors the runtime override
+        (``shadow`` forces Python, ``edge`` forces Rust) when one is active.
     """
+    override = _runtime_override_mode("mcp")
+    if override == "shadow":
+        return False
+    if override == "edge":
+        return bool(settings.experimental_rust_mcp_runtime_enabled)
     return bool(settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled)
 
 
@@ -254,9 +305,7 @@ def _current_mcp_session_auth_reuse_mode() -> str:
     Returns:
         ``"rust"`` when Rust session auth reuse is enabled, otherwise ``"python"``.
     """
-    if settings.experimental_rust_mcp_runtime_enabled and settings.experimental_rust_mcp_session_auth_reuse_enabled:
-        return "rust"
-    return "python"
+    return "rust" if _should_mount_public_rust_transport() else "python"
 
 
 def _mcp_runtime_status_payload() -> Dict[str, Any]:
@@ -265,9 +314,22 @@ def _mcp_runtime_status_payload() -> Dict[str, Any]:
     Returns:
         Diagnostic payload describing the active MCP runtime configuration.
     """
+    # First-Party
+    from mcpgateway.runtime_state import get_runtime_state  # pylint: disable=import-outside-toplevel
+
+    state = get_runtime_state()
+    mcp_override = state.override_mode("mcp")
     payload: Dict[str, Any] = {
         "mode": _current_mcp_runtime_mode(),
         "mounted": _current_mcp_transport_mount(),
+        "boot_mode": _boot_mcp_runtime_mode(),
+        "boot_mounted": _boot_mcp_transport_mount(),
+        "effective_mode": mcp_override or _boot_mcp_runtime_mode(),
+        "override_active": mcp_override is not None,
+        "override_version": state.version("mcp"),
+        "cluster_propagation": str(state.cluster_propagation),
+        "boot_reconcile_status": str(state.boot_reconcile_status("mcp")),
+        "pod_id": state.pod_id,
         "rust_build_included": _rust_build_included(),
         "rust_runtime_enabled": settings.experimental_rust_mcp_runtime_enabled,
         "session_core_mode": _current_mcp_session_core_mode(),
@@ -298,6 +360,16 @@ def _mcp_runtime_status_payload() -> Dict[str, Any]:
             payload["sidecar_transport"] = "http"
             payload["sidecar_target"] = settings.experimental_rust_mcp_runtime_url
 
+    last_change = state.last_change("mcp")
+    if last_change is not None:
+        payload["last_change"] = {
+            "version": last_change.version,
+            "mode": last_change.mode,
+            "initiator_user": last_change.initiator_user,
+            "initiator_pod": last_change.initiator_pod,
+            "timestamp": last_change.timestamp,
+        }
+
     return payload
 
 
@@ -314,28 +386,68 @@ def _current_a2a_runtime_mode() -> str:
     return "python"
 
 
+def _boot_a2a_runtime_mode() -> str:
+    """Return the boot-time A2A runtime mode label derived from settings.
+
+    Returns:
+        One of ``"off"``, ``"shadow"``, or ``"edge"`` (``edge`` and ``full`` collapse to the same flag set).
+    """
+    if not settings.experimental_rust_a2a_runtime_enabled:
+        return "off"
+    if not settings.experimental_rust_a2a_runtime_delegate_enabled:
+        return "shadow"
+    return "edge"
+
+
+def _should_delegate_a2a_to_rust() -> bool:
+    """Return whether registered A2A invocations should be delegated to the Rust runtime.
+
+    Honors the runtime override (``shadow`` forces Python, ``edge`` forces Rust)
+    when one is active and the Rust A2A runtime is enabled at boot.
+
+    Returns:
+        ``True`` when the Rust A2A runtime should service invocations.
+    """
+    override = _runtime_override_mode("a2a")
+    if override == "shadow":
+        return False
+    if override == "edge":
+        return bool(settings.experimental_rust_a2a_runtime_enabled)
+    return bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled)
+
+
 def _current_a2a_invoke_mode() -> str:
     """Return which runtime currently owns registered A2A agent invocation.
 
     Returns:
-        ``"rust"`` when delegation is enabled, otherwise ``"python"``.
+        ``"rust"`` when delegation is enabled (or overridden to ``edge``), otherwise ``"python"``.
     """
-    if settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled:
-        return "rust"
-    return "python"
+    return "rust" if _should_delegate_a2a_to_rust() else "python"
 
 
 def _a2a_runtime_status_payload() -> Dict[str, Any]:
     """Return A2A runtime diagnostics for version and UI surfaces.
 
     Returns:
-        Dict with mode, invoke_mode, flags, and optional sidecar transport details.
+        Dict with mode, invoke_mode, flags, override state, and optional sidecar transport details.
     """
+    # First-Party
+    from mcpgateway.runtime_state import get_runtime_state  # pylint: disable=import-outside-toplevel
+
+    state = get_runtime_state()
+    a2a_override = state.override_mode("a2a")
     payload: Dict[str, Any] = {
         "mode": _current_a2a_runtime_mode(),
         "invoke_mode": _current_a2a_invoke_mode(),
+        "boot_mode": _boot_a2a_runtime_mode(),
+        "effective_mode": a2a_override or _boot_a2a_runtime_mode(),
+        "override_active": a2a_override is not None,
+        "override_version": state.version("a2a"),
+        "cluster_propagation": str(state.cluster_propagation),
+        "boot_reconcile_status": str(state.boot_reconcile_status("a2a")),
+        "pod_id": state.pod_id,
         "rust_runtime_enabled": settings.experimental_rust_a2a_runtime_enabled,
-        "rust_delegate_enabled": bool(settings.experimental_rust_a2a_runtime_enabled and settings.experimental_rust_a2a_runtime_delegate_enabled),
+        "rust_delegate_enabled": _should_delegate_a2a_to_rust(),
     }
 
     if settings.experimental_rust_a2a_runtime_enabled:
@@ -346,6 +458,16 @@ def _a2a_runtime_status_payload() -> Dict[str, Any]:
         else:
             payload["sidecar_transport"] = "http"
             payload["sidecar_target"] = settings.experimental_rust_a2a_runtime_url
+
+    last_change = state.last_change("a2a")
+    if last_change is not None:
+        payload["last_change"] = {
+            "version": last_change.version,
+            "mode": last_change.mode,
+            "initiator_user": last_change.initiator_user,
+            "initiator_pod": last_change.initiator_pod,
+            "timestamp": last_change.timestamp,
+        }
 
     return payload
 
@@ -375,6 +497,51 @@ def current_mcp_transport_mount() -> str:
         Runtime label identifying the currently mounted public MCP transport.
     """
     return _current_mcp_transport_mount()
+
+
+def boot_mcp_runtime_mode() -> str:
+    """Return the boot-time runtime mode label derived from settings.
+
+    Returns:
+        One of ``"off"``, ``"shadow"``, ``"edge"``, or ``"full"``.
+    """
+    return _boot_mcp_runtime_mode()
+
+
+def boot_mcp_transport_mount() -> str:
+    """Return the transport mount selected by boot-time settings (no override applied).
+
+    Returns:
+        ``"rust"`` when boot settings select Rust ingress, otherwise ``"python"``.
+    """
+    return _boot_mcp_transport_mount()
+
+
+def boot_a2a_runtime_mode() -> str:
+    """Return the boot-time A2A runtime mode label derived from settings.
+
+    Returns:
+        One of ``"off"``, ``"shadow"``, or ``"edge"``.
+    """
+    return _boot_a2a_runtime_mode()
+
+
+def should_delegate_a2a_to_rust() -> bool:
+    """Return whether registered A2A invocations should be delegated to the Rust runtime.
+
+    Returns:
+        ``True`` when the Rust A2A runtime should service invocations.
+    """
+    return _should_delegate_a2a_to_rust()
+
+
+def a2a_runtime_status_payload() -> Dict[str, Any]:
+    """Return A2A runtime diagnostics for version, health, and UI surfaces.
+
+    Returns:
+        Diagnostic payload describing the active A2A runtime configuration.
+    """
+    return _a2a_runtime_status_payload()
 
 
 def should_mount_public_rust_transport() -> bool:

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -506,7 +506,7 @@ def _deployment_allows_override_mode(runtime, mode):
             return MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG
         return MoveCompatibility.OK
 
-    return MoveCompatibility.NO_DISPATCHER
+    return MoveCompatibility.NO_DISPATCHER  # pragma: no cover — _coerce_runtime rejects unknown kinds upstream
 
 
 def deployment_allows_override_mode(runtime, mode):

--- a/mcpgateway/version.py
+++ b/mcpgateway/version.py
@@ -435,6 +435,93 @@ def _should_delegate_a2a_to_rust() -> bool:
     return a2a_safe_for_delegate
 
 
+def _deployment_allows_override_mode(runtime, mode):
+    """Return a ``MoveCompatibility`` for whether ``mode`` can take effect on this deployment.
+
+    Single source of truth shared by the admin router (which translates the
+    rejection reason into a 409 detail string) and the coordinator (which
+    surfaces the rejection reason via ``BootReconcileStatus``). Two concerns
+    compose:
+
+    1. **Is there a mechanism that could honor the override?** For MCP, an
+       override is observed only by the ``MCPStreamableHTTPModeDispatcher``,
+       which is mounted for ``boot=shadow`` and ``boot=edge`` only. ``boot=off``
+       has no Rust sidecar (``NO_DISPATCHER``); ``boot=full`` mounts a plain
+       Rust proxy with no dispatcher (``BOOT_FULL_STRANDS``). For A2A,
+       overrides are observed per-invocation, requiring the A2A runtime to be
+       enabled at boot — ``boot=off`` returns ``NO_DISPATCHER``.
+    2. **Does the target mode satisfy the safety invariant?** An ``edge``
+       override additionally requires the session-auth-reuse (MCP) or
+       delegate-enabled (A2A) flag; without it, routing public traffic to
+       Rust would be unsafe. Failure surfaces as ``EDGE_NEEDS_SAFETY_FLAG``.
+
+    Args:
+        runtime: ``RuntimeKind`` (or its string value) being evaluated.
+        mode: ``OverrideMode`` (or its string value) being requested.
+
+    Returns:
+        A ``MoveCompatibility`` member; ``OK`` when the override can both
+        be observed and safely honored, otherwise the structured rejection
+        reason.
+    """
+    # First-Party: lazy to avoid the version <-> runtime_state import cycle.
+    from mcpgateway.runtime_state import (  # pylint: disable=import-outside-toplevel
+        MoveCompatibility,
+        OverrideMode,
+        RuntimeKind,
+        _coerce_mode,
+        _coerce_runtime,
+    )
+
+    kind = _coerce_runtime(runtime)
+    target = _coerce_mode(mode)
+
+    if kind == RuntimeKind.MCP:
+        if not settings.experimental_rust_mcp_runtime_enabled:
+            return MoveCompatibility.NO_DISPATCHER
+        is_full_boot = bool(
+            settings.experimental_rust_mcp_session_auth_reuse_enabled
+            and settings.experimental_rust_mcp_session_core_enabled
+            and settings.experimental_rust_mcp_event_store_enabled
+            and settings.experimental_rust_mcp_resume_core_enabled
+            and settings.experimental_rust_mcp_live_stream_core_enabled
+            and settings.experimental_rust_mcp_affinity_core_enabled
+        )
+        if is_full_boot:
+            return MoveCompatibility.BOOT_FULL_STRANDS
+        if target == OverrideMode.SHADOW:
+            return MoveCompatibility.OK
+        # target == OverrideMode.EDGE
+        if not settings.experimental_rust_mcp_session_auth_reuse_enabled:
+            return MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG
+        return MoveCompatibility.OK
+
+    if kind == RuntimeKind.A2A:
+        if not settings.experimental_rust_a2a_runtime_enabled:
+            return MoveCompatibility.NO_DISPATCHER
+        if target == OverrideMode.SHADOW:
+            return MoveCompatibility.OK
+        # target == OverrideMode.EDGE
+        if not settings.experimental_rust_a2a_runtime_delegate_enabled:
+            return MoveCompatibility.EDGE_NEEDS_SAFETY_FLAG
+        return MoveCompatibility.OK
+
+    return MoveCompatibility.NO_DISPATCHER
+
+
+def deployment_allows_override_mode(runtime, mode):
+    """Public wrapper for ``_deployment_allows_override_mode``.
+
+    Args:
+        runtime: ``RuntimeKind`` or string runtime kind.
+        mode: ``OverrideMode`` or string target mode.
+
+    Returns:
+        A ``MoveCompatibility`` member.
+    """
+    return _deployment_allows_override_mode(runtime, mode)
+
+
 def _current_a2a_invoke_mode() -> str:
     """Return which runtime currently owns registered A2A agent invocation.
 

--- a/tests/integration/test_runtime_state_cluster.py
+++ b/tests/integration/test_runtime_state_cluster.py
@@ -199,6 +199,12 @@ async def test_two_coordinators_converge_through_pubsub(monkeypatch: pytest.Monk
 @pytest.mark.asyncio
 async def test_fresh_pod_reconciles_to_persisted_hint(monkeypatch: pytest.MonkeyPatch):
     """A pod that boots after a flip on another pod must reconcile to the persisted hint."""
+    # Simulate an edge-boot deployment for both pods so the a2a hint's
+    # mode=edge is compatible with the safety invariant; without this the
+    # coordinator (correctly) discards the hint as INCOMPATIBLE_HINT.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", True, raising=False)
+
     broker = FakeRedisBroker()
 
     state_a = RuntimeState()

--- a/tests/integration/test_runtime_state_cluster.py
+++ b/tests/integration/test_runtime_state_cluster.py
@@ -1,0 +1,283 @@
+# -*- coding: utf-8 -*-
+"""Integration test: two ``RuntimeStateCoordinator`` instances converge via pub/sub.
+
+The unit-test suite for ``runtime_state`` covers each Redis call site with a
+single mocked client. This test stands up two coordinator instances pointed at
+the same in-process Redis simulator (a hand-rolled broker that implements just
+enough of ``publish``/``subscribe``/``get_message``/``incr``/``get``/``set``
+for the coordinator) so we can prove the cross-pod convergence end-to-end.
+
+We deliberately avoid ``fakeredis`` (not in the project's dependency set) and
+keep the simulator local to this file.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+import time
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.runtime_state import (
+    BootReconcileStatus,
+    ClusterPropagation,
+    OverrideMode,
+    RuntimeKind,
+    RuntimeState,
+    RuntimeStateCoordinator,
+    _hint_key,
+    _version_key,
+    reset_runtime_state_coordinator_for_tests,
+    reset_runtime_state_for_tests,
+)
+
+
+class FakeRedisBroker:
+    """Shared, in-process simulator of Redis pub/sub + key-value semantics.
+
+    Sufficient to back any number of ``FakeRedisClient`` instances pointed at
+    the same broker — what one publishes, the others receive.
+    """
+
+    def __init__(self) -> None:
+        self.kv: Dict[str, bytes] = {}
+        self.counters: Dict[str, int] = {}
+        self.subscribers: List[List[Dict[str, Any]]] = []  # each subscriber gets its own queue
+
+    def register_subscriber(self) -> List[Dict[str, Any]]:
+        queue: List[Dict[str, Any]] = []
+        self.subscribers.append(queue)
+        return queue
+
+    def publish(self, channel: str, payload: bytes) -> None:
+        for queue in self.subscribers:
+            queue.append({"type": "message", "channel": channel.encode(), "data": payload})
+
+
+class FakeRedisClient:
+    """Per-coordinator Redis-like client backed by the shared broker."""
+
+    def __init__(self, broker: FakeRedisBroker) -> None:
+        self._broker = broker
+
+    async def get(self, key: str) -> Optional[bytes]:
+        return self._broker.kv.get(key)
+
+    async def set(self, key: str, value: bytes, ex: Optional[int] = None) -> bool:  # pylint: disable=unused-argument
+        self._broker.kv[key] = value
+        return True
+
+    async def incr(self, key: str) -> int:
+        self._broker.counters[key] = self._broker.counters.get(key, 0) + 1
+        return self._broker.counters[key]
+
+    async def publish(self, channel: str, payload: bytes) -> int:
+        self._broker.publish(channel, payload)
+        return len(self._broker.subscribers)
+
+    def pubsub(self) -> "FakePubSub":
+        return FakePubSub(self._broker)
+
+
+class FakePubSub:
+    """Per-subscriber pubsub stand-in with its own message queue."""
+
+    def __init__(self, broker: FakeRedisBroker) -> None:
+        self._broker = broker
+        self._queue = broker.register_subscriber()
+        self._subscribed: List[str] = []
+
+    async def subscribe(self, *channels: str) -> None:
+        self._subscribed.extend(channels)
+
+    async def unsubscribe(self, *_channels: str) -> None:
+        return None
+
+    async def aclose(self) -> None:
+        return None
+
+    async def get_message(self, ignore_subscribe_messages: bool = True, timeout: float = 1.0):  # pylint: disable=unused-argument
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._queue:
+                msg = self._queue.pop(0)
+                if msg.get("channel", b"").decode() in self._subscribed:
+                    return msg
+                continue
+            await asyncio.sleep(0.01)
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+    yield
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_two_coordinators_converge_through_pubsub(monkeypatch: pytest.MonkeyPatch):
+    """A flip on coordinator A must converge to the local state owned by coordinator B."""
+    broker = FakeRedisBroker()
+
+    # Each coordinator gets its own RuntimeState (simulating two pods) and its
+    # own FakeRedisClient pointing at the shared broker.
+    state_a = RuntimeState()
+    state_b = RuntimeState()
+    state_a._pod_id = "pod-A"  # noqa: SLF001 — test fixture exposes internal id for cross-pod simulation
+    state_b._pod_id = "pod-B"  # noqa: SLF001 — test fixture exposes internal id for cross-pod simulation
+
+    coord_a = RuntimeStateCoordinator()
+    coord_b = RuntimeStateCoordinator()
+
+    # The coordinator's get_runtime_state() lookup uses the module singleton.
+    # We swap that lookup per-coordinator by patching just before each .start().
+    import mcpgateway.runtime_state as runtime_state_module
+
+    monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=FakeRedisClient(broker)))
+    await coord_a.start()
+
+    monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=FakeRedisClient(broker)))
+    await coord_b.start()
+
+    try:
+        # Coordinator A "issues" a flip: allocate a version, apply locally, publish.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+        version = await coord_a.next_version("mcp", state_a.version("mcp"))
+        change = await state_a.apply_local("mcp", "shadow", initiator_user="alice@example.com", version=version)
+        assert change is not None
+        assert await coord_a.publish(change) is True
+
+        # Coordinator B's listen loop should observe the message and apply it
+        # to its own RuntimeState.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+        for _ in range(50):
+            if state_b.override_mode("mcp") == OverrideMode.SHADOW:
+                break
+            await asyncio.sleep(0.05)
+
+        assert state_b.override_mode("mcp") == OverrideMode.SHADOW
+        assert state_b.version("mcp") == version
+        last = state_b.last_change("mcp")
+        assert last is not None
+        assert last.runtime == RuntimeKind.MCP
+        assert last.initiator_pod == "pod-A"
+        assert last.initiator_user == "alice@example.com"
+        # Coordinator A's local state already had the flip applied; it must not
+        # double-apply when the broker echoes its own message.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+        assert state_a.version("mcp") == version
+
+        # Both coordinators should report healthy propagation throughout.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+        assert state_a.cluster_propagation == ClusterPropagation.REDIS
+        assert state_a.boot_reconcile_status("mcp") == BootReconcileStatus.OK
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+        assert state_b.cluster_propagation == ClusterPropagation.REDIS
+        # B reconciled from the empty hint at boot (before A published), so OK.
+        assert state_b.boot_reconcile_status("mcp") == BootReconcileStatus.OK
+
+    finally:
+        # stop() reaches into get_runtime_state() to reset cluster_propagation;
+        # rebind to each coordinator's state for clean shutdown.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+        await coord_a.stop()
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+        await coord_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_fresh_pod_reconciles_to_persisted_hint(monkeypatch: pytest.MonkeyPatch):
+    """A pod that boots after a flip on another pod must reconcile to the persisted hint."""
+    broker = FakeRedisBroker()
+
+    state_a = RuntimeState()
+    state_b = RuntimeState()
+    state_a._pod_id = "pod-A"  # noqa: SLF001 — test fixture exposes internal id for cross-pod simulation
+    state_b._pod_id = "pod-B"  # noqa: SLF001 — test fixture exposes internal id for cross-pod simulation
+
+    coord_a = RuntimeStateCoordinator()
+    coord_b = RuntimeStateCoordinator()
+
+    import mcpgateway.runtime_state as runtime_state_module
+
+    # Bring up coordinator A and have it apply + publish a flip.
+    monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=FakeRedisClient(broker)))
+    await coord_a.start()
+
+    try:
+        version = await coord_a.next_version("a2a", state_a.version("a2a"))
+        change = await state_a.apply_local("a2a", "edge", initiator_user="bob@example.com", version=version)
+        assert change is not None
+        assert await coord_a.publish(change) is True
+
+        # The hint key must now hold the published payload.
+        assert _hint_key("a2a") in broker.kv
+        # Bring up coordinator B AFTER the publish; it should reconcile from the
+        # persisted hint at start time, not via pub/sub.
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+        monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=FakeRedisClient(broker)))
+        await coord_b.start()
+        assert state_b.override_mode("a2a") == OverrideMode.EDGE
+        assert state_b.version("a2a") == version
+        # Boot reconciliation succeeded → OK.
+        assert state_b.boot_reconcile_status("a2a") == BootReconcileStatus.OK
+        # And the version-key counter survived B's start (no INCR happened).
+        assert broker.counters[_version_key("a2a")] == version
+    finally:
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_a)
+        await coord_a.stop()
+        monkeypatch.setattr(runtime_state_module, "get_runtime_state", lambda: state_b)
+        await coord_b.stop()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_flips_allocate_distinct_versions_via_incr(monkeypatch: pytest.MonkeyPatch):
+    """Two near-simultaneous PATCHes through one broker allocate distinct, monotonic versions.
+
+    A full two-pod end-to-end concurrent-flip test would require binding a
+    ``RuntimeState`` per ``RuntimeStateCoordinator`` (today both reach into
+    the module-level singleton). That refactor is tracked separately; for
+    now we prove the version-allocation half of the story — which is the
+    half that actually prevents silent collisions at peer dedup time.
+    """
+    broker = FakeRedisBroker()
+    state = RuntimeState()
+    state._pod_id = "pod-test"  # noqa: SLF001 — test fixture exposes internal id for cross-pod simulation
+
+    coord = RuntimeStateCoordinator()
+    monkeypatch.setattr("mcpgateway.runtime_state.get_runtime_state", lambda: state)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=FakeRedisClient(broker)))
+    await coord.start()
+
+    try:
+        # Two PATCHes allocate distinct versions via INCR; nothing falls back
+        # to current_version + 1.
+        v_first = await coord.next_version("mcp", state.version("mcp"))
+        change_first = await state.apply_local("mcp", "shadow", initiator_user="alice", version=v_first)
+        assert change_first is not None
+
+        v_second = await coord.next_version("mcp", state.version("mcp"))
+        assert v_second == v_first + 1
+        change_second = await state.apply_local("mcp", "edge", initiator_user="bob", version=v_second)
+        assert change_second is not None
+
+        # The persisted Redis counter advanced exactly once per allocation.
+        assert broker.counters[_version_key("mcp")] == v_second
+
+        # Both publishes succeed; the broker holds two distinct payloads.
+        assert await coord.publish(change_first) is True
+        assert await coord.publish(change_second) is True
+    finally:
+        await coord.stop()

--- a/tests/integration/test_runtime_state_cluster.py
+++ b/tests/integration/test_runtime_state_cluster.py
@@ -126,6 +126,12 @@ def _reset_singletons():
 @pytest.mark.asyncio
 async def test_two_coordinators_converge_through_pubsub(monkeypatch: pytest.MonkeyPatch):
     """A flip on coordinator A must converge to the local state owned by coordinator B."""
+    # Both coordinators must look like edge-boot so the published shadow flip
+    # is compatible on the receiver (per the new _deployment_allows_override_mode
+    # check in the listen-loop).
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
     broker = FakeRedisBroker()
 
     # Each coordinator gets its own RuntimeState (simulating two pods) and its

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -223,6 +223,10 @@ async def test_patch_mcp_mode_409_when_boot_mode_off(allow_admin, off_boot, admi
     with pytest.raises(HTTPException) as exc:
         await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
     assert exc.value.status_code == 409
+    # Recommendation must be 'shadow' or 'edge' — must NOT recommend 'full',
+    # which would just trade NO_DISPATCHER for BOOT_FULL_STRANDS.
+    assert "'shadow' or 'edge'" in exc.value.detail
+    assert "'full'" not in exc.value.detail
 
 
 @pytest.mark.asyncio
@@ -232,6 +236,9 @@ async def test_patch_a2a_mode_409_when_boot_mode_off(allow_admin, off_boot, admi
     with pytest.raises(HTTPException) as exc:
         await router_module.patch_a2a_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
     assert exc.value.status_code == 409
+    # A2A has no 'full' mode at all — the recommendation must not mention it.
+    assert "'shadow' or 'edge'" in exc.value.detail
+    assert "'full'" not in exc.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -8,6 +8,7 @@ desired allow/deny outcome and exercise the endpoint functions directly.
 """
 
 # Standard
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 # Third-Party
@@ -466,3 +467,51 @@ async def test_patch_mcp_mode_superseded_path_writes_audit_and_returns_status(al
     assert audit_kwargs["additional_context"]["attempted_version"] == 50
     assert audit_kwargs["additional_context"]["superseded_by_version"] == 100
     assert audit_kwargs["additional_context"]["superseded_by_mode"] == "edge"
+
+
+# ---------------------------------------------------------------------
+# _warn_if_behind_reverse_proxy — diagnostic for non-nginx reverse-proxy
+# topologies where the proxy itself won't follow the override.
+# ---------------------------------------------------------------------
+
+
+def test_warn_if_behind_reverse_proxy_logs_when_xforward_headers_detected(caplog):
+    """A PATCH that arrives via a reverse proxy (X-Forwarded-* present) gets a warning naming the headers."""
+    # First-Party
+    from mcpgateway.routers.runtime_admin_router import _warn_if_behind_reverse_proxy
+    from mcpgateway.runtime_state import RuntimeKind
+
+    request = SimpleNamespace(headers={"x-forwarded-for": "10.0.0.1", "x-forwarded-proto": "https"})
+    caplog.set_level("WARNING", logger="mcpgateway.routers.runtime_admin_router")
+    _warn_if_behind_reverse_proxy(request, runtime=RuntimeKind.MCP)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("reverse proxy" in w.message for w in warnings), [w.message for w in warnings]
+    assert any("x-forwarded-for" in w.message and "x-forwarded-proto" in w.message for w in warnings)
+
+
+def test_warn_if_behind_reverse_proxy_silent_when_no_forwarded_headers(caplog):
+    """No X-Forwarded-* present → no warning (silent path covers the early return)."""
+    # First-Party
+    from mcpgateway.routers.runtime_admin_router import _warn_if_behind_reverse_proxy
+    from mcpgateway.runtime_state import RuntimeKind
+
+    request = SimpleNamespace(headers={"content-type": "application/json"})
+    caplog.set_level("WARNING", logger="mcpgateway.routers.runtime_admin_router")
+    _warn_if_behind_reverse_proxy(request, runtime=RuntimeKind.MCP)
+    assert [r for r in caplog.records if "reverse proxy" in r.message] == []
+
+
+def test_warn_if_behind_reverse_proxy_handles_missing_headers_attribute(caplog):
+    """A request stub without a ``headers`` attribute hits the defensive early return without raising."""
+    # First-Party
+    from mcpgateway.routers.runtime_admin_router import _warn_if_behind_reverse_proxy
+    from mcpgateway.runtime_state import RuntimeKind
+
+    caplog.set_level("WARNING", logger="mcpgateway.routers.runtime_admin_router")
+    # Build an object that explicitly lacks ``headers`` — getattr returns None,
+    # the function returns immediately with no warning.
+    request = SimpleNamespace()
+    request.headers = None
+    _warn_if_behind_reverse_proxy(request, runtime=RuntimeKind.MCP)
+    assert [r for r in caplog.records if "reverse proxy" in r.message] == []

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -1,0 +1,361 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``mcpgateway.routers.runtime_admin_router``.
+
+The endpoints are decorated with ``@require_permission("admin.system_config")``,
+which calls ``PermissionService(db).check_permission(...)``. We patch the
+``PermissionService`` class in ``mcpgateway.middleware.rbac`` to return the
+desired allow/deny outcome and exercise the endpoint functions directly.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+
+# First-Party
+from mcpgateway.routers import runtime_admin_router as router_module
+from mcpgateway.runtime_state import (
+    reset_runtime_state_coordinator_for_tests,
+    reset_runtime_state_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+    yield
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+
+@pytest.fixture
+def admin_user():
+    return {"email": "admin@example.com", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def non_admin_user():
+    return {"email": "user@example.com", "is_admin": False, "ip_address": "127.0.0.1", "user_agent": "tests"}
+
+
+@pytest.fixture
+def db_session():
+    return MagicMock()
+
+
+@pytest.fixture
+def request_no_proxy():
+    """Build a minimal Request stand-in whose headers don't trip the reverse-proxy WARN."""
+    req = MagicMock()
+    req.headers = {}
+    return req
+
+
+@pytest.fixture
+def request_via_proxy():
+    """Build a Request stand-in carrying X-Forwarded-For so the reverse-proxy WARN fires."""
+    req = MagicMock()
+    req.headers = {"x-forwarded-for": "203.0.113.1"}
+    return req
+
+
+@pytest.fixture
+def allow_admin(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns True."""
+
+    class AllowAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return True
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", AllowAll)
+
+
+@pytest.fixture
+def deny_all(monkeypatch: pytest.MonkeyPatch):
+    """Patch PermissionService so check_permission always returns False."""
+
+    class DenyAll:
+        def __init__(self, _db):
+            pass
+
+        async def check_permission(self, **_kwargs):
+            return False
+
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DenyAll)
+
+
+@pytest.fixture
+def edge_boot(monkeypatch: pytest.MonkeyPatch):
+    """Make the boot mode look like ``edge`` for both runtimes."""
+    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "edge")
+    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "edge")
+    monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "rust")
+    monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: True)
+
+
+@pytest.fixture
+def off_boot(monkeypatch: pytest.MonkeyPatch):
+    """Make the boot mode look like ``off`` for both runtimes."""
+    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "off")
+    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "off")
+    monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "python")
+    monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: False)
+
+
+@pytest.fixture
+def full_boot(monkeypatch: pytest.MonkeyPatch):
+    """Make the boot mode look like ``full`` for the MCP runtime."""
+    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "full")
+    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "edge")
+    monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "rust")
+    monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: True)
+
+
+# ---------------------------------------------------------------------------
+# GET endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_mode_returns_state(allow_admin, edge_boot, admin_user):
+    payload = await router_module.get_mcp_mode(user=admin_user)
+    assert payload["runtime"] == "mcp"
+    assert payload["boot_mode"] == "edge"
+    assert payload["effective_mode"] == "edge"
+    assert payload["override_active"] is False
+    assert payload["mounted"] == "rust"
+    assert payload["supported_override_modes"] == ["edge", "shadow"]
+
+
+@pytest.mark.asyncio
+async def test_get_a2a_mode_returns_state(allow_admin, edge_boot, admin_user):
+    payload = await router_module.get_a2a_mode(user=admin_user)
+    assert payload["runtime"] == "a2a"
+    assert payload["boot_mode"] == "edge"
+    assert payload["invoke_mode"] == "rust"
+    assert payload["override_active"] is False
+
+
+# ---------------------------------------------------------------------------
+# PATCH happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_flips_to_shadow(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    audit = MagicMock()
+    monkeypatch.setattr(router_module, "get_security_logger", lambda: audit)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    assert payload["effective_mode"] == "shadow"
+    assert payload["override_active"] is True
+    audit.log_data_access.assert_called_once()
+    call = audit.log_data_access.call_args.kwargs
+    assert call["resource_type"] == "runtime_config"
+    assert call["resource_id"] == "mcp_mode"
+    assert call["new_values"]["mode"] == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_patch_a2a_mode_flips_to_shadow(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_a2a_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert payload["effective_mode"] == "shadow"
+    assert payload["override_active"] is True
+
+
+# ---------------------------------------------------------------------------
+# Validation: 400 / 409
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_rejects_unsupported_mode_at_pydantic_layer():
+    # Pydantic Literal["shadow", "edge"] rejects "off" at construction time.
+    with pytest.raises(Exception):
+        router_module.RuntimeModeUpdate(mode="off")
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_409_when_boot_mode_off(allow_admin, off_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="edge")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_patch_a2a_mode_409_when_boot_mode_off(allow_admin, off_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="edge")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_a2a_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_409_when_boot_mode_full(allow_admin, full_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """boot_mode=full mounts a plain RustMCPRuntimeProxy with no dispatcher; flips would silently no-op."""
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
+    assert "full" in exc.value.detail
+
+
+# ---------------------------------------------------------------------------
+# 403: non-admin without the required permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_403_when_permission_denied(deny_all, edge_boot, non_admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    # is_admin must be false so allow_admin_bypass doesn't shortcut the check.
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=non_admin_user, db=db_session)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_publishes_via_coordinator(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """A successful flip with publish ok and Redis attached reports propagated.
+
+    Also pins the ModeChange payload shape passed to coordinator.publish so a
+    future refactor that swaps argument order or drops a field is caught.
+    """
+    from mcpgateway.runtime_state import OverrideMode, RuntimeKind
+
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    coordinator = MagicMock()
+    coordinator.next_version = AsyncMock(return_value=42)
+    coordinator.publish = AsyncMock(return_value=True)
+    coordinator.cluster_propagation_enabled = True
+    monkeypatch.setattr(router_module, "get_runtime_state_coordinator", lambda: coordinator)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    coordinator.next_version.assert_awaited_once()
+    coordinator.publish.assert_awaited_once()
+    published = coordinator.publish.await_args.args[0]
+    assert published.runtime == RuntimeKind.MCP
+    assert published.mode == OverrideMode.SHADOW
+    assert published.version == 42
+    assert published.initiator_user == admin_user["email"]
+    assert payload["override_version"] == 42
+    assert payload["publish_status"] == "propagated"
+    assert payload["audit_persisted"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_reports_publish_failure(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """A publish failure surfaces as publish_status=failed but the local flip still succeeds."""
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    coordinator = MagicMock()
+    coordinator.next_version = AsyncMock(return_value=7)
+    coordinator.publish = AsyncMock(return_value=False)
+    coordinator.cluster_propagation_enabled = True
+    monkeypatch.setattr(router_module, "get_runtime_state_coordinator", lambda: coordinator)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    assert payload["override_active"] is True
+    assert payload["effective_mode"] == "shadow"
+    assert payload["publish_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_503_when_incr_unavailable(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """When Redis INCR cannot allocate a safe version, the PATCH must fail closed (503)."""
+    from mcpgateway.runtime_state import RuntimeStateError
+
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    coordinator = MagicMock()
+    coordinator.next_version = AsyncMock(side_effect=RuntimeStateError("INCR failed"))
+    coordinator.publish = AsyncMock(return_value=True)
+    monkeypatch.setattr(router_module, "get_runtime_state_coordinator", lambda: coordinator)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 503
+    coordinator.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_audit_failure_does_not_block_flip(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """A SQLAlchemyError in audit logging must NOT roll back the override."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    audit = MagicMock()
+    audit.log_data_access.side_effect = SQLAlchemyError("db down")
+    monkeypatch.setattr(router_module, "get_security_logger", lambda: audit)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    assert payload["override_active"] is True
+    assert payload["effective_mode"] == "shadow"
+    assert payload["audit_persisted"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_non_db_audit_failure_does_not_block_flip(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Non-SQLAlchemy audit failures (network sink, AttributeError, etc.) must also NOT break the response."""
+    audit = MagicMock()
+    audit.log_data_access.side_effect = AttributeError("misconfigured logger")
+    monkeypatch.setattr(router_module, "get_security_logger", lambda: audit)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    assert payload["override_active"] is True
+    assert payload["effective_mode"] == "shadow"
+    assert payload["audit_persisted"] is False
+    assert payload["publish_status"] in ("propagated", "local-only")
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_superseded_path_writes_audit_and_returns_status(allow_admin, edge_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Race-loser PATCH must surface publish_status=superseded AND write a success=False audit row."""
+    audit = MagicMock()
+    monkeypatch.setattr(router_module, "get_security_logger", lambda: audit)
+
+    # Pre-load state with a higher version so the next apply_local returns None.
+    from mcpgateway.runtime_state import get_runtime_state
+
+    await get_runtime_state().apply_local("mcp", "edge", initiator_user="winner", version=100)
+
+    coordinator = MagicMock()
+    # next_version returns a value LOWER than the pre-applied 100, so apply_local drops it.
+    coordinator.next_version = AsyncMock(return_value=50)
+    coordinator.publish = AsyncMock(return_value=True)
+    coordinator.cluster_propagation_enabled = True
+    monkeypatch.setattr(router_module, "get_runtime_state_coordinator", lambda: coordinator)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    assert payload["publish_status"] == "superseded"
+    coordinator.publish.assert_not_awaited()
+    audit.log_data_access.assert_called_once()
+    audit_kwargs = audit.log_data_access.call_args.kwargs
+    assert audit_kwargs["success"] is False
+    assert audit_kwargs["additional_context"]["outcome"] == "superseded"
+    assert audit_kwargs["additional_context"]["attempted_version"] == 50
+    assert audit_kwargs["additional_context"]["superseded_by_version"] == 100
+    assert audit_kwargs["additional_context"]["superseded_by_mode"] == "edge"

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -117,6 +117,22 @@ def full_boot(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: True)
 
 
+@pytest.fixture
+def shadow_boot(monkeypatch: pytest.MonkeyPatch):
+    """Make the boot mode look like ``shadow`` for both runtimes.
+
+    A shadow-boot deployment has the Rust sidecar present but
+    ``session_auth_reuse_enabled`` / ``delegate_enabled`` are False — so the
+    safety invariant for routing public traffic to Rust is NOT met. The
+    router must reject PATCH attempts with 409 rather than apply an override
+    that would silently fail to take effect at the transport layer.
+    """
+    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "shadow")
+    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "shadow")
+    monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "python")
+    monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: False)
+
+
 # ---------------------------------------------------------------------------
 # GET endpoints
 # ---------------------------------------------------------------------------
@@ -212,6 +228,29 @@ async def test_patch_mcp_mode_409_when_boot_mode_full(allow_admin, full_boot, ad
         await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
     assert exc.value.status_code == 409
     assert "full" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_409_when_boot_mode_shadow(allow_admin, shadow_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Safety invariant: boot=shadow didn't opt into session-auth-reuse, so edge override can't take effect."""
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="edge")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
+    assert "shadow" in exc.value.detail
+    assert "session-auth-reuse" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_patch_a2a_mode_409_when_boot_mode_shadow(allow_admin, shadow_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Safety invariant (A2A): boot=shadow didn't opt into delegate-enabled."""
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="edge")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_a2a_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
+    assert "shadow" in exc.value.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -90,45 +90,60 @@ def deny_all(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", DenyAll)
 
 
+def _set_mcp_settings(monkeypatch: pytest.MonkeyPatch, *, runtime: bool, session_auth: bool = False, all_cores: bool = False) -> None:
+    """Apply the MCP-side settings combination that the boot-mode helpers derive labels from."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", runtime, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", session_auth, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_event_store_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_resume_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_live_stream_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_affinity_core_enabled", all_cores, raising=False)
+
+
+def _set_a2a_settings(monkeypatch: pytest.MonkeyPatch, *, runtime: bool, delegate: bool = False) -> None:
+    """Apply the A2A-side settings combination."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", runtime, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", delegate, raising=False)
+
+
 @pytest.fixture
 def edge_boot(monkeypatch: pytest.MonkeyPatch):
-    """Make the boot mode look like ``edge`` for both runtimes."""
-    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "edge")
-    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "edge")
+    """Make both runtimes look like ``edge`` boot (runtime + safety flag, no extra cores)."""
+    _set_mcp_settings(monkeypatch, runtime=True, session_auth=True, all_cores=False)
+    _set_a2a_settings(monkeypatch, runtime=True, delegate=True)
     monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "rust")
     monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: True)
 
 
 @pytest.fixture
 def off_boot(monkeypatch: pytest.MonkeyPatch):
-    """Make the boot mode look like ``off`` for both runtimes."""
-    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "off")
-    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "off")
+    """Make both runtimes look like ``off`` boot (no Rust runtime enabled)."""
+    _set_mcp_settings(monkeypatch, runtime=False)
+    _set_a2a_settings(monkeypatch, runtime=False)
     monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "python")
     monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: False)
 
 
 @pytest.fixture
 def full_boot(monkeypatch: pytest.MonkeyPatch):
-    """Make the boot mode look like ``full`` for the MCP runtime."""
-    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "full")
-    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "edge")
+    """Make the MCP runtime look like ``full`` boot (runtime + safety flag + all cores). A2A stays edge."""
+    _set_mcp_settings(monkeypatch, runtime=True, session_auth=True, all_cores=True)
+    _set_a2a_settings(monkeypatch, runtime=True, delegate=True)
     monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "rust")
     monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: True)
 
 
 @pytest.fixture
 def shadow_boot(monkeypatch: pytest.MonkeyPatch):
-    """Make the boot mode look like ``shadow`` for both runtimes.
+    """Make both runtimes look like ``shadow`` boot (runtime enabled, safety flag NOT set).
 
-    A shadow-boot deployment has the Rust sidecar present but
-    ``session_auth_reuse_enabled`` / ``delegate_enabled`` are False — so the
-    safety invariant for routing public traffic to Rust is NOT met. The
-    router must reject PATCH attempts with 409 rather than apply an override
-    that would silently fail to take effect at the transport layer.
+    The router must accept ``mode=shadow`` (escape hatch) but reject
+    ``mode=edge`` because the safety invariant requires the
+    session-auth-reuse / delegate-enabled flag.
     """
-    monkeypatch.setattr(router_module.version_module, "boot_mcp_runtime_mode", lambda: "shadow")
-    monkeypatch.setattr(router_module.version_module, "boot_a2a_runtime_mode", lambda: "shadow")
+    _set_mcp_settings(monkeypatch, runtime=True, session_auth=False, all_cores=False)
+    _set_a2a_settings(monkeypatch, runtime=True, delegate=False)
     monkeypatch.setattr(router_module.version_module, "current_mcp_transport_mount", lambda: "python")
     monkeypatch.setattr(router_module.version_module, "should_delegate_a2a_to_rust", lambda: False)
 
@@ -227,7 +242,19 @@ async def test_patch_mcp_mode_409_when_boot_mode_full(allow_admin, full_boot, ad
     with pytest.raises(HTTPException) as exc:
         await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
     assert exc.value.status_code == 409
-    assert "full" in exc.value.detail
+    assert "Full-boot" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_edge_409_when_boot_mode_full(allow_admin, full_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Symmetric: mode=edge on boot=full also 409s. The dispatcher check beats the edge-safety check today,
+    but a refactor that reorders the gates could regress silently — pin both target modes against full-boot.
+    """
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+    body = router_module.RuntimeModeUpdate(mode="edge")
+    with pytest.raises(HTTPException) as exc:
+        await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+    assert exc.value.status_code == 409
 
 
 @pytest.mark.asyncio
@@ -239,7 +266,7 @@ async def test_patch_mcp_mode_409_when_boot_mode_shadow(allow_admin, shadow_boot
         await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
     assert exc.value.status_code == 409
     assert "shadow" in exc.value.detail
-    assert "session-auth-reuse" in exc.value.detail
+    assert "experimental_rust_mcp_session_auth_reuse_enabled" in exc.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_runtime_admin_router.py
@@ -253,6 +253,40 @@ async def test_patch_a2a_mode_409_when_boot_mode_shadow(allow_admin, shadow_boot
     assert "shadow" in exc.value.detail
 
 
+@pytest.mark.asyncio
+async def test_patch_mcp_mode_shadow_clears_stale_override_on_shadow_boot(allow_admin, shadow_boot, admin_user, db_session, request_no_proxy, monkeypatch: pytest.MonkeyPatch):
+    """Escape hatch: mode=shadow must be accepted on a shadow-boot deployment even when state
+    holds a stale override=edge inherited from a prior edge-boot via Redis hint. Without this,
+    the admin API cannot clear lingering state and the operator has to flush Redis manually.
+    """
+    # First-Party
+    from mcpgateway.runtime_state import OverrideMode, get_runtime_state
+
+    monkeypatch.setattr(router_module, "get_security_logger", MagicMock)
+
+    # Simulate a stale override=edge landing in state (e.g. via a hint written
+    # by a former edge-boot pod, replayed when this shadow-boot pod started).
+    state = get_runtime_state()
+    await state.apply_local("mcp", "edge", initiator_user="prior-edge-boot", version=7)
+    assert state.override_mode("mcp") == OverrideMode.EDGE
+
+    coordinator = MagicMock()
+    coordinator.next_version = AsyncMock(return_value=8)
+    coordinator.publish = AsyncMock(return_value=True)
+    coordinator.cluster_propagation_enabled = True
+    monkeypatch.setattr(router_module, "get_runtime_state_coordinator", lambda: coordinator)
+
+    body = router_module.RuntimeModeUpdate(mode="shadow")
+    payload = await router_module.patch_mcp_mode(body, request=request_no_proxy, user=admin_user, db=db_session)
+
+    # The flip succeeded: override is now shadow, publish was called.
+    assert state.override_mode("mcp") == OverrideMode.SHADOW
+    assert state.version("mcp") == 8
+    assert payload["override_active"] is True
+    assert payload["effective_mode"] == "shadow"
+    coordinator.publish.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # 403: non-admin without the required permission
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -285,6 +285,48 @@ class TestConditionalPaths:
         assert "rust-public" not in module.mcp_transport_app.names()
         assert "rust-internal" in module.mcp_transport_app.names()
 
+    def test_import_logs_error_when_public_ingress_misconfigured_on_shadow_boot(self, monkeypatch, caplog):
+        """shadow boot + mcp_rust_ingress=public is a misconfig: boot must log at error so it survives the default LOG_LEVEL=ERROR."""
+        caplog.set_level("ERROR")
+        module = _import_fresh_main_module(
+            monkeypatch,
+            overrides={
+                "experimental_rust_mcp_runtime_enabled": True,
+                # session-auth-reuse OFF → boot mode is shadow, the public
+                # listener is not bound, and `mcp_rust_ingress=public` is
+                # the operator misconfig we want to surface loudly.
+                "experimental_rust_mcp_session_auth_reuse_enabled": False,
+                "mcp_rust_ingress": "public",
+            },
+        )
+
+        assert module.mcp_transport_app.__class__.__name__ == "MCPIngressMount"
+        # rust-public is never registered on shadow boot — the public
+        # listener isn't bound there. Without the error log, an operator
+        # would never know their setting is being silently overridden.
+        assert "rust-public" not in module.mcp_transport_app.names()
+        assert any("mcp_rust_ingress=public is set on boot=shadow" in rec.message and rec.levelname == "ERROR" for rec in caplog.records)
+
+    def test_select_mcp_ingress_downgrades_public_to_internal_on_shadow_boot(self, monkeypatch):
+        """Even when an active edge override would otherwise route to Rust, shadow boot must NEVER select rust-public."""
+        module = _import_fresh_main_module(
+            monkeypatch,
+            overrides={
+                "experimental_rust_mcp_runtime_enabled": True,
+                "experimental_rust_mcp_session_auth_reuse_enabled": False,
+                "mcp_rust_ingress": "public",
+            },
+        )
+
+        # Force the safety predicate True (as a runtime edge override
+        # would) and assert the selector still refuses to return
+        # "rust-public" on shadow boot. This is the regression guard:
+        # dropping the `boot_mcp_runtime_mode() == "edge"` clause would
+        # silently route auth-sensitive traffic to an unregistered name,
+        # whose only fallback is the python transport.
+        with patch.object(module, "_should_mount_public_rust_transport", return_value=True):
+            assert module._select_mcp_ingress({}) == "rust-internal"
+
     def test_import_warns_when_rust_artifacts_present_but_runtime_disabled(self, monkeypatch, caplog):
         """A Rust-built image with the runtime flag disabled should warn loudly at import time."""
         caplog.set_level("WARNING")

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -232,7 +232,7 @@ class TestConditionalPaths:
     """Test conditional code paths to improve coverage."""
 
     def test_import_uses_rust_mcp_proxy_when_enabled(self, monkeypatch):
-        """Module import should swap the mounted /mcp app to the Rust proxy when enabled."""
+        """When boot mode is edge, the dispatcher's effective transport is the Rust proxy."""
         module = _import_fresh_main_module(
             monkeypatch,
             overrides={
@@ -242,10 +242,13 @@ class TestConditionalPaths:
             },
         )
 
-        assert module.mcp_transport_app.__class__.__name__ == "RustMCPRuntimeProxy"
+        assert module.mcp_transport_app.__class__.__name__ == "MCPStreamableHTTPModeDispatcher"
+        # In edge boot mode with no override, public /mcp routes to the Rust proxy.
+        assert module._should_mount_public_rust_transport() is True
+        assert module.mcp_transport_app._rust_transport.__class__.__name__ == "RustMCPRuntimeProxy"
 
     def test_import_keeps_python_transport_when_rust_runtime_lacks_session_auth_reuse(self, monkeypatch):
-        """Module import should keep public /mcp on Python when Rust session auth reuse is disabled."""
+        """When boot mode is shadow, the dispatcher's effective transport is Python."""
         module = _import_fresh_main_module(
             monkeypatch,
             overrides={
@@ -255,7 +258,10 @@ class TestConditionalPaths:
             },
         )
 
-        assert module.mcp_transport_app.__class__.__name__ == "MCPRuntimeHeaderTransportWrapper"
+        assert module.mcp_transport_app.__class__.__name__ == "MCPStreamableHTTPModeDispatcher"
+        # In shadow boot mode with no override, public /mcp stays on Python.
+        assert module._should_mount_public_rust_transport() is False
+        assert module.mcp_transport_app._python_transport.__class__.__name__ == "MCPRuntimeHeaderTransportWrapper"
 
     def test_import_warns_when_rust_artifacts_present_but_runtime_disabled(self, monkeypatch, caplog):
         """A Rust-built image with the runtime flag disabled should warn loudly at import time."""
@@ -284,6 +290,165 @@ class TestConditionalPaths:
         # Test the functionality that exercises the loop path
         response = test_client.get("/health", headers=auth_headers)
         assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_mcp_dispatcher_routes_per_request_after_runtime_override(monkeypatch):
+    """An admin override flip must change which transport receives the *next* request."""
+    # First-Party
+    from mcpgateway.main import MCPStreamableHTTPModeDispatcher
+    from mcpgateway.runtime_state import (
+        get_runtime_state,
+        reset_runtime_state_coordinator_for_tests,
+        reset_runtime_state_for_tests,
+    )
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+    # Boot settings: edge (rust would normally win).
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
+    python_calls = []
+    rust_calls = []
+
+    class FakeTransport:
+        def __init__(self, sink):
+            self._sink = sink
+
+        async def handle_streamable_http(self, scope, receive, send):
+            self._sink.append(scope.get("path", "/"))
+
+    dispatcher = MCPStreamableHTTPModeDispatcher(
+        python_transport=FakeTransport(python_calls),
+        rust_transport=FakeTransport(rust_calls),
+    )
+
+    async def _no_send(_msg):
+        pass
+
+    async def _no_receive():
+        return {"type": "http.request"}
+
+    # Boot mode is edge → no override → routes to Rust.
+    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+    # Apply admin override → shadow → next request routes to Python.
+    await get_runtime_state().apply_local("mcp", "shadow", initiator_user="admin", version=1)
+    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+    # Flip back to edge → routes to Rust again.
+    await get_runtime_state().apply_local("mcp", "edge", initiator_user="admin", version=2)
+    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+
+    assert rust_calls == ["/mcp", "/mcp"]
+    assert python_calls == ["/mcp"]
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_mcp_dispatcher_in_flight_request_finishes_on_original_transport(monkeypatch):
+    """Drain semantics: a flip mid-request must not redirect an already-dispatched call."""
+    import asyncio as _asyncio
+
+    # First-Party
+    from mcpgateway.main import MCPStreamableHTTPModeDispatcher
+    from mcpgateway.runtime_state import (
+        get_runtime_state,
+        reset_runtime_state_coordinator_for_tests,
+        reset_runtime_state_for_tests,
+    )
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+    # Boot edge → no override → first request routes to Rust.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
+    rust_started = _asyncio.Event()
+    rust_release = _asyncio.Event()
+    rust_completed = _asyncio.Event()
+    python_calls = []
+
+    class GatedRustTransport:
+        async def handle_streamable_http(self, scope, receive, send):
+            rust_started.set()
+            await rust_release.wait()
+            rust_completed.set()
+
+    class TrackingPythonTransport:
+        async def handle_streamable_http(self, scope, receive, send):
+            python_calls.append(scope.get("path", "/"))
+
+    dispatcher = MCPStreamableHTTPModeDispatcher(
+        python_transport=TrackingPythonTransport(),
+        rust_transport=GatedRustTransport(),
+    )
+
+    async def _no_send(_msg):
+        pass
+
+    async def _no_receive():
+        return {"type": "http.request"}
+
+    # Kick off the in-flight request — boot mode is edge so it lands on Rust.
+    in_flight = _asyncio.create_task(dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send))
+    # Wait until the Rust transport is mid-execution.
+    await _asyncio.wait_for(rust_started.wait(), timeout=1.0)
+    # Now flip the runtime override to shadow; the in-flight request was already
+    # dispatched to Rust and must finish there.
+    await get_runtime_state().apply_local("mcp", "shadow", initiator_user="admin", version=1)
+    # New request after the flip should land on Python.
+    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp/post-flip"}, _no_receive, _no_send)
+    assert python_calls == ["/mcp/post-flip"]
+    assert not rust_completed.is_set()
+    # Release the gated request and verify it completed on Rust.
+    rust_release.set()
+    await _asyncio.wait_for(in_flight, timeout=1.0)
+    assert rust_completed.is_set()
+    # The post-flip request was the only Python landing; the in-flight request
+    # never re-routed.
+    assert python_calls == ["/mcp/post-flip"]
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_apply_runtime_mode_headers_reflects_override(monkeypatch):
+    """After a runtime override, _apply_runtime_mode_headers must surface the new mount."""
+    # Third-Party
+    from fastapi import Response
+
+    # First-Party
+    from mcpgateway.main import _apply_runtime_mode_headers
+    from mcpgateway.runtime_state import (
+        get_runtime_state,
+        reset_runtime_state_coordinator_for_tests,
+        reset_runtime_state_for_tests,
+    )
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
+    # Boot edge → header reports rust.
+    response = Response()
+    _apply_runtime_mode_headers(response)
+    assert response.headers["x-contextforge-mcp-transport-mounted"] == "rust"
+
+    # Flip to shadow → header reports python on the *next* response.
+    await get_runtime_state().apply_local("mcp", "shadow", initiator_user="admin", version=1)
+    response = Response()
+    _apply_runtime_mode_headers(response)
+    assert response.headers["x-contextforge-mcp-transport-mounted"] == "python"
+
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
 
 
 class TestJwtIdentityExtractor:
@@ -2838,12 +3003,7 @@ class TestMCPPathRewriteMiddleware:
         """Documented pattern works when root_path is set in scope."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/servers/123/mcp",
-            "root_path": "/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/servers/123/mcp", "root_path": "/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -2857,12 +3017,7 @@ class TestMCPPathRewriteMiddleware:
         """Handle complex multi-level prefixes."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/dev/mcp-gateway/service/gateway/servers/123/mcp",
-            "root_path": "/dev/mcp-gateway/service/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/dev/mcp-gateway/service/gateway/servers/123/mcp", "root_path": "/dev/mcp-gateway/service/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -2876,15 +3031,10 @@ class TestMCPPathRewriteMiddleware:
         """Handle prefix in path when scope['root_path'] is empty but APP_ROOT_PATH is set."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/servers/123/mcp",
-            "root_path": "",  # Not set in scope
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/servers/123/mcp", "root_path": "", "headers": []}  # Not set in scope
         receive, send = AsyncMock(), AsyncMock()
 
-        with patch('mcpgateway.config.settings.app_root_path', '/gateway'):
+        with patch("mcpgateway.config.settings.app_root_path", "/gateway"):
             with patch("mcpgateway.main.streamable_http_auth", return_value=True):
                 await middleware._call_streamable_http(scope, receive, send)
 
@@ -2910,12 +3060,7 @@ class TestMCPPathRewriteMiddleware:
         """Workaround /mcp/servers/{id} with prefix passes through."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/mcp/servers/123",
-            "root_path": "/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/mcp/servers/123", "root_path": "/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -2972,12 +3117,7 @@ class TestMCPPathRewriteMiddleware:
         """PR #3892 security: Arbitrary paths ending with /mcp are NOT rewritten."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/arbitrary/prefix/mcp",
-            "root_path": "",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/arbitrary/prefix/mcp", "root_path": "", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -2992,12 +3132,7 @@ class TestMCPPathRewriteMiddleware:
         """Security: Arbitrary paths rejected even with root_path."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/arbitrary/prefix/mcp",
-            "root_path": "/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/arbitrary/prefix/mcp", "root_path": "/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -3013,12 +3148,7 @@ class TestMCPPathRewriteMiddleware:
         """Security: Empty server ID with prefix is rejected."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/servers//mcp",
-            "root_path": "/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/servers//mcp", "root_path": "/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
         sent = []
 
@@ -10106,6 +10236,7 @@ class TestRemainingCoverageGaps:
         assert response.headers["x-contextforge-mcp-resume-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-live-stream-core-mode"] == "python"
         assert response.headers["x-contextforge-mcp-session-auth-reuse-mode"] == "python"
+
     async def test_healthcheck_redis_removed(self, monkeypatch):
         """Test that /health endpoint no longer checks Redis."""
         # First-Party
@@ -10136,7 +10267,6 @@ class TestRemainingCoverageGaps:
         # Verify no status_items in response (simple dict format)
         assert "status_items" not in result
         assert "mcp_runtime" in result
-
 
     async def test_readiness_check_invalidate_failure_is_best_effort(self, monkeypatch):
         # First-Party
@@ -10286,6 +10416,7 @@ class TestRemainingCoverageGaps:
         assert result["status"] == "unhealthy"
         assert "error" in result
         assert response.headers["x-contextforge-mcp-runtime-mode"] == "rust-managed"
+
     async def test_readiness_check_redis_exception_handling(self, monkeypatch):
         """Test that /ready endpoint checks Redis and handles exceptions."""
         # First-Party
@@ -10306,6 +10437,7 @@ class TestRemainingCoverageGaps:
         # Mock Redis availability check to raise an exception
         async def mock_is_redis_available_exception():
             raise RuntimeError("Redis connection timeout")
+
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available_exception)
 
         # Configure Redis to be enabled for this test
@@ -10350,9 +10482,11 @@ class TestRemainingCoverageGaps:
                 return None
 
         monkeypatch.setattr(main_mod, "SessionLocal", lambda: FakeSession())
+
         # Mock Redis availability check to return True (healthy)
         async def mock_is_redis_available():
             return True
+
         monkeypatch.setattr(main_mod, "is_redis_available", mock_is_redis_available)
         # Configure Redis to be enabled for this test
         monkeypatch.setattr(main_mod.settings, "cache_type", "redis")
@@ -10375,7 +10509,6 @@ class TestRemainingCoverageGaps:
         assert redis_status is not None
         assert redis_status.status_code == 200
         assert redis_status.message == "Cache Connection Successful"
-
 
     async def test_sse_endpoint_cookie_auth_and_disconnect_cleanup(self, monkeypatch):
         # First-Party

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -232,7 +232,7 @@ class TestConditionalPaths:
     """Test conditional code paths to improve coverage."""
 
     def test_import_uses_rust_mcp_proxy_when_enabled(self, monkeypatch):
-        """When boot mode is edge, the dispatcher's effective transport is the Rust proxy."""
+        """When boot mode is edge, the ingress mount selects rust-internal by default."""
         module = _import_fresh_main_module(
             monkeypatch,
             overrides={
@@ -242,13 +242,31 @@ class TestConditionalPaths:
             },
         )
 
-        assert module.mcp_transport_app.__class__.__name__ == "MCPStreamableHTTPModeDispatcher"
-        # In edge boot mode with no override, public /mcp routes to the Rust proxy.
+        assert module.mcp_transport_app.__class__.__name__ == "MCPIngressMount"
+        # In edge boot mode with no override, public /mcp routes through the
+        # registered Rust ingress (default shape: rust-internal).
         assert module._should_mount_public_rust_transport() is True
-        assert module.mcp_transport_app._rust_transport.__class__.__name__ == "RustMCPRuntimeProxy"
+        assert module._select_mcp_ingress({}) == "rust-internal"
+        assert "rust-internal" in module.mcp_transport_app.names()
+        assert "rust-public" in module.mcp_transport_app.names()  # registered for boot=edge
+        assert "python" in module.mcp_transport_app.names()
+
+    def test_import_selects_rust_public_ingress_when_settings_say_so(self, monkeypatch):
+        """When boot is edge AND settings.mcp_rust_ingress=public, the selector picks rust-public."""
+        module = _import_fresh_main_module(
+            monkeypatch,
+            overrides={
+                "experimental_rust_mcp_runtime_enabled": True,
+                "experimental_rust_mcp_session_auth_reuse_enabled": True,
+                "mcp_rust_ingress": "public",
+            },
+        )
+
+        assert module.mcp_transport_app.__class__.__name__ == "MCPIngressMount"
+        assert module._select_mcp_ingress({}) == "rust-public"
 
     def test_import_keeps_python_transport_when_rust_runtime_lacks_session_auth_reuse(self, monkeypatch):
-        """When boot mode is shadow, the dispatcher's effective transport is Python."""
+        """When boot mode is shadow, the ingress mount selects the Python transport."""
         module = _import_fresh_main_module(
             monkeypatch,
             overrides={
@@ -258,10 +276,14 @@ class TestConditionalPaths:
             },
         )
 
-        assert module.mcp_transport_app.__class__.__name__ == "MCPStreamableHTTPModeDispatcher"
+        assert module.mcp_transport_app.__class__.__name__ == "MCPIngressMount"
         # In shadow boot mode with no override, public /mcp stays on Python.
         assert module._should_mount_public_rust_transport() is False
-        assert module.mcp_transport_app._python_transport.__class__.__name__ == "MCPRuntimeHeaderTransportWrapper"
+        assert module._select_mcp_ingress({}) == "python"
+        # rust-public is NOT registered on shadow boot — public listener
+        # isn't bound and the safety invariant isn't met.
+        assert "rust-public" not in module.mcp_transport_app.names()
+        assert "rust-internal" in module.mcp_transport_app.names()
 
     def test_import_warns_when_rust_artifacts_present_but_runtime_disabled(self, monkeypatch, caplog):
         """A Rust-built image with the runtime flag disabled should warn loudly at import time."""
@@ -293,15 +315,16 @@ class TestConditionalPaths:
 
 
 @pytest.mark.asyncio
-async def test_mcp_dispatcher_routes_per_request_after_runtime_override(monkeypatch):
-    """An admin override flip must change which transport receives the *next* request."""
+async def test_mcp_ingress_mount_routes_per_request_after_runtime_override(monkeypatch):
+    """An admin override flip must change which ingress receives the *next* request."""
     # First-Party
-    from mcpgateway.main import MCPStreamableHTTPModeDispatcher
+    from mcpgateway.main import _select_mcp_ingress
     from mcpgateway.runtime_state import (
         get_runtime_state,
         reset_runtime_state_coordinator_for_tests,
         reset_runtime_state_for_tests,
     )
+    from mcpgateway.transports.mcp_ingress_mount import MCPIngressMount
 
     reset_runtime_state_for_tests()
     reset_runtime_state_coordinator_for_tests()
@@ -309,21 +332,20 @@ async def test_mcp_dispatcher_routes_per_request_after_runtime_override(monkeypa
     # Boot settings: edge (rust would normally win).
     monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
     monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.mcp_rust_ingress", "internal", raising=False)
 
     python_calls = []
     rust_calls = []
 
-    class FakeTransport:
-        def __init__(self, sink):
-            self._sink = sink
+    async def python_app(scope, _receive, _send):
+        python_calls.append(scope.get("path", "/"))
 
-        async def handle_streamable_http(self, scope, receive, send):
-            self._sink.append(scope.get("path", "/"))
+    async def rust_app(scope, _receive, _send):
+        rust_calls.append(scope.get("path", "/"))
 
-    dispatcher = MCPStreamableHTTPModeDispatcher(
-        python_transport=FakeTransport(python_calls),
-        rust_transport=FakeTransport(rust_calls),
-    )
+    mount = MCPIngressMount(selector=_select_mcp_ingress, fallback=python_app)
+    mount.register("python", python_app)
+    mount.register("rust-internal", rust_app)
 
     async def _no_send(_msg):
         pass
@@ -331,14 +353,14 @@ async def test_mcp_dispatcher_routes_per_request_after_runtime_override(monkeypa
     async def _no_receive():
         return {"type": "http.request"}
 
-    # Boot mode is edge → no override → routes to Rust.
-    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+    # Boot mode is edge → no override → routes to rust-internal.
+    await mount.dispatch({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
     # Apply admin override → shadow → next request routes to Python.
     await get_runtime_state().apply_local("mcp", "shadow", initiator_user="admin", version=1)
-    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+    await mount.dispatch({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
     # Flip back to edge → routes to Rust again.
     await get_runtime_state().apply_local("mcp", "edge", initiator_user="admin", version=2)
-    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
+    await mount.dispatch({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send)
 
     assert rust_calls == ["/mcp", "/mcp"]
     assert python_calls == ["/mcp"]
@@ -348,17 +370,18 @@ async def test_mcp_dispatcher_routes_per_request_after_runtime_override(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_mcp_dispatcher_in_flight_request_finishes_on_original_transport(monkeypatch):
+async def test_mcp_ingress_mount_in_flight_request_finishes_on_original_ingress(monkeypatch):
     """Drain semantics: a flip mid-request must not redirect an already-dispatched call."""
     import asyncio as _asyncio
 
     # First-Party
-    from mcpgateway.main import MCPStreamableHTTPModeDispatcher
+    from mcpgateway.main import _select_mcp_ingress
     from mcpgateway.runtime_state import (
         get_runtime_state,
         reset_runtime_state_coordinator_for_tests,
         reset_runtime_state_for_tests,
     )
+    from mcpgateway.transports.mcp_ingress_mount import MCPIngressMount
 
     reset_runtime_state_for_tests()
     reset_runtime_state_coordinator_for_tests()
@@ -366,26 +389,24 @@ async def test_mcp_dispatcher_in_flight_request_finishes_on_original_transport(m
     # Boot edge → no override → first request routes to Rust.
     monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
     monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.mcp_rust_ingress", "internal", raising=False)
 
     rust_started = _asyncio.Event()
     rust_release = _asyncio.Event()
     rust_completed = _asyncio.Event()
     python_calls = []
 
-    class GatedRustTransport:
-        async def handle_streamable_http(self, scope, receive, send):
-            rust_started.set()
-            await rust_release.wait()
-            rust_completed.set()
+    async def gated_rust_app(_scope, _receive, _send):
+        rust_started.set()
+        await rust_release.wait()
+        rust_completed.set()
 
-    class TrackingPythonTransport:
-        async def handle_streamable_http(self, scope, receive, send):
-            python_calls.append(scope.get("path", "/"))
+    async def tracking_python_app(scope, _receive, _send):
+        python_calls.append(scope.get("path", "/"))
 
-    dispatcher = MCPStreamableHTTPModeDispatcher(
-        python_transport=TrackingPythonTransport(),
-        rust_transport=GatedRustTransport(),
-    )
+    mount = MCPIngressMount(selector=_select_mcp_ingress, fallback=tracking_python_app)
+    mount.register("python", tracking_python_app)
+    mount.register("rust-internal", gated_rust_app)
 
     async def _no_send(_msg):
         pass
@@ -394,14 +415,14 @@ async def test_mcp_dispatcher_in_flight_request_finishes_on_original_transport(m
         return {"type": "http.request"}
 
     # Kick off the in-flight request — boot mode is edge so it lands on Rust.
-    in_flight = _asyncio.create_task(dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send))
-    # Wait until the Rust transport is mid-execution.
+    in_flight = _asyncio.create_task(mount.dispatch({"type": "http", "method": "POST", "path": "/mcp"}, _no_receive, _no_send))
+    # Wait until the Rust ingress is mid-execution.
     await _asyncio.wait_for(rust_started.wait(), timeout=1.0)
     # Now flip the runtime override to shadow; the in-flight request was already
     # dispatched to Rust and must finish there.
     await get_runtime_state().apply_local("mcp", "shadow", initiator_user="admin", version=1)
     # New request after the flip should land on Python.
-    await dispatcher.handle_streamable_http({"type": "http", "method": "POST", "path": "/mcp/post-flip"}, _no_receive, _no_send)
+    await mount.dispatch({"type": "http", "method": "POST", "path": "/mcp/post-flip"}, _no_receive, _no_send)
     assert python_calls == ["/mcp/post-flip"]
     assert not rust_completed.is_set()
     # Release the gated request and verify it completed on Rust.
@@ -3074,12 +3095,7 @@ class TestMCPPathRewriteMiddleware:
         """Regression test for #4266: modified_path should be app-relative for server_id extraction."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/gateway/servers/abc123/mcp",
-            "root_path": "/gateway",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/gateway/servers/abc123/mcp", "root_path": "/gateway", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):
@@ -3097,11 +3113,7 @@ class TestMCPPathRewriteMiddleware:
         """When no root_path, modified_path equals original path."""
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
-        scope = {
-            "type": "http",
-            "path": "/servers/xyz789/mcp",
-            "headers": []
-        }
+        scope = {"type": "http", "path": "/servers/xyz789/mcp", "headers": []}
         receive, send = AsyncMock(), AsyncMock()
 
         with patch("mcpgateway.main.streamable_http_auth", return_value=True):

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -282,6 +282,82 @@ def test_constants_match_kinds():
     assert SUPPORTED_OVERRIDE_MODES == frozenset({"shadow", "edge"})
 
 
+# ---------------------------------------------------------------------------
+# I5: table-driven _deployment_allows_override_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("runtime_enabled", "session_auth", "all_cores", "mode", "expected_label"),
+    [
+        # boot=off (runtime disabled): every mode rejected as NO_DISPATCHER
+        (False, False, False, "shadow", "no_dispatcher"),
+        (False, False, False, "edge", "no_dispatcher"),
+        # boot=shadow (runtime, no safety flag, no cores): shadow OK; edge needs safety flag
+        (True, False, False, "shadow", "ok"),
+        (True, False, False, "edge", "edge_needs_safety_flag"),
+        # boot=edge (runtime + safety flag, no cores): both modes OK
+        (True, True, False, "shadow", "ok"),
+        (True, True, False, "edge", "ok"),
+        # boot=full (all six flags): both modes rejected as BOOT_FULL_STRANDS
+        (True, True, True, "shadow", "boot_full_strands"),
+        (True, True, True, "edge", "boot_full_strands"),
+    ],
+    ids=[
+        "off-shadow",
+        "off-edge",
+        "shadow-shadow",
+        "shadow-edge",
+        "edge-shadow",
+        "edge-edge",
+        "full-shadow",
+        "full-edge",
+    ],
+)
+def test_deployment_allows_override_mode_mcp_table(monkeypatch: pytest.MonkeyPatch, runtime_enabled, session_auth, all_cores, mode, expected_label):
+    """Pin every (boot config × target mode) → MoveCompatibility outcome for MCP."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", runtime_enabled, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", session_auth, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_event_store_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_resume_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_live_stream_core_enabled", all_cores, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_affinity_core_enabled", all_cores, raising=False)
+
+    from mcpgateway.runtime_state import MoveCompatibility
+    from mcpgateway.version import deployment_allows_override_mode
+
+    result = deployment_allows_override_mode("mcp", mode)
+    assert result == MoveCompatibility(expected_label)
+
+
+@pytest.mark.parametrize(
+    ("runtime_enabled", "delegate_enabled", "mode", "expected_label"),
+    [
+        # boot=off (runtime disabled): every mode NO_DISPATCHER
+        (False, False, "shadow", "no_dispatcher"),
+        (False, False, "edge", "no_dispatcher"),
+        # boot=shadow (runtime, no delegate): shadow OK; edge needs delegate
+        (True, False, "shadow", "ok"),
+        (True, False, "edge", "edge_needs_safety_flag"),
+        # boot=edge (runtime + delegate): both modes OK
+        (True, True, "shadow", "ok"),
+        (True, True, "edge", "ok"),
+    ],
+    ids=["off-shadow", "off-edge", "shadow-shadow", "shadow-edge", "edge-shadow", "edge-edge"],
+)
+def test_deployment_allows_override_mode_a2a_table(monkeypatch: pytest.MonkeyPatch, runtime_enabled, delegate_enabled, mode, expected_label):
+    """Pin every (boot config × target mode) → MoveCompatibility outcome for A2A."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", runtime_enabled, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", delegate_enabled, raising=False)
+
+    from mcpgateway.runtime_state import MoveCompatibility
+    from mcpgateway.version import deployment_allows_override_mode
+
+    result = deployment_allows_override_mode("a2a", mode)
+    assert result == MoveCompatibility(expected_label)
+
+
 @pytest.mark.asyncio
 async def test_override_edge_cannot_bypass_session_auth_reuse_invariant(monkeypatch: pytest.MonkeyPatch):
     """Safety invariant: an admin override=edge on a deployment that didn't opt into
@@ -348,7 +424,7 @@ async def test_reconcile_from_hint_discards_incompatible_mode(monkeypatch: pytes
         # The stale edge hint must NOT have been applied.
         assert state.override_mode("mcp") is None
         assert state.version("mcp") == 0
-        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_SAFETY_FLAG
     finally:
         await coord.stop()
 
@@ -385,7 +461,7 @@ async def test_reconcile_from_hint_discards_shadow_on_full_boot(monkeypatch: pyt
     try:
         state = get_runtime_state()
         assert state.override_mode("mcp") is None
-        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_BOOT_FULL
     finally:
         await coord.stop()
 
@@ -411,7 +487,7 @@ async def test_reconcile_from_hint_discards_any_mode_on_off_boot(monkeypatch: py
     try:
         state = get_runtime_state()
         assert state.override_mode("mcp") is None
-        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER
     finally:
         await coord.stop()
 
@@ -437,7 +513,98 @@ async def test_reconcile_from_hint_discards_a2a_hint_on_a2a_off_boot(monkeypatch
     try:
         state = get_runtime_state()
         assert state.override_mode("a2a") is None
-        assert state.boot_reconcile_status("a2a") == BootReconcileStatus.INCOMPATIBLE_HINT
+        assert state.boot_reconcile_status("a2a") == BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_edge_on_full_boot(monkeypatch: pytest.MonkeyPatch):
+    """Symmetric to shadow-on-full: an edge hint on boot=full also strands."""
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_event_store_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_resume_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_live_stream_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_affinity_core_enabled", True, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "edge", "version": 9, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.override_mode("mcp") is None
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_BOOT_FULL
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_edge_on_off_boot(monkeypatch: pytest.MonkeyPatch):
+    """Symmetric to shadow-on-off: an edge hint on boot=off also discards."""
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "edge", "version": 5, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.override_mode("mcp") is None
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_NO_DISPATCHER
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_incompatible_hint_does_not_delete_redis_key_or_downgrade_propagation(monkeypatch: pytest.MonkeyPatch):
+    """Discarded hint must leave the Redis key alone (a future compatible-boot pod must still see it)
+    and must NOT downgrade cluster_propagation (the discard is internal — pubsub is healthy).
+    """
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "edge", "version": 7, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    redis.delete = AsyncMock(return_value=1)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_SAFETY_FLAG
+        # S1: hint key must NOT be deleted from Redis.
+        redis.delete.assert_not_awaited()
+        # S2: an internal discard must not falsely degrade pubsub propagation.
+        assert state.cluster_propagation == PROPAGATION_REDIS
     finally:
         await coord.stop()
 
@@ -650,6 +817,11 @@ async def test_reconcile_from_hint_does_not_clobber_higher_local_version(monkeyp
 @pytest.mark.asyncio
 async def test_listen_loop_applies_remote_pubsub_message(monkeypatch: pytest.MonkeyPatch):
     """End-to-end pub/sub message should round-trip through the listen loop into RuntimeState."""
+    # Make the deployment compatible with the incoming a2a/shadow payload —
+    # otherwise _listen_loop will (correctly) discard the message.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", True, raising=False)
+
     redis = _make_redis_mock()
     pubsub = redis.pubsub.return_value
     payload = orjson.dumps({"runtime": "a2a", "mode": "shadow", "version": 11, "initiator_pod": "remote-pod", "initiator_user": "carol", "timestamp": 1.0})
@@ -723,21 +895,36 @@ async def test_listen_loop_downgrades_after_consecutive_failures(monkeypatch: py
 
 @pytest.mark.asyncio
 async def test_listen_loop_repromotes_after_recovery(monkeypatch: pytest.MonkeyPatch):
-    """A successful receive after degraded must promote cluster_propagation back to redis."""
+    """A successful receive of a real message after degraded must promote cluster_propagation back to redis.
+
+    Per the I2 fix, a non-exception return of ``None`` (no message) is NOT
+    counted as recovery — only a real message is. This prevents a pubsub
+    that's "broken in a way that returns None reliably" from falsely clearing
+    the failure counter.
+    """
     import asyncio as _asyncio
 
     from mcpgateway.runtime_state import LISTEN_LOOP_DEGRADE_THRESHOLD
 
+    # Make the deployment compatible with the recovery message we'll deliver.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", True, raising=False)
+
     redis = _make_redis_mock()
     pubsub = redis.pubsub.return_value
     fail_count = {"n": 0}
+    real_message_payload = orjson.dumps({"runtime": "a2a", "mode": "shadow", "version": 1, "initiator_pod": "remote-pod", "timestamp": 1.0})
 
     async def flaky_get_message(*args, **kwargs):
         if fail_count["n"] < LISTEN_LOOP_DEGRADE_THRESHOLD:
             fail_count["n"] += 1
             raise RuntimeError("pubsub down")
-        # Recovery: behave like an idle pubsub (None message).
+        # Recovery: deliver one real message, then idle.
+        if fail_count["n"] == LISTEN_LOOP_DEGRADE_THRESHOLD:
+            fail_count["n"] += 1
+            return {"type": "message", "channel": RUNTIME_STATE_CHANNEL.encode(), "data": real_message_payload}
         await _asyncio.sleep(0.02)
+        return None
 
     pubsub.get_message = AsyncMock(side_effect=flaky_get_message)
     monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
@@ -746,7 +933,7 @@ async def test_listen_loop_repromotes_after_recovery(monkeypatch: pytest.MonkeyP
     await coord.start()
     try:
         for _ in range(80):
-            if get_runtime_state().cluster_propagation == PROPAGATION_REDIS and fail_count["n"] >= LISTEN_LOOP_DEGRADE_THRESHOLD:
+            if get_runtime_state().cluster_propagation == PROPAGATION_REDIS and fail_count["n"] > LISTEN_LOOP_DEGRADE_THRESHOLD:
                 break
             await _asyncio.sleep(0.05)
         assert get_runtime_state().cluster_propagation == PROPAGATION_REDIS

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -1007,3 +1007,350 @@ async def test_listen_loop_dedupes_self_pubsub_message(monkeypatch: pytest.Monke
         assert state.version("mcp") == 0
     finally:
         await coord.stop()
+
+
+# ---------------------------------------------------------------------
+# Defensive ValueError branches — accessor methods on RuntimeState
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("boot_reconcile_status", "coordinator_offline"),
+        ("override_mode", None),
+        ("version", 0),
+        ("last_change", None),
+    ],
+)
+def test_runtime_state_accessors_return_safe_defaults_for_unknown_runtime(method, expected):
+    """Accessors must not raise when handed an unknown runtime kind — they return a safe default so callers (e.g. health endpoints) keep working."""
+    state = RuntimeState()
+    result = getattr(state, method)("rpc")  # "rpc" is not a registered kind
+    if method == "boot_reconcile_status":
+        assert result.value == expected
+    else:
+        assert result == expected
+
+
+# ---------------------------------------------------------------------
+# RuntimeStateCoordinator.start: idempotent + degraded path
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinator_start_is_idempotent():
+    """Calling start() twice is a no-op; the second call returns immediately without re-attaching."""
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        await coord.start()  # second call must not raise / re-attach
+        assert coord._started is True  # noqa: SLF001 — verifying idempotency
+    finally:
+        await coord.stop()
+
+
+# ---------------------------------------------------------------------
+# _reconcile_from_hint: no-redis and malformed-mode paths
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_no_redis_marks_status_ok():
+    """When Redis isn't configured, boot reconcile is trivially OK — no hint to apply."""
+    coord = RuntimeStateCoordinator()
+    coord._redis = None  # noqa: SLF001 — explicitly model the no-Redis deployment
+    await coord._reconcile_from_hint("mcp")  # noqa: SLF001
+    assert get_runtime_state().boot_reconcile_status("mcp").value == "ok"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_malformed_mode_in_payload_falls_through():
+    """A hint payload whose ``mode`` field can't be coerced is treated as 'no compatibility check' and falls through to apply_remote."""
+    coord = RuntimeStateCoordinator()
+    coord._redis = MagicMock()
+    coord._redis.get = AsyncMock(return_value=orjson.dumps({"mode": "not-a-mode", "version": 1, "initiator_pod": "pod-x"}))
+    await coord._reconcile_from_hint("mcp")  # noqa: SLF001
+    # Either OK (apply_remote rejected the malformed mode silently) or an
+    # incompatible-* status — the important thing is no exception bubbled up.
+    assert get_runtime_state().boot_reconcile_status("mcp") is not None
+
+
+# ---------------------------------------------------------------------
+# _cleanup_pubsub: timeout + close paths
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pubsub_handles_unsubscribe_timeout_and_close_paths():
+    """Both unsubscribe and close take the timeout/exception arms cleanly — they must never raise out of _cleanup_pubsub."""
+    # Standard
+    import asyncio as _asyncio
+
+    coord = RuntimeStateCoordinator()
+    fake_pubsub = MagicMock()
+    fake_pubsub.unsubscribe = AsyncMock(side_effect=_asyncio.TimeoutError())
+    fake_pubsub.aclose = AsyncMock(side_effect=_asyncio.TimeoutError())
+    coord._pubsub = fake_pubsub  # noqa: SLF001
+
+    # Must not raise.
+    await coord._cleanup_pubsub()  # noqa: SLF001
+    assert coord._pubsub is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pubsub_falls_back_to_close_when_aclose_missing():
+    """Older redis clients expose ``close`` not ``aclose`` — the cleanup must fall back without raising."""
+    coord = RuntimeStateCoordinator()
+    fake_pubsub = MagicMock(spec=["unsubscribe", "close"])  # NO aclose
+    fake_pubsub.unsubscribe = AsyncMock(return_value=None)
+    fake_pubsub.close = AsyncMock(return_value=None)
+    coord._pubsub = fake_pubsub  # noqa: SLF001
+
+    await coord._cleanup_pubsub()  # noqa: SLF001
+    fake_pubsub.close.assert_awaited_once()
+    assert coord._pubsub is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_cleanup_pubsub_swallows_unsubscribe_and_close_exceptions():
+    """Non-timeout exceptions during unsubscribe / close are caught and logged, never raised."""
+    coord = RuntimeStateCoordinator()
+    fake_pubsub = MagicMock()
+    fake_pubsub.unsubscribe = AsyncMock(side_effect=RuntimeError("unsub blew up"))
+    fake_pubsub.aclose = AsyncMock(side_effect=RuntimeError("close blew up"))
+    coord._pubsub = fake_pubsub  # noqa: SLF001
+
+    await coord._cleanup_pubsub()  # noqa: SLF001
+    assert coord._pubsub is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------
+# Listen-loop edge cases — exercised by driving _listen_loop with a
+# fake pubsub that yields specific message shapes.
+# ---------------------------------------------------------------------
+
+
+class _ScriptedPubSub:
+    """Async stub that yields a scripted sequence of get_message values, then signals the coordinator's stop_event so _listen_loop exits cleanly."""
+
+    def __init__(self, script: list, stop_event) -> None:
+        # Each entry is either a callable returning a dict (or raising) OR a
+        # bare value yielded as-is.
+        self._script = list(script)
+        self._stop = stop_event
+
+    async def get_message(self, ignore_subscribe_messages: bool = True, timeout: float = 1.0):  # noqa: ARG002
+        if not self._script:
+            # Set the stop_event then yield None so the coordinator hits its
+            # "non-message return" continue and re-checks the loop condition.
+            self._stop.set()
+            return None
+        item = self._script.pop(0)
+        if callable(item):
+            return item()
+        return item
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_recovers_cluster_propagation_after_idle_following_errors():
+    """After a stretch of receive errors degrades cluster_propagation, an idle-timeout (no message) restores it."""
+    # Standard
+    import asyncio as _asyncio
+
+    state = get_runtime_state()
+    state.set_cluster_propagation(PROPAGATION_DEGRADED)
+
+    coord = RuntimeStateCoordinator()
+    coord._started = True  # noqa: SLF001
+    stop = _asyncio.Event()
+    coord._stop_event = stop  # noqa: SLF001
+
+    # First call raises a non-Timeout to bump consecutive_errors > 0;
+    # second call raises TimeoutError to take the recovery branch.
+    def _raise_runtime():
+        raise RuntimeError("transient receive error")
+
+    def _raise_timeout():
+        raise _asyncio.TimeoutError()
+
+    coord._pubsub = _ScriptedPubSub([_raise_runtime, _raise_timeout], stop)  # noqa: SLF001
+
+    await coord._listen_loop()  # noqa: SLF001
+
+    assert state.cluster_propagation == PROPAGATION_REDIS
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_discards_malformed_pubsub_payload(caplog):
+    """A pub/sub message whose data isn't valid JSON is logged and skipped — no crash, no state change."""
+    # Standard
+    import asyncio as _asyncio
+
+    coord = RuntimeStateCoordinator()
+    coord._started = True  # noqa: SLF001
+    stop = _asyncio.Event()
+    coord._stop_event = stop  # noqa: SLF001
+
+    coord._pubsub = _ScriptedPubSub(  # noqa: SLF001
+        [{"type": "message", "data": b"not-valid-json{{{"}],
+        stop,
+    )
+
+    caplog.set_level("WARNING", logger="mcpgateway.runtime_state")
+    await coord._listen_loop()  # noqa: SLF001
+
+    assert any("malformed pub/sub payload" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_skips_message_with_empty_data():
+    """A pub/sub message with empty ``data`` is skipped without raising."""
+    # Standard
+    import asyncio as _asyncio
+
+    coord = RuntimeStateCoordinator()
+    coord._started = True  # noqa: SLF001
+    stop = _asyncio.Event()
+    coord._stop_event = stop  # noqa: SLF001
+
+    coord._pubsub = _ScriptedPubSub([{"type": "message", "data": ""}], stop)  # noqa: SLF001
+
+    # Must not raise.
+    await coord._listen_loop()  # noqa: SLF001
+    assert get_runtime_state().override_mode("mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_treats_uncoerceable_payload_fields_as_none(monkeypatch, caplog):
+    """When ``mode`` or ``runtime`` in the payload can't be coerced to enums, the compatibility check is skipped and apply_remote handles the malformed payload."""
+    # Standard
+    import asyncio as _asyncio
+
+    coord = RuntimeStateCoordinator()
+    coord._started = True  # noqa: SLF001
+    stop = _asyncio.Event()
+    coord._stop_event = stop  # noqa: SLF001
+
+    payload = orjson.dumps(
+        {
+            "runtime": "not-a-real-runtime",
+            "mode": "not-a-real-mode",
+            "version": 1,
+            "initiator_pod": "pod-other",
+        }
+    )
+    coord._pubsub = _ScriptedPubSub([{"type": "message", "data": payload}], stop)  # noqa: SLF001
+
+    caplog.set_level("WARNING", logger="mcpgateway.runtime_state")
+    await coord._listen_loop()  # noqa: SLF001
+
+    # No state change; apply_remote should have rejected the malformed payload.
+    assert get_runtime_state().override_mode("mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_decodes_bytes_payload_and_reaches_compatibility_check(monkeypatch, caplog):
+    """Message data delivered as bytes is decoded UTF-8, JSON-parsed, and reaches the per-pod compatibility check."""
+    # Standard
+    import asyncio as _asyncio
+
+    # First-Party
+    from mcpgateway.config import settings as _settings
+
+    # Enable MCP runtime + safety flag so the compatibility check returns OK
+    # for an edge override; we can then apply_remote it.
+    monkeypatch.setattr(_settings, "experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr(_settings, "experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
+    state = get_runtime_state()
+    coord = RuntimeStateCoordinator()
+    coord._started = True  # noqa: SLF001
+    stop = _asyncio.Event()
+    coord._stop_event = stop  # noqa: SLF001
+
+    payload = orjson.dumps(
+        {
+            "runtime": "mcp",
+            "mode": "edge",
+            "version": 99,
+            "initiator_user": "alice@example.com",
+            "initiator_pod": "pod-other",
+            "timestamp": 1234567890.0,
+        }
+    )
+    coord._pubsub = _ScriptedPubSub([{"type": "message", "data": payload}], stop)  # noqa: SLF001
+
+    caplog.set_level("INFO", logger="mcpgateway.runtime_state")
+    await coord._listen_loop()  # noqa: SLF001
+
+    # The bytes payload was decoded, parsed, found compatible, and applied.
+    assert state.override_mode("mcp") == "edge"
+    assert state.version("mcp") == 99
+
+
+# ---------------------------------------------------------------------
+# version.py status payload includes last_change after an override
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_runtime_status_payload_includes_last_change_after_override(monkeypatch):
+    """After an override is applied, _mcp_runtime_status_payload exposes a last_change block."""
+    # First-Party
+    from mcpgateway.config import settings as _settings
+    from mcpgateway.version import _mcp_runtime_status_payload
+
+    monkeypatch.setattr(_settings, "experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr(_settings, "experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
+    state = get_runtime_state()
+    await state.apply_local("mcp", "edge", initiator_user="alice@example.com", version=42)
+
+    payload = _mcp_runtime_status_payload()
+    assert "last_change" in payload
+    assert payload["last_change"]["version"] == 42
+    assert payload["last_change"]["mode"] == "edge"
+    assert payload["last_change"]["initiator_user"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_a2a_runtime_status_payload_includes_last_change_after_override(monkeypatch):
+    """After an A2A override is applied, _a2a_runtime_status_payload exposes a last_change block."""
+    # First-Party
+    from mcpgateway.config import settings as _settings
+    from mcpgateway.version import _a2a_runtime_status_payload
+
+    monkeypatch.setattr(_settings, "experimental_rust_a2a_runtime_enabled", True, raising=False)
+
+    state = get_runtime_state()
+    await state.apply_local("a2a", "shadow", initiator_user="bob@example.com", version=7)
+
+    payload = _a2a_runtime_status_payload()
+    assert "last_change" in payload
+    assert payload["last_change"]["version"] == 7
+    assert payload["last_change"]["mode"] == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_should_delegate_a2a_to_rust_returns_false_under_shadow_override(monkeypatch):
+    """An A2A shadow override forces _should_delegate_a2a_to_rust to False even when boot flags allow delegation."""
+    # First-Party
+    from mcpgateway.config import settings as _settings
+    from mcpgateway.version import _should_delegate_a2a_to_rust
+
+    monkeypatch.setattr(_settings, "experimental_rust_a2a_runtime_enabled", True, raising=False)
+    monkeypatch.setattr(_settings, "experimental_rust_a2a_runtime_delegate_enabled", True, raising=False)
+
+    state = get_runtime_state()
+    await state.apply_local("a2a", "shadow", initiator_user=None, version=1)
+
+    assert _should_delegate_a2a_to_rust() is False
+
+
+def test_boot_mcp_transport_mount_returns_underlying_value():
+    """``boot_mcp_transport_mount`` is a thin public wrapper — verify it returns the same value as the underlying helper."""
+    # First-Party
+    from mcpgateway.version import _boot_mcp_transport_mount, boot_mcp_transport_mount
+
+    assert boot_mcp_transport_mount() == _boot_mcp_transport_mount()

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -354,6 +354,95 @@ async def test_reconcile_from_hint_discards_incompatible_mode(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_shadow_on_full_boot(monkeypatch: pytest.MonkeyPatch):
+    """A shadow hint must NOT be applied on boot=full — full mounts a plain RustMCPRuntimeProxy
+    with no dispatcher, so the override would strand in state (diagnostics say shadow; transport
+    always routes to Rust). The router also 409s for any PATCH on boot=full, so without this
+    guard the operator would have no path to clear the stale override.
+    """
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    # boot=full: all cores enabled.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_event_store_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_resume_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_live_stream_core_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_affinity_core_enabled", True, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "shadow", "version": 9, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.override_mode("mcp") is None
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_any_mode_on_off_boot(monkeypatch: pytest.MonkeyPatch):
+    """boot=off has no Rust sidecar at all — no hint can take effect. Must be discarded."""
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "shadow", "version": 3, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.override_mode("mcp") is None
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_a2a_hint_on_a2a_off_boot(monkeypatch: pytest.MonkeyPatch):
+    """A2A boot=off has runtime disabled — no hint can take effect."""
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "a2a", "mode": "shadow", "version": 11, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("a2a") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        assert state.override_mode("a2a") is None
+        assert state.boot_reconcile_status("a2a") == BootReconcileStatus.INCOMPATIBLE_HINT
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_from_hint_accepts_shadow_mode_on_shadow_boot(monkeypatch: pytest.MonkeyPatch):
     """A shadow hint is always compatible — shadow is the Python-default and every boot serves Python for shadow overrides."""
     monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -238,6 +238,12 @@ async def test_coordinator_next_version_local_when_redis_missing(monkeypatch: py
 
 @pytest.mark.asyncio
 async def test_coordinator_reconciles_from_hint(monkeypatch: pytest.MonkeyPatch):
+    # Simulate an edge-boot deployment so the persisted hint's mode=edge is
+    # compatible with the safety invariant; otherwise _reconcile_from_hint
+    # would (correctly) discard the hint as INCOMPATIBLE_HINT.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", True, raising=False)
+
     hint_payload = orjson.dumps(
         {
             "runtime": "mcp",
@@ -299,6 +305,80 @@ async def test_override_edge_cannot_bypass_session_auth_reuse_invariant(monkeypa
     from mcpgateway.version import should_mount_public_rust_transport
 
     assert should_mount_public_rust_transport() is False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_discards_incompatible_mode(monkeypatch: pytest.MonkeyPatch):
+    """A hint written by a former edge-boot pod must NOT be applied on a shadow-boot deployment.
+
+    Without this guard, a shadow-boot pod would reconcile to override=edge even though the
+    transport layer refuses to honor it — and the admin API would need the escape-hatch
+    PATCH to clear misleading diagnostics. The coordinator discards the hint and records
+    ``INCOMPATIBLE_HINT`` so operators can see what happened via /health.
+    """
+    # First-Party
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    # Shadow-boot: runtime enabled but session-auth-reuse NOT enabled.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps(
+        {
+            "runtime": "mcp",
+            "mode": "edge",
+            "version": 42,
+            "initiator_pod": "prior-edge-boot",
+            "initiator_user": "operator",
+            "timestamp": 1.0,
+        }
+    )
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = get_runtime_state()
+        # The stale edge hint must NOT have been applied.
+        assert state.override_mode("mcp") is None
+        assert state.version("mcp") == 0
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.INCOMPATIBLE_HINT
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_accepts_shadow_mode_on_shadow_boot(monkeypatch: pytest.MonkeyPatch):
+    """A shadow hint is always compatible — shadow is the Python-default and every boot serves Python for shadow overrides."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", False, raising=False)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "shadow", "version": 5, "initiator_pod": "other", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        from mcpgateway.runtime_state import BootReconcileStatus, OverrideMode
+
+        state = get_runtime_state()
+        assert state.override_mode("mcp") == OverrideMode.SHADOW
+        assert state.version("mcp") == 5
+        assert state.boot_reconcile_status("mcp") == BootReconcileStatus.OK
+    finally:
+        await coord.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -1,0 +1,614 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``mcpgateway.runtime_state``."""
+
+# Standard
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+import orjson
+import pytest
+
+# First-Party
+from mcpgateway.runtime_state import (
+    PROPAGATION_DEGRADED,
+    PROPAGATION_REDIS,
+    RUNTIME_KINDS,
+    RUNTIME_STATE_CHANNEL,
+    SUPPORTED_OVERRIDE_MODES,
+    ModeChange,
+    RuntimeState,
+    RuntimeStateCoordinator,
+    RuntimeStateError,
+    _hint_key,
+    _version_key,
+    get_runtime_state,
+    reset_runtime_state_coordinator_for_tests,
+    reset_runtime_state_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Ensure each test starts with fresh state and coordinator singletons."""
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+    yield
+    reset_runtime_state_for_tests()
+    reset_runtime_state_coordinator_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_apply_local_records_change():
+    state = RuntimeState()
+    change = await state.apply_local("mcp", "edge", initiator_user="alice@example.com", version=1)
+    assert change.runtime == "mcp"
+    assert change.mode == "edge"
+    assert change.version == 1
+    assert change.initiator_user == "alice@example.com"
+    assert change.initiator_pod == state.pod_id
+    assert state.override_mode("mcp") == "edge"
+    assert state.version("mcp") == 1
+    assert state.last_change("mcp") == change
+
+
+@pytest.mark.asyncio
+async def test_apply_local_isolates_runtimes():
+    state = RuntimeState()
+    await state.apply_local("mcp", "edge", initiator_user=None, version=1)
+    assert state.override_mode("mcp") == "edge"
+    assert state.override_mode("a2a") is None
+    await state.apply_local("a2a", "shadow", initiator_user=None, version=7)
+    assert state.override_mode("a2a") == "shadow"
+    assert state.version("a2a") == 7
+    assert state.version("mcp") == 1  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_apply_local_rejects_unsupported_mode():
+    state = RuntimeState()
+    with pytest.raises(ValueError):
+        await state.apply_local("mcp", "off", initiator_user=None, version=1)
+
+
+@pytest.mark.asyncio
+async def test_apply_local_rejects_unknown_runtime():
+    state = RuntimeState()
+    with pytest.raises(ValueError):
+        await state.apply_local("rpc", "edge", initiator_user=None, version=1)
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_advances_state_when_newer():
+    state = RuntimeState()
+    payload = {
+        "runtime": "mcp",
+        "mode": "edge",
+        "version": 5,
+        "initiator_pod": "other-pod",
+        "initiator_user": "bob",
+        "timestamp": 1700000000.0,
+    }
+    change = await state.apply_remote(payload)
+    assert change is not None
+    assert change.mode == "edge"
+    assert change.version == 5
+    assert state.override_mode("mcp") == "edge"
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_drops_stale_versions():
+    state = RuntimeState()
+    await state.apply_local("mcp", "edge", initiator_user=None, version=10)
+    payload = {
+        "runtime": "mcp",
+        "mode": "shadow",
+        "version": 5,
+        "initiator_pod": "other-pod",
+    }
+    assert await state.apply_remote(payload) is None
+    assert state.override_mode("mcp") == "edge"
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_dedupes_self_messages():
+    state = RuntimeState()
+    payload = {
+        "runtime": "mcp",
+        "mode": "edge",
+        "version": 99,
+        "initiator_pod": state.pod_id,
+    }
+    assert await state.apply_remote(payload) is None
+    assert state.override_mode("mcp") is None
+
+
+@pytest.mark.asyncio
+async def test_apply_remote_rejects_malformed_payload():
+    state = RuntimeState()
+    assert await state.apply_remote({"mode": "edge"}) is None  # missing runtime/version
+    assert await state.apply_remote({"runtime": "mcp", "mode": "off", "version": 1, "initiator_pod": "x"}) is None
+    assert await state.apply_remote({"runtime": "rpc", "mode": "edge", "version": 1, "initiator_pod": "x"}) is None
+    assert state.override_mode("mcp") is None
+
+
+# ---------------------------------------------------------------------------
+# RuntimeStateCoordinator
+# ---------------------------------------------------------------------------
+
+
+def _make_redis_mock(get_value: Any = None, incr_value: int = 1) -> MagicMock:
+    """Build an async Redis mock with the methods the coordinator uses."""
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=get_value)
+    redis.set = AsyncMock(return_value=True)
+    redis.incr = AsyncMock(return_value=incr_value)
+    redis.publish = AsyncMock(return_value=1)
+    pubsub = MagicMock()
+    pubsub.subscribe = AsyncMock(return_value=None)
+    pubsub.unsubscribe = AsyncMock(return_value=None)
+    pubsub.aclose = AsyncMock(return_value=None)
+    pubsub.get_message = AsyncMock(side_effect=__import__("asyncio").TimeoutError())
+    redis.pubsub = MagicMock(return_value=pubsub)
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_coordinator_falls_back_when_redis_unavailable(monkeypatch: pytest.MonkeyPatch):
+    coord = RuntimeStateCoordinator()
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=None),
+    )
+    await coord.start()
+    assert coord.started is True
+    assert coord.cluster_propagation_enabled is False
+    state = __import__("mcpgateway.runtime_state", fromlist=["get_runtime_state"]).get_runtime_state()
+    assert state.cluster_propagation == "disabled"
+    await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publish_no_op_when_redis_missing(monkeypatch: pytest.MonkeyPatch):
+    coord = RuntimeStateCoordinator()
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=None),
+    )
+    await coord.start()
+    change = ModeChange(runtime="mcp", version=1, mode="edge", initiator_user="x", initiator_pod="p", timestamp=0.0)
+    # Must not raise even though Redis is None.
+    await coord.publish(change)
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publish_writes_pubsub_and_hint(monkeypatch: pytest.MonkeyPatch):
+    redis = _make_redis_mock()
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=redis),
+    )
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        assert coord.cluster_propagation_enabled is True
+        change = ModeChange(runtime="a2a", version=42, mode="edge", initiator_user="alice", initiator_pod="pod-1", timestamp=1.0)
+        await coord.publish(change)
+        redis.publish.assert_awaited_once()
+        published_channel, published_payload = redis.publish.await_args.args
+        assert published_channel == RUNTIME_STATE_CHANNEL
+        decoded = orjson.loads(published_payload)
+        assert decoded["runtime"] == "a2a"
+        assert decoded["mode"] == "edge"
+        assert decoded["version"] == 42
+        redis.set.assert_awaited_once()
+        set_args = redis.set.await_args
+        assert set_args.args[0] == _hint_key("a2a")
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_next_version_uses_redis_counter(monkeypatch: pytest.MonkeyPatch):
+    redis = _make_redis_mock(incr_value=99)
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=redis),
+    )
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        version = await coord.next_version("mcp", current_version=10)
+        assert version == 99
+        redis.incr.assert_awaited_once_with(_version_key("mcp"))
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_next_version_local_when_redis_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=None),
+    )
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    assert await coord.next_version("mcp", current_version=10) == 11
+
+
+@pytest.mark.asyncio
+async def test_coordinator_reconciles_from_hint(monkeypatch: pytest.MonkeyPatch):
+    hint_payload = orjson.dumps(
+        {
+            "runtime": "mcp",
+            "mode": "edge",
+            "version": 17,
+            "initiator_pod": "remote-pod",
+            "initiator_user": "carol@example.com",
+            "timestamp": 1.0,
+        }
+    )
+
+    async def fake_get(key):
+        if key == _hint_key("mcp"):
+            return hint_payload
+        return None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=redis),
+    )
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        state = __import__("mcpgateway.runtime_state", fromlist=["get_runtime_state"]).get_runtime_state()
+        assert state.override_mode("mcp") == "edge"
+        assert state.version("mcp") == 17
+    finally:
+        await coord.stop()
+
+
+def test_constants_match_kinds():
+    assert RUNTIME_KINDS == frozenset({"mcp", "a2a"})
+    assert SUPPORTED_OVERRIDE_MODES == frozenset({"shadow", "edge"})
+
+
+# ---------------------------------------------------------------------------
+# Block 1+2 follow-up coverage
+# ---------------------------------------------------------------------------
+
+
+def test_mode_change_post_init_rejects_bogus_runtime():
+    with pytest.raises(ValueError):
+        ModeChange(runtime="rpc", version=1, mode="edge", initiator_user=None, initiator_pod="p", timestamp=0.0)
+
+
+def test_mode_change_post_init_rejects_bogus_mode():
+    with pytest.raises(ValueError):
+        ModeChange(runtime="mcp", version=1, mode="off", initiator_user=None, initiator_pod="p", timestamp=0.0)
+
+
+@pytest.mark.asyncio
+async def test_apply_local_drops_stale_local_version():
+    """Concurrent local PATCHes can land out of order; the older one must be dropped."""
+    state = RuntimeState()
+    first = await state.apply_local("mcp", "edge", initiator_user="alice", version=10)
+    assert first is not None and first.version == 10
+    # Pretend a second PATCH allocated v=11 and landed first.
+    later = await state.apply_local("mcp", "shadow", initiator_user="bob", version=11)
+    assert later is not None and later.version == 11
+    # Now the v=10 writer (which had been awaiting the lock) lands; must drop.
+    stale = await state.apply_local("mcp", "edge", initiator_user="alice", version=10)
+    assert stale is None
+    assert state.version("mcp") == 11
+    assert state.override_mode("mcp") == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_propagation_degraded_when_redis_raises(monkeypatch: pytest.MonkeyPatch):
+    """Configured-but-broken Redis must surface as 'degraded', not 'disabled'."""
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(side_effect=RuntimeError("redis exploded")),
+    )
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    assert coord.started is True
+    assert get_runtime_state().cluster_propagation == PROPAGATION_DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_coordinator_marks_propagation_degraded_when_subscribe_fails(monkeypatch: pytest.MonkeyPatch):
+    """Pub/sub subscribe failure with Redis attached should mark degraded, not disabled.
+
+    Also asserts ``boot_reconcile_status`` flips to ``PUBSUB_UNAVAILABLE`` for
+    every runtime even though ``_reconcile_from_hint`` ran first and marked
+    them all ``OK`` (the hint key was empty). Without that override, /health
+    would silently advertise ``OK`` boot reconciliation while the listener was
+    actually dead.
+    """
+    # First-Party
+    from mcpgateway.runtime_state import BootReconcileStatus
+
+    redis = _make_redis_mock()
+    pubsub = redis.pubsub.return_value
+    pubsub.subscribe = AsyncMock(side_effect=RuntimeError("subscribe failed"))
+    monkeypatch.setattr(
+        "mcpgateway.utils.redis_client.get_redis_client",
+        AsyncMock(return_value=redis),
+    )
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    state = get_runtime_state()
+    assert state.cluster_propagation == PROPAGATION_DEGRADED
+    for kind in RUNTIME_KINDS:
+        assert state.boot_reconcile_status(kind) == BootReconcileStatus.PUBSUB_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publish_returns_true_when_redis_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    change = ModeChange(runtime="mcp", version=1, mode="edge", initiator_user="x", initiator_pod="p", timestamp=0.0)
+    assert await coord.publish(change) is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publish_returns_false_on_redis_publish_error(monkeypatch: pytest.MonkeyPatch):
+    redis = _make_redis_mock()
+    redis.publish = AsyncMock(side_effect=RuntimeError("publish failed"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        change = ModeChange(runtime="mcp", version=1, mode="edge", initiator_user="x", initiator_pod="p", timestamp=0.0)
+        assert await coord.publish(change) is False
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_publish_returns_false_when_hint_set_fails(monkeypatch: pytest.MonkeyPatch):
+    redis = _make_redis_mock()
+    redis.set = AsyncMock(side_effect=RuntimeError("set failed"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        change = ModeChange(runtime="mcp", version=1, mode="edge", initiator_user="x", initiator_pod="p", timestamp=0.0)
+        assert await coord.publish(change) is False
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_next_version_raises_on_incr_error(monkeypatch: pytest.MonkeyPatch):
+    """A bare INCR failure must not silently fall back to a colliding local version."""
+    redis = _make_redis_mock()
+    redis.incr = AsyncMock(side_effect=RuntimeError("incr failed"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        with pytest.raises(RuntimeStateError):
+            await coord.next_version("mcp", current_version=10)
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_next_version_raises_when_counter_below_local(monkeypatch: pytest.MonkeyPatch):
+    """If the Redis counter is below local (e.g. counter was deleted), raise rather than publish a stale version."""
+    redis = _make_redis_mock(incr_value=3)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        with pytest.raises(RuntimeStateError):
+            await coord.next_version("mcp", current_version=10)
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_does_not_clobber_higher_local_version(monkeypatch: pytest.MonkeyPatch):
+    """Boot reconciliation must not roll local state back to a stale persisted hint."""
+    state = get_runtime_state()
+    await state.apply_local("mcp", "shadow", initiator_user="local", version=99)
+
+    hint_payload = orjson.dumps({"runtime": "mcp", "mode": "edge", "version": 5, "initiator_pod": "remote-pod", "initiator_user": "remote", "timestamp": 1.0})
+
+    async def fake_get(key):
+        return hint_payload if key == _hint_key("mcp") else None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        # Local v=99 must win over stale hint v=5.
+        assert state.version("mcp") == 99
+        assert state.override_mode("mcp") == "shadow"
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_applies_remote_pubsub_message(monkeypatch: pytest.MonkeyPatch):
+    """End-to-end pub/sub message should round-trip through the listen loop into RuntimeState."""
+    redis = _make_redis_mock()
+    pubsub = redis.pubsub.return_value
+    payload = orjson.dumps({"runtime": "a2a", "mode": "shadow", "version": 11, "initiator_pod": "remote-pod", "initiator_user": "carol", "timestamp": 1.0})
+    delivered = {"yielded": False}
+
+    async def fake_get_message(*args, **kwargs):
+        if delivered["yielded"]:
+            # After the first delivery, behave like a normal idle pubsub.
+            await __import__("asyncio").sleep(0.05)
+            return None
+        delivered["yielded"] = True
+        return {"type": "message", "channel": RUNTIME_STATE_CHANNEL.encode(), "data": payload}
+
+    pubsub.get_message = AsyncMock(side_effect=fake_get_message)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        # Give the listen loop a brief window to consume the queued message.
+        for _ in range(20):
+            if get_runtime_state().override_mode("a2a") == "shadow":
+                break
+            await __import__("asyncio").sleep(0.05)
+        assert get_runtime_state().override_mode("a2a") == "shadow"
+        assert get_runtime_state().version("a2a") == 11
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_cluster_propagation_surfaces_in_runtime_status_payload(monkeypatch: pytest.MonkeyPatch):
+    """The /health-bound payload must include cluster_propagation so dashboards can alert on degraded."""
+    from mcpgateway import version as version_module
+
+    state = get_runtime_state()
+    state.set_cluster_propagation(PROPAGATION_DEGRADED)
+
+    mcp_payload = version_module.mcp_runtime_status_payload()
+    a2a_payload = version_module.a2a_runtime_status_payload()
+
+    assert mcp_payload["cluster_propagation"] == PROPAGATION_DEGRADED
+    assert a2a_payload["cluster_propagation"] == PROPAGATION_DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_downgrades_after_consecutive_failures(monkeypatch: pytest.MonkeyPatch):
+    """Consecutive get_message failures must downgrade cluster_propagation to degraded."""
+    import asyncio as _asyncio
+
+    from mcpgateway.runtime_state import LISTEN_LOOP_DEGRADE_THRESHOLD
+
+    redis = _make_redis_mock()
+    pubsub = redis.pubsub.return_value
+    pubsub.get_message = AsyncMock(side_effect=RuntimeError("pubsub down"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        # Wait until the loop has registered enough failures to downgrade.
+        for _ in range(60):
+            if get_runtime_state().cluster_propagation == PROPAGATION_DEGRADED:
+                break
+            await _asyncio.sleep(0.05)
+        assert get_runtime_state().cluster_propagation == PROPAGATION_DEGRADED
+        assert pubsub.get_message.await_count >= LISTEN_LOOP_DEGRADE_THRESHOLD
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_repromotes_after_recovery(monkeypatch: pytest.MonkeyPatch):
+    """A successful receive after degraded must promote cluster_propagation back to redis."""
+    import asyncio as _asyncio
+
+    from mcpgateway.runtime_state import LISTEN_LOOP_DEGRADE_THRESHOLD
+
+    redis = _make_redis_mock()
+    pubsub = redis.pubsub.return_value
+    fail_count = {"n": 0}
+
+    async def flaky_get_message(*args, **kwargs):
+        if fail_count["n"] < LISTEN_LOOP_DEGRADE_THRESHOLD:
+            fail_count["n"] += 1
+            raise RuntimeError("pubsub down")
+        # Recovery: behave like an idle pubsub (None message).
+        await _asyncio.sleep(0.02)
+
+    pubsub.get_message = AsyncMock(side_effect=flaky_get_message)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        for _ in range(80):
+            if get_runtime_state().cluster_propagation == PROPAGATION_REDIS and fail_count["n"] >= LISTEN_LOOP_DEGRADE_THRESHOLD:
+                break
+            await _asyncio.sleep(0.05)
+        assert get_runtime_state().cluster_propagation == PROPAGATION_REDIS
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_marks_degraded_on_redis_failure(monkeypatch: pytest.MonkeyPatch):
+    """A Redis read failure during boot reconciliation must downgrade to degraded."""
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=RuntimeError("redis read failed"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        assert get_runtime_state().cluster_propagation == PROPAGATION_DEGRADED
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_from_hint_marks_degraded_on_malformed_payload(monkeypatch: pytest.MonkeyPatch):
+    """A malformed JSON hint must downgrade cluster_propagation to degraded."""
+
+    async def fake_get(key):
+        # Return malformed JSON for the mcp hint key only.
+        if key == _hint_key("mcp"):
+            return b"{not json"
+        return None
+
+    redis = _make_redis_mock()
+    redis.get = AsyncMock(side_effect=fake_get)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        assert get_runtime_state().cluster_propagation == PROPAGATION_DEGRADED
+    finally:
+        await coord.stop()
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_dedupes_self_pubsub_message(monkeypatch: pytest.MonkeyPatch):
+    """A pub/sub message originating from this pod must not bump local state."""
+    redis = _make_redis_mock()
+    pubsub = redis.pubsub.return_value
+
+    state = get_runtime_state()
+    self_payload = orjson.dumps({"runtime": "mcp", "mode": "edge", "version": 99, "initiator_pod": state.pod_id, "timestamp": 1.0})
+    delivered = {"yielded": False}
+
+    async def fake_get_message(*args, **kwargs):
+        if delivered["yielded"]:
+            await __import__("asyncio").sleep(0.05)
+            return None
+        delivered["yielded"] = True
+        return {"type": "message", "channel": RUNTIME_STATE_CHANNEL.encode(), "data": self_payload}
+
+    pubsub.get_message = AsyncMock(side_effect=fake_get_message)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=redis))
+
+    coord = RuntimeStateCoordinator()
+    await coord.start()
+    try:
+        # Wait long enough for the listen loop to have processed the message.
+        await __import__("asyncio").sleep(0.2)
+        assert state.override_mode("mcp") is None
+        assert state.version("mcp") == 0
+    finally:
+        await coord.stop()

--- a/tests/unit/mcpgateway/test_runtime_state.py
+++ b/tests/unit/mcpgateway/test_runtime_state.py
@@ -276,6 +276,45 @@ def test_constants_match_kinds():
     assert SUPPORTED_OVERRIDE_MODES == frozenset({"shadow", "edge"})
 
 
+@pytest.mark.asyncio
+async def test_override_edge_cannot_bypass_session_auth_reuse_invariant(monkeypatch: pytest.MonkeyPatch):
+    """Safety invariant: an admin override=edge on a deployment that didn't opt into
+    session-auth-reuse at boot must NOT cause public /mcp to route to Rust.
+
+    This is the belt in the belt-and-braces: the router rejects such PATCHes with
+    409, but even if the override somehow landed in state (e.g. cluster reconcile
+    from a hint written before we tightened the router), the read side must refuse
+    to break the documented safety invariant.
+    """
+    # Simulate boot=shadow: Rust runtime enabled, session-auth-reuse NOT enabled.
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_mcp_session_auth_reuse_enabled", False, raising=False)
+
+    # Force the override to "edge" directly on state (bypassing the router).
+    state = get_runtime_state()
+    await state.apply_local("mcp", "edge", initiator_user="replay", version=1)
+    assert state.override_mode("mcp") == "edge"
+
+    # The read side must still refuse to route to Rust.
+    from mcpgateway.version import should_mount_public_rust_transport
+
+    assert should_mount_public_rust_transport() is False
+
+
+@pytest.mark.asyncio
+async def test_override_edge_cannot_bypass_delegate_enabled_invariant(monkeypatch: pytest.MonkeyPatch):
+    """Same invariant for A2A: edge override cannot bypass the delegate_enabled requirement."""
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.config.settings.experimental_rust_a2a_runtime_delegate_enabled", False, raising=False)
+
+    state = get_runtime_state()
+    await state.apply_local("a2a", "edge", initiator_user="replay", version=1)
+
+    from mcpgateway.version import should_delegate_a2a_to_rust
+
+    assert should_delegate_a2a_to_rust() is False
+
+
 # ---------------------------------------------------------------------------
 # Block 1+2 follow-up coverage
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
+++ b/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
@@ -100,6 +100,44 @@ async def test_dispatch_503s_when_selector_misses_and_no_fallback():
     assert "alpha" in body_text  # available list
 
 
+@pytest.mark.asyncio
+async def test_dispatch_logs_warning_when_falling_back_to_fallback(caplog):
+    """Selector miss + fallback → warning log so a misrouted ingress is never silent."""
+    sink: List[str] = []
+    fallback = _make_recording_app("fallback", sink)
+    mount = MCPIngressMount(selector=lambda _scope: "ghost", fallback=fallback)
+    mount.register("alpha", _make_recording_app("alpha", sink))
+
+    async def _noop(*_):
+        pass
+
+    caplog.set_level("WARNING", logger="mcpgateway.transports.mcp_ingress_mount")
+    await mount.dispatch({"type": "http", "path": "/x"}, _noop, _noop)
+
+    assert sink == ["fallback:/x"]
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("'ghost'" in w.message and "alpha" in w.message for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_503_path_logs_warning(caplog):
+    """Selector miss + no fallback → 503 ALSO emits a warning, not just a wire response."""
+    mount = MCPIngressMount(selector=lambda _scope: "ghost")
+    mount.register("alpha", _make_recording_app("alpha", []))
+
+    async def _capture_send(_msg):
+        pass
+
+    async def _noop_receive():
+        return {"type": "http.request"}
+
+    caplog.set_level("WARNING", logger="mcpgateway.transports.mcp_ingress_mount")
+    await mount.dispatch({"type": "http", "path": "/x"}, _noop_receive, _capture_send)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("'ghost'" in w.message and "503" in w.message for w in warnings)
+
+
 def test_register_is_idempotent_and_replaces():
     sink: List[str] = []
     mount = MCPIngressMount(selector=lambda _scope: "alpha")

--- a/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
+++ b/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``mcpgateway.transports.mcp_ingress_mount.MCPIngressMount``.
+
+The mount is intentionally tiny: a registry of named ASGI apps + a
+selector function. These tests exercise the registry/selector/fallback
+contract in isolation from the runtime-mode policy that drives it in
+production (see ``test_main_extended.py`` for the integrated tests).
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from typing import List
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.transports.mcp_ingress_mount import MCPIngressMount
+
+
+def _make_recording_app(label: str, sink: List[str]):
+    async def _app(scope, _receive, _send):
+        sink.append(f"{label}:{scope.get('path', '/')}")
+
+    return _app
+
+
+@pytest.mark.asyncio
+async def test_dispatch_routes_to_registered_ingress():
+    sink: List[str] = []
+    mount = MCPIngressMount(selector=lambda _scope: "alpha")
+    mount.register("alpha", _make_recording_app("alpha", sink))
+    mount.register("beta", _make_recording_app("beta", sink))
+
+    async def _no_send(_msg):
+        pass
+
+    async def _no_receive():
+        return {"type": "http.request"}
+
+    await mount.dispatch({"type": "http", "path": "/mcp"}, _no_receive, _no_send)
+    assert sink == ["alpha:/mcp"]
+
+
+@pytest.mark.asyncio
+async def test_set_selector_swaps_routing_atomically():
+    sink: List[str] = []
+    mount = MCPIngressMount(selector=lambda _scope: "alpha")
+    mount.register("alpha", _make_recording_app("alpha", sink))
+    mount.register("beta", _make_recording_app("beta", sink))
+
+    async def _noop(*_):
+        pass
+
+    await mount.dispatch({"type": "http", "path": "/1"}, _noop, _noop)
+    mount.set_selector(lambda _scope: "beta")
+    await mount.dispatch({"type": "http", "path": "/2"}, _noop, _noop)
+    assert sink == ["alpha:/1", "beta:/2"]
+
+
+@pytest.mark.asyncio
+async def test_unregister_returns_app_and_routes_fall_through_to_fallback():
+    sink: List[str] = []
+    fallback = _make_recording_app("fallback", sink)
+    mount = MCPIngressMount(selector=lambda _scope: "alpha", fallback=fallback)
+    alpha_app = _make_recording_app("alpha", sink)
+    mount.register("alpha", alpha_app)
+
+    removed = mount.unregister("alpha")
+    assert removed is alpha_app
+
+    async def _noop(*_):
+        pass
+
+    await mount.dispatch({"type": "http", "path": "/x"}, _noop, _noop)
+    assert sink == ["fallback:/x"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_503s_when_selector_misses_and_no_fallback():
+    mount = MCPIngressMount(selector=lambda _scope: "ghost")
+    mount.register("alpha", _make_recording_app("alpha", []))
+
+    captured = {}
+
+    async def _capture_send(message):
+        captured.setdefault("messages", []).append(message)
+
+    async def _noop_receive():
+        return {"type": "http.request"}
+
+    await mount.dispatch({"type": "http", "path": "/x"}, _noop_receive, _capture_send)
+    start = captured["messages"][0]
+    body = captured["messages"][1]
+    assert start["status"] == 503
+    body_text = body["body"].decode("utf-8")
+    assert "'ghost'" in body_text
+    assert "alpha" in body_text  # available list
+
+
+def test_register_is_idempotent_and_replaces():
+    sink: List[str] = []
+    mount = MCPIngressMount(selector=lambda _scope: "alpha")
+    first = _make_recording_app("first", sink)
+    second = _make_recording_app("second", sink)
+    mount.register("alpha", first)
+    mount.register("alpha", second)
+    assert mount._ingresses["alpha"] is second  # noqa: SLF001 — direct registry inspection in test
+
+
+def test_names_returns_sorted_registered_ingresses():
+    mount = MCPIngressMount(selector=lambda _scope: "alpha")
+    mount.register("zebra", _make_recording_app("z", []))
+    mount.register("alpha", _make_recording_app("a", []))
+    mount.register("mike", _make_recording_app("m", []))
+    assert mount.names() == ["alpha", "mike", "zebra"]

--- a/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
+++ b/tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py
@@ -154,3 +154,32 @@ def test_names_returns_sorted_registered_ingresses():
     mount.register("alpha", _make_recording_app("a", []))
     mount.register("mike", _make_recording_app("m", []))
     assert mount.names() == ["alpha", "mike", "zebra"]
+
+
+@pytest.mark.asyncio
+async def test_set_fallback_swaps_the_fallback_app_at_runtime():
+    """set_fallback replaces the fallback so a misconfigured selector routes to the new app on the next request."""
+    sink: List[str] = []
+    mount = MCPIngressMount(selector=lambda _scope: "ghost")
+    mount.set_fallback(_make_recording_app("first", sink))
+
+    async def _noop(*_):
+        pass
+
+    await mount.dispatch({"type": "http", "path": "/a"}, _noop, _noop)
+    mount.set_fallback(_make_recording_app("second", sink))
+    await mount.dispatch({"type": "http", "path": "/b"}, _noop, _noop)
+    # set_fallback(None) restores the 503-on-miss behavior.
+    mount.set_fallback(None)
+    captured = []
+
+    async def _capture(message):
+        captured.append(message)
+
+    async def _no_receive():
+        return {"type": "http.request"}
+
+    await mount.dispatch({"type": "http", "path": "/c"}, _no_receive, _capture)
+
+    assert sink == ["first:/a", "second:/b"]
+    assert any(msg.get("type") == "http.response.start" and msg.get("status") == 503 for msg in captured)

--- a/tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py
+++ b/tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py
@@ -1,0 +1,573 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``mcpgateway.transports.rust_mcp_public_proxy``.
+
+The public proxy is the no-nginx-in-front ingress: it forwards client
+traffic to Rust's authenticated public listener with nginx-style
+forwarded headers, so Rust's ``/_internal/mcp/authenticate`` callback
+sees the original client info instead of ``127.0.0.1``. These tests pin
+the security-critical behavior (XFF spoof rejection, auth header
+preservation), the streaming contract (close-on-exit), and the error
+path mappings.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from typing import Callable, List, Optional
+
+# Third-Party
+import httpx
+import pytest
+
+try:
+    # Pragmatic test seam: MockTransport returns a fully-buffered Response
+    # whose stream is already consumed; AsyncIteratorByteStream is the
+    # smallest public-API equivalent for crafting a streamable Response.
+    # No public alternative exists in current httpx; revisit if/when
+    # httpx exposes a stable streaming-response helper.
+    from httpx._content import AsyncIteratorByteStream  # noqa: PLC2701 — see comment above
+except ImportError as exc:  # pragma: no cover — surfaces a future httpx refactor
+    raise RuntimeError("test_rust_mcp_public_proxy depends on httpx._content.AsyncIteratorByteStream; " "httpx may have moved this private symbol — pin httpx or update the import.") from exc
+
+# First-Party
+from mcpgateway.transports.rust_mcp_public_proxy import (
+    RustMCPPublicProxyApp,
+    _build_forwarded_headers,
+    _format_forwarded_for,
+    build_rust_public_proxy_app,
+)
+
+# ---------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------
+
+
+def _make_scope(
+    *,
+    method: str = "POST",
+    path: str = "/mcp",
+    headers: Optional[List[tuple]] = None,
+    client: Optional[tuple] = ("198.51.100.7", 50001),
+    scheme: str = "http",
+) -> dict:
+    """Build a minimal HTTP ASGI scope for the proxy under test."""
+    base_headers = [(b"host", b"gateway.example:4444")]
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "scheme": scheme,
+        "headers": base_headers + (headers or []),
+        "server": ("gateway.example", 4444),
+        "client": client,
+    }
+
+
+def _make_receive(body: bytes = b"") -> Callable:
+    """Return a single-body ASGI receive callable that disconnects after the body."""
+    sent = {"done": False}
+
+    async def receive() -> dict:
+        if sent["done"]:
+            return {"type": "http.disconnect"}
+        sent["done"] = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+class _SendCollector:
+    """ASGI ``send`` callable that records every message for assertions."""
+
+    def __init__(self) -> None:
+        self.messages: List[dict] = []
+
+    async def __call__(self, message: dict) -> None:
+        self.messages.append(message)
+
+    @property
+    def status(self) -> Optional[int]:
+        for msg in self.messages:
+            if msg.get("type") == "http.response.start":
+                return msg["status"]
+        return None
+
+    @property
+    def body(self) -> bytes:
+        return b"".join(msg.get("body", b"") for msg in self.messages if msg.get("type") == "http.response.body")
+
+    @property
+    def headers(self) -> dict:
+        for msg in self.messages:
+            if msg.get("type") == "http.response.start":
+                return {name.decode("latin-1").lower(): value.decode("latin-1") for name, value in msg["headers"]}
+        return {}
+
+
+def _make_proxy(handler: Callable[[httpx.Request], httpx.Response]) -> RustMCPPublicProxyApp:
+    """Build a proxy whose lazily-cached client is wired to an httpx MockTransport."""
+    proxy = RustMCPPublicProxyApp(upstream_url="http://upstream.test")
+    # Pre-seed the lazy client so _get_client returns ours unchanged.
+    proxy._client = httpx.AsyncClient(  # noqa: SLF001 — test seam
+        base_url="http://upstream.test",
+        transport=httpx.MockTransport(handler),
+    )
+    return proxy
+
+
+def _streaming_response(status: int, body: bytes, headers: Optional[dict] = None) -> httpx.Response:
+    """Construct an httpx.Response whose body is a real async stream.
+
+    ``MockTransport`` returns a fully-buffered ``httpx.Response`` whose
+    stream is already consumed, so calling ``aiter_raw()`` afterwards
+    raises ``StreamConsumed``. Wrapping the bytes in
+    ``AsyncIteratorByteStream`` keeps the response streamable and
+    matches what real upstreams produce when the proxy calls
+    ``client.send(..., stream=True)``.
+    """
+
+    async def _gen():
+        yield body
+
+    return httpx.Response(status, stream=AsyncIteratorByteStream(_gen()), headers=headers or {})
+
+
+# ---------------------------------------------------------------------
+# _format_forwarded_for — pure function, RFC 7239 §6.3 conformance
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,port,expected",
+    [
+        ("198.51.100.7", 50001, '"198.51.100.7:50001"'),
+        ("198.51.100.7", 0, '"198.51.100.7"'),
+        ("2001:db8::1", 8080, '"[2001:db8::1]:8080"'),
+        ("2001:db8::1", 0, '"[2001:db8::1]"'),
+        # Defensive: callers passing already-bracketed IPv6 must not
+        # end up double-bracketed.
+        ("[2001:db8::1]", 8080, '"[2001:db8::1]:8080"'),
+        ("[2001:db8::1]", 0, '"[2001:db8::1]"'),
+        (None, 50001, "unknown"),
+        ("", 50001, "unknown"),
+    ],
+)
+def test_format_forwarded_for(host: Optional[str], port: int, expected: str) -> None:
+    """Known clients are quoted (with IPv6 bracketed exactly once); absent clients become ``unknown`` without a synthetic ``:0``."""
+    assert _format_forwarded_for(host, port) == expected
+
+
+# ---------------------------------------------------------------------
+# _build_forwarded_headers — security-critical
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_forwarded_headers_drops_client_supplied_chain() -> None:
+    """Client-supplied X-Forwarded-* / Forwarded / X-Real-IP must NOT survive into the upstream request."""
+    # Third-Party
+    from starlette.requests import Request
+
+    scope = _make_scope(
+        headers=[
+            (b"x-forwarded-for", b"10.0.0.1, evil.example"),
+            (b"x-forwarded-proto", b"https"),
+            (b"x-forwarded-host", b"attacker.example"),
+            (b"x-forwarded-port", b"443"),
+            (b"x-real-ip", b"10.0.0.1"),
+            (b"forwarded", b"for=10.0.0.1;proto=https;host=attacker.example"),
+        ],
+    )
+    request = Request(scope, _make_receive())
+
+    headers = _build_forwarded_headers(request)
+
+    # Real ASGI client info wins; the spoofed leftmost IP is gone.
+    assert headers["X-Forwarded-For"] == "198.51.100.7"
+    assert headers["X-Real-IP"] == "198.51.100.7"
+    assert headers["X-Forwarded-Proto"] == "http"
+    assert headers["X-Forwarded-Host"] == "gateway.example:4444"
+    # The attacker's ``for=10.0.0.1`` must not be reflected anywhere.
+    assert "10.0.0.1" not in headers["Forwarded"]
+    assert "attacker.example" not in headers["Forwarded"]
+    assert headers["Forwarded"] == 'for="198.51.100.7:50001";proto=http;host="gateway.example:4444"'
+
+
+@pytest.mark.asyncio
+async def test_build_forwarded_headers_strips_hop_by_hop_and_preserves_auth() -> None:
+    """Hop-by-hop headers are dropped; Authorization and Cookie pass through."""
+    # Third-Party
+    from starlette.requests import Request
+
+    scope = _make_scope(
+        headers=[
+            (b"connection", b"close"),
+            (b"keep-alive", b"timeout=5"),
+            (b"transfer-encoding", b"chunked"),
+            (b"content-length", b"42"),
+            (b"upgrade", b"h2c"),
+            (b"proxy-authorization", b"Basic blah"),
+            (b"authorization", b"Bearer good-token"),
+            (b"cookie", b"session=abc"),
+            (b"content-type", b"application/json"),
+            (b"mcp-session-id", b"session-1"),
+        ],
+    )
+    request = Request(scope, _make_receive())
+
+    headers = _build_forwarded_headers(request)
+
+    # Hop-by-hop: gone.
+    assert "connection" not in {k.lower() for k in headers}
+    assert "keep-alive" not in {k.lower() for k in headers}
+    assert "transfer-encoding" not in {k.lower() for k in headers}
+    assert "content-length" not in {k.lower() for k in headers}
+    assert "upgrade" not in {k.lower() for k in headers}
+    assert "proxy-authorization" not in {k.lower() for k in headers}
+    assert "host" not in {k.lower() for k in headers}
+    # Application headers and credentials: preserved.
+    assert headers["authorization"] == "Bearer good-token"
+    assert headers["cookie"] == "session=abc"
+    assert headers["content-type"] == "application/json"
+    assert headers["mcp-session-id"] == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_build_forwarded_headers_unknown_client_emits_for_unknown() -> None:
+    """When ``request.client`` is None, Forwarded uses ``for=unknown`` (no synthetic ``:0``)."""
+    # Third-Party
+    from starlette.requests import Request
+
+    scope = _make_scope(client=None)
+    request = Request(scope, _make_receive())
+
+    headers = _build_forwarded_headers(request)
+
+    assert headers["X-Forwarded-For"] == "unknown"
+    assert headers["X-Real-IP"] == "unknown"
+    assert headers["Forwarded"].startswith("for=unknown;")
+    # No bogus ":0" port snuck in.
+    assert ":0" not in headers["Forwarded"]
+
+
+# ---------------------------------------------------------------------
+# Proxy ASGI behavior
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_request_and_streams_response() -> None:
+    """A successful round-trip: status, body, content-type all passed through."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        return _streaming_response(200, b"hello-from-rust", {"content-type": "text/plain"})
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    await proxy(_make_scope(method="POST", path="/mcp"), _make_receive(b"payload"), send)
+
+    assert send.status == 200
+    assert send.body == b"hello-from-rust"
+    assert send.headers.get("content-type") == "text/plain"
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/mcp")
+
+
+@pytest.mark.asyncio
+async def test_proxy_passes_through_auth_failures_unchanged() -> None:
+    """A 401 from upstream reaches the client unmodified — the proxy does not synthesize 200/502."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _streaming_response(401, b"who are you", {"www-authenticate": "Bearer"})
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    assert send.status == 401
+    assert send.body == b"who are you"
+    assert send.headers.get("www-authenticate") == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_hop_by_hop_response_headers() -> None:
+    """``Transfer-Encoding`` / ``Connection`` from upstream must not propagate downstream."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _streaming_response(
+            200,
+            b"ok",
+            {
+                "content-type": "application/json",
+                "connection": "close",
+                # httpx normally manages transfer-encoding itself; assert
+                # that any hop-by-hop survivor is filtered by us.
+                "keep-alive": "timeout=5",
+            },
+        )
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    # Hop-by-hop response headers are absent downstream.
+    assert "connection" not in send.headers
+    assert "keep-alive" not in send.headers
+    assert "transfer-encoding" not in send.headers
+    # Application headers survive.
+    assert send.headers.get("content-type") == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_502_on_upstream_httpx_error(caplog) -> None:
+    """An ``httpx.HTTPError`` from the upstream call becomes a logged 502."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("upstream down")
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+    caplog.set_level("ERROR", logger="mcpgateway.transports.rust_mcp_public_proxy")
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    assert send.status == 502
+    assert b"unavailable" in send.body
+    assert any("rust-public ingress" in rec.message and "ConnectError" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_500_on_unexpected_exception(caplog) -> None:
+    """A non-HTTPError exception during forwarding becomes a logged 500 instead of leaking."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise RuntimeError("unexpected internal failure")
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+    caplog.set_level("ERROR", logger="mcpgateway.transports.rust_mcp_public_proxy")
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    assert send.status == 500
+    assert any("unexpected error" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_proxy_re_raises_cancelled_error_during_send() -> None:
+    """asyncio.CancelledError from the upstream send must propagate, not be swallowed as 502/500.
+
+    The proxy explicitly catches and re-raises CancelledError before the
+    httpx.HTTPError / Exception handlers so a client disconnect during
+    the upstream call doesn't get masked as an "unavailable" 502 in the
+    logs. CancelledError IS BaseException, so the explicit handler is
+    belt-and-suspenders against future refactors that broaden the catch.
+    """
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise asyncio.CancelledError()
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    with pytest.raises(asyncio.CancelledError):
+        await proxy(_make_scope(), _make_receive(), send)
+
+    # No 502/500 was sent — the cancel propagated before any response.
+    assert send.messages == []
+
+
+@pytest.mark.asyncio
+async def test_body_iter_logs_debug_on_mid_stream_cancellation(caplog) -> None:
+    """asyncio.CancelledError raised mid-stream takes the dedicated debug-log branch in _body_iter.
+
+    Asserting the debug log fires proves the dedicated ``except
+    asyncio.CancelledError`` arm was taken (vs. the broader
+    ``except Exception`` arm, which uses ``logger.exception`` and would
+    spam stack traces for every client tab close on an SSE stream).
+    Whether Starlette then propagates the cancel or surfaces it as a
+    silent client disconnect is its own concern — we test the proxy's
+    contract, not Starlette's.
+    """
+
+    async def _exploding_stream():
+        yield b"first-chunk"
+        raise asyncio.CancelledError()
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=AsyncIteratorByteStream(_exploding_stream()), headers={"content-type": "text/event-stream"})
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+    caplog.set_level("DEBUG", logger="mcpgateway.transports.rust_mcp_public_proxy")
+
+    # Don't assert raise/no-raise — depends on Starlette's task-group behavior.
+    try:
+        await proxy(_make_scope(), _make_receive(), send)
+    except asyncio.CancelledError:
+        pass
+
+    debug_msgs = [r.message for r in caplog.records if r.levelname == "DEBUG"]
+    assert any("client disconnected mid-stream" in msg for msg in debug_msgs), debug_msgs
+    # And the log must NOT include a stack-trace-bearing "exception" record from the broad Exception arm.
+    error_msgs = [r.message for r in caplog.records if r.levelname == "ERROR"]
+    assert not any("error streaming body" in msg for msg in error_msgs), error_msgs
+
+
+@pytest.mark.parametrize("status", [401, 403, 500, 503])
+@pytest.mark.asyncio
+async def test_proxy_logs_warning_on_auth_relevant_upstream_status(status: int, caplog) -> None:
+    """Upstream 401/403/5xx statuses each get a warning so a flood after a credential rotation or backend outage is visible."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return _streaming_response(status, b"")
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+    caplog.set_level("WARNING", logger="mcpgateway.transports.rust_mcp_public_proxy")
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    assert send.status == status
+    assert any(f"returned {status}" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_404_on_non_http_scope() -> None:
+    """Lifespan / websocket scopes are not handled here and return 404 immediately."""
+    proxy = _make_proxy(lambda _r: httpx.Response(200))
+    send = _SendCollector()
+
+    async def _no_receive() -> dict:
+        return {"type": "lifespan.startup"}
+
+    await proxy({"type": "lifespan"}, _no_receive, send)
+
+    assert send.status == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_does_not_forward_client_supplied_xff() -> None:
+    """End-to-end: client sets X-Forwarded-For; upstream sees only the trusted ASGI client info."""
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return _streaming_response(200, b"ok")
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    scope = _make_scope(
+        headers=[
+            (b"x-forwarded-for", b"10.0.0.1"),
+            (b"x-real-ip", b"10.0.0.1"),
+            (b"forwarded", b"for=10.0.0.1"),
+        ],
+    )
+    await proxy(scope, _make_receive(), send)
+
+    assert captured["headers"]["x-forwarded-for"] == "198.51.100.7"
+    assert captured["headers"]["x-real-ip"] == "198.51.100.7"
+    assert "10.0.0.1" not in captured["headers"]["forwarded"]
+
+
+# ---------------------------------------------------------------------
+# Lazy client lifecycle
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_client_constructs_lazily_and_reuses() -> None:
+    """First request constructs the AsyncClient; subsequent requests reuse it."""
+    proxy = RustMCPPublicProxyApp(upstream_url="http://upstream.test")
+    assert proxy._client is None  # noqa: SLF001 — verifying no I/O at construction
+
+    client_a = await proxy._get_client()  # noqa: SLF001
+    client_b = await proxy._get_client()  # noqa: SLF001
+
+    assert client_a is client_b
+    await client_a.aclose()
+
+
+def test_factory_returns_proxy_instance() -> None:
+    """``build_rust_public_proxy_app`` exposes the same constructor surface for the mount registry."""
+    app = build_rust_public_proxy_app(upstream_url="http://upstream.test")
+    assert isinstance(app, RustMCPPublicProxyApp)
+
+
+# ---------------------------------------------------------------------
+# Streaming contract
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_body_streams_multiple_chunks() -> None:
+    """Multi-chunk SSE-style responses are forwarded chunk-by-chunk."""
+    chunks = [b"event: tick\n", b"data: 1\n\n", b"event: tick\n", b"data: 2\n\n"]
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        async def _stream():
+            for chunk in chunks:
+                yield chunk
+
+        return httpx.Response(200, stream=AsyncIteratorByteStream(_stream()), headers={"content-type": "text/event-stream"})
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+
+    await proxy(_make_scope(method="GET", path="/mcp"), _make_receive(), send)
+
+    assert send.status == 200
+    assert send.body == b"".join(chunks)
+    assert send.headers.get("content-type") == "text/event-stream"
+
+
+@pytest.mark.asyncio
+async def test_response_body_aclose_called_after_normal_completion() -> None:
+    """The upstream response is closed after streaming completes — tested by proxying through an interceptor."""
+    closed: List[bool] = []
+
+    class _AcloseSpy(httpx.AsyncClient):
+        """AsyncClient subclass that records aclose() on every response it sends."""
+
+        async def send(self, request, **kwargs):  # type: ignore[override]
+            response = await super().send(request, **kwargs)
+            original_aclose = response.aclose
+
+            async def _spy_aclose() -> None:
+                closed.append(True)
+                await original_aclose()
+
+            response.aclose = _spy_aclose  # type: ignore[method-assign]
+            return response
+
+    proxy = RustMCPPublicProxyApp(upstream_url="http://upstream.test")
+    proxy._client = _AcloseSpy(  # noqa: SLF001
+        base_url="http://upstream.test",
+        transport=httpx.MockTransport(lambda _r: _streaming_response(200, b"streamed-body")),
+    )
+    send = _SendCollector()
+
+    await proxy(_make_scope(), _make_receive(), send)
+
+    assert send.body == b"streamed-body"
+    # aclose is idempotent and may be called by both _body_iter's finally
+    # and Starlette's StreamingResponse cleanup; we only care that it
+    # ran at least once so the upstream connection returns to the pool.
+    assert closed, "upstream response must be closed after _body_iter exits"
+
+    await proxy._client.aclose()  # noqa: SLF001

--- a/tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py
+++ b/tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py
@@ -370,11 +370,12 @@ async def test_proxy_returns_500_on_unexpected_exception(caplog) -> None:
 async def test_proxy_re_raises_cancelled_error_during_send() -> None:
     """asyncio.CancelledError from the upstream send must propagate, not be swallowed as 502/500.
 
-    The proxy explicitly catches and re-raises CancelledError before the
-    httpx.HTTPError / Exception handlers so a client disconnect during
-    the upstream call doesn't get masked as an "unavailable" 502 in the
-    logs. CancelledError IS BaseException, so the explicit handler is
-    belt-and-suspenders against future refactors that broaden the catch.
+    Since CancelledError is BaseException in Python 3.8+, neither the
+    httpx.HTTPError nor the broad ``except Exception`` arm catches it —
+    it propagates naturally out of __call__. This test pins that
+    contract so a future refactor that widens the catch (e.g. to
+    BaseException) doesn't accidentally mask client disconnects as
+    bogus 502 responses.
     """
 
     def handler(_request: httpx.Request) -> httpx.Response:
@@ -388,6 +389,31 @@ async def test_proxy_re_raises_cancelled_error_during_send() -> None:
 
     # No 502/500 was sent — the cancel propagated before any response.
     assert send.messages == []
+
+
+@pytest.mark.asyncio
+async def test_body_iter_logs_exception_on_mid_stream_non_cancel_error(caplog) -> None:
+    """A non-cancellation exception mid-stream takes the broad ``except Exception`` arm and logs with traceback."""
+
+    async def _exploding_stream():
+        yield b"first-chunk"
+        raise RuntimeError("upstream-died-mid-stream")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=AsyncIteratorByteStream(_exploding_stream()), headers={"content-type": "text/event-stream"})
+
+    proxy = _make_proxy(handler)
+    send = _SendCollector()
+    caplog.set_level("ERROR", logger="mcpgateway.transports.rust_mcp_public_proxy")
+
+    # Don't assert on raise/no-raise — depends on Starlette's task-group behavior.
+    try:
+        await proxy(_make_scope(), _make_receive(), send)
+    except RuntimeError:
+        pass
+
+    error_records = [r for r in caplog.records if r.levelname == "ERROR"]
+    assert any("error streaming body" in rec.message and "upstream-died-mid-stream" in (rec.exc_text or "") for rec in error_records), [(r.message, r.exc_text) for r in error_records]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4273
Partial: #4278 (nginx-style public proxy is one of the deployment shapes addressed here; the broader reverse-proxy follow-up tracked in #4278 remains open for non-nginx topologies beyond the bundled proxy.)

---

## 📝 Summary

Adds a runtime-mutable override for `RUST_MCP_MODE` (and the parallel `RUST_A2A_MODE`) so operators can flip between `shadow` and `edge` without a process restart, propagated cluster-wide via Redis pub/sub. Also lands the swappable `MCPIngressMount` + nginx-style Rust public proxy this requires.

**Architecture changes**
- `mcpgateway/runtime_state.py` (new): per-runtime override storage with monotonic versioning, `RuntimeStateCoordinator` for Redis pub/sub, structured `MoveCompatibility` rejection reasons, fail-closed `BootReconcileStatus` surfacing. Reads are lock-free; writes use per-runtime async locks.
- `mcpgateway/routers/runtime_admin_router.py` (new): `GET`/`PATCH /admin/runtime/{mcp,a2a}-mode`, gated by `@require_permission("admin.system_config")`. 409 on incompatible boot mode (with operator-actionable detail naming the exact env var), 503 on Redis INCR failure, audit row on every attempt (success or rejection).
- `mcpgateway/transports/mcp_ingress_mount.py` (new): replaces the closed-set `MCPStreamableHTTPModeDispatcher` with a registry of named ASGI ingresses + a swappable selector. Adding a new ingress is one `register()` call.
- `mcpgateway/transports/rust_mcp_public_proxy.py` (new): nginx-style reverse proxy to Rust's authenticated public listener, used when the gateway is the only public ingress. Streams both directions (SSE-friendly), preserves `Authorization`/`Cookie`, drops client-supplied forwarded-chain headers (XFF spoof prevention).
- `mcpgateway/version.py`: `_should_mount_public_rust_transport` now consults the override _and_ preserves the boot-time safety invariants (session-auth-reuse for MCP, delegate-enabled for A2A) — an `edge` override on a pod that didn't boot the safety flag stays on Python.

**Safety invariants preserved**
- Override never bypasses session-auth-reuse / delegate-enabled boot flags. Per-target-mode compatibility gating (`MoveCompatibility` enum: `NO_DISPATCHER`, `BOOT_FULL_STRANDS`, `EDGE_NEEDS_SAFETY_FLAG`, `OK`) is the single source of truth shared by the admin router (translates to 409 detail) and the coordinator (surfaces via `BootReconcileStatus`).
- `boot=full` and `boot=off` discard incompatible Redis hints rather than promoting orphaned state.
- Fresh pods reconcile from a Redis hint at boot but discard `INCOMPATIBLE_HINT` cases with a structured rejection reason logged.
- `mcp_rust_ingress=public` on `boot=shadow` is detected as a misconfig at boot — the selector downgrades to `rust-internal` and an `error`-level log fires (loud enough to survive default `LOG_LEVEL=ERROR`).

**Security fix in the public proxy**
- `_build_forwarded_headers` now drops client-supplied `Forwarded` / `X-Forwarded-*` / `X-Real-IP` from the inbound request before re-deriving them from `request.client`. The earlier draft appended to the client-supplied `X-Forwarded-For`, letting any caller spoof their own source IP to Rust's `/_internal/mcp/authenticate` callback. Closed at both unit and end-to-end test layers.
- `_format_forwarded_for` is RFC 7239 §6.3-conformant (no synthetic `for=unknown:0`, IPv6 bracketed exactly once).

**Documentation**
- ADR-050: documents the decision _not_ to extract a generic cluster-wide settings propagation framework (N=1 — too few examples to abstract). Includes a defenses checklist enumerating the non-obvious invariants the copy-modify path must preserve when the next mutable setting arrives.
- ADR-051: documents the swappable `MCPIngressMount` design + the nginx-style public proxy ingress, with migration notes from `MCPStreamableHTTPModeDispatcher`.
- `docs/docs/architecture/rust-mcp-runtime.md`: route table, behavior contract, cluster-wide propagation section.

---

## 🏷️ Type of Change
- [x] Feature / Enhancement
- [x] Documentation (two new ADRs)
- [ ] Bug fix
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ |
| Unit tests                | `make test`     | ✅ (1839+ across touched modules) |
| Coverage ≥ 80%            | `make coverage` | ✅ on touched files (interrogate 100%) |

**New test files**
- `tests/unit/mcpgateway/test_runtime_state.py` (45 tests): state machine, type invariants, table-driven `_deployment_allows_override_mode`, coordinator lifecycle, boot reconciliation, live pub/sub listener.
- `tests/unit/mcpgateway/routers/test_runtime_admin_router.py` (18 tests): GET/PATCH happy paths, 400/403/409/503 contracts, audit fail-open, race-loser superseded path.
- `tests/unit/mcpgateway/transports/test_mcp_ingress_mount.py` (8 tests): registry, selector swap, fallback, 503-on-miss, log severity.
- `tests/unit/mcpgateway/transports/test_rust_mcp_public_proxy.py` (24 tests): XFF spoof rejection, hop-by-hop strip both directions, status passthrough, error mapping (502/500/CancelledError), parametrized auth-status warnings, lazy client, multi-chunk SSE, close-on-exit.
- `tests/integration/test_runtime_state_cluster.py` (3 tests, `@pytest.mark.integration`): two coordinators converge, fresh pod reconciles from hint, INCR allocates distinct versions.

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (two new ADRs, `rust-mcp-runtime.md`, `.env.example`)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Operator-facing surface**
- New env: `MCP_RUST_INGRESS` (Literal `internal` | `public`, default `internal`), `MCP_RUST_PUBLIC_PROXY_UPSTREAM` (default `http://127.0.0.1:8787`).
- New admin endpoints: `GET /admin/runtime/mcp-mode`, `PATCH /admin/runtime/mcp-mode`, `GET /admin/runtime/a2a-mode`, `PATCH /admin/runtime/a2a-mode`. RBAC: `admin.system_config`.
- Operators behind a reverse proxy: `_warn_if_behind_reverse_proxy` detects `X-Forwarded-*` and warns when an override request arrives via a proxy chain.

**Why this isn't the framework deferred in ADR-050**
ADR-051 explains: the new mount is scoped to the single `/mcp` mount point and the ingress shapes that mount can hold. It doesn't introduce a registry of runtime settings, a propagation channel, or a coordinator — those remain purpose-built in `runtime_state.py`. When a second non-Rust ingress shape appears or the selector grows past ~50 LOC of policy, the right move is to extract policy into composable predicates rather than abstract the mount.