### PR TITLE
fix(auth): resolve proxy auth database lookup for team/admin context

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-24T21:03:53Z",
+  "generated_at": "2026-04-25T08:30:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5456,7 +5456,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 681,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9530,7 +9530,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12937,
+        "line_number": 13105,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9538,7 +9538,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14112,
+        "line_number": 14280,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4527,23 +4527,71 @@ def _set_user_identity_from_dict(ctx: dict[str, Any]) -> None:
         )
 
 
-def _set_proxy_user_context(proxy_user: str) -> None:
-    """Set user context for a proxy-authenticated request (no team context, non-admin).
+async def _set_proxy_user_context(proxy_user: str) -> dict[str, Any] | None:
+    """Authenticate a proxy-identified user and set per-request transport context.
+
+    Performs a DB lookup via EmailAuthService, resolves team/admin state via
+    :func:`mcpgateway.auth._resolve_teams_from_db`, enforces ``is_active``, and
+    handles the platform-admin bootstrap (``REQUIRE_USER_IN_DB=False`` + email
+    matches ``settings.platform_admin_email``).  On success, sets
+    ``user_context_var``, user identity, and trace context.  Mirrors the REST
+    ``_authenticate_proxy_user`` helper in ``verify_credentials.py`` so that
+    trusted-proxy MCP clients receive the same DB-backed team/admin resolution
+    as REST admin/API callers (fixes #4262 on the primary MCP transport path).
 
     Args:
-        proxy_user: Email address of the proxy-authenticated user.
+        proxy_user: Email address supplied by the trusted upstream proxy via
+            ``settings.proxy_user_header``.
+
+    Returns:
+        ``None`` on success.  On failure, returns a dict with ``detail`` (str)
+        and optional ``headers`` (dict) suitable for passing to
+        ``_StreamableHttpAuthHandler._send_error`` to produce a 401 response.
     """
-    _proxy_ctx: dict[str, Any] = {
-        "email": proxy_user,
-        "teams": [],
-        "is_authenticated": True,
-        "is_admin": False,
-        "permission_is_admin": False,
-        "auth_method": "proxy",
-    }
-    user_context_var.set(_proxy_ctx)
-    _set_user_identity_from_dict(_proxy_ctx)
-    set_trace_context_from_teams([], user_email=proxy_user, is_admin=False, auth_method="proxy")
+    # First-Party
+    from mcpgateway.auth import _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
+    from mcpgateway.db import get_db  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
+
+    db = next(get_db())
+    try:
+        auth_service = EmailAuthService(db)
+        user_info = await auth_service.get_user_by_email(proxy_user)
+
+        if user_info:
+            # Enforce account-active check (matches JWT path in _enforce_revocation_and_active_user).
+            # A disabled user - including a disabled admin - must not be able to authenticate via
+            # trusted-proxy mode and inherit their pre-disable authorizations.
+            if not user_info.is_active:
+                return {"detail": "Account disabled", "headers": {"WWW-Authenticate": "Bearer"}}
+
+            token_teams = await _resolve_teams_from_db(proxy_user, user_info)
+            is_admin = user_info.is_admin
+        else:
+            platform_admin_email = getattr(settings, "platform_admin_email", "admin@example.com")
+            if not settings.require_user_in_db and proxy_user == platform_admin_email:
+                token_teams = None  # Admin bypass
+                is_admin = True
+            else:
+                return {"detail": "User not found in database", "headers": {"WWW-Authenticate": "Bearer"}}
+
+        _proxy_ctx: dict[str, Any] = {
+            "email": proxy_user,
+            "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
+            "is_authenticated": True,
+            "is_admin": is_admin,
+            "permission_is_admin": is_admin,
+            "auth_method": "proxy",
+            "token_use": "session",  # nosec B105 - Not a password; JWT claim type. DB-backed team resolution.
+        }
+        user_context_var.set(_proxy_ctx)
+        _set_user_identity_from_dict(_proxy_ctx)
+        # For trace context, admin bypass (teams=None) is represented as [] to match the existing
+        # pre-authentication contract of set_trace_context_from_teams.
+        set_trace_context_from_teams(token_teams or [], user_email=proxy_user, is_admin=is_admin, auth_method="proxy")
+        return None
+    finally:
+        db.close()
 
 
 def get_streamable_http_auth_context() -> dict[str, Any]:
@@ -4673,8 +4721,12 @@ class _StreamableHttpAuthHandler:
 
         # Determine authentication strategy based on settings
         if proxy_trusted and proxy_user:
-            _set_proxy_user_context(proxy_user)
-            return True  # Trusted proxy supplied user
+            # DB-backed authentication of the proxy-supplied identity; returns None on success
+            # or {"detail": ..., "headers": ...} on failure (unknown user, disabled user).
+            proxy_error = await _set_proxy_user_context(proxy_user)
+            if proxy_error:
+                return await self._send_error(**proxy_error)
+            return True  # Trusted proxy supplied valid, active user
 
         # --- Standard JWT authentication flow (client auth enabled) ---
         token: str | None = None

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4550,11 +4550,12 @@ async def _set_proxy_user_context(proxy_user: str) -> dict[str, Any] | None:
     """
     # First-Party
     from mcpgateway.auth import _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
-    from mcpgateway.db import get_db  # pylint: disable=import-outside-toplevel
     from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
 
-    db = next(get_db())
-    try:
+    # Use the module-local async get_db() context manager (line 721) rather than
+    # mcpgateway.db.get_db: it provides proper cancellation handling for MCP
+    # handlers cancelled mid-auth (client disconnect, timeout).
+    async with get_db() as db:
         auth_service = EmailAuthService(db)
         user_info = await auth_service.get_user_by_email(proxy_user)
 
@@ -4590,8 +4591,6 @@ async def _set_proxy_user_context(proxy_user: str) -> dict[str, Any] | None:
         # pre-authentication contract of set_trace_context_from_teams.
         set_trace_context_from_teams(token_teams or [], user_email=proxy_user, is_admin=is_admin, auth_method="proxy")
         return None
-    finally:
-        db.close()
 
 
 def get_streamable_http_auth_context() -> dict[str, Any]:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -442,6 +442,16 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
         user_info = await auth_service.get_user_by_email(proxy_user)
 
         if user_info:
+            # Enforce account-active check (matches the JWT path in _enforce_revocation_and_active_user:398-399).
+            # Without this, a disabled user - including a disabled admin - could authenticate via trusted-proxy
+            # mode and inherit their pre-disable authorizations.
+            if not user_info.is_active:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Account disabled",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
             # Resolve teams from DB (returns None for admin bypass, [] for no teams, or list of team IDs)
             token_teams = await _resolve_teams_from_db(proxy_user, user_info)
             payload = {
@@ -451,6 +461,10 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                 "is_admin": user_info.is_admin,
                 "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
                 "email": proxy_user,
+                # token_use: "session" signals DB-backed team resolution to downstream dispatchers
+                # (main.py:2870, streamablehttp_transport.py:1998) so they route via resolve_session_teams
+                # rather than treating the proxy payload as an API-token payload with embedded teams.
+                "token_use": "session",  # nosec B105 - Not a password; JWT claim type
             }
         else:
             # User not in DB - handle based on REQUIRE_USER_IN_DB setting
@@ -464,6 +478,7 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                     "is_admin": True,
                     "teams": None,  # Admin bypass
                     "email": proxy_user,
+                    "token_use": "session",  # nosec B105 - Not a password; JWT claim type
                 }
             else:
                 raise HTTPException(
@@ -483,9 +498,21 @@ async def require_auth(request: Request, credentials: Optional[HTTPAuthorization
     """Require authentication via JWT token or proxy headers.
 
     FastAPI dependency that checks for authentication via:
-    1. Proxy headers (if mcp_client_auth_enabled=false and trust_proxy_auth=true)
+    1. Proxy headers (if mcp_client_auth_enabled=false and is_proxy_auth_trust_active())
     2. JWT token in Authorization header (Bearer scheme)
     3. JWT token in cookies
+
+    Proxy authentication path (see :func:`_authenticate_proxy_user`):
+        When configured, the proxy-supplied user identity is looked up in
+        the DB via ``EmailAuthService`` and their team/admin context is
+        resolved. The resulting enriched payload
+        (``sub``, ``source``, ``token``, ``is_admin``, ``teams``, ``email``)
+        is cached on ``request.state._jwt_verified_payload`` so downstream
+        middleware and handlers get the same shape used for JWT-authenticated
+        requests. When ``REQUIRE_USER_IN_DB=False`` and the proxy user matches
+        ``settings.platform_admin_email``, a platform-admin bootstrap payload
+        (``is_admin=True``, ``teams=None``) is returned without requiring a
+        DB record; otherwise an unknown proxy user raises 401.
 
     If authentication is required but no token is provided, raises an HTTP 401 error.
 
@@ -496,11 +523,13 @@ async def require_auth(request: Request, credentials: Optional[HTTPAuthorization
 
     Returns:
         str | dict: The verified credentials payload if authenticated,
-            proxy user if proxy auth enabled, or "anonymous" if authentication is not required.
+            the enriched proxy payload if proxy auth succeeded, or
+            ``"anonymous"`` if authentication is not required.
 
     Raises:
         HTTPException: 401 status if authentication is required but no valid
-            token is provided.
+            token is provided, or if a proxy-identified user is unknown and
+            the platform-admin bootstrap conditions do not apply.
 
     Examples:
         >>> from mcpgateway.utils import verify_credentials as vc

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -486,7 +486,52 @@ async def require_auth(request: Request, credentials: Optional[HTTPAuthorization
             # Extract user from proxy header
             proxy_user = request.headers.get(settings.proxy_user_header)
             if proxy_user:
-                return {"sub": proxy_user, "source": "proxy", "token": None}  # nosec B105 - None is not a password
+                # First-Party
+                from mcpgateway.auth import _resolve_teams_from_db
+                from mcpgateway.db import get_db
+                from mcpgateway.services.email_auth_service import EmailAuthService
+
+                # Query database for user info
+                db = next(get_db())
+                try:
+                    auth_service = EmailAuthService(db)
+                    user_info = await auth_service.get_user_by_email(proxy_user)
+
+                    if user_info:
+                        # Resolve teams from DB (returns None for admin bypass, [] for no teams, or list of team IDs)
+                        token_teams = await _resolve_teams_from_db(proxy_user, user_info)
+                        is_admin = user_info.is_admin
+
+                        # Build enriched payload similar to session tokens
+                        payload = {
+                            "sub": proxy_user,
+                            "source": "proxy",
+                            "token": None,
+                            "is_admin": is_admin,
+                            "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
+                            "email": proxy_user,
+                        }
+
+                        # Cache in request state for downstream use (same pattern as JWT tokens)
+                        request.state._jwt_verified_payload = (None, payload)
+
+                        return payload
+                    else:
+                        # User not in DB - handle based on REQUIRE_USER_IN_DB setting
+                        platform_admin_email = getattr(settings, "platform_admin_email", "admin@example.com")
+                        if not settings.require_user_in_db and proxy_user == platform_admin_email:
+                            # Platform admin bootstrap
+                            payload = {"sub": proxy_user, "source": "proxy", "token": None, "is_admin": True, "teams": None, "email": proxy_user}  # Admin bypass
+                            request.state._jwt_verified_payload = (None, payload)
+                            return payload
+                        else:
+                            raise HTTPException(
+                                status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="User not found in database",
+                                headers={"WWW-Authenticate": "Bearer"},
+                            )
+                finally:
+                    db.close()
             # No proxy header - check auth_required (matches RBAC/WebSocket behavior)
             if settings.auth_required:
                 raise HTTPException(

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -399,6 +399,86 @@ async def _enforce_revocation_and_active_user(payload: dict) -> None:
         _raise_auth_401("Account disabled")
 
 
+async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
+    """Authenticate a proxy-identified user and build an enriched auth payload.
+
+    Performs a DB lookup for the proxy-identified user, resolves their teams
+    and admin status via ``_resolve_teams_from_db``, caches the payload on
+    ``request.state._jwt_verified_payload``, and returns it.
+
+    Supports a platform-admin bootstrap flow: when
+    ``settings.require_user_in_db`` is ``False`` **and** the proxy header
+    matches ``settings.platform_admin_email``, an admin payload is returned
+    without requiring a DB record (same policy applied to JWTs in
+    ``_enforce_revocation_and_active_user``).
+
+    This helper is shared by :func:`require_auth` and
+    :func:`require_auth_header_first` so that proxy-authenticated callers get
+    the same enriched context regardless of the entry point (REST admin paths
+    vs MCP streamable HTTP transport).
+
+    Args:
+        request: FastAPI request used to cache the payload for downstream code.
+        proxy_user: The authenticated user identifier from the configured
+            proxy header (e.g. ``X-Authenticated-User``).
+
+    Returns:
+        dict: Enriched auth payload with keys ``sub``, ``source``, ``token``,
+        ``is_admin``, ``teams``, and ``email``. ``teams`` is ``None`` for
+        admin bypass, ``[]`` for public-only, or a list of team ID strings.
+
+    Raises:
+        HTTPException: 401 when the proxy-identified user is not present in
+            the DB and the platform-admin bootstrap conditions do not apply.
+    """
+    # First-Party
+    from mcpgateway.auth import _resolve_teams_from_db  # pylint: disable=import-outside-toplevel
+    from mcpgateway.db import get_db  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.email_auth_service import EmailAuthService  # pylint: disable=import-outside-toplevel
+
+    db = next(get_db())
+    try:
+        auth_service = EmailAuthService(db)
+        user_info = await auth_service.get_user_by_email(proxy_user)
+
+        if user_info:
+            # Resolve teams from DB (returns None for admin bypass, [] for no teams, or list of team IDs)
+            token_teams = await _resolve_teams_from_db(proxy_user, user_info)
+            payload = {
+                "sub": proxy_user,
+                "source": "proxy",
+                "token": None,  # nosec B105 - None is not a password
+                "is_admin": user_info.is_admin,
+                "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
+                "email": proxy_user,
+            }
+        else:
+            # User not in DB - handle based on REQUIRE_USER_IN_DB setting
+            platform_admin_email = getattr(settings, "platform_admin_email", "admin@example.com")
+            if not settings.require_user_in_db and proxy_user == platform_admin_email:
+                # Platform admin bootstrap (matches the JWT path in _enforce_revocation_and_active_user)
+                payload = {
+                    "sub": proxy_user,
+                    "source": "proxy",
+                    "token": None,  # nosec B105 - None is not a password
+                    "is_admin": True,
+                    "teams": None,  # Admin bypass
+                    "email": proxy_user,
+                }
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="User not found in database",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+        # Cache in request state for downstream use (same pattern as JWT tokens)
+        request.state._jwt_verified_payload = (None, payload)
+        return payload
+    finally:
+        db.close()
+
+
 async def require_auth(request: Request, credentials: Optional[HTTPAuthorizationCredentials] = Depends(security), jwt_token: Optional[str] = Cookie(default=None)) -> str | dict:
     """Require authentication via JWT token or proxy headers.
 
@@ -486,52 +566,7 @@ async def require_auth(request: Request, credentials: Optional[HTTPAuthorization
             # Extract user from proxy header
             proxy_user = request.headers.get(settings.proxy_user_header)
             if proxy_user:
-                # First-Party
-                from mcpgateway.auth import _resolve_teams_from_db
-                from mcpgateway.db import get_db
-                from mcpgateway.services.email_auth_service import EmailAuthService
-
-                # Query database for user info
-                db = next(get_db())
-                try:
-                    auth_service = EmailAuthService(db)
-                    user_info = await auth_service.get_user_by_email(proxy_user)
-
-                    if user_info:
-                        # Resolve teams from DB (returns None for admin bypass, [] for no teams, or list of team IDs)
-                        token_teams = await _resolve_teams_from_db(proxy_user, user_info)
-                        is_admin = user_info.is_admin
-
-                        # Build enriched payload similar to session tokens
-                        payload = {
-                            "sub": proxy_user,
-                            "source": "proxy",
-                            "token": None,
-                            "is_admin": is_admin,
-                            "teams": token_teams,  # None for admin bypass, [] for public-only, or list of team IDs
-                            "email": proxy_user,
-                        }
-
-                        # Cache in request state for downstream use (same pattern as JWT tokens)
-                        request.state._jwt_verified_payload = (None, payload)
-
-                        return payload
-                    else:
-                        # User not in DB - handle based on REQUIRE_USER_IN_DB setting
-                        platform_admin_email = getattr(settings, "platform_admin_email", "admin@example.com")
-                        if not settings.require_user_in_db and proxy_user == platform_admin_email:
-                            # Platform admin bootstrap
-                            payload = {"sub": proxy_user, "source": "proxy", "token": None, "is_admin": True, "teams": None, "email": proxy_user}  # Admin bypass
-                            request.state._jwt_verified_payload = (None, payload)
-                            return payload
-                        else:
-                            raise HTTPException(
-                                status_code=status.HTTP_401_UNAUTHORIZED,
-                                detail="User not found in database",
-                                headers={"WWW-Authenticate": "Bearer"},
-                            )
-                finally:
-                    db.close()
+                return await _authenticate_proxy_user(request, proxy_user)
             # No proxy header - check auth_required (matches RBAC/WebSocket behavior)
             if settings.auth_required:
                 raise HTTPException(
@@ -1089,12 +1124,14 @@ async def require_auth_header_first(
     if request is None:
         request = Request(scope={"type": "http", "headers": []})
 
-    # Proxy auth path — identical to require_auth
+    # Proxy auth path — shares _authenticate_proxy_user() with require_auth
+    # so proxy-authenticated callers get the same enriched payload (teams,
+    # is_admin, email, request.state caching) regardless of entry point.
     if not settings.mcp_client_auth_enabled:
         if is_proxy_auth_trust_active():
             proxy_user = request.headers.get(settings.proxy_user_header)
             if proxy_user:
-                return {"sub": proxy_user, "source": "proxy", "token": None}  # nosec B105 - None is not a password
+                return await _authenticate_proxy_user(request, proxy_user)
             if settings.auth_required:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -4893,11 +4893,11 @@ async def test_streamable_http_auth_proxy_user_when_client_auth_disabled(monkeyp
     mock_user.is_active = True
     mock_user.email = "proxy_user@example.com"
 
-    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
-        "mcpgateway.services.email_auth_service.EmailAuthService"
-    ) as mock_auth_service, patch(
-        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
-    ) as mock_resolve_teams:
+    with (
+        patch("mcpgateway.db.get_db") as mock_get_db,
+        patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service,
+        patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams,
+    ):
         mock_get_db.return_value = iter([Mock()])
         mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
         mock_resolve_teams.return_value = []
@@ -4944,11 +4944,11 @@ async def test_streamable_http_auth_proxy_user_with_bearer_header(monkeypatch):
     mock_user.is_active = True
     mock_user.email = "proxy_fallback@example.com"
 
-    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
-        "mcpgateway.services.email_auth_service.EmailAuthService"
-    ) as mock_auth_service, patch(
-        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
-    ) as mock_resolve_teams:
+    with (
+        patch("mcpgateway.db.get_db") as mock_get_db,
+        patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service,
+        patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams,
+    ):
         mock_get_db.return_value = iter([Mock()])
         mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
         mock_resolve_teams.return_value = []
@@ -4962,6 +4962,129 @@ async def test_streamable_http_auth_proxy_user_with_bearer_header(monkeypatch):
     assert user_ctx["email"] == "proxy_fallback@example.com"
     assert user_ctx["teams"] == []
     assert user_ctx["is_admin"] is False
+
+
+# ---------------------------------------------------------------------------
+# Proxy auth: disabled user rejected via _set_proxy_user_context (line 4567, 4727)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_proxy_rejects_disabled_user(monkeypatch):
+    """Disabled user gets 401 'Account disabled' through proxy auth (lines 4567, 4727)."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_client_auth_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth_dangerously", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.proxy_user_header", "x-forwarded-user")
+
+    scope = _make_scope(
+        "/servers/1/mcp",
+        headers=[
+            (b"x-forwarded-user", b"disabled@example.com"),
+        ],
+    )
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    mock_user = Mock()
+    mock_user.is_admin = True
+    mock_user.is_active = False
+    mock_user.email = "disabled@example.com"
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+
+        result = await streamable_http_auth(scope, None, send)
+
+    assert result is False
+    starts = [m for m in sent if m.get("type") == "http.response.start"]
+    assert starts and starts[0]["status"] == 401
+    bodies = [m for m in sent if m.get("type") == "http.response.body"]
+    assert bodies and b"Account disabled" in bodies[0]["body"]
+
+
+# ---------------------------------------------------------------------------
+# Proxy auth: admin bypass when user not in DB (lines 4572-4575)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_proxy_admin_bypass_no_db_record(monkeypatch):
+    """Platform admin email gets admin bypass when not in DB and require_user_in_db=False (lines 4572-4575)."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_client_auth_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth_dangerously", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.proxy_user_header", "x-forwarded-user")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.require_user_in_db", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.platform_admin_email", "admin@example.com")
+
+    scope = _make_scope(
+        "/servers/1/mcp",
+        headers=[
+            (b"x-forwarded-user", b"admin@example.com"),
+        ],
+    )
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=None)
+
+        result = await streamable_http_auth(scope, None, send)
+
+    assert result is True
+    assert sent == []
+
+    user_ctx = tr.user_context_var.get()
+    assert user_ctx["email"] == "admin@example.com"
+    assert user_ctx["teams"] is None
+    assert user_ctx["is_admin"] is True
+    assert user_ctx["auth_method"] == "proxy"
+
+
+# ---------------------------------------------------------------------------
+# Proxy auth: unknown user rejected (line 4577, 4727)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_proxy_rejects_unknown_user(monkeypatch):
+    """Unknown user (not in DB, not platform admin) gets 401 'User not found' (lines 4577, 4727)."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_client_auth_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth_dangerously", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.proxy_user_header", "x-forwarded-user")
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.require_user_in_db", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.platform_admin_email", "admin@example.com")
+
+    scope = _make_scope(
+        "/servers/1/mcp",
+        headers=[
+            (b"x-forwarded-user", b"unknown@example.com"),
+        ],
+    )
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=None)
+
+        result = await streamable_http_auth(scope, None, send)
+
+    assert result is False
+    starts = [m for m in sent if m.get("type") == "http.response.start"]
+    assert starts and starts[0]["status"] == 401
+    bodies = [m for m in sent if m.get("type") == "http.response.body"]
+    assert bodies and b"User not found in database" in bodies[0]["body"]
 
 
 @pytest.mark.asyncio
@@ -4995,11 +5118,11 @@ async def test_streamable_http_auth_proxy_user_context_on_valid_jwt(monkeypatch)
     mock_user.is_active = True
     mock_user.email = "proxy_user@example.com"
 
-    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
-        "mcpgateway.services.email_auth_service.EmailAuthService"
-    ) as mock_auth_service, patch(
-        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
-    ) as mock_resolve_teams:
+    with (
+        patch("mcpgateway.db.get_db") as mock_get_db,
+        patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service,
+        patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams,
+    ):
         mock_get_db.return_value = iter([Mock()])
         mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
         mock_resolve_teams.return_value = []

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -27,7 +27,7 @@ from contextlib import asynccontextmanager
 import json
 from types import SimpleNamespace
 from typing import List
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
 from fastapi import HTTPException
@@ -4871,7 +4871,7 @@ async def test_complete_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_streamable_http_auth_proxy_user_when_client_auth_disabled(monkeypatch):
-    """Test auth sets user context for proxy user when client auth disabled (lines 1740-1750)."""
+    """Proxy user with valid DB record authenticates and gets DB-backed team/admin context."""
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_client_auth_enabled", False)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth", True)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.trust_proxy_auth_dangerously", True)
@@ -4888,7 +4888,22 @@ async def test_streamable_http_auth_proxy_user_when_client_auth_disabled(monkeyp
     async def send(msg):
         sent.append(msg)
 
-    result = await streamable_http_auth(scope, None, send)
+    mock_user = Mock()
+    mock_user.is_admin = False
+    mock_user.is_active = True
+    mock_user.email = "proxy_user@example.com"
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
+        "mcpgateway.services.email_auth_service.EmailAuthService"
+    ) as mock_auth_service, patch(
+        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+    ) as mock_resolve_teams:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+        mock_resolve_teams.return_value = []
+
+        result = await streamable_http_auth(scope, None, send)
+
     assert result is True
     assert sent == []  # No 401 sent
 
@@ -4924,7 +4939,22 @@ async def test_streamable_http_auth_proxy_user_with_bearer_header(monkeypatch):
     async def send(msg):
         sent.append(msg)
 
-    result = await streamable_http_auth(scope, None, send)
+    mock_user = Mock()
+    mock_user.is_admin = False
+    mock_user.is_active = True
+    mock_user.email = "proxy_fallback@example.com"
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
+        "mcpgateway.services.email_auth_service.EmailAuthService"
+    ) as mock_auth_service, patch(
+        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+    ) as mock_resolve_teams:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+        mock_resolve_teams.return_value = []
+
+        result = await streamable_http_auth(scope, None, send)
+
     assert result is True
     assert sent == []
 
@@ -4960,7 +4990,22 @@ async def test_streamable_http_auth_proxy_user_context_on_valid_jwt(monkeypatch)
     async def send(msg):
         sent.append(msg)
 
-    result = await streamable_http_auth(scope, None, send)
+    mock_user = Mock()
+    mock_user.is_admin = False
+    mock_user.is_active = True
+    mock_user.email = "proxy_user@example.com"
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
+        "mcpgateway.services.email_auth_service.EmailAuthService"
+    ) as mock_auth_service, patch(
+        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+    ) as mock_resolve_teams:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+        mock_resolve_teams.return_value = []
+
+        result = await streamable_http_auth(scope, None, send)
+
     assert result is True
 
     user_ctx = tr.user_context_var.get()

--- a/tests/unit/mcpgateway/utils/test_proxy_auth.py
+++ b/tests/unit/mcpgateway/utils/test_proxy_auth.py
@@ -203,17 +203,18 @@ class TestProxyAuthentication:
                         assert result["email"] == "custom-user"
 
     @pytest.mark.asyncio
-    async def test_jwt_auth_with_proxy_enabled(self, mock_settings, mock_request):
-        """Test that JWT auth still works when proxy auth is configured."""
+    async def test_mcp_client_auth_mode_skips_proxy_path(self, mock_settings, mock_request):
+        """With mcp_client_auth_enabled=True the proxy branch is skipped; anonymous returned when auth_required=False."""
         mock_settings.mcp_client_auth_enabled = True
         mock_settings.trust_proxy_auth = True
         mock_settings.auth_required = False  # Allow anonymous
 
-        # Even with proxy trust enabled, if MCP client auth is enabled,
-        # it should use standard JWT flow
+        # mcp_client_auth_enabled=True routes through the standard JWT flow even
+        # when proxy trust is configured; with no token and auth optional, we
+        # expect "anonymous" (not a proxy payload).
         with patch.object(vc, "settings", mock_settings):
             result = await vc.require_auth(mock_request, None, None)
-            assert result == "anonymous"  # No token provided, auth not required
+            assert result == "anonymous"
 
     @pytest.mark.asyncio
     async def test_backwards_compatibility(self, mock_settings, mock_request):
@@ -441,6 +442,93 @@ class TestProxyAuthentication:
 
         assert result["is_admin"] is True
         assert result["teams"] is None
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_disabled_user_raises_401(self, mock_settings, mock_request):
+        """Disabled users must NOT authenticate via proxy (matches JWT _enforce_revocation_and_active_user)."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "disabled-user@example.com"}
+        mock_request.state = Mock()
+
+        disabled_user = Mock()
+        disabled_user.is_admin = False
+        disabled_user.is_active = False  # Account disabled
+        disabled_user.email = "disabled-user@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=disabled_user)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await vc.require_auth(mock_request, None, None)
+
+        assert exc_info.value.status_code == 401
+        assert "Account disabled" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_disabled_admin_raises_401(self, mock_settings, mock_request):
+        """Disabled admins must NOT authenticate via proxy even though is_admin=True on the record."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "disabled-admin@example.com"}
+        mock_request.state = Mock()
+
+        disabled_admin = Mock()
+        disabled_admin.is_admin = True
+        disabled_admin.is_active = False  # Even disabled admins must be rejected
+        disabled_admin.email = "disabled-admin@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=disabled_admin)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await vc.require_auth(mock_request, None, None)
+
+        assert exc_info.value.status_code == 401
+        assert "Account disabled" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_payload_has_token_use_session(self, mock_settings, mock_request):
+        """Proxy payload sets token_use='session' so downstream dispatchers use DB-backed team resolution."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "user@example.com"}
+        mock_request.state = Mock()
+
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.is_active = True
+        mock_user.email = "user@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service, patch(
+            "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+        ) as mock_resolve_teams:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            mock_resolve_teams.return_value = ["team1"]
+
+            result = await vc.require_auth(mock_request, None, None)
+
+        # token_use: "session" routes main.py:2870 and streamablehttp_transport.py:1998 dispatchers
+        # to resolve_session_teams (DB-backed) rather than normalize_token_teams (embedded teams).
+        assert result["token_use"] == "session"
 
 
 class TestRBACProxyAuthentication:
@@ -731,20 +819,28 @@ class TestWebSocketAuthentication:
 
     @pytest.mark.asyncio
     async def test_streamable_http_auth_with_proxy_header(self):
-        """streamable_http_auth should allow request when proxy header present and auth disabled."""
-        # from types import SimpleNamespace
-        # from starlette.datastructures import Headers
+        """streamable_http_auth allows request when proxy header matches a valid active DB user."""
         # First-Party
         from mcpgateway.transports.streamablehttp_transport import streamable_http_auth
 
-        # Build ASGI scope
         scope = {
             "type": "http",
             "path": "/servers/123/mcp",
             "headers": [(b"x-authenticated-user", b"proxy-user")],
         }
-        # Patch settings dynamically
-        with patch("mcpgateway.transports.streamablehttp_transport.settings") as mock_settings:
+
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.is_active = True
+        mock_user.email = "proxy-user"
+
+        with patch("mcpgateway.transports.streamablehttp_transport.settings") as mock_settings, patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service, patch(
+            "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+        ) as mock_resolve_teams:
             mock_settings.mcp_client_auth_enabled = False
             mock_settings.trust_proxy_auth = True
             mock_settings.trust_proxy_auth_dangerously = True
@@ -752,6 +848,11 @@ class TestWebSocketAuthentication:
             mock_settings.jwt_secret_key = TEST_JWT_SECRET
             mock_settings.jwt_algorithm = "HS256"
             mock_settings.auth_required = False
+            mock_settings.require_user_in_db = True
+
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            mock_resolve_teams.return_value = []
 
             allowed = await streamable_http_auth(scope, AsyncMock(), AsyncMock())
             assert allowed is True

--- a/tests/unit/mcpgateway/utils/test_proxy_auth.py
+++ b/tests/unit/mcpgateway/utils/test_proxy_auth.py
@@ -43,6 +43,8 @@ class TestProxyAuthentication:
             proxy_user_header = "X-Authenticated-User"
             require_token_expiration = False
             docs_allow_basic_auth = False
+            require_user_in_db = True
+            platform_admin_email = "admin@example.com"
 
         return MockSettings()
 
@@ -112,10 +114,31 @@ class TestProxyAuthentication:
         mock_settings.trust_proxy_auth = True
         mock_settings.trust_proxy_auth_dangerously = True
         mock_request.headers = {"X-Authenticated-User": "proxy-user"}
+        mock_request.state = Mock()
+
+        # Mock database user lookup
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.email = "proxy-user"
 
         with patch.object(vc, "settings", mock_settings):
-            result = await vc.require_auth(mock_request, None, None)
-            assert result == {"sub": "proxy-user", "source": "proxy", "token": None}
+            with patch("mcpgateway.db.get_db") as mock_get_db:
+                with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+                    with patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams:
+                        # Setup mocks
+                        mock_db = Mock()
+                        mock_get_db.return_value = iter([mock_db])
+                        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+                        mock_resolve_teams.return_value = ["team1"]
+
+                        result = await vc.require_auth(mock_request, None, None)
+
+                        assert result["sub"] == "proxy-user"
+                        assert result["source"] == "proxy"
+                        assert result["token"] is None
+                        assert result["is_admin"] is False
+                        assert result["teams"] == ["team1"]
+                        assert result["email"] == "proxy-user"
 
     @pytest.mark.asyncio
     async def test_proxy_auth_without_header_raises_when_auth_required(self, mock_settings, mock_request):
@@ -153,10 +176,31 @@ class TestProxyAuthentication:
         mock_settings.trust_proxy_auth_dangerously = True
         mock_settings.proxy_user_header = "X-Remote-User"
         mock_request.headers = {"X-Remote-User": "custom-user"}
+        mock_request.state = Mock()
+
+        # Mock database user lookup
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.email = "custom-user"
 
         with patch.object(vc, "settings", mock_settings):
-            result = await vc.require_auth(mock_request, None, None)
-            assert result == {"sub": "custom-user", "source": "proxy", "token": None}
+            with patch("mcpgateway.db.get_db") as mock_get_db:
+                with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+                    with patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams:
+                        # Setup mocks
+                        mock_db = Mock()
+                        mock_get_db.return_value = iter([mock_db])
+                        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+                        mock_resolve_teams.return_value = ["team1"]
+
+                        result = await vc.require_auth(mock_request, None, None)
+
+                        assert result["sub"] == "custom-user"
+                        assert result["source"] == "proxy"
+                        assert result["token"] is None
+                        assert result["is_admin"] is False
+                        assert result["teams"] == ["team1"]
+                        assert result["email"] == "custom-user"
 
     @pytest.mark.asyncio
     async def test_jwt_auth_with_proxy_enabled(self, mock_settings, mock_request):
@@ -192,15 +236,90 @@ class TestProxyAuthentication:
         mock_settings.trust_proxy_auth = True
         mock_settings.trust_proxy_auth_dangerously = True
         mock_request.headers = {"X-Authenticated-User": "proxy-user"}
+        mock_request.state = Mock()
 
         # Create a valid JWT token
         token = jwt.encode({"sub": "jwt-user"}, mock_settings.jwt_secret_key, algorithm="HS256")
         creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
+        # Mock database user lookup
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.email = "proxy-user"
+
         with patch.object(vc, "settings", mock_settings):
-            # When MCP client auth is disabled, proxy takes precedence
-            result = await vc.require_auth(mock_request, creds, None)
-            assert result == {"sub": "proxy-user", "source": "proxy", "token": None}
+            with patch("mcpgateway.db.get_db") as mock_get_db:
+                with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+                    with patch("mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock) as mock_resolve_teams:
+                        # Setup mocks
+                        mock_db = Mock()
+                        mock_get_db.return_value = iter([mock_db])
+                        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+                        mock_resolve_teams.return_value = ["team1"]
+
+                        # When MCP client auth is disabled, proxy takes precedence
+                        result = await vc.require_auth(mock_request, creds, None)
+
+                        assert result["sub"] == "proxy-user"
+                        assert result["source"] == "proxy"
+                        assert result["token"] is None
+                        assert result["is_admin"] is False
+                        assert result["teams"] == ["team1"]
+                        assert result["email"] == "proxy-user"
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_platform_admin_bootstrap(self, mock_settings, mock_request):
+        """Test proxy authentication with platform admin bootstrap when user not in DB."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_settings.require_user_in_db = False
+        mock_settings.platform_admin_email = "admin@example.com"
+        mock_request.headers = {"X-Authenticated-User": "admin@example.com"}
+        mock_request.state = Mock()
+
+        with patch.object(vc, "settings", mock_settings):
+            with patch("mcpgateway.db.get_db") as mock_get_db:
+                with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+                    # Setup mocks - user NOT found in DB
+                    mock_db = Mock()
+                    mock_get_db.return_value = iter([mock_db])
+                    mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=None)
+
+                    result = await vc.require_auth(mock_request, None, None)
+
+                    # Should bootstrap platform admin
+                    assert result["sub"] == "admin@example.com"
+                    assert result["source"] == "proxy"
+                    assert result["token"] is None
+                    assert result["is_admin"] is True
+                    assert result["teams"] is None  # Admin bypass
+                    assert result["email"] == "admin@example.com"
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_user_not_found_raises_401(self, mock_settings, mock_request):
+        """Test proxy authentication raises 401 when user not in DB and not platform admin."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_settings.require_user_in_db = True
+        mock_settings.platform_admin_email = "admin@example.com"
+        mock_request.headers = {"X-Authenticated-User": "unknown-user@example.com"}
+        mock_request.state = Mock()
+
+        with patch.object(vc, "settings", mock_settings):
+            with patch("mcpgateway.db.get_db") as mock_get_db:
+                with patch("mcpgateway.services.email_auth_service.EmailAuthService") as mock_auth_service:
+                    # Setup mocks - user NOT found in DB
+                    mock_db = Mock()
+                    mock_get_db.return_value = iter([mock_db])
+                    mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=None)
+
+                    with pytest.raises(HTTPException) as exc_info:
+                        await vc.require_auth(mock_request, None, None)
+
+                    assert exc_info.value.status_code == 401
+                    assert "User not found in database" in exc_info.value.detail
 
 
 class TestRBACProxyAuthentication:

--- a/tests/unit/mcpgateway/utils/test_proxy_auth.py
+++ b/tests/unit/mcpgateway/utils/test_proxy_auth.py
@@ -321,6 +321,127 @@ class TestProxyAuthentication:
                     assert exc_info.value.status_code == 401
                     assert "User not found in database" in exc_info.value.detail
 
+    @pytest.mark.asyncio
+    async def test_proxy_auth_admin_user_in_db_yields_admin_bypass(self, mock_settings, mock_request):
+        """Admin user found in DB gets is_admin=True and teams=None (admin bypass)."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "admin-user@example.com"}
+        mock_request.state = Mock()
+
+        mock_user = Mock()
+        mock_user.is_admin = True
+        mock_user.email = "admin-user@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service, patch(
+            "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+        ) as mock_resolve_teams:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            # _resolve_teams_from_db returns None for admins (admin bypass)
+            mock_resolve_teams.return_value = None
+
+            result = await vc.require_auth(mock_request, None, None)
+
+        assert result["sub"] == "admin-user@example.com"
+        assert result["is_admin"] is True
+        assert result["teams"] is None
+        assert result["source"] == "proxy"
+
+    @pytest.mark.asyncio
+    async def test_proxy_auth_multiple_teams(self, mock_settings, mock_request):
+        """Non-admin user with multiple team memberships returns the full list."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "multi-team-user@example.com"}
+        mock_request.state = Mock()
+
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.email = "multi-team-user@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service, patch(
+            "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+        ) as mock_resolve_teams:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            mock_resolve_teams.return_value = ["team-a", "team-b", "team-c"]
+
+            result = await vc.require_auth(mock_request, None, None)
+
+        assert result["is_admin"] is False
+        assert result["teams"] == ["team-a", "team-b", "team-c"]
+
+    @pytest.mark.asyncio
+    async def test_require_auth_header_first_proxy_returns_enriched_payload(self, mock_settings, mock_request):
+        """Parity test: require_auth_header_first returns the enriched payload (same helper)."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_request.headers = {"X-Authenticated-User": "mcp-user@example.com"}
+        mock_request.cookies = {}
+        mock_request.state = Mock()
+
+        mock_user = Mock()
+        mock_user.is_admin = False
+        mock_user.email = "mcp-user@example.com"
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service, patch(
+            "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+        ) as mock_resolve_teams:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+            mock_resolve_teams.return_value = ["team1"]
+
+            result = await vc.require_auth_header_first(auth_header=None, jwt_token=None, request=mock_request)
+
+        # Same enriched shape as require_auth (both go through _authenticate_proxy_user)
+        assert result["sub"] == "mcp-user@example.com"
+        assert result["source"] == "proxy"
+        assert result["token"] is None
+        assert result["is_admin"] is False
+        assert result["teams"] == ["team1"]
+        assert result["email"] == "mcp-user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_require_auth_header_first_proxy_admin_bootstrap(self, mock_settings, mock_request):
+        """Parity test: require_auth_header_first supports platform-admin bootstrap."""
+        mock_settings.mcp_client_auth_enabled = False
+        mock_settings.trust_proxy_auth = True
+        mock_settings.trust_proxy_auth_dangerously = True
+        mock_settings.require_user_in_db = False
+        mock_settings.platform_admin_email = "admin@example.com"
+        mock_request.headers = {"X-Authenticated-User": "admin@example.com"}
+        mock_request.cookies = {}
+        mock_request.state = Mock()
+
+        with patch.object(vc, "settings", mock_settings), patch(
+            "mcpgateway.db.get_db"
+        ) as mock_get_db, patch(
+            "mcpgateway.services.email_auth_service.EmailAuthService"
+        ) as mock_auth_service:
+            mock_get_db.return_value = iter([Mock()])
+            mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=None)
+
+            result = await vc.require_auth_header_first(auth_header=None, jwt_token=None, request=mock_request)
+
+        assert result["is_admin"] is True
+        assert result["teams"] is None
+
 
 class TestRBACProxyAuthentication:
     """Test cases for RBAC middleware proxy authentication functionality."""

--- a/tests/unit/mcpgateway/utils/test_verify_credentials.py
+++ b/tests/unit/mcpgateway/utils/test_verify_credentials.py
@@ -1653,20 +1653,40 @@ async def test_require_auth_header_first_no_request_uses_jwt_token_param(monkeyp
 
 @pytest.mark.asyncio
 async def test_require_auth_header_first_proxy_auth_returns_proxy_user(monkeypatch):
-    """Proxy user is returned when mcp_client_auth_enabled=False and trust_proxy_auth=True."""
+    """Proxy user returns the enriched payload (shared helper with require_auth)."""
     monkeypatch.setattr(vc.settings, "mcp_client_auth_enabled", False, raising=False)
     monkeypatch.setattr(vc.settings, "trust_proxy_auth", True, raising=False)
     monkeypatch.setattr(vc.settings, "trust_proxy_auth_dangerously", True, raising=False)
     monkeypatch.setattr(vc.settings, "proxy_user_header", "x-authenticated-user", raising=False)
     monkeypatch.setattr(vc.settings, "auth_required", True, raising=False)
+    monkeypatch.setattr(vc.settings, "require_user_in_db", True, raising=False)
 
     mock_request = Mock(spec=Request)
     mock_request.headers = {"x-authenticated-user": "proxy-user@example.com"}
     mock_request.cookies = {}
+    mock_request.state = Mock()
 
-    result = await vc.require_auth_header_first(auth_header=None, jwt_token=None, request=mock_request)
+    mock_user = Mock()
+    mock_user.is_admin = False
+    mock_user.email = "proxy-user@example.com"
+
+    with patch("mcpgateway.db.get_db") as mock_get_db, patch(
+        "mcpgateway.services.email_auth_service.EmailAuthService"
+    ) as mock_auth_service, patch(
+        "mcpgateway.auth._resolve_teams_from_db", new_callable=AsyncMock
+    ) as mock_resolve_teams:
+        mock_get_db.return_value = iter([Mock()])
+        mock_auth_service.return_value.get_user_by_email = AsyncMock(return_value=mock_user)
+        mock_resolve_teams.return_value = ["team1"]
+
+        result = await vc.require_auth_header_first(auth_header=None, jwt_token=None, request=mock_request)
+
     assert result["sub"] == "proxy-user@example.com"
     assert result["source"] == "proxy"
+    assert result["token"] is None
+    assert result["is_admin"] is False
+    assert result["teams"] == ["team1"]
+    assert result["email"] == "proxy-user@example.com"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4262

---

## 📝 Summary

Fixes a bug in proxy-based authentication where users authenticated via trusted proxy headers were only granted public-only access, regardless of their actual database permissions. The system was not resolving team memberships or admin privileges from the database for proxy-authenticated users.

**Problem**: When `TRUST_PROXY_AUTH=true`, the authentication flow extracted user identity from the proxy header but stopped there - no database lookup occurred to determine the user's teams or admin status. This resulted in:
- Platform admin users unable to access admin endpoints
- All users (including admins) only seeing public tools
- Private tools remaining inaccessible even for authorized users
- Missing RBAC context for proxy-authenticated requests

**Solution**: Enhanced the proxy authentication path to perform database lookups and resolve team memberships using the same pattern as session token authentication.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🔧 Technical Changes

### Core Implementation (`mcpgateway/utils/verify_credentials.py`)

1. **Database Lookup Integration**
   - Added `EmailAuthService.get_user_by_email()` call in proxy auth path
   - Queries database to retrieve user record with teams and admin status
   - Follows same pattern as session token authentication

2. **Team Resolution**
   - Uses `_resolve_teams_from_db()` helper function
   - Returns `None` for admin users (admin bypass - sees all teams)
   - Returns `[]` for users with no team memberships (public-only)
   - Returns list of team IDs for regular users

3. **Platform Admin Bootstrap**
   - Special handling when `REQUIRE_USER_IN_DB=false`
   - Allows platform admin email to authenticate even if not in database
   - Creates admin-level payload with `is_admin=true` and `teams=None`

4. **Request State Caching**
   - Enriched payload stored in `request.state._jwt_verified_payload`
   - Downstream handlers can access team/admin context
   - Consistent with session token behavior

5. **Error Handling**
   - Returns 401 if user not found in database (when `REQUIRE_USER_IN_DB=true`)
   - Proper error messages for debugging

### Test Coverage (`tests/unit/mcpgateway/utils/test_proxy_auth.py`)

**Updated Existing Tests** (3):
- `test_proxy_auth_with_header` - Added database mocking for normal user
- `test_custom_proxy_header` - Added database mocking for custom header
- `test_mixed_auth_scenario` - Added database mocking for mixed auth

**New Tests** (2):
- `test_proxy_auth_platform_admin_bootstrap` - Verifies admin bootstrap when user not in DB
- `test_proxy_auth_user_not_found_raises_401` - Verifies 401 when user not found and bootstrap disabled

All tests mock:
- `get_db()` for database session
- `EmailAuthService.get_user_by_email()` for user lookup
- `_resolve_teams_from_db()` for team resolution

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Security Considerations
- Maintains two-layer security model (token scoping + RBAC)
- Database is now the authority for proxy-authenticated users
- Admin bypass properly implemented (`teams=None`)
- Fail-closed behavior when user not found

### Behavior Changes
**Before**: Proxy-authenticated users → public-only access
**After**: Proxy-authenticated users → database-resolved teams/admin status

### Configuration Requirements
No new configuration required. Works with existing settings:
- `TRUST_PROXY_AUTH=true` - Enable proxy authentication
- `PROXY_USER_HEADER` - Header name (default: `X-Authenticated-User`)
- `REQUIRE_USER_IN_DB` - Whether to require DB user record (default: `true`)
- `PLATFORM_ADMIN_EMAIL` - Platform admin email for bootstrap