### PR TITLE
fix: bump cpex-secrets-detection to 0.2.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-19T16:27:13Z",
+  "generated_at": "2026-04-20T13:12:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 exclude-newer = "10 days"
-exclude-newer-package = { "cpex-rate-limiter" = "2026-04-09T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-09T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-09T23:59:59Z", "cpex-url-reputation" = "2026-04-09T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
+exclude-newer-package = { "cpex-rate-limiter" = "2026-04-09T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-09T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-20T23:59:59Z", "cpex-url-reputation" = "2026-04-09T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
 
 [tool.uv.sources]
 compliance-reference-server = { path = "mcp-servers/python/compliance_reference_server", editable = true }
@@ -265,7 +265,7 @@ plugins = [
     "cpex-pii-filter>=0.2.0",
     "cpex-rate-limiter>=0.0.3",
     "cpex-retry-with-backoff>=0.1.0",
-    "cpex-secrets-detection>=0.1.0",
+    "cpex-secrets-detection>=0.2.0",
     "cpex-url-reputation>=0.1.1",
 ]
 


### PR DESCRIPTION
## What changed
- Require `cpex-secrets-detection>=0.2.0` in the `[plugins]` extra.
- Move the package-specific `tool.uv.exclude-newer-package` cutoff to April 20, 2026 so `uv` can resolve the new release once it is published.

## Why
- The repository still references `0.1.0` for `cpex-secrets-detection`.
- This PR prepares the dependency bump to `0.2.0`.

## Blocker
- PyPI still reports `cpex-secrets-detection 0.1.0` as the latest release as of April 20, 2026.
- `uv lock --upgrade-package cpex-secrets-detection` currently fails for that reason, so `uv.lock` is intentionally unchanged in this draft PR.

## Validation
- Commit hooks passed during `git commit`.
- `uv lock --upgrade-package cpex-secrets-detection` fails because only `0.1.0` is currently available on PyPI.
