### PR TITLE
feat(transport): restore GET /mcp server-to-client stream (ADR-052)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-20T13:12:10Z",
+  "generated_at": "2026-04-20T13:47:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -994,7 +994,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 943,
+        "line_number": 950,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1040,
+        "line_number": 1047,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1101,
+        "line_number": 1108,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1136,
+        "line_number": 1143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1675,
+        "line_number": 1682,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1752,
+        "line_number": 1759,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2064,
+        "line_number": 2071,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2521,
+        "line_number": 2528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2521,
+        "line_number": 2528,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2534,
+        "line_number": 2541,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2679,
+        "line_number": 2686,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2700,
+        "line_number": 2707,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2708,
+        "line_number": 2715,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2713,
+        "line_number": 2720,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4888,7 +4888,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2275,
+        "line_number": 2297,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9584,7 +9584,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11609,
+        "line_number": 12820,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9592,7 +9592,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12784,
+        "line_number": 13995,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/crates/mcp_runtime/DEVELOPING.md
+++ b/crates/mcp_runtime/DEVELOPING.md
@@ -126,6 +126,36 @@ Add this when the change is close to shipping:
 make verify
 ```
 
+## GET /mcp Stream Relay (ADR-052)
+
+The Rust live-stream branch in `forward_transport_request` (`src/lib.rs`)
+relays Python's `GET /mcp` SSE stream byte-for-byte after parsing it back
+into typed `Event` frames. As of ADR-052, Python serves a spec-conformant
+SSE stream backed by a per-session event bus (Redis Pub/Sub + ring buffer in
+multi-node, in-process deque + `asyncio.Event` in single-node). The relay
+itself did not need code changes — it inherited the new behavior the moment
+Python stopped returning 405.
+
+What this means for development:
+
+- The `session_id.is_none()` 405 in the live-stream branch is spec-mandated
+  (GET requires a session id) and stays. Tests that assert on this 405 are
+  still valid.
+- For the GET-with-session path, the relay opens an upstream GET to Python's
+  `/mcp`, parses the resulting SSE byte stream, and re-emits each frame.
+  No Rust event-bus machinery needed; Python is the source of truth.
+- The Pub/Sub channel (`mcp:session:{sid}:events`) and event-store keys
+  (`mcpgw:eventstore:{sid}:*`) are owned by Python. Rust does not write to
+  them in v1. A future iteration could have Rust subscribe directly to skip
+  the Python hop, but the current relay is the simpler design and keeps the
+  fanout policy in one place.
+- `live_stream_core_enabled()` continues to gate this path; deployments
+  that want Python to serve the stream end-to-end (no Rust relay) leave
+  this disabled and let the request fall through to the Python proxy.
+
+When debugging GET-stream failures, check Python first — `make logs` for
+`ServerEventBus` lines reveals the chosen backend and any publish errors.
+
 ## Compose-Backed MCP Validation
 
 Rust-local tests are not enough for this runtime. You also need live validation

--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -4627,21 +4627,24 @@ async fn forward_transport_request(
         && accepts_sse(&incoming_headers)
         && !incoming_headers.contains_key("last-event-id")
     {
-        // #4205: Guard the live-stream relay with a 405 when we have no
+        // ADR-052: Guard the live-stream relay with a 405 when we have no
         // session to anchor a passive SSE stream to. Two branches land here:
         //   (a) session_core is disabled globally — Rust has no session
         //       infrastructure to validate against.
         //   (b) session_core is enabled but no valid session id was presented
         //       (neither `Mcp-Session-Id`/`x-mcp-session-id` header nor
         //       `session_id` query parameter).
-        // Without this gate, `handle_live_stream_transport_request` commits
-        // to a `text/event-stream` response before discovering the backend
-        // can't anchor the stream, producing the empty-stream cascade that
-        // times out strict MCP clients (the #4205 symptom). For GETs that
-        // don't enter this branch (live_stream_core disabled, or no SSE
-        // Accept), we let the request fall through to the Python transport
-        // bridge, which has its own 405 logic — Rust must not pre-empt that
-        // proxy path.
+        // The 405 is spec-mandated, not a workaround: per MCP Streamable HTTP
+        // ("Listening for messages from the server"), GET /mcp requires a
+        // session id. The Python transport bridge enforces the same rule.
+        //
+        // What changed in ADR-052: the GET-with-session path below now
+        // delivers real server-initiated messages (Python's GET handler
+        // returns a Pub/Sub-backed SSE stream). The Rust relay was always
+        // correctly designed; the empty-stream cascade that motivated the
+        // #4205 405 was a downstream symptom of Python returning 405 for
+        // *every* GET. With Python serving spec-conformant SSE, this relay
+        // passes events through unchanged.
         //
         // Why 405 rather than 404/400: the `/mcp` path exists and the
         // request is syntactically valid; 405 + `Allow: POST, DELETE` tells
@@ -4711,6 +4714,49 @@ async fn forward_transport_request(
             &uri,
             session_id.as_deref(),
         );
+    }
+
+    // Session-less DELETE: the MCP Streamable HTTP spec frames DELETE as
+    // "client-initiated termination — server MAY support, else 405". Without
+    // a session id there is nothing to terminate; the spec-conformant answers
+    // are 405 (this gateway does not honor the attempt) or 200/204 (treat as
+    // a no-op). We pick 405 to match the GET-without-session symmetry in
+    // this file and to give the client a clear `Allow` header.
+    //
+    // We probe the header (or query string) directly rather than the
+    // ``session_id`` variable above: that variable is only populated when
+    // Rust is validating sessions (``session_core_enabled``). In edge mode
+    // Python validates sessions, so a request with a real ``Mcp-Session-Id``
+    // header arrives here with ``session_id == None`` — and we still want
+    // to forward such DELETEs to Python rather than reject them. Without
+    // this branch DELETE without any session header falls through to the
+    // generic backend-forward path and the Python SDK returns 400
+    // "Missing session ID", which fails
+    // `test_delete_mcp_terminates_session_or_405`.
+    if method == reqwest::Method::DELETE
+        && runtime_session_id_from_request(&incoming_headers, &uri).is_none()
+    {
+        let mut response = json_response(
+            StatusCode::METHOD_NOT_ALLOWED,
+            json!({
+                "detail": "DELETE /mcp requires Mcp-Session-Id; without one there is no session to terminate."
+            }),
+        );
+        response.headers_mut().insert(
+            HeaderName::from_static("allow"),
+            HeaderValue::from_static("POST, GET, DELETE"),
+        );
+        inject_runtime_capability_headers(
+            &mut response,
+            &[
+                (SESSION_CORE_HEADER, state.session_core_enabled()),
+                (EVENT_STORE_HEADER, state.event_store_enabled()),
+                (RESUME_CORE_HEADER, state.resume_core_enabled()),
+                (LIVE_STREAM_CORE_HEADER, state.live_stream_core_enabled()),
+                (AFFINITY_CORE_HEADER, state.affinity_core_enabled()),
+            ],
+        );
+        return response;
     }
 
     if state.session_core_enabled() && method == reqwest::Method::DELETE && session_id.is_some() {
@@ -11279,6 +11325,11 @@ mod unit_tests {
         .await;
         assert_eq!(get_response.status(), StatusCode::OK);
 
+        // ADR-052: DELETE without a session id returns 405 directly without
+        // touching the backend (the spec frames DELETE as "client-initiated
+        // termination — server MAY support, else 405", and there is nothing
+        // to terminate without a session id). Verify the new contract; the
+        // backend should NOT receive a DELETE call.
         let delete_response = transport_delete_server_scoped(
             State(state),
             AxumPath("server-xyz".to_string()),
@@ -11287,15 +11338,22 @@ mod unit_tests {
             "/servers/server-xyz/mcp".parse::<Uri>().expect("uri"),
         )
         .await;
-        assert_eq!(delete_response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(delete_response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let allow = delete_response
+            .headers()
+            .get("allow")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            allow.contains("DELETE"),
+            "405 Allow header should advertise DELETE, got {allow:?}"
+        );
 
         let calls = calls.lock().expect("lock");
         assert_eq!(
             *calls,
-            vec![
-                ("GET".to_string(), Some("server-xyz".to_string())),
-                ("DELETE".to_string(), Some("server-xyz".to_string())),
-            ]
+            vec![("GET".to_string(), Some("server-xyz".to_string()))],
+            "session-less DELETE must not reach the backend (ADR-052)"
         );
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -440,11 +440,18 @@ services:
       # - SSRF_DNS_FAIL_CLOSED=true
       # - SSRF_ALLOWED_NETWORKS=["10.20.0.0/16"]
 
-      # Uncomment to enable stateful sessions for Streamable HTTP transport
-      # - USE_STATEFUL_SESSIONS=true
+      # Required for the GET /mcp server-to-client SSE stream (ADR-052).
+      # Without this, GET /mcp returns 405 because the gateway has no event
+      # store to anchor a stream against.
+      - USE_STATEFUL_SESSIONS=true
 
-      # Uncomment to enable session affinity between downstream (from client) and upstrean (to MCP server) sessions
-      # - MCPGATEWAY_SESSION_AFFINITY_ENABLED=true
+      # Required for cross-worker routing in the multi-replica testing-up
+      # config. The GET stream itself doesn't need affinity (Pub/Sub fans out
+      # to any node), but the POST that carries a downstream's response to a
+      # server-initiated request must reach the worker holding the upstream
+      # RequestResponder — which is what affinity routes for. ADR-052 §
+      # "Why we skip affinity for GET" explains the asymmetry.
+      - MCPGATEWAY_SESSION_AFFINITY_ENABLED=true
 
       ## Uncomment to enable HTTPS (run `make certs` first)
       # - SSL=true

--- a/docs/docs/architecture/adr/052-get-stream-and-server-initiated-requests.md
+++ b/docs/docs/architecture/adr/052-get-stream-and-server-initiated-requests.md
@@ -1,0 +1,227 @@
+# ADR-052: GET /mcp Stream and Server-Initiated Request Correlation
+
+- *Status:* Proposed
+- *Date:* 2026-04-19
+- *Deciders:* Platform Team
+- *Related:* [ADR-038: Multi-Worker Session Affinity](038-multi-worker-session-affinity.md), [ADR-043: Rust MCP Runtime Sidecar](043-rust-mcp-runtime-sidecar-mode-model.md), [Issue #4205: GET /mcp 405 fallback](https://github.com/IBM/mcp-context-forge/issues/4205), [Issue #4299: Per-session upstream isolation](https://github.com/IBM/mcp-context-forge/issues/4299), [MCP spec — Listening for messages from the server](https://modelcontextprotocol.io/specification/draft/basic/transports#listening-for-messages-from-the-server)
+
+## Context
+
+The MCP Streamable HTTP spec defines a server-to-client stream: the client opens `GET /mcp` with `Accept: text/event-stream`, optionally carrying `Last-Event-Id`, and the server returns an SSE stream that delivers server-initiated JSON-RPC messages — notifications (logging, progress, list-changed) and *requests* the server makes of the client (sampling/createMessage, elicitation/create, roots/list).
+
+**What we have today (post-#4205, #4299).** Both the Python gateway (`streamablehttp_transport.py:3004-3031`) and the Rust runtime (`crates/mcp_runtime/src/lib.rs:4654-4706`) return `405 Method Not Allowed` on `GET /mcp` whenever stateful sessions are disabled OR no `Mcp-Session-Id` header is present. The 405 was correct under #4205 because there was no infrastructure to deliver server-initiated messages to a downstream listener — the per-session message handler in `services/notification_service.py:369-431` consumes upstream notifications only to trigger internal list-refresh, and `routers/reverse_proxy.py:532` carries an explicit `# TODO: Implement message queue for SSE delivery`.
+
+**Why we need it back.** Restoring the GET stream is a prerequisite for several upcoming features that all depend on server-to-client delivery: structured logging visible to the client, progress notifications, sampling/elicitation passthrough (extending the work in [ADR-022](022-elicitation-passthrough.md) to streamable HTTP), and list-changed notifications that today are absorbed into refresh logic instead of forwarded.
+
+**The multi-node problem.** The downstream client opens GET on whatever node the load balancer picks (call it node A). The upstream MCP session lives on the worker that owns it via the affinity machinery (ADR-038) — call it node B. Notifications from upstream arrive at node B, but the client is listening on node A. We need cross-node delivery without forcing the GET to land on the affinity owner.
+
+## Decision
+
+The GET stream is **node-agnostic**: any node accepts the GET, validates the session, and tails a Redis-backed per-session event channel. The affinity invariant from ADR-038 still pins POST/DELETE to one worker (because the upstream `ClientSession` lives in that worker's memory), but GET deliberately does not participate in affinity.
+
+Three concrete pieces:
+
+### 1. Server event bus — Pub/Sub + event store
+
+A new module `mcpgateway/transports/server_event_bus.py` exposes a small `ServerEventBus` interface:
+
+- `publish(session_id, message) -> str` — appends to a per-session ring buffer; returns the new event ID. Then signals listeners.
+- `subscribe(session_id, *, last_event_id) -> AsyncIterator[Event]` — replays from the buffer starting after `last_event_id` (or current head if absent), then tails new events. Yields `(event_id, message)` tuples shaped for SSE framing.
+
+Two implementations behind the same interface, selected by `cache_type`:
+
+- **`RedisServerEventBus`** (`cache_type == "redis"`) — `publish` writes to the existing `RedisEventStore` (Lua-atomic per-session ring buffer) and `PUBLISH`es on `mcp:session:{session_id}:events`. `subscribe` replays from the store, then `SUBSCRIBE`s the channel and tails. Pub/Sub provides the wake-up signal; the event store is the durable source of truth for ordering and replay. Standard Postgres `LISTEN/NOTIFY` + table pattern.
+- **`InMemoryServerEventBus`** (default — `cache_type` ∈ `{memory, none, database}`) — `publish` appends to a process-local `dict[session_id, deque]` (same ring-buffer semantics as the Redis store) and notifies waiting subscribers via `asyncio.Event`. `subscribe` replays the deque, then awaits new events. Identical observable behavior for a single-process gateway.
+
+The factory in `server_event_bus.py` reads `settings.cache_type` once at startup and binds the singleton. Same-shape interface means call sites — `notification_service.py`, the GET handler, the request-correlation sweeper — never branch on backend.
+
+### 2. Single-listener claim — new `SessionAffinity` methods
+
+The MCP spec mandates one GET stream per session ("If the client has opened a single SSE stream … the server SHOULD NOT open a new SSE stream"). The claim API:
+
+- `SessionAffinity.claim_listener(session_id, connection_id) -> bool` — atomic claim. Returns `True` on success, `False` if a live listener already exists.
+- `SessionAffinity.heartbeat_listener(session_id, connection_id)` — refreshes the claim while the GET handler holds the connection.
+- `SessionAffinity.release_listener(session_id, connection_id)` — releases on disconnect, conditional on `connection_id` match (don't release someone else's claim).
+
+Two backends behind the same API, parallel to the event bus:
+
+- **Multi-node** (`cache_type == "redis"`) — `SET NX EX` on `mcp:session:{session_id}:listener` with value `{node_id, connection_id, ts}`. Same Redis primitive `register_session_mapping()` already uses for worker ownership.
+- **Single-node** — process-local `dict[session_id, ClaimEntry]` guarded by an `asyncio.Lock`. Same atomicity guarantee within the process; no cross-process coordination needed because there is only one process.
+
+A second GET on the same session sees the claim and returns `409 Conflict` with `Retry-After`.
+
+### 3. Server-initiated request correlation — worker-local
+
+When the upstream `ClientSession` produces a `RequestResponder` (sampling/elicitation/roots-list), the per-session message handler in `notification_service.py`:
+
+1. Builds a JSON-RPC envelope keyed by the responder's `request_id`.
+2. Registers `(session_id, request_id) -> asyncio.Future` in a worker-local `dict` under lock.
+3. Spawns a **holder task** that owns the `RequestResponder` as a context manager and `await`s the future under `asyncio.wait_for(..., timeout=_pending_request_ttl_seconds)`.
+4. Publishes the envelope on the event bus.
+
+When the downstream client POSTs the JSON-RPC response on `/mcp` (still affinity-routed to the worker holding the upstream session — that's the whole point of ADR-038 for POST), the POST handler intercepts: if the body is a JSON-RPC response whose ID matches a local pending entry, `complete_request` resolves the future and the holder task calls `responder.respond(...)`. Timeout handling is per-task via `wait_for` — **there is no background sweeper scanning the dict**; each holder cleans its own entry in its `finally` block.
+
+**This is intentionally worker-local state.** The pending `RequestResponder` future *is* a worker-local object — it can't be resolved on any other node, so there is nothing to gain by putting the dispatch table in Redis. Affinity routing of the POST already gets us to the right worker.
+
+## Why we skip affinity for GET
+
+Affinity exists because the upstream `ClientSession` lives in one worker's memory. POSTs that need to invoke that session must reach that worker. GET is different: the GET handler doesn't touch the upstream session — it only reads from the event bus. Pub/Sub fanout means every node already sees every event for every session it's listening for. Routing GET through affinity would add a hop with no benefit and would force a single node to fan out streams it has no other reason to serve.
+
+The single-listener claim is what enforces uniqueness, not affinity. Where the listener happens to land is irrelevant.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                       GET /mcp DATA FLOW                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│   Client (Last-Event-Id: e42)                                           │
+│        │                                                                │
+│        ▼                                                                │
+│   ┌─────────┐                                ┌──────────────────────┐   │
+│   │ NODE A  │  GET /mcp                      │  NODE B (affinity    │   │
+│   │ (any)   │  ─────────────────────────►    │  owner of session)   │   │
+│   │         │                                │                      │   │
+│   │ claim_  │   SET NX                       │  upstream            │   │
+│   │ listener├──────────────►┌────────┐       │  ClientSession       │   │
+│   │         │               │ Redis  │       │       │              │   │
+│   │ subscribe (sid)         │        │  ◄────┤  notification        │   │
+│   │  │  ┌────────────────── │ EventStore     │  arrives             │   │
+│   │  │  │ replay e43..      │ (ring) │       │       │              │   │
+│   │  │  │                   │        │       │       ▼              │   │
+│   │  │  │  PUB e44 ◄────────┤Pub/Sub │ ◄──── │  publish(sid, msg)   │   │
+│   │  ▼  ▼                   └────────┘       │                      │   │
+│   │ SSE stream ──────────► client            │                      │   │
+│   └─────────┘                                └──────────────────────┘   │
+│                                                                         │
+│   Server-initiated request (sampling): same path, plus correlation      │
+│        ┌────────────────────────────────────────────────────────────┐   │
+│        │ NODE B stores (sid, req_id) → RequestResponder locally     │   │
+│        │ Client POSTs response → affinity routes to NODE B → match  │   │
+│        │ → resolve RequestResponder                                 │   │
+│        └────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Configuration
+
+Two new settings in `mcpgateway/config.py`:
+
+- `mcp_get_stream_enabled: bool = True` — master switch; when `False`, retains the current 405 behavior. Default on.
+- `mcp_get_stream_listener_ttl_seconds: int = 30` — TTL for the listener claim; refreshed by heartbeat.
+
+The `cache_type` setting (existing) implicitly chooses single-node vs. multi-node mode for both the event bus and the listener claim — no separate flag.
+
+Existing prerequisite still applies: `use_stateful_sessions=True` is required.
+
+## Single-node vs. multi-node — fallback contract
+
+The gateway must run correctly with no Redis. The two backends are functionally equivalent for a single process; what they cost is cross-process delivery, which is meaningless in a single-process deployment.
+
+| Concern | `cache_type == "redis"` (multi-node) | otherwise (single-node) |
+|---|---|---|
+| Event bus | `RedisEventStore` + Pub/Sub | In-memory deque + `asyncio.Event` |
+| Listener claim | Redis `SET NX EX` | In-process dict + `asyncio.Lock` |
+| Replay (`Last-Event-Id`) | From Redis ring buffer | From in-memory deque |
+| Pending request correlation | Worker-local dict (same in both modes) | Same |
+
+**Backend selection is at startup**, not per call. The factory reads `cache_type` once and caches the singleton. Switching `cache_type` requires a restart — same as every other Redis-dependent feature in the codebase.
+
+**Failure mode in multi-node.** If `cache_type == "redis"` is configured but Redis is unreachable when a GET arrives, we close the stream with `503 Service Unavailable` so the client reconnects. We deliberately do NOT silently fall back to in-memory: that would silently lose cross-node delivery and produce sessions that work on whichever node happens to hold both the upstream and the listener — a partition we'd rather surface as an error.
+
+**Failure mode in single-node.** No remote dependency to fail. The deque grows bounded by the same `max_events_per_stream` setting that bounds the Redis ring buffer, so memory is bounded.
+
+**Multi-worker single-node (gunicorn -w 4 with `cache_type=memory`)** is not a supported configuration for the GET stream — the in-memory bus is per-process. Operators running multiple workers should set `cache_type=redis`. The 405 behavior remains as a documented fallback if `mcp_get_stream_enabled=False`.
+
+## Consequences
+
+### Positive
+
+- **Restores spec-conformant server-to-client streaming.** Notifications, progress, sampling, elicitation, roots-list all flow.
+- **Unblocks downstream features** that depend on server-initiated messages (visible logging, progress, elicitation passthrough on streamable HTTP).
+- **No new infrastructure.** Reuses `RedisEventStore` (already there for resume) and the Redis `SET NX` claim pattern (already there for affinity).
+- **Cleaner load distribution.** GET streams can land on any node; we are not pinning long-lived connections to the affinity owner.
+- **Worker-local request correlation is the simplest model that works.** No distributed dispatch table; affinity already routes the response to the right worker.
+
+### Negative
+
+- **`SessionAffinity` accumulates a second responsibility.** It now manages both worker ownership (where requests route) and listener claims (which connection holds the GET stream). These are conceptually distinct and the module name is starting to over-fit. We accept this debt for v1 (see "Naming debt" below) rather than churn the module surface in the same change that adds the feature.
+- **Pub/Sub fanout has at-least-once semantics under network partition.** Subscribers may briefly miss messages; the event store + `Last-Event-Id` resume covers this when the client reconnects, but a client that holds a single connection through a Redis blip may see a gap. Acceptable for v1 — the spec assumes reconnection-with-resume as the recovery model.
+- **Single-listener claim adds one Redis round trip per GET.** Negligible for the workload, but worth naming.
+
+### Neutral
+
+- **Affinity invariant from ADR-038 narrows in scope.** Still applies to POST/DELETE; explicitly does not apply to GET. ADR-038 should get a one-paragraph cross-reference to this ADR.
+- **`reverse_proxy.py:532` TODO is resolved by the same event bus** if reverse-proxy SSE wants to participate; out of scope for this change.
+
+## Naming debt
+
+`SessionAffinity` (`mcpgateway/services/session_affinity.py`) was named when its sole job was "pin a session to a worker." With this ADR it gains the listener-claim methods, which are not affinity at all — they are presence/uniqueness state that any node consults. A future PR should split:
+
+- `SessionAffinity` → keeps `register_session_mapping`, `forward_request_to_owner`, worker heartbeat, RPC listener.
+- `SessionPresence` (new) → owns `claim_listener`, `heartbeat_listener`, `release_listener`, plus any future "is this session live anywhere?" queries.
+
+Both would share the same Redis namespace conventions and TTL settings. For this ADR we add the methods to `SessionAffinity` and document the debt; the split is a name-only refactor that is safer to do separately.
+
+## Single-listener invariant — declaration
+
+The MCP spec requires that a server SHOULD NOT open a second SSE stream for the same session. Until now, no code in this repo asserted this — the 405 guard only checked for session-ID *presence*, not for an existing live stream. This ADR introduces the invariant and locates its enforcement in `SessionAffinity.claim_listener`. Cite this section when adding tests or downstream features that depend on the one-listener guarantee.
+
+## Session ownership on GET
+
+The GET stream gates on session ownership the same way POST and DELETE do: `_validate_streamable_session_access()` runs before the SSE response opens. Treating the `Mcp-Session-Id` header as a bearer (i.e. "anyone who knows it can subscribe") is **not** the model — that would let any authenticated caller attach to another user's server-initiated traffic (notifications, sampling/elicitation requests, progress, logs) and would also let an attacker who claims the single-listener slot first pin the rightful owner out of the session until TTL expiry.
+
+Concrete rules:
+
+- The session id must belong to the authenticated caller, or the caller must be a platform admin. Mirrors the POST gate (`mcpgateway/transports/streamablehttp_transport.py:_validate_streamable_session_access`).
+- Unknown / made-up session ids return `404`, not `200 SSE`.
+- Non-owner access returns `403`, recorded under the `session_denied` outcome of `transport_get_rejected_total`.
+- Per-server OAuth enforcement (`oauth_enabled`) runs in the auth middleware before the GET branch is reached, so an unauthenticated GET to an oauth-required server still gets the spec-conformant `401` with `WWW-Authenticate: Bearer resource_metadata=...`.
+
+Tests in `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py`:
+
+- `test_handle_streamable_http_get_denies_non_owner_session` — wrong-owner deny path.
+- `test_handle_streamable_http_get_denies_unknown_session` — unknown-id 404 path.
+- `test_streamable_http_auth_rejects_unauthenticated_oauth_server_on_get` — middleware 401.
+- `test_streamable_http_auth_allows_authenticated_oauth_server_on_get` — symmetric authenticated path.
+
+## Migration and rollout
+
+- **Default on.** `mcp_get_stream_enabled=True` ships in the same release as the implementation. Operators can revert to 405 behavior with a single env var if a regression appears.
+- **Tests.** The current happy-path 405 tests in `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py:6490+` are converted to assert SSE is returned for valid sessions; the negative cases (stateless mode, missing/invalid session ID) keep their 405 assertions. New tests cover `Last-Event-Id` resume, multi-worker fanout against a mock Redis, and the 409 response on second listener.
+- **Compliance harness.** Connect → notification fanout → `Last-Event-Id` resume exercised end-to-end by the protocol-compliance matrix in docker-compose; a dedicated transport-core test for the GET stream can be added later when a stable harness anchor exists (not required for this ADR to ship).
+- **Rust runtime.** The `session_id.is_none()` 405 branch in
+  `crates/mcp_runtime/src/lib.rs` (`forward_transport_request`) **stays** —
+  it's spec-mandated (GET requires a session id) and applies in both
+  Python-served and Rust-relayed configurations. What changed for ADR-052
+  is that the GET-with-session path now relays a real SSE stream end to
+  end (Python's GET handler returns events instead of 405). The Rust
+  relay code itself needed no behavior change — comments around the 405
+  branch were updated to point at ADR-052, and `crates/mcp_runtime/DEVELOPING.md`
+  § "GET /mcp Stream Relay" documents the unchanged data flow for relay-mode
+  developers.
+
+## Trying it out
+
+See [GET /mcp Stream Quickstart](../get-stream-quickstart.md) for hands-on
+verification across three deployment tiers — bare `make dev`, single-replica
+compose, and `make testing-up` (3-replica multi-node with Redis).
+
+## References
+
+- Implementation:
+  - `mcpgateway/transports/server_event_bus.py` (new)
+  - `mcpgateway/transports/streamablehttp_transport.py` (replace 405 branch)
+  - `mcpgateway/services/session_affinity.py` (add listener-claim methods)
+  - `mcpgateway/services/notification_service.py` (publish to event bus, request correlation)
+  - `mcpgateway/config.py` (`mcp_get_stream_enabled`)
+  - `crates/mcp_runtime/src/lib.rs` (drop 405 branch in live-stream path)
+- Tests:
+  - `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py`
+  - `tests/unit/mcpgateway/services/test_session_affinity.py`
+  - `tests/unit/mcpgateway/transports/test_server_event_bus.py` (new)
+  - `tests/unit/mcpgateway/transports/test_redis_event_store.py` (cross-stream, evicted-cursor, no-cursor replay)
+  - `tests/unit/mcpgateway/services/test_notification_service.py` (request correlation, id-collision, publish-failure telemetry, shutdown timeout)
+- Spec: [Streamable HTTP — Listening for messages from the server](https://modelcontextprotocol.io/specification/draft/basic/transports#listening-for-messages-from-the-server)
+- Prior ADRs: [ADR-022](022-elicitation-passthrough.md), [ADR-038](038-multi-worker-session-affinity.md), [ADR-043](043-rust-mcp-runtime-sidecar-mode-model.md)

--- a/docs/docs/architecture/adr/index.md
+++ b/docs/docs/architecture/adr/index.md
@@ -54,5 +54,6 @@ This page tracks all significant design decisions made for ContextForge project,
 | 0049  | Multi-Protocol Virtual Servers                       | Accepted | Architecture | 2026-04-16 |
 | 0050  | Defer Generic Cluster-Wide Settings Propagation Framework | Accepted | Architecture | 2026-04-18 |
 | 0051  | Swappable MCP Ingress Mount                          | Accepted | Architecture | 2026-04-18 |
+| 0052  | GET /mcp Stream and Server-Initiated Request Correlation | Proposed | MCP Protocol | 2026-04-19 |
 
 > ✳️ Add new decisions chronologically and link to them from this table.

--- a/docs/docs/architecture/get-stream-quickstart.md
+++ b/docs/docs/architecture/get-stream-quickstart.md
@@ -1,0 +1,195 @@
+# GET /mcp Stream — Quickstart
+
+Hands-on guide for exercising the server-to-client SSE stream introduced in
+[ADR-052](adr/052-get-stream-and-server-initiated-requests.md). Three
+deployment shapes, in increasing complexity:
+
+1. Bare `make dev` (single process, no Redis)
+2. `make compose-up` (single-replica container, no Redis)
+3. `make testing-up` (3-replica multi-node, Redis-backed)
+
+Pick the lowest tier that exercises what you're trying to verify. The wire
+protocol is identical in all three; only the cross-process / cross-node
+fanout differs.
+
+## Prerequisite (all tiers)
+
+The GET stream requires stateful sessions. Without them you'll keep getting
+405. Add this to `.env`:
+
+```bash
+USE_STATEFUL_SESSIONS=true
+```
+
+`MCP_GET_STREAM_ENABLED=true` is the default; you only need to set it
+explicitly if you want to flip the kill switch off.
+
+## Tier 1 — Bare `make dev`
+
+```bash
+make dev
+```
+
+Backend selection: `cache_type` defaults to `database`, so the bus binds
+`InMemoryServerEventBus` and the listener claim uses an in-process dict +
+`asyncio.Lock`. Single process, no Redis required.
+
+What works: GET stream, `Last-Event-Id` resume, single-listener 409,
+server-initiated request correlation. Everything that doesn't depend on
+fanout across processes.
+
+What doesn't work in this tier: cross-worker delivery (there's only one
+worker). If you start `gunicorn -w 4` against this config, each worker has
+its own event-bus state — clients hitting different workers won't see each
+other's events. That's by design (see ADR-052 § "Single-node vs. multi-node
+fallback contract") and is why we ship `cache_type=redis` for multi-worker.
+
+## Tier 2 — `make compose-up` (single replica, no Redis enforcement)
+
+For containerized testing without spinning up the full Redis-backed stack:
+
+```bash
+make compose-up           # docker-compose.yml + override.lite.yml; 2 replicas
+```
+
+To collapse to single replica without Redis affinity:
+
+```bash
+GATEWAY_REPLICAS=1 make compose-up
+```
+
+The default `make compose-up` runs 2 replicas, which means you'd need
+`MCPGATEWAY_SESSION_AFFINITY_ENABLED=true` and Redis in the picture (see
+Tier 3) — otherwise POSTs may land on a different replica than holds the
+upstream session, and request correlation will fail. Stick to single
+replica here unless you're ready for the multi-node setup.
+
+## Tier 3 — `make testing-up` (multi-node, Redis-backed)
+
+This is the right tier for verifying ADR-052 multi-node behavior — Pub/Sub
+fanout, listener-claim race resolution, POST affinity routing.
+
+### What you get out of the box
+
+`make testing-up` brings up the testing profile with:
+
+- 3 gateway replicas (`GATEWAY_REPLICAS=3`)
+- 24 gunicorn workers per replica (`GUNICORN_WORKERS=24`) — 72 worker
+  processes total
+- nginx on `:8080` fronting them
+- PostgreSQL, Redis, Locust, fast_test_server, A2A echo agent, MCP Inspector
+- `CACHE_TYPE=redis` already set in `docker-compose.yml`
+
+### The two flags you need to enable
+
+Edit `docker-compose.yml` and uncomment:
+
+```yaml
+- USE_STATEFUL_SESSIONS=true                        # line ~444
+- MCPGATEWAY_SESSION_AFFINITY_ENABLED=true          # line ~447
+```
+
+`USE_STATEFUL_SESSIONS` is the GET-stream prerequisite (Tier 1's flag, same
+meaning). `MCPGATEWAY_SESSION_AFFINITY_ENABLED` is what makes POST routing
+land on the worker holding the upstream session — without it, server-
+initiated request correlation will fail because the response POST won't
+reach the worker holding the `RequestResponder`.
+
+Then:
+
+```bash
+make testing-down              # if already running
+make testing-up                # rebuilds against your edits
+```
+
+### Verifying it works end-to-end
+
+Open the MCP Inspector at `http://localhost:6274`. Connect to the gateway
+via `http://nginx:80/mcp` (or the gateway URL surfaced in the testing-up
+output). Run `initialize` — you'll get an `Mcp-Session-Id` back.
+
+Then in a separate terminal:
+
+```bash
+TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
+        --username admin@example.com --exp 60 --secret KEY)
+SID=<paste-the-mcp-session-id-from-inspector>
+
+# 1. Open the GET stream — holds open with text/event-stream
+curl -N \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Mcp-Session-Id: $SID" \
+  -H "Accept: text/event-stream" \
+  http://localhost:8080/mcp
+
+# 2. From a third terminal, trigger an upstream notification (e.g., reload
+#    a tool on fast_test_server). The notification should appear in the
+#    GET stream from step 1.
+
+# 3. Single-listener invariant: open a second GET on the same SID → 409
+curl -i -H "Authorization: Bearer $TOKEN" \
+       -H "Mcp-Session-Id: $SID" \
+       -H "Accept: text/event-stream" \
+       http://localhost:8080/mcp
+# expect: HTTP/1.1 409 Conflict, Retry-After: 1
+```
+
+### Watching the cross-node fanout
+
+Tail the gateway logs while a GET is held open and a notification fires:
+
+```bash
+docker compose logs -f gateway | grep -E "ServerEventBus|listener|publish"
+```
+
+You should see the bus pick `Redis backend` at startup, the listener-claim
+on whichever worker accepts the GET, and the publish from whichever worker
+holds the upstream session — and they may be different workers. That's the
+point of ADR-052: GET is node-agnostic.
+
+To force the cross-node case deterministically, scale to many replicas and
+hit the gateway with parallel sessions. nginx round-robins, so within a
+few requests you'll have a session whose GET and POST land on different
+workers.
+
+### Tearing down
+
+```bash
+make testing-down
+```
+
+## Common gotchas
+
+- **No upstream MCP server registered = no notifications to fan out.** The
+  GET stream stays open with keepalives but won't carry payloads. Register
+  an MCP server (the `fast_test_server` is auto-registered by
+  `make testing-up`) and exercise something that emits notifications.
+- **`USE_STATEFUL_SESSIONS=false` (the default) → 405.** This is by design
+  per spec — the GET stream needs an event store.
+- **Session id from the wrong `initialize`.** A `Mcp-Session-Id` issued
+  yesterday won't match anything today; re-run `initialize`.
+- **`Accept` header missing.** GET /mcp requires `Accept: text/event-stream`
+  (or `*/*`); other Accept values get 406.
+- **Multi-replica without `MCPGATEWAY_SESSION_AFFINITY_ENABLED`.** GET still
+  works (Pub/Sub doesn't need affinity), but POSTs may land on the wrong
+  worker — server-initiated request correlation breaks because the
+  `RequestResponder` lives in one worker's memory.
+
+## Where to look in code
+
+- `mcpgateway/transports/server_event_bus.py` — bus implementations and
+  factory
+- `mcpgateway/transports/streamablehttp_transport.py` —
+  `_handle_get_stream`, `_maybe_intercept_response_post`
+- `mcpgateway/services/session_affinity.py` — `claim_listener` /
+  `heartbeat_listener` / `release_listener`
+- `mcpgateway/services/notification_service.py` —
+  `_forward_notification_to_stream`, `_forward_request_to_stream`,
+  `complete_request`
+
+## Related
+
+- [ADR-052: GET /mcp Stream and Server-Initiated Request Correlation](adr/052-get-stream-and-server-initiated-requests.md)
+- [ADR-038: Multi-Worker Session Affinity](adr/038-multi-worker-session-affinity.md)
+- [Rust MCP Runtime — DEVELOPING § GET /mcp Stream Relay](../../crates/mcp_runtime/DEVELOPING.md)
+- [MCP Streamable HTTP — Listening for messages from the server](https://modelcontextprotocol.io/specification/draft/basic/transports#listening-for-messages-from-the-server)

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1905,6 +1905,28 @@ class Settings(BaseSettings):
     streamable_http_max_events_per_stream: int = 100  # Ring buffer capacity per stream
     streamable_http_event_ttl: int = 3600  # Event stream TTL in seconds (1 hour)
 
+    # GET /mcp server-to-client stream (ADR-052)
+    # When True, GET /mcp returns an SSE stream that delivers server-initiated
+    # JSON-RPC messages (notifications and server-initiated requests) for the
+    # session identified by Mcp-Session-Id. Requires use_stateful_sessions=True.
+    # Backend (Redis vs in-memory) follows cache_type — see ADR-052 for the
+    # single-node vs multi-node fallback contract.
+    mcp_get_stream_enabled: bool = True
+    # TTL for the per-session listener claim. Refreshed by heartbeat while the
+    # GET handler holds the connection; expires shortly after disconnect so a
+    # client can reconnect without operator intervention.
+    mcp_get_stream_listener_ttl_seconds: int = 30
+    # Soft cap (bytes) on how much the body-peek helpers will buffer
+    # before stopping the peek and falling through to the SDK's
+    # streaming receive path. The request is NEVER rejected — the
+    # cap only bounds peek-path memory. Bare-uvicorn deployments
+    # without an upstream nginx have no other body cap; the body-peek
+    # path runs on every POST that has a pending request or hits a
+    # no-session MCP path. 4 MiB matches typical RPC payload sizes
+    # and stops trickle attacks dead without stranding legitimate
+    # large ``sampling/createMessage`` responses.
+    mcp_body_peek_max_bytes: int = 4 * 1024 * 1024
+
     # Development
     dev_mode: bool = False
     reload: bool = False

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1642,24 +1642,65 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         app.state.update_http_pool_metrics()
 
     # Initialize the session-affinity service (Redis-backed worker mapping,
-    # heartbeat, session-owner forwarding). Only needed when affinity is on.
-    # The upstream-session pooling concept that used to live here has moved
-    # to UpstreamSessionRegistry (see issue #4205).
-    if settings.mcpgateway_session_affinity_enabled:
-        # First-Party
-        from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    # heartbeat, session-owner forwarding). Cross-worker upstream
+    # ``ClientSession`` state lives in ``UpstreamSessionRegistry`` —
+    # SessionAffinity owns only the affinity layer.
+    # Always initialize SessionAffinity, regardless of
+    # ``mcpgateway_session_affinity_enabled``. The affinity flag controls
+    # cross-worker Redis routing; the GET /mcp listener-claim dict
+    # (ADR-052) is single-node bookkeeping that lives on the same instance
+    # and needs to be a process-wide singleton even with affinity off.
+    # Without the always-init, the GET handler would fall back to a fresh
+    # ``SessionAffinity()`` per request → each request gets its own
+    # ``_listener_claims`` dict → two concurrent GETs both win the claim
+    # and the single-listener invariant is broken in the default
+    # single-node deployment.
+    #
+    # The Redis-backed background tasks (heartbeat, RPC listener) are
+    # internally gated on the affinity flag, so always-init is safe.
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
 
-        init_session_affinity()
-        logger.info("MCP session pool initialized")
+    # Use enable_notifications=False here so we don't double-init the
+    # notification service — main.lifespan does that explicitly below.
+    init_session_affinity(enable_notifications=False)
+    logger.info(
+        "Session-affinity service initialized (affinity_enabled=%s)",
+        settings.mcpgateway_session_affinity_enabled,
+    )
 
     # Initialize the upstream session registry (#4205). 1:1 binding between a
     # downstream MCP session and its upstream session per gateway, replacing
     # the old identity-keyed sharing semantics. Always on — no feature flag.
+    #
+    # Wire a notification handler factory so server-initiated messages can be
+    # forwarded to GET /mcp listeners (ADR-052). The factory bakes
+    # downstream_session_id into the per-session handler closure.
     # First-Party
+    from mcpgateway.services.notification_service import init_notification_service  # pylint: disable=import-outside-toplevel
     from mcpgateway.services.upstream_session_registry import init_upstream_session_registry  # pylint: disable=import-outside-toplevel
 
-    init_upstream_session_registry()
-    logger.info("Upstream session registry initialized")
+    _notification_svc = init_notification_service()
+    # Initialize the worker before any session is wired through it.
+    # Without this, list_changed notifications enqueue into a service
+    # whose `_process_refresh_queue` worker never runs and refreshes
+    # silently never fire. The gateway_service is wired here
+    # unconditionally — the affinity branch's
+    # `start_affinity_notification_service` only re-runs under affinity,
+    # and without this hand-off the single-node default would leave
+    # `_gateway_service is None` and drop every refresh.
+    await _notification_svc.initialize(gateway_service=gateway_service)
+
+    def _notification_handler_factory(url: str, gateway_id, *, downstream_session_id: str):  # type: ignore[no-untyped-def]
+        """Per-session message handler that routes upstream notifications and forwards server-initiated messages to the GET /mcp listener (ADR-052)."""
+        return _notification_svc.create_message_handler(
+            gateway_id or url,
+            url,
+            downstream_session_id=downstream_session_id,
+        )
+
+    init_upstream_session_registry(message_handler_factory=_notification_handler_factory)
+    logger.info("Upstream session registry initialized (notification fanout enabled)")
 
     # Initialize LLM chat router Redis client (only if LLM chat is enabled —
     # importing the router pulls in the langchain stack which is several
@@ -1762,9 +1803,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         await prompt_service.initialize()
         await gateway_service.initialize()
 
-        # Start heartbeat, RPC listener, and notification service for multi-worker
-        # session affinity. The upstream-session-pool that used to live under
-        # this guard is gone (#4205); only the affinity layer remains here.
+        # Start heartbeat, RPC listener, and notification service for
+        # multi-worker session affinity. The upstream-session pool is
+        # owned by ``UpstreamSessionRegistry`` and runs unconditionally;
+        # only the cross-worker affinity machinery is gated here.
         if settings.mcpgateway_session_affinity_enabled:
             # First-Party
             from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -131,16 +131,53 @@ oauth_verify_events_counter = Counter(
     ["outcome"],
 )
 
-# Streamable HTTP GET rejections (#4205). Clients that probe a passive SSE
-# stream before `initialize` (or against a stateless gateway) are 405'd with
+# Streamable HTTP GET rejections. Clients that probe a passive SSE stream
+# before `initialize` (or against a stateless gateway) are 405'd with
 # `Allow: POST, DELETE`. Outcome labels mirror the Rust runtime's counter
 # split so ops can distinguish client-side from deployment-config causes:
 #   no_session_id           — client didn't present `Mcp-Session-Id`
 #   stateful_disabled       — this gateway runs with `use_stateful_sessions=False`
+#   feature_disabled        — `mcp_get_stream_enabled=False` operator override
+#   not_acceptable          — client's `Accept` header doesn't allow `text/event-stream` (406)
+#   session_denied          — caller doesn't own the session id presented (403/404)
+#   listener_conflict       — another GET stream already holds the session's listener slot (409)
+#   bus_unavailable         — singleton/Redis unreachable; client should retry (503)
 transport_get_rejected_counter = Counter(
     "transport_get_rejected_total",
-    "GET /mcp 405 rejections by reason (no session anchor available)",
+    "GET /mcp rejections by reason",
     ["outcome"],
+)
+
+# ADR-052: Active GET /mcp listeners served by this worker. Gauge so ops can
+# correlate active streams with backlog / Redis pressure.
+transport_get_active_listeners_gauge = Gauge(
+    "transport_get_active_listeners",
+    "Active GET /mcp SSE streams currently held by this worker",
+)
+
+# ADR-052: Server-initiated events delivered to GET /mcp listeners by kind.
+transport_get_events_delivered_counter = Counter(
+    "transport_get_events_delivered_total",
+    "Server-initiated events delivered over GET /mcp by JSON-RPC method",
+    ["method"],
+)
+
+# ADR-052: Per-session bus listener-queue overflow events (subscriber too slow).
+# Operators alert on rate; without this counter the only signal was a
+# WARNING log line.
+server_event_bus_overflow_counter = Counter(
+    "server_event_bus_overflow_total",
+    "GET /mcp listener queue overflowed (subscriber drained too slowly)",
+)
+
+# ADR-052: Failed publish attempts on the server event bus (caller could not
+# enqueue a server-initiated message for the GET /mcp listener). Reason
+# label distinguishes backend-down (typed BusBackendError) from arbitrary
+# transport failures (catch-all). Operators can alert on rate per-reason.
+server_event_bus_publish_failed_counter = Counter(
+    "server_event_bus_publish_failed_total",
+    "Server-event-bus publish attempts that failed",
+    ["reason"],
 )
 
 

--- a/mcpgateway/services/notification_service.py
+++ b/mcpgateway/services/notification_service.py
@@ -6,20 +6,26 @@ SPDX-License-Identifier: Apache-2.0
 Authors: Keval Mahajan
 
 Description:
-    MCP Notification Service for handling server notifications with debounced
-    gateway refresh. Provides centralized notification handling for MCP sessions
-    including tools/list_changed, resources/list_changed, and prompts/list_changed.
+    Centralized handler for MCP server-to-gateway notifications AND the
+    server-to-client fanout surface introduced by ADR-052 (GET /mcp stream).
+    Connects upstream ``ClientSession`` message-handler callbacks to the
+    per-session event bus and to the worker-local request-correlation dict
+    that lets downstream POSTs resolve held ``RequestResponder`` instances.
 
-    Key Features:
-    - Debounced refresh to prevent notification storms
-    - Flag merging during debounce (notifications within window merge their refresh flags)
-    - Per-gateway refresh locking to prevent concurrent refresh races
-    - Per-gateway refresh tracking with capability awareness
-    - Compatible with SessionAffinity for pooled session notification handling
-    - Per-gateway session isolation ensures correct notification attribution
-    - Supports tools, resources, and prompts list_changed notifications
-
-    Capable of handling other tasks as well like cancellation, progress notifications, etc. (to be implemented here)
+    Responsibilities:
+    - Debounced gateway refresh triggered by ``tools/resources/prompts
+      list_changed`` notifications (with flag merging during the debounce
+      window, per-gateway refresh lock, capability-aware filtering).
+    - ``ServerNotification`` fanout to the GET /mcp event bus so
+      downstream clients on the SSE stream see the notification.
+    - ``ServerRequest`` correlation (``_forward_request_to_stream`` +
+      ``complete_request``) for sampling / elicitation / roots-list —
+      registers the responder under ``(session_id, request_id)``, spawns
+      a holder task, publishes the envelope, and waits for a downstream
+      POST to resolve it. Timeout is per-task via ``wait_for``; there is
+      no background sweeper.
+    - Bounded ``shutdown`` that drains holder tasks within a configurable
+      timeout and cancels any stragglers.
 
 Usage:
     ```python
@@ -96,6 +102,37 @@ class GatewayCapabilities:
     tools_list_changed: bool = False
     resources_list_changed: bool = False
     prompts_list_changed: bool = False
+
+
+def _record_publish_failure(
+    downstream_session_id: str,
+    request_id: str,
+    *,
+    reason: str,
+    exc: BaseException,
+    counter: Any,
+) -> None:
+    """Increment the publish-failure counter and log the failure at the correct level.
+
+    Shared between ``_forward_request_to_stream`` (request fanout) and
+    ``_forward_notification_to_stream`` (notification fanout) so a
+    sustained Redis outage moves both metrics identically and
+    operators get the same traceback treatment regardless of which
+    publish path fired.
+    """
+    try:
+        counter.labels(reason=reason).inc()
+    except Exception as metric_exc:  # noqa: BLE001 — metric failures must not crash the publish path
+        logger.debug("publish-failed counter raised: %s", metric_exc)
+    log_method = logger.warning if reason == "backend_unavailable" else logger.error
+    log_method(
+        "Failed to publish server-initiated message %s/%s (%s): %s — cancelling responder",
+        downstream_session_id,
+        request_id,
+        reason,
+        exc,
+        exc_info=exc if reason == "transport_error" else None,
+    )
 
 
 def _empty_notification_type_set() -> Set[NotificationType]:
@@ -193,6 +230,19 @@ class NotificationService:
         self._refreshes_triggered = 0
         self._refreshes_failed = 0
 
+        # Server-initiated request correlation (ADR-052). Worker-local: the
+        # POST carrying the response is affinity-routed to the worker that
+        # holds the upstream RequestResponder, so a process-local dict is
+        # sufficient — no Redis dispatch table needed. Key:
+        # (downstream_session_id, request_id). Value: future the holder task
+        # awaits; the response payload is set when the downstream POST lands.
+        self._pending_requests: Dict[tuple[str, str], asyncio.Future[Any]] = {}
+        self._pending_lock = asyncio.Lock()
+        self._pending_request_ttl_seconds: float = 60.0
+        self._pending_holder_tasks: Set[asyncio.Task[None]] = set()
+        # Bounded shutdown drain — see shutdown() docstring rationale.
+        self._shutdown_drain_timeout_seconds: float = 5.0
+
     async def initialize(self, gateway_service: Optional["GatewayService"] = None) -> None:
         """Initialize the notification service and start background worker.
 
@@ -214,6 +264,15 @@ class NotificationService:
         if gateway_service:
             self._gateway_service = gateway_service
 
+        # Idempotent: two init paths can call this — `main.lifespan` runs
+        # it once for the single-node case, and (when affinity is on)
+        # `start_affinity_notification_service` re-runs it later with the
+        # gateway_service set. Refresh the reference but don't double-spawn
+        # the worker — that would leak the first task and produce duplicate refreshes.
+        if self._worker_task is not None and not self._worker_task.done():
+            logger.debug("NotificationService already initialized; refreshing gateway_service ref only")
+            return
+
         self._shutdown_event.clear()
         self._worker_task = asyncio.create_task(self._process_refresh_queue())
         logger.info("NotificationService initialized with debounce=%ss", self.debounce_seconds)
@@ -232,8 +291,44 @@ class NotificationService:
         """
         self._gateway_service = gateway_service
 
+    @staticmethod
+    async def _safe_cancel(
+        responder: "RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult]",
+        downstream_session_id: str,
+        request_id: str,
+    ) -> None:
+        """Wrap ``responder.cancel()`` so its exceptions never escape the holder task.
+
+        ``RequestResponder.cancel()`` sends a cancellation *error response*
+        back through the upstream session (``ErrorData(code=0,
+        message="Request cancelled")``, not a JSON-RPC notification) and
+        can raise on a broken transport (``BrokenResourceError``,
+        ``ClosedResourceError``, etc). If those exceptions escape, the
+        holder-task done-callback logs them as a generic
+        ``exited with exception`` line — losing the cancel-vs-respond
+        context that an operator needs to tell "downstream never
+        responded" apart from "upstream session already torn down".
+        Catching and logging here produces a specific cancel-site log
+        line and lets the holder task finish its normal return path.
+        """
+        try:
+            await responder.cancel()
+        except Exception as exc:  # noqa: BLE001 — by design; logged + swallowed
+            logger.warning(
+                "responder.cancel() raised for %s/%s: %s",
+                downstream_session_id,
+                request_id,
+                exc,
+            )
+
     async def shutdown(self) -> None:
         """Shutdown the notification service and cleanup resources.
+
+        Cancels the refresh-queue worker AND any in-flight server-initiated
+        request holder tasks (ADR-052). Without the holder cleanup, every
+        held responder would sit in ``wait_for(60s)`` past process shutdown,
+        keeping the upstream MCP session's responder context manager alive
+        and leaking tasks.
 
         Example:
             >>> import asyncio
@@ -254,6 +349,36 @@ class NotificationService:
             except asyncio.CancelledError:
                 pass
             self._worker_task = None
+
+        # Cancel and drain holder tasks. Snapshot the set first because each
+        # task's done-callback mutates `_pending_holder_tasks` on completion.
+        # Bounded wait — each holder's ``responder.__exit__`` sends a
+        # cancellation notification through the upstream session, which is
+        # the very thing that may be hung. Don't block shutdown forever.
+        holders = list(self._pending_holder_tasks)
+        for task in holders:
+            task.cancel()
+        if holders:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*holders, return_exceptions=True),
+                    timeout=self._shutdown_drain_timeout_seconds,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "NotificationService.shutdown: %d holder tasks did not drain within %ss; abandoning",
+                    sum(1 for t in holders if not t.done()),
+                    self._shutdown_drain_timeout_seconds,
+                )
+        self._pending_holder_tasks.clear()
+
+        # Drop any remaining pending entries so a late `complete_request`
+        # call after shutdown doesn't hang on a future nobody is awaiting.
+        async with self._pending_lock:
+            for key, future in list(self._pending_requests.items()):
+                if not future.done():
+                    future.cancel()
+                self._pending_requests.pop(key, None)
 
         self._gateway_capabilities.clear()
         self._last_refresh_enqueued.clear()
@@ -346,15 +471,24 @@ class NotificationService:
         self,
         gateway_id: str,
         gateway_url: Optional[str] = None,
+        *,
+        downstream_session_id: Optional[str] = None,
     ) -> MessageHandlerCallback:
         """Create a message handler callback for a specific gateway.
 
         Returns a callback suitable for passing to ClientSession's message_handler
-        parameter. The handler routes notifications to this service for processing.
+        parameter. The handler routes notifications to this service for processing
+        AND, when ``downstream_session_id`` is provided, forwards
+        ``ServerNotification`` envelopes to the GET /mcp listener for that
+        session via the server event bus (ADR-052).
 
         Args:
             gateway_id: The gateway ID this handler is for.
             gateway_url: Optional URL for logging context.
+            downstream_session_id: Downstream MCP session id (the
+                ``Mcp-Session-Id`` from the client). When provided,
+                server-initiated notifications are published to the GET
+                stream for this session.
 
         Returns:
             Async callable suitable for ClientSession message_handler.
@@ -374,14 +508,479 @@ class NotificationService:
             Args:
                 message: The message received from the server.
             """
-            # Only process ServerNotification objects
             if isinstance(message, mcp_types.ServerNotification):
+                # Internal handling: list-changed → debounced refresh.
                 await self._handle_notification(gateway_id, message, gateway_url)
+                # Spec-defined fanout: forward the envelope to the GET /mcp
+                # listener for this downstream session, if a listener exists.
+                if downstream_session_id is not None:
+                    await self._forward_notification_to_stream(downstream_session_id, message)
+            elif isinstance(message, RequestResponder):
+                if downstream_session_id is not None:
+                    await self._forward_request_to_stream(downstream_session_id, message)
+                # If no downstream session is wired the responder will be
+                # auto-cancelled when the message handler returns and the SDK
+                # cleans up; we deliberately do nothing in that path.
             elif isinstance(message, Exception):
                 logger.warning("Received exception from MCP server %s: %s", gateway_id, message)
-            # RequestResponder messages are handled by the session itself
 
         return message_handler
+
+    async def _forward_request_to_stream(
+        self,
+        downstream_session_id: str,
+        responder: "RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult]",
+    ) -> None:
+        """Forward a server-initiated request to the GET /mcp listener and hold the responder.
+
+        We register a future in the worker-local pending dict, publish the
+        JSON-RPC request envelope on the event bus, and spawn a holder task
+        that enters the responder's context manager and awaits the future.
+        When the downstream client POSTs back the response, ``complete_request``
+        sets the future and the holder relays it to the responder.
+
+        Failure to forward (no event bus, no listener, etc.) cancels the
+        responder so the upstream session sees a clean error rather than
+        hanging.
+
+        Args:
+            downstream_session_id: Target downstream MCP session id.
+            responder: The SDK ``RequestResponder`` to hold open until the
+                downstream client replies.
+        """
+        try:
+            # First-Party
+            from mcpgateway.transports.server_event_bus import get_server_event_bus  # pylint: disable=import-outside-toplevel
+            from mcp.types import JSONRPCMessage, JSONRPCRequest  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:  # pragma: no cover
+            logger.debug("Server event bus unavailable, cancelling responder: %s", exc)
+            with responder:
+                await responder.cancel()
+            return
+
+        # Third-Party
+        from pydantic import ValidationError  # pylint: disable=import-outside-toplevel
+
+        request_id = str(responder.request_id)
+        # Build the JSON-RPC request envelope from the SDK's typed request.
+        # The narrow catch lets shape-drift bugs (AttributeError when
+        # ``responder.request`` loses ``root``, ValidationError from
+        # ``model_dump``, TypeError from a typed-args mismatch) surface
+        # with a traceback instead of being smuggled into a generic
+        # warning. ``exc_info`` preserves the stack — operators chasing
+        # "envelope build failed" otherwise have nothing to file a bug
+        # against.
+        try:
+            inner = responder.request.root if hasattr(responder.request, "root") else responder.request
+            payload = inner.model_dump(by_alias=True, exclude_none=True)
+        except (AttributeError, ValidationError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to build request payload for %s/%s: %s",
+                downstream_session_id,
+                request_id,
+                exc,
+                exc_info=exc,
+            )
+            with responder:
+                await responder.cancel()
+            return
+        # JSON-RPC requires a non-empty ``method``. Defense-in-depth:
+        # if upstream ever hands us a request without one, log and
+        # cancel rather than publishing a malformed wire frame.
+        method = payload.get("method")
+        if not isinstance(method, str) or not method:
+            logger.warning(
+                "Refusing to publish server-initiated request %s/%s with empty method (payload shape: %r)",
+                downstream_session_id,
+                request_id,
+                sorted(payload.keys()) if isinstance(payload, dict) else type(payload).__name__,
+            )
+            with responder:
+                await responder.cancel()
+            return
+        envelope = JSONRPCMessage(
+            JSONRPCRequest(
+                jsonrpc="2.0",
+                id=responder.request_id,
+                method=method,
+                params=payload.get("params"),
+            )
+        )
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[Any] = loop.create_future()
+        key = (downstream_session_id, request_id)
+
+        # Order: register pending → spawn holder → publish (with cleanup
+        # on failure). The reverse order (publish first) loses fast
+        # downstream responses in multi-node: node A publishes, the
+        # listener on node B delivers to the client, the client POSTs the
+        # response back, and node A's complete_request finds an empty
+        # pending dict because the register hadn't happened yet. With
+        # this order, complete_request can match the response as soon as
+        # it arrives. The holder uses ``wait_for(future)`` and tolerates
+        # being cancelled by the publish-failure cleanup below — that
+        # race is benign (just one extra cancel call).
+        async with self._pending_lock:
+            # Upstream is supposed to issue unique JSON-RPC ids per session,
+            # but we've seen reuse occur during reconnect / recovery. When
+            # it does, the prior in-flight request gets silently cancelled
+            # by this defensive replace — log loudly so the protocol
+            # violation has a forensic trail (operators looking at timed-out
+            # responder errors otherwise have no way to tell "downstream
+            # never replied" apart from "we cancelled it because of id reuse").
+            existing = self._pending_requests.pop(key, None)
+            if existing is not None and not existing.done():
+                logger.warning(
+                    "Server-initiated request id collision for %s/%s — upstream reused id; cancelling prior pending future (likely an upstream protocol violation)",
+                    downstream_session_id,
+                    request_id,
+                )
+                existing.cancel()
+            self._pending_requests[key] = future
+
+        async def hold() -> None:
+            """Hold the responder open until ``future`` resolves or the TTL elapses."""
+            primary_exc: Optional[BaseException] = None
+            try:
+                try:
+                    with responder:
+                        try:
+                            response_payload = await asyncio.wait_for(
+                                future,
+                                timeout=self._pending_request_ttl_seconds,
+                            )
+                        except asyncio.TimeoutError:
+                            logger.info(
+                                "Server-initiated request %s/%s timed out; cancelling",
+                                downstream_session_id,
+                                request_id,
+                            )
+                            await self._safe_cancel(responder, downstream_session_id, request_id)
+                            return
+                        except asyncio.CancelledError as exc:
+                            # Track the primary failure so we can detect
+                            # if responder.__exit__ shadows it on the way
+                            # out. Without this, the done-callback would
+                            # log the wrong cause and operators would
+                            # chase a teardown error instead of the real
+                            # cancellation.
+                            primary_exc = exc
+                            await self._safe_cancel(responder, downstream_session_id, request_id)
+                            raise
+                        try:
+                            await self._respond_with_payload(responder, response_payload)
+                        except Exception as respond_exc:  # noqa: BLE001 — surface the failure, don't crash the task silently
+                            logger.warning(
+                                "responder.respond() raised for %s/%s: %s",
+                                downstream_session_id,
+                                request_id,
+                                respond_exc,
+                            )
+                except BaseException as exc:
+                    if primary_exc is not None and exc is not primary_exc:
+                        logger.warning(
+                            "responder.__exit__ raised %s for %s/%s, shadowing primary %s — operator should investigate teardown failure",
+                            type(exc).__name__,
+                            downstream_session_id,
+                            request_id,
+                            type(primary_exc).__name__,
+                        )
+                    raise
+            finally:
+                async with self._pending_lock:
+                    if self._pending_requests.get(key) is future:
+                        self._pending_requests.pop(key, None)
+
+        def _on_holder_done(t: "asyncio.Task[None]") -> None:
+            """Discard the holder task and log any exception that escaped.
+
+            asyncio's "Task exception was never retrieved" warning at GC
+            time is unreliable; this captures the failure into the
+            standard logger immediately.
+            """
+            self._pending_holder_tasks.discard(t)
+            if t.cancelled():
+                return
+            exc = t.exception()
+            if exc is not None:
+                logger.warning(
+                    "Request-holder task for %s/%s exited with exception: %s",
+                    downstream_session_id,
+                    request_id,
+                    exc,
+                    exc_info=exc,
+                )
+
+        task = asyncio.create_task(hold(), name=f"request-holder:{downstream_session_id[:8]}:{request_id}")
+        self._pending_holder_tasks.add(task)
+        task.add_done_callback(_on_holder_done)
+
+        # Separate try blocks for the two distinct failure modes:
+        #
+        #   (a) ``get_server_event_bus()`` — bus singleton construction
+        #       or config resolution. A RuntimeError or BusBackendError
+        #       here is expected when Redis is unavailable; anything
+        #       else is a programming error and should propagate with a
+        #       traceback in the done-callback rather than being
+        #       bucketed as a publish failure.
+        #
+        #   (b) ``bus.publish()`` — the actual wire call. Typed
+        #       ``BusBackendError`` is a retryable Redis outage;
+        #       ``ConnectionError`` / ``OSError`` are transient
+        #       transport failures. Narrow both so real bugs in the
+        #       publish path propagate instead of being classified as
+        #       "transport_error".
+        # First-Party
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter  # pylint: disable=import-outside-toplevel
+        from mcpgateway.transports.server_event_bus import BusBackendError  # pylint: disable=import-outside-toplevel
+
+        try:
+            bus = await get_server_event_bus()
+        except (RuntimeError, BusBackendError) as exc:
+            _record_publish_failure(
+                downstream_session_id,
+                request_id,
+                reason="backend_unavailable",
+                exc=exc,
+                counter=server_event_bus_publish_failed_counter,
+            )
+            if not future.done():
+                future.cancel()
+            return
+        try:
+            await bus.publish(downstream_session_id, envelope)
+        except (BusBackendError, ConnectionError, OSError) as exc:
+            reason = "backend_unavailable" if isinstance(exc, BusBackendError) else "transport_error"
+            _record_publish_failure(
+                downstream_session_id,
+                request_id,
+                reason=reason,
+                exc=exc,
+                counter=server_event_bus_publish_failed_counter,
+            )
+            if not future.done():
+                future.cancel()
+
+    @staticmethod
+    async def _respond_with_payload(
+        responder: "RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult]",
+        payload: Dict[str, Any],
+    ) -> None:
+        """Translate a downstream JSON-RPC response payload into ``responder.respond()``.
+
+        Args:
+            responder: The held SDK responder.
+            payload: Parsed JSON-RPC envelope from the downstream POST.
+        """
+        # Third-Party
+        from pydantic import ValidationError  # pylint: disable=import-outside-toplevel
+
+        if "error" in payload and payload["error"] is not None:
+            try:
+                error = mcp_types.ErrorData.model_validate(payload["error"])
+            except ValidationError as exc:
+                # Substituting INTERNAL_ERROR silently strips the original
+                # error context — operators would only see a generic
+                # message and have no way to trace what the downstream
+                # actually said. Log at warning + include the raw payload
+                # at debug so the trail isn't lost.
+                logger.warning(
+                    "Downstream error payload failed validation; substituting INTERNAL_ERROR: %s",
+                    exc,
+                )
+                logger.debug("Original error payload: %r", payload.get("error"))
+                error = mcp_types.ErrorData(
+                    code=mcp_types.INTERNAL_ERROR,
+                    message="Malformed error from downstream",
+                    data=None,
+                )
+            await responder.respond(error)
+            return
+        try:
+            result = mcp_types.ClientResult.model_validate(payload.get("result") or {})
+        except ValidationError as exc:
+            logger.warning("Could not validate downstream result, sending error: %s", exc)
+            await responder.respond(
+                mcp_types.ErrorData(
+                    code=mcp_types.INTERNAL_ERROR,
+                    message=f"Downstream returned an unrecognized result: {exc}",
+                    data=None,
+                )
+            )
+            return
+        await responder.respond(result)
+
+    def has_pending_request(self, downstream_session_id: str) -> bool:
+        """Return True if any server-initiated request is awaiting a response.
+
+        Cheap O(n) scan over a dict that is normally empty or has a handful
+        of entries — used by the POST handler to decide whether to peek at
+        the request body for response interception. No lock taken: stale
+        reads are acceptable here. A stale-missing entry (returns ``False``
+        when one was just registered) means the POST falls through to the
+        SDK; the held responder TTLs out and the client retries — no data
+        loss. A stale-present entry (returns ``True`` when no entry
+        actually matches by id) costs one wasted body-buffer plus an SDK
+        replay, with no functional harm.
+
+        Args:
+            downstream_session_id: The session whose pending requests are
+                being checked.
+
+        Returns:
+            True if there is at least one pending server-initiated request
+            for this session.
+        """
+        # Snapshot via tuple() so a concurrent _forward_request_to_stream /
+        # complete_request / shutdown that mutates the dict during our
+        # scan can't trigger ``RuntimeError: dictionary changed size
+        # during iteration``. The docstring above commits to lock-free
+        # reads; this is the cheapest way to keep that promise honest
+        # for the dict's typical "handful of entries" size.
+        return any(sid == downstream_session_id for sid, _ in tuple(self._pending_requests))
+
+    async def complete_request(
+        self,
+        downstream_session_id: str,
+        request_id: str,
+        payload: Dict[str, Any],
+    ) -> bool:
+        """Resolve a held server-initiated request with the downstream's response payload.
+
+        Args:
+            downstream_session_id: The session the response arrived on.
+            request_id: JSON-RPC id of the response.
+            payload: Full JSON-RPC envelope (must include ``result`` or
+                ``error``).
+
+        Returns:
+            True if a held request was matched and its future resolved,
+            False otherwise (the POST handler then falls through to the
+            normal SDK path).
+        """
+        key = (downstream_session_id, str(request_id))
+        async with self._pending_lock:
+            future = self._pending_requests.get(key)
+            if future is None:
+                # No holder for this id — common case (downstream
+                # responded after the holder TTL'd, or the id never had
+                # a holder because the request was dispatched the
+                # legacy SDK way).
+                logger.debug(
+                    "complete_request: no pending holder for %s/%s",
+                    downstream_session_id,
+                    request_id,
+                )
+                return False
+            if future.done():
+                # done() covers "already resolved" and "cancelled by
+                # shutdown between the get() and our set_result()". We
+                # check inside the lock so concurrent shutdown can't
+                # cancel between this check and the set_result below.
+                # Distinct from the no-holder case because the SDK
+                # fall-through here will 4xx/5xx with no responder
+                # waiting; operators chasing those errors need the
+                # breadcrumb to tie them back to the cancelled holder.
+                logger.debug(
+                    "complete_request: holder for %s/%s already done (cancelled by shutdown or duplicate response); SDK fall-through will surface as 4xx",
+                    downstream_session_id,
+                    request_id,
+                )
+                return False
+            future.set_result(payload)
+        return True
+
+    async def _forward_notification_to_stream(
+        self,
+        downstream_session_id: str,
+        notification: mcp_types.ServerNotification,
+    ) -> None:
+        """Publish a server-initiated notification to the GET /mcp event bus.
+
+        Failure here must not break upstream message processing — the bus is
+        best-effort delivery, not a transactional path. We log at debug
+        level when no listener is wired (common during tests / single-process
+        boot before the bus singleton is created).
+
+        Args:
+            downstream_session_id: Target downstream session id.
+            notification: The ServerNotification envelope from the upstream
+                MCP session.
+        """
+        try:
+            # First-Party
+            from mcpgateway.transports.server_event_bus import get_server_event_bus  # pylint: disable=import-outside-toplevel
+            from mcp.types import JSONRPCMessage, JSONRPCNotification  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:  # pragma: no cover — dependency presence is invariant in this codebase
+            logger.debug("Server event bus unavailable, dropping notification: %s", exc)
+            return
+        # Third-Party
+        from pydantic import ValidationError  # pylint: disable=import-outside-toplevel
+
+        # First-Party
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter  # pylint: disable=import-outside-toplevel
+        from mcpgateway.transports.server_event_bus import BusBackendError  # pylint: disable=import-outside-toplevel
+
+        # Envelope-build first (narrow catch) so shape-drift bugs surface
+        # with a traceback rather than being bucketed as a publish
+        # failure.
+        try:
+            # ServerNotification.root is the underlying typed notification
+            # (e.g. ToolsListChangedNotification). We re-wrap as a
+            # JSON-RPC envelope so the SSE listener can serialize it
+            # without knowing about MCP's typed-union shape.
+            inner = notification.root
+            payload = inner.model_dump(by_alias=True, exclude_none=True)
+        except (AttributeError, ValidationError, TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to build notification payload for %s: %s",
+                downstream_session_id,
+                exc,
+                exc_info=exc,
+            )
+            return
+        method = payload.get("method")
+        if not isinstance(method, str) or not method:
+            # Defense-in-depth: publishing a notification with an empty
+            # ``method`` would put a malformed JSON-RPC frame on the wire.
+            logger.warning(
+                "Refusing to publish server-initiated notification to %s with empty method (payload shape: %r)",
+                downstream_session_id,
+                sorted(payload.keys()) if isinstance(payload, dict) else type(payload).__name__,
+            )
+            return
+        envelope = JSONRPCMessage(
+            JSONRPCNotification(
+                jsonrpc="2.0",
+                method=method,
+                params=payload.get("params"),
+            )
+        )
+        # Separate try for bus-get vs publish so a ``get_server_event_bus``
+        # programming bug doesn't get bucketed as ``transport_error``.
+        try:
+            bus = await get_server_event_bus()
+        except (RuntimeError, BusBackendError) as exc:
+            _record_publish_failure(
+                downstream_session_id,
+                f"notif/{method}",
+                reason="backend_unavailable",
+                exc=exc,
+                counter=server_event_bus_publish_failed_counter,
+            )
+            return
+        try:
+            await bus.publish(downstream_session_id, envelope)
+        except (BusBackendError, ConnectionError, OSError) as exc:
+            reason = "backend_unavailable" if isinstance(exc, BusBackendError) else "transport_error"
+            _record_publish_failure(
+                downstream_session_id,
+                f"notif/{method}",
+                reason=reason,
+                exc=exc,
+                counter=server_event_bus_publish_failed_counter,
+            )
 
     async def _handle_notification(
         self,

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -4,12 +4,11 @@
 Keeps each downstream MCP session (identified by its ``Mcp-Session-Id``)
 pinned to one gateway worker across the horizontal-scale deployment, so
 the worker-local ``UpstreamSessionRegistry`` can serve subsequent calls
-without rebuilding upstream state. The upstream ClientSession pooling
-that used to live in this file is gone — see
-``mcpgateway.services.upstream_session_registry`` for the 1:1 replacement
-(issue #4205).
+without rebuilding upstream state. Per-worker upstream ``ClientSession``
+state lives in ``mcpgateway.services.upstream_session_registry``; this
+module owns the cross-worker affinity layer only.
 
-What survives here:
+Surface:
 
 * Redis-backed ``(downstream_session_id, url, transport, gateway_id)`` →
   owning-worker mapping so any worker can look up who owns a session.
@@ -31,24 +30,24 @@ from __future__ import annotations
 
 # Standard
 import asyncio
+from enum import Enum
 import hashlib
 import logging
 import os
 import re
 import socket
 import time
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Dict, Optional
 import uuid
 
 # Third-Party
 import httpx
-from mcp.shared.session import RequestResponder
-import mcp.types as mcp_types
 import orjson
 
 # First-Party
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
+from mcpgateway.services.upstream_session_registry import MessageHandlerFactory  # re-exported as the single source of truth
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
 
 # Shared session-id validation (downstream MCP session IDs used for affinity).
@@ -64,16 +63,37 @@ WORKER_ID = f"{socket.gethostname()}:{os.getpid()}"
 logger = logging.getLogger(__name__)
 
 
-# Type alias for message handler factory.
-# Factory that creates message handlers given URL and optional gateway_id.
-# The handler receives ServerNotification, ServerRequest responders, or Exceptions.
-MessageHandlerFactory = Callable[
-    [str, Optional[str]],  # (url, gateway_id)
-    Callable[
-        [RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult] | mcp_types.ServerNotification | Exception],
-        Any,  # Coroutine
-    ],
-]
+class SessionAffinityNotInitializedError(RuntimeError):
+    """Raised when ``get_session_affinity()`` is called before ``init_session_affinity()``.
+
+    Subclasses ``RuntimeError`` for backwards compatibility with callers
+    that still write ``except RuntimeError``. The dedicated type lets the
+    GET handler distinguish "service genuinely not initialized" from
+    "any random RuntimeError" — the former is recoverable in single-node
+    mode (transient instance) but must fail closed in Redis multi-node
+    where the cross-process invariant matters.
+
+    Named distinctly from ``upstream_session_registry``'s
+    ``RegistryNotInitializedError`` so a caller can't accidentally
+    silence one service's "not initialized" path by catching the other
+    via the wrong import.
+    """
+
+
+class ListenerClaimResult(Enum):
+    """Outcome of a GET-stream listener claim attempt (ADR-052).
+
+    The tri-state lets the GET handler distinguish "another client holds
+    this session's listener slot" (409 Conflict) from "the storage backing
+    the claim is unavailable" (503 Service Unavailable). A boolean shape
+    would force clients to tight-loop on 409 during a Redis outage since
+    503 is the retryable signal — see ADR-052 § "Single-node vs.
+    multi-node fallback contract".
+    """
+
+    WON = "won"
+    CONFLICT = "conflict"
+    UNAVAILABLE = "unavailable"
 
 
 class SessionAffinity:
@@ -118,6 +138,15 @@ class SessionAffinity:
         self._forwarded_request_failures = 0
         self._forwarded_request_timeouts = 0
 
+        # GET-stream listener claims (ADR-052). Single-node fallback when
+        # cache_type != "redis"; in multi-node the Redis key is authoritative
+        # and this dict is unused. Tuple is (connection_id, expires_at).
+        # Tracked for extraction into a SessionPresence service in #4334 —
+        # this is presence state, not affinity, but lives here today
+        # because both layers share the singleton lifecycle.
+        self._listener_claims: Dict[str, tuple[str, float]] = {}
+        self._listener_lock = asyncio.Lock()
+
     @staticmethod
     def is_valid_mcp_session_id(session_id: str) -> bool:
         """Validate downstream MCP session ID format for affinity.
@@ -161,6 +190,11 @@ class SessionAffinity:
     def _session_owner_key(mcp_session_id: str) -> str:
         """Return Redis key for session ownership tracking."""
         return f"mcpgw:pool_owner:{mcp_session_id}"
+
+    @staticmethod
+    def _listener_claim_key(mcp_session_id: str) -> str:
+        """Return Redis key for the GET-stream listener claim (ADR-052)."""
+        return f"mcp:session:{mcp_session_id}:listener"
 
     def _worker_heartbeat_key(self) -> str:
         """Redis key for this worker's heartbeat."""
@@ -338,6 +372,216 @@ class SessionAffinity:
             logger.debug("Invalid mcp_session_id for owner cleanup, skipping")
             return
         await self._cleanup_session_owner(mcp_session_id)
+
+    # ------------------------------------------------------------------
+    # GET-stream listener claims (ADR-052)
+    #
+    # Public surface:
+    #   - claim_listener → ListenerClaimResult (Won / Conflict / Unavailable)
+    #   - heartbeat_listener → bool (True = still owner, False = lost)
+    #   - release_listener → bool (True = released, False = not owner / expired)
+    #
+    # The tri-state result on claim is the key: Redis-down (Unavailable) and
+    # someone-else-has-it (Conflict) are different conditions and the GET
+    # handler responds 503 vs 409 accordingly. ADR-052 calls this out.
+    #
+    # The MCP spec mandates one server→client SSE stream per session. The
+    # claim is held by whichever node accepts the GET; cross-node uniqueness
+    # uses a Redis SET NX, single-node uses an in-process dict + lock. Same
+    # API both ways.
+    # ------------------------------------------------------------------
+
+    # Lua: heartbeat (refresh TTL) only if the caller still owns the claim.
+    _HEARTBEAT_LISTENER_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then redis.call('EXPIRE', KEYS[1], ARGV[2]) return 1 else return 0 end"
+    # Lua: release only if the caller still owns the claim.
+    _RELEASE_LISTENER_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then redis.call('DEL', KEYS[1]) return 1 else return 0 end"
+
+    @staticmethod
+    def _log_redis_listener_error(operation: str, mcp_session_id: str, exc: BaseException) -> None:
+        """Log a Redis listener-claim failure at the appropriate level.
+
+        Transient connection issues (``ConnectionError``, ``TimeoutError``,
+        ``BusyLoadingError``) are routine and noisy — keep them at debug
+        so production isn't flooded during a brief Redis blip. Auth and
+        protocol errors (``AuthenticationError``, ``ResponseError``,
+        ``DataError``) signal config drift or a Lua script regression
+        that operators must see — log at warning. Anything else
+        (``OSError``, programming errors) gets warning + traceback.
+        """
+        # Lazy import — redis is only required when cache_type=redis.
+        try:
+            # Third-Party
+            from redis import exceptions as redis_exc  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            logger.warning("Listener-%s: %s for %s", operation, exc, mcp_session_id, exc_info=exc)
+            return
+        # Order matters: AuthenticationError subclasses ConnectionError in
+        # redis-py, so the config/protocol bucket has to win the isinstance
+        # check before the transient bucket; otherwise a credentials
+        # rotation gets silently logged at debug.
+        if isinstance(exc, (redis_exc.AuthenticationError, redis_exc.ResponseError, redis_exc.DataError, redis_exc.NoScriptError)):
+            logger.warning(
+                "Listener-%s Redis configuration/protocol failure for %s: %s (%s)",
+                operation,
+                mcp_session_id,
+                exc,
+                type(exc).__name__,
+            )
+            return
+        if isinstance(exc, (redis_exc.ConnectionError, redis_exc.TimeoutError, redis_exc.BusyLoadingError)):
+            logger.debug(
+                "Listener-%s Redis transient failure for %s: %s",
+                operation,
+                mcp_session_id,
+                exc,
+            )
+            return
+        logger.warning(
+            "Listener-%s Redis call failed for %s: %s",
+            operation,
+            mcp_session_id,
+            exc,
+            exc_info=exc,
+        )
+
+    async def claim_listener(self, mcp_session_id: str, connection_id: str) -> "ListenerClaimResult":
+        """Claim the single GET /mcp listener slot for a session.
+
+        Args:
+            mcp_session_id: Downstream MCP session id.
+            connection_id: Stable identifier for the GET connection trying
+                to claim — also the value to present to ``heartbeat_listener``
+                and ``release_listener``.
+
+        Returns:
+            ``ListenerClaimResult.WON`` — the caller now holds the claim.
+            ``ListenerClaimResult.CONFLICT`` — another listener already
+            holds it (caller should respond 409).
+            ``ListenerClaimResult.UNAVAILABLE`` — Redis-mode storage failed
+            (Redis configured but unreachable, eval errored, etc.) — the
+            caller should respond 503 because the single-listener invariant
+            cannot be enforced. Also returned for invalid session ids,
+            since callers shouldn't 409 a malformed input.
+        """
+        if not self.is_valid_mcp_session_id(mcp_session_id):
+            return ListenerClaimResult.UNAVAILABLE
+        ttl = settings.mcp_get_stream_listener_ttl_seconds
+        # Multi-node: Redis SET NX EX is the authority.
+        if settings.cache_type == "redis":
+            try:
+                # First-Party
+                from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+                redis = await get_redis_client()
+                if redis is None:
+                    # cache_type=redis but no client — configuration drift or
+                    # startup race. Treat as unavailable, not conflict.
+                    return ListenerClaimResult.UNAVAILABLE
+                key = self._listener_claim_key(mcp_session_id)
+                won = bool(await redis.set(key, connection_id, nx=True, ex=ttl))
+                return ListenerClaimResult.WON if won else ListenerClaimResult.CONFLICT
+            except Exception as exc:
+                # Redis configured but unreachable / eval failed. Surface
+                # explicitly so the GET handler returns 503 (per ADR-052),
+                # not 409 — the previous boolean return collapsed both.
+                self._log_redis_listener_error("claim", mcp_session_id, exc)
+                return ListenerClaimResult.UNAVAILABLE
+        # Single-node: in-process dict guarded by lock gives the same atomicity.
+        async with self._listener_lock:
+            self._purge_expired_listener_claims_locked()
+            existing = self._listener_claims.get(mcp_session_id)
+            if existing is not None:
+                return ListenerClaimResult.CONFLICT
+            self._listener_claims[mcp_session_id] = (connection_id, time.time() + ttl)
+            return ListenerClaimResult.WON
+
+    async def heartbeat_listener(self, mcp_session_id: str, connection_id: str) -> bool:
+        """Refresh a held listener claim.
+
+        Args:
+            mcp_session_id: Downstream MCP session id.
+            connection_id: The connection id presented at ``claim_listener``.
+
+        Returns:
+            True if the heartbeat refreshed the TTL, False if the claim no
+            longer belongs to ``connection_id`` (caller should close the
+            stream).
+        """
+        if not self.is_valid_mcp_session_id(mcp_session_id):
+            return False
+        ttl = settings.mcp_get_stream_listener_ttl_seconds
+        if settings.cache_type == "redis":
+            try:
+                # First-Party
+                from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+                redis = await get_redis_client()
+                if redis is None:
+                    return False
+                key = self._listener_claim_key(mcp_session_id)
+                result = await redis.eval(self._HEARTBEAT_LISTENER_LUA, 1, key, connection_id, ttl)
+                return bool(result)
+            except Exception as exc:
+                self._log_redis_listener_error("heartbeat", mcp_session_id, exc)
+                return False
+        async with self._listener_lock:
+            # Purge expired claims so a stale entry whose TTL elapsed
+            # without a release call (worker crashed mid-stream, etc.)
+            # doesn't read as "still owned by us" — without this purge
+            # the .get() below would return a tuple whose connection_id
+            # match still hits even though the slot is logically free.
+            self._purge_expired_listener_claims_locked()
+            existing = self._listener_claims.get(mcp_session_id)
+            if existing is None or existing[0] != connection_id:
+                return False
+            self._listener_claims[mcp_session_id] = (connection_id, time.time() + ttl)
+            return True
+
+    async def release_listener(self, mcp_session_id: str, connection_id: str) -> bool:
+        """Release a held listener claim. No-op if the caller no longer owns it.
+
+        Args:
+            mcp_session_id: Downstream MCP session id.
+            connection_id: The connection id presented at ``claim_listener``.
+
+        Returns:
+            True if the claim was released by this call, False if it had
+            already expired or belonged to someone else.
+        """
+        if not self.is_valid_mcp_session_id(mcp_session_id):
+            return False
+        if settings.cache_type == "redis":
+            try:
+                # First-Party
+                from mcpgateway.utils.redis_client import get_redis_client  # pylint: disable=import-outside-toplevel
+
+                redis = await get_redis_client()
+                if redis is None:
+                    return False
+                key = self._listener_claim_key(mcp_session_id)
+                result = await redis.eval(self._RELEASE_LISTENER_LUA, 1, key, connection_id)
+                return bool(result)
+            except Exception as exc:
+                self._log_redis_listener_error("release", mcp_session_id, exc)
+                return False
+        async with self._listener_lock:
+            # Same purge rationale as ``heartbeat_listener``: an
+            # expired-but-undeleted entry whose connection_id matches
+            # ours would otherwise return ``True`` from this release
+            # call as if a real claim was dropped.
+            self._purge_expired_listener_claims_locked()
+            existing = self._listener_claims.get(mcp_session_id)
+            if existing is None or existing[0] != connection_id:
+                return False
+            self._listener_claims.pop(mcp_session_id, None)
+            return True
+
+    def _purge_expired_listener_claims_locked(self) -> None:
+        """Drop expired in-memory listener claims. Caller holds ``_listener_lock``."""
+        now = time.time()
+        expired = [sid for sid, (_, exp) in self._listener_claims.items() if exp <= now]
+        for sid in expired:
+            self._listener_claims.pop(sid, None)
 
     async def close_all(self) -> None:
         """Stop background tasks and clear affinity state. Call at shutdown."""
@@ -921,10 +1165,14 @@ def get_session_affinity() -> SessionAffinity:
     """Return the global session-affinity service instance.
 
     Raises:
-        RuntimeError: If the service has not been initialized.
+        SessionAffinityNotInitializedError: If ``init_session_affinity()``
+            has not yet been called. Subclasses ``RuntimeError`` so
+            callers that catch the base class still work, but narrow
+            consumers (like the GET handler) use the dedicated type to
+            distinguish "not initialized" from other runtime errors.
     """
     if _mcp_session_pool is None:
-        raise RuntimeError("Session-affinity service not initialized. Call init_session_affinity() first.")
+        raise SessionAffinityNotInitializedError("Session-affinity service not initialized. Call init_session_affinity() first.")
     return _mcp_session_pool
 
 
@@ -959,9 +1207,9 @@ def init_session_affinity(
 
         notification_svc = init_notification_service(debounce_seconds=notification_debounce_seconds)
 
-        def default_handler_factory(url: str, gateway_id: Optional[str]):
-            """Create a message handler that routes MCP notifications to the notification service."""
-            return notification_svc.create_message_handler(gateway_id or url, url)
+        def default_handler_factory(url: str, gateway_id: Optional[str], *, downstream_session_id: str):
+            """Create a message handler that routes MCP notifications and forwards server-initiated messages to the GET /mcp listener (ADR-052)."""
+            return notification_svc.create_message_handler(gateway_id or url, url, downstream_session_id=downstream_session_id)
 
         effective_handler_factory = default_handler_factory
         logger.info("MCP notification service created (debounce=%ss)", notification_debounce_seconds)

--- a/mcpgateway/services/upstream_session_registry.py
+++ b/mcpgateway/services/upstream_session_registry.py
@@ -31,7 +31,7 @@ from enum import Enum
 import logging
 import time
 from types import MappingProxyType
-from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Protocol
 
 # Third-Party
 import anyio
@@ -71,26 +71,44 @@ HttpxClientFactory = Callable[
     httpx.AsyncClient,
 ]
 
-# Factory building a per-session MCP message handler. Optional; if absent, no
-# handler is wired and server-initiated messages will be dropped.
-MessageHandlerFactory = Callable[
-    [str, Optional[str]],  # (url, gateway_id)
-    Callable[
-        [RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult] | mcp_types.ServerNotification | Exception],
-        Any,
-    ],
+# Type alias for the per-session message handler that the SDK ClientSession
+# calls into. Receives ServerNotification, ServerRequest responders, or Exceptions.
+MessageHandler = Callable[
+    [RequestResponder[mcp_types.ServerRequest, mcp_types.ClientResult] | mcp_types.ServerNotification | Exception],
+    Any,
 ]
+
+
+class MessageHandlerFactory(Protocol):
+    """Build a per-session MCP message handler.
+
+    Optional. If absent, no handler is wired and server-initiated messages
+    will be dropped. The ``downstream_session_id`` is keyword-only so any
+    future positional additions can't accidentally shuffle existing args.
+
+    The handler closure uses ``downstream_session_id`` to forward
+    server-initiated messages to the correct GET /mcp listener.
+    """
+
+    def __call__(
+        self,
+        url: str,
+        gateway_id: Optional[str],
+        *,
+        downstream_session_id: str,
+    ) -> MessageHandler:
+        """Build the per-session message handler. See class docstring."""
+
 
 # Factory for constructing an upstream MCP session.
 #
-# Return shape is ``(ClientSession, _unused)``. The second slot is vestigial —
-# the owner task attaches ``_cf_owner_task`` and ``_cf_shutdown_event`` onto
-# the ClientSession object itself, so ``_create_session()`` ignores the second
-# return value. Kept in the signature because (a) fake factories in the test
-# suite mirror the shape and (b) collapsing to a single return is a breaking
-# change for any downstream overrides — safe to do in the same commit that
-# replaces the attribute-smuggling convention with a typed handle (separate
-# follow-up).
+# Return shape is ``(ClientSession, _unused)``. The second slot is
+# vestigial — the owner task attaches ``_cf_owner_task`` and
+# ``_cf_shutdown_event`` onto the ClientSession object itself, so
+# ``_create_session()`` ignores the second return value. The shape is
+# kept stable here because fake factories in the test suite and any
+# downstream overrides mirror it. Issue #4344 tracks replacing the
+# attribute-smuggling with a typed handle and collapsing the tuple.
 #
 # Defaults to the real MCP transports; tests inject a fake so no network is
 # touched.
@@ -334,7 +352,11 @@ async def _default_session_factory(req: SessionCreateRequest) -> tuple[ClientSes
                 message_handler = None
                 if req.message_handler_factory is not None:
                     try:
-                        message_handler = req.message_handler_factory(req.url, req.gateway_id)
+                        message_handler = req.message_handler_factory(
+                            req.url,
+                            req.gateway_id,
+                            downstream_session_id=req.downstream_session_id,
+                        )
                     except Exception as exc:  # noqa: BLE001 — handler failure is not fatal
                         logger.warning(
                             "Failed to build message handler for %s: %s",

--- a/mcpgateway/transports/redis_event_store.py
+++ b/mcpgateway/transports/redis_event_store.py
@@ -9,8 +9,10 @@ Design goals:
 """
 
 # Standard
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING
+from typing import AsyncIterator, Optional, TYPE_CHECKING
 import uuid
 
 # Third-Party
@@ -90,6 +92,67 @@ redis.call('EXPIRE', events_key, ttl)
 redis.call('EXPIRE', messages_key, ttl)
 
 return seq_num
+"""
+
+
+# Same as ``_STORE_EVENT_LUA`` but appends a ``PUBLISH`` to a supplied
+# channel (ARGV[7]) with a payload (ARGV[8]). Because Redis runs Lua
+# atomically (no other client commands execute while the script runs),
+# the store and publish are atomic from a reader's perspective — a
+# concurrent ``replay_after_with_ids`` can't observe the stored event
+# without the Pub/Sub wake-up also having fired. Returns the same
+# seq_num as ``_STORE_EVENT_LUA``.
+#
+# Built by replacing the final ``return seq_num`` of the base script
+# with ``PUBLISH`` + ``return seq_num``. Use ``str.replace`` with
+# ``count=-1`` so a drift in the base script is noticed (wrong number
+# of replacements would produce an obviously-broken script).
+_STORE_AND_NOTIFY_EVENT_LUA = _STORE_EVENT_LUA.replace(
+    "return seq_num",
+    "redis.call('PUBLISH', ARGV[7], ARGV[8])\nreturn seq_num",
+    1,  # exactly one occurrence expected
+)
+
+
+# Best-effort atomic eviction of a single event. Used by the event bus
+# after a failed ``store_event_with_notify`` EVAL: even with atomic
+# Lua on the server side, the client-visible failure might mean the
+# script ran server-side but the reply was lost (network drop between
+# Redis completing execution and the TCP ack). ``evict_event`` is
+# idempotent — if the event never landed, ZREM returns 0 and the
+# script is a no-op.
+_EVICT_EVENT_LUA = r"""
+-- KEYS:
+--  1) meta_key
+--  2) events_key
+--  3) messages_key
+-- ARGV:
+--  1) event_id
+--  2) index_prefix
+
+local meta_key = KEYS[1]
+local events_key = KEYS[2]
+local messages_key = KEYS[3]
+local event_id = ARGV[1]
+local index_prefix = ARGV[2]
+
+-- Only evict if the event is actually present. Returning 0 tells the
+-- caller the entry was already gone (idempotent).
+local removed = redis.call('ZREM', events_key, event_id)
+if removed == 0 then
+  return 0
+end
+redis.call('HDEL', messages_key, event_id)
+redis.call('DEL', index_prefix .. event_id)
+local count = redis.call('HINCRBY', meta_key, 'count', -1)
+if count < 0 then
+  redis.call('HSET', meta_key, 'count', 0)
+end
+local first = redis.call('ZRANGE', events_key, 0, 0, 'WITHSCORES')
+if #first >= 2 then
+  redis.call('HSET', meta_key, 'start_seq', tonumber(first[2]))
+end
+return 1
 """
 
 
@@ -204,6 +267,74 @@ class RedisEventStore(EventStore):
 
         return event_id
 
+    async def store_event_with_notify(
+        self,
+        stream_id: str,
+        message: JSONRPCMessage,
+        *,
+        channel: str,
+        payload: bytes,
+        event_id_override: Optional[str] = None,
+    ) -> str:
+        """Store an event and fire a ``PUBLISH`` wake-up in one atomic Lua script.
+
+        Redis runs Lua atomically, so this eliminates the race window
+        where a concurrent ``replay_after_with_ids`` could observe the
+        stored event between ``store_event`` and a follow-up ``publish``
+        (which could later fail and rollback) — the reader either sees
+        nothing or sees the event *and* the wake-up has already been
+        dispatched.
+
+        Args:
+            stream_id: Stream to store on.
+            message: JSON-RPC message (non-None — priming events use
+                the plain ``store_event`` path).
+            channel: Pub/Sub channel to notify.
+            payload: Pub/Sub payload bytes (typically references the
+                returned event id, which callers pre-bind via
+                ``event_id_override``).
+            event_id_override: When supplied, use this as the event
+                id instead of generating a fresh UUID. Lets callers
+                that need the id inside ``payload`` construct both in
+                one atomic step.
+
+        Returns:
+            Event id for the stored event (matches
+            ``event_id_override`` when provided).
+
+        Raises:
+            RuntimeError: If the Redis client is unavailable.
+        """
+        redis: Redis = await get_redis_client()
+        if redis is None:
+            raise RuntimeError("Redis client not available - cannot store+notify event")
+
+        event_id = event_id_override if event_id_override is not None else str(uuid.uuid4())
+        message_dict = message.model_dump() if hasattr(message, "model_dump") else dict(message)
+        message_json = orjson.dumps(message_dict)
+
+        meta_key = self._get_stream_meta_key(stream_id)
+        events_key = self._get_stream_events_key(stream_id)
+        messages_key = self._get_stream_messages_key(stream_id)
+
+        await redis.eval(
+            _STORE_AND_NOTIFY_EVENT_LUA,
+            3,
+            meta_key,
+            events_key,
+            messages_key,
+            event_id,
+            message_json,
+            int(self.ttl),
+            int(self.max_events),
+            self._event_index_prefix(),
+            stream_id,
+            channel,
+            payload,
+        )
+
+        return event_id
+
     async def replay_events_after(self, last_event_id: str, send_callback: EventCallback) -> str | None:
         """Replay events after a specific event_id.
 
@@ -260,3 +391,189 @@ class RedisEventStore(EventStore):
             await send_callback(msg)
 
         return stream_id
+
+    async def replay_after_with_ids(
+        self,
+        stream_id: str,
+        last_event_id: Optional[str],
+    ) -> AsyncIterator[tuple[str, JSONRPCMessage]]:
+        """Yield ``(event_id, message)`` for events strictly after ``last_event_id``.
+
+        Unlike :meth:`replay_events_after` (the SDK contract), this preserves
+        the original event id alongside the message — needed by callers that
+        re-emit SSE frames where the ``id:`` field must round-trip end to
+        end (ADR-052 GET stream).
+
+        When ``last_event_id`` is ``None``, yields every event still in the
+        ring buffer for ``stream_id``. This handles the reconnect-without-
+        cursor case: a client that drops before receiving any event ids
+        still needs the buffered server-initiated requests delivered, or
+        the ``RequestResponder`` on the gateway side just times out.
+
+        Yields nothing when:
+            * the Redis client is unavailable,
+            * the index entry for ``last_event_id`` has expired or never
+              existed (the event was evicted from the ring buffer),
+            * the index points at a different stream id than requested
+              (defense against cross-session id collision).
+
+        Args:
+            stream_id: The stream to replay from.
+            last_event_id: Resume cursor (exclusive). ``None`` means
+                "replay everything in the buffer".
+
+        Yields:
+            ``(event_id, message)`` tuples in stream order.
+        """
+        redis: Redis = await get_redis_client()
+        if redis is None:
+            return
+        if last_event_id is None:
+            # Reconnect without cursor: yield everything currently in the
+            # ring buffer. Use ``-inf`` as the lower bound of the score range.
+            events_key = self._get_stream_events_key(stream_id)
+            messages_key = self._get_stream_messages_key(stream_id)
+            event_ids_all = await redis.zrangebyscore(events_key, "-inf", "+inf")
+            for ev_bytes in event_ids_all:
+                ev_id = ev_bytes.decode("latin-1") if isinstance(ev_bytes, (bytes, bytearray)) else str(ev_bytes)
+                raw = await redis.hget(messages_key, ev_id)
+                if raw is None:
+                    continue
+                try:
+                    msg = JSONRPCMessage.model_validate(orjson.loads(raw))
+                except Exception as exc:
+                    logger.warning("Discarding malformed event %s for %s: %s", ev_id, stream_id, exc)
+                    continue
+                yield ev_id, msg
+            return
+        index_raw = await redis.get(self._event_index_key(last_event_id))
+        if not index_raw:
+            return
+        try:
+            info = orjson.loads(index_raw)
+            cursor_stream_id = info["stream_id"]
+            last_seq = int(info["seq_num"])
+        except Exception as exc:  # noqa: BLE001 — log so corruption is visible to operators
+            logger.warning(
+                "Malformed event-index entry for %s on stream %s: %s",
+                last_event_id,
+                stream_id,
+                exc,
+            )
+            return
+        if cursor_stream_id != stream_id:
+            # Could be benign (event id collision after eviction) or a
+            # security signal (cross-tenant injection). Log so operators
+            # can spot patterns without it being silently swallowed.
+            logger.warning(
+                "Cross-stream event-index mismatch for %s: index points at %s, requested %s",
+                last_event_id,
+                cursor_stream_id,
+                stream_id,
+            )
+            return
+        meta_key = self._get_stream_meta_key(stream_id)
+        events_key = self._get_stream_events_key(stream_id)
+        messages_key = self._get_stream_messages_key(stream_id)
+        # Eviction detection: the index key TTLs out separately from the
+        # ring-buffer entry, so a cursor whose seq < the buffer's
+        # current start_seq is pointing past the surviving tail. Without
+        # this guard, the GET stream would silently replay only the
+        # post-eviction events and the client would never learn that
+        # a gap was lost — exactly what Last-Event-Id resume is meant
+        # to surface.
+        start_seq_bytes = await redis.hget(meta_key, "start_seq")
+        if start_seq_bytes:
+            try:
+                start_seq = int(start_seq_bytes)
+            except (TypeError, ValueError):
+                start_seq = None
+            if start_seq is not None and last_seq < start_seq:
+                logger.warning(
+                    "Last-Event-Id %s on %s is older than buffer start_seq=%s; cursor evicted",
+                    last_event_id,
+                    stream_id,
+                    start_seq,
+                )
+                return
+        event_ids = await redis.zrangebyscore(events_key, last_seq + 1, "+inf")
+        for ev_bytes in event_ids:
+            ev_id = ev_bytes.decode("latin-1") if isinstance(ev_bytes, (bytes, bytearray)) else str(ev_bytes)
+            raw = await redis.hget(messages_key, ev_id)
+            if raw is None:
+                continue
+            try:
+                msg = JSONRPCMessage.model_validate(orjson.loads(raw))
+            except Exception as exc:
+                logger.warning("Discarding malformed event %s for %s: %s", ev_id, stream_id, exc)
+                continue
+            yield ev_id, msg
+
+    async def evict_event(self, stream_id: str, event_id: str) -> bool:
+        """Best-effort removal of a single event from the ring buffer.
+
+        Idempotent on data: returns ``True`` when the event was
+        present and removed, ``False`` when it was already gone.
+        Raises ``RuntimeError`` when the Redis client is unavailable
+        — callers need to distinguish "nothing to clean up" from "we
+        couldn't even check" (the latter is a potential orphan the
+        operator should see in the logs).
+
+        Used by ``RedisServerEventBus.publish`` after a failed
+        ``store_event_with_notify`` EVAL: the Lua may have completed
+        server-side even when the client saw an error, so we try to
+        evict the event to prevent an orphan in the replay buffer.
+
+        Args:
+            stream_id: Stream the event belongs to.
+            event_id: Event id passed to ``store_event_with_notify``.
+
+        Returns:
+            ``True`` if an event was removed, ``False`` if none was
+            present to remove.
+
+        Raises:
+            RuntimeError: If the Redis client is unavailable.
+        """
+        redis: Redis = await get_redis_client()
+        if redis is None:
+            raise RuntimeError("Redis client not available - cannot verify/evict event")
+        meta_key = self._get_stream_meta_key(stream_id)
+        events_key = self._get_stream_events_key(stream_id)
+        messages_key = self._get_stream_messages_key(stream_id)
+        result = await redis.eval(
+            _EVICT_EVENT_LUA,
+            3,
+            meta_key,
+            events_key,
+            messages_key,
+            event_id,
+            self._event_index_prefix(),
+        )
+        return bool(result)
+
+    async def fetch_event(self, stream_id: str, event_id: str) -> Optional[JSONRPCMessage]:
+        """Look up a single message body by event id on this stream.
+
+        Returns ``None`` when the Redis client is unavailable, the event
+        has been evicted, or the stored payload fails to validate.
+
+        Args:
+            stream_id: Stream the event belongs to.
+            event_id: Event id assigned at ``store_event`` time.
+
+        Returns:
+            The validated JSON-RPC message, or ``None``.
+        """
+        redis: Redis = await get_redis_client()
+        if redis is None:
+            return None
+        messages_key = self._get_stream_messages_key(stream_id)
+        raw = await redis.hget(messages_key, event_id)
+        if raw is None:
+            return None
+        try:
+            return JSONRPCMessage.model_validate(orjson.loads(raw))
+        except Exception as exc:
+            logger.warning("Discarding malformed event %s for %s: %s", event_id, stream_id, exc)
+            return None

--- a/mcpgateway/transports/server_event_bus.py
+++ b/mcpgateway/transports/server_event_bus.py
@@ -1,0 +1,668 @@
+# -*- coding: utf-8 -*-
+"""Server-to-client event bus for the MCP GET /mcp stream (ADR-052).
+
+Backs the spec-defined "Listening for messages from the server" SSE stream.
+Server-initiated JSON-RPC messages (notifications and requests) are
+``publish``-ed by whichever worker holds the upstream MCP session and
+``subscribe``-d by the GET /mcp handler on whichever node the client landed.
+
+Two interchangeable backends sit behind ``ServerEventBus``:
+
+* ``RedisServerEventBus`` (selected when ``cache_type == "redis"``) — durable
+  per-session ring buffer via :class:`RedisEventStore` + Pub/Sub fanout on
+  ``mcp:session:{sid}:events`` so any node can serve the stream.
+
+* ``InMemoryServerEventBus`` (default) — process-local ring buffer with
+  ``asyncio.Queue`` per subscriber. Single-process semantics are identical
+  to Redis for one process; cross-worker delivery is intentionally absent
+  because that is a multi-node concern.
+
+The factory ``get_server_event_bus()`` reads ``cache_type`` once at first
+call and binds the singleton; switching backends requires a restart.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Standard
+from __future__ import annotations
+
+import abc
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+import logging
+from typing import AsyncIterator, Optional
+import uuid
+
+# Third-Party
+from mcp.types import JSONRPCMessage
+import orjson
+
+# First-Party
+from mcpgateway.config import settings
+from mcpgateway.services.metrics import server_event_bus_overflow_counter
+from mcpgateway.transports.redis_event_store import RedisEventStore
+from mcpgateway.utils.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+
+_PUBSUB_CHANNEL_PREFIX = "mcp:session:"
+_PUBSUB_CHANNEL_SUFFIX = ":events"
+
+
+def _channel(session_id: str) -> str:
+    """Return the Pub/Sub channel name for a downstream session.
+
+    Args:
+        session_id: Downstream MCP session id.
+
+    Returns:
+        Redis channel name used for live-event fanout.
+    """
+    return f"{_PUBSUB_CHANNEL_PREFIX}{session_id}{_PUBSUB_CHANNEL_SUFFIX}"
+
+
+@dataclass(frozen=True)
+class BusEvent:
+    """One event delivered to a GET /mcp listener.
+
+    ``event_id`` is what becomes the SSE ``id:`` field and the value the
+    client echoes in ``Last-Event-Id`` on reconnect. ``message`` is the
+    JSON-RPC envelope (notification or server-initiated request) the
+    listener serializes into the SSE ``data:`` field.
+    """
+
+    event_id: str
+    message: JSONRPCMessage
+
+
+class ListenerBacklogOverflow(RuntimeError):
+    """Raised when a subscriber's queue overflows.
+
+    The GET handler treats this as a signal to close the SSE stream so the
+    client reconnects with ``Last-Event-Id`` and replays from the durable
+    buffer, rather than continuing to silently drop messages. The
+    distinction from :class:`BusBackendError` is what callers care about;
+    the message string carries the session id for log lines.
+    """
+
+
+class BusBackendError(RuntimeError):
+    """Raised when the bus backend itself fails (Redis Pub/Sub pump dies, etc.).
+
+    Distinct from ``ListenerBacklogOverflow`` so the GET handler can log
+    "backend outage" separately from "consumer too slow" — operators
+    chasing reconnect storms otherwise look at queue-depth metrics for
+    what is really a Redis hiccup. The message string carries session id
+    and reason for log lines.
+    """
+
+
+class ServerEventBus(abc.ABC):
+    """Abstract bus for server→client messages on a downstream session."""
+
+    @abc.abstractmethod
+    async def publish(self, session_id: str, message: JSONRPCMessage) -> str:
+        """Append ``message`` to the session's stream and signal listeners.
+
+        Args:
+            session_id: Downstream MCP session id.
+            message: JSON-RPC envelope to deliver.
+
+        Returns:
+            The event id assigned to this message.
+        """
+
+    @abc.abstractmethod
+    def subscribe(
+        self,
+        session_id: str,
+        *,
+        last_event_id: Optional[str] = None,
+    ) -> AsyncIterator[BusEvent]:
+        """Yield events for ``session_id`` until the caller stops iterating.
+
+        Replays from ``last_event_id`` if provided (and still in the
+        backlog), then tails new events. The async iterator is the unit
+        of cancellation — closing it releases all backend resources.
+
+        Implementations are async generators (``async def`` with ``yield``).
+        The ABC method is declared as a plain ``def`` returning
+        ``AsyncIterator[BusEvent]`` so the call signature reads
+        ``it = bus.subscribe(sid)`` — same shape as the implementations'
+        ``async def`` + ``yield`` (which Python evaluates to a generator
+        without entering the coroutine). Type checkers see consistent
+        return shapes on both sides.
+
+        Args:
+            session_id: Downstream MCP session id.
+            last_event_id: Resume from this event id (exclusive). When
+                ``None`` or evicted, only new events are delivered.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Release any backend resources held by the bus."""
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend
+# ---------------------------------------------------------------------------
+
+
+# How deep a per-listener queue grows before we treat the consumer as too slow
+# and force a reconnect. Conservative — server-initiated traffic is sparse.
+_DEFAULT_LISTENER_QUEUE_DEPTH = 256
+
+
+class InMemoryServerEventBus(ServerEventBus):
+    """Process-local bus.
+
+    Per session we keep a bounded ring buffer (for replay) and a list of
+    subscriber ``asyncio.Queue`` objects (for live tail). All state is
+    confined to this process — operators running multiple workers should
+    use :class:`RedisServerEventBus` so events fan out across nodes.
+    """
+
+    def __init__(
+        self,
+        max_events_per_stream: int = 100,
+        listener_queue_depth: int = _DEFAULT_LISTENER_QUEUE_DEPTH,
+    ) -> None:
+        """Initialize the in-memory bus.
+
+        Args:
+            max_events_per_stream: Per-session ring-buffer depth.
+            listener_queue_depth: Per-subscriber queue depth before
+                ``ListenerBacklogOverflow`` is signaled.
+        """
+        self._max_events = max_events_per_stream
+        self._queue_depth = listener_queue_depth
+        self._buffers: dict[str, deque[BusEvent]] = {}
+        self._listeners: dict[str, list[asyncio.Queue[BusEvent | None]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def publish(self, session_id: str, message: JSONRPCMessage) -> str:
+        """Append the message to the session's ring buffer and signal listeners.
+
+        The queue puts run *under* ``_lock`` so two concurrent
+        publishers cannot interleave drain-on-overflow with normal
+        puts. Without that atomicity, the ``None`` sentinel can be
+        silently swallowed by ``QueueFull`` — the consumer then stops
+        receiving events but never raises ``ListenerBacklogOverflow``.
+        """
+        event = BusEvent(event_id=str(uuid.uuid4()), message=message)
+        async with self._lock:
+            buf = self._buffers.setdefault(session_id, deque(maxlen=self._max_events))
+            buf.append(event)
+            queues = list(self._listeners.get(session_id, ()))
+            for queue in queues:
+                try:
+                    queue.put_nowait(event)
+                except asyncio.QueueFull:
+                    # Subscriber too slow. Drain whatever is already
+                    # buffered and inject the ``None`` sentinel so the
+                    # subscriber sees the overflow on its next ``get()``
+                    # and raises ``ListenerBacklogOverflow``. Dropped
+                    # events are recoverable: the client reconnects with
+                    # ``Last-Event-Id`` and replays from the backlog
+                    # (which still holds them).
+                    logger.warning(
+                        "In-memory listener queue overflow for session %s — closing stream",
+                        session_id,
+                    )
+                    server_event_bus_overflow_counter.inc()
+                    while not queue.empty():
+                        try:
+                            queue.get_nowait()
+                        except asyncio.QueueEmpty:
+                            break
+                    queue.put_nowait(None)
+        return event.event_id
+
+    async def subscribe(  # pylint: disable=invalid-overridden-method
+        self,
+        session_id: str,
+        *,
+        last_event_id: Optional[str] = None,
+    ) -> AsyncIterator[BusEvent]:
+        """Yield events for the session — replay from ``last_event_id`` then tail."""
+        queue: asyncio.Queue[BusEvent | None] = asyncio.Queue(maxsize=self._queue_depth)
+        # Snapshot replay candidates and register the queue atomically so we
+        # don't miss events that arrive between snapshot and registration.
+        async with self._lock:
+            buf = self._buffers.get(session_id)
+            replay = list(buf) if buf else []
+            self._listeners.setdefault(session_id, []).append(queue)
+
+        try:
+            for event in _events_after(replay, last_event_id):
+                yield event
+            while True:
+                event = await queue.get()
+                if event is None:
+                    raise ListenerBacklogOverflow(f"Listener queue overflowed for session {session_id}")
+                yield event
+        finally:
+            async with self._lock:
+                listeners = self._listeners.get(session_id)
+                if listeners:
+                    try:
+                        listeners.remove(queue)
+                    except ValueError:
+                        pass
+                    if not listeners:
+                        self._listeners.pop(session_id, None)
+
+    async def close(self) -> None:
+        """Drop all session state and signal every listener to terminate."""
+        async with self._lock:
+            self._buffers.clear()
+            for queues in self._listeners.values():
+                for queue in queues:
+                    try:
+                        queue.put_nowait(None)
+                    except asyncio.QueueFull:
+                        pass
+            self._listeners.clear()
+
+
+def _events_after(events: list[BusEvent], last_event_id: Optional[str]) -> list[BusEvent]:
+    """Return events strictly after ``last_event_id``.
+
+    When ``last_event_id`` is ``None`` the caller is reconnecting without
+    a cursor — return every buffered event so a client that dropped
+    before receiving any event ids still gets the buffered
+    server-initiated requests it missed. (For brand-new sessions the
+    buffer is empty so this is a no-op.)
+
+    When ``last_event_id`` is set but unknown to this buffer the cursor
+    has been evicted; return nothing rather than silently delivering
+    only the surviving tail.
+    """
+    if last_event_id is None:
+        return list(events)
+    for idx, event in enumerate(events):
+        if event.event_id == last_event_id:
+            return events[idx + 1 :]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Redis backend
+# ---------------------------------------------------------------------------
+
+
+class RedisServerEventBus(ServerEventBus):
+    """Redis-backed bus.
+
+    Events are persisted in a per-session :class:`RedisEventStore` ring
+    buffer (Lua-atomic, TTL-bounded) and a wake-up signal is published on
+    a per-session Pub/Sub channel. The combination — durable store for
+    correctness, Pub/Sub for latency — is the standard ``LISTEN/NOTIFY``
+    pattern adapted to Redis.
+    """
+
+    def __init__(
+        self,
+        store: Optional[RedisEventStore] = None,
+        listener_queue_depth: int = _DEFAULT_LISTENER_QUEUE_DEPTH,
+    ) -> None:
+        """Initialize the Redis-backed bus.
+
+        Args:
+            store: Optional pre-built event store; defaults to one keyed
+                from the streamable-http settings.
+            listener_queue_depth: Per-subscriber queue depth before
+                ``ListenerBacklogOverflow`` is signaled.
+        """
+        self._store = store or RedisEventStore(
+            max_events_per_stream=settings.streamable_http_max_events_per_stream,
+            ttl=settings.streamable_http_event_ttl,
+        )
+        self._queue_depth = listener_queue_depth
+
+    async def publish(self, session_id: str, message: JSONRPCMessage) -> str:
+        """Persist the event and fire the Pub/Sub wake-up atomically.
+
+        Store + ``PUBLISH`` happen inside a single Redis Lua script
+        (``RedisEventStore.store_event_with_notify``). Redis runs Lua
+        atomically (no other client command executes during a script),
+        so a concurrent ``replay_after_with_ids`` cannot observe the
+        event between the store and the notify — either nothing is
+        visible or both the event is in the buffer AND the wake-up has
+        been dispatched.
+
+        The tricky part is client-visible failure: an exception from
+        ``store_event_with_notify`` does **not** prove "nothing was
+        written." Redis's Lua atomicity protects other clients, but
+        the network between our client and Redis can drop AFTER the
+        script executed fully server-side but BEFORE the reply
+        reaches us. In that window the event is in the buffer, the
+        PUBLISH has fired, and yet the caller sees an error. Leaving
+        the stored event behind would orphan it on the next
+        reconnect-without-cursor (Codex stop-hook finding).
+
+        So after any exception, best-effort evict by the pre-bound
+        event id. ``evict_event`` is idempotent — returns ``False``
+        when the event never landed, ``True`` when the orphan was
+        removed. Either way we raise ``BusBackendError`` so the
+        caller cancels the holder immediately.
+        """
+        # Pre-check the client at the bus layer so the
+        # missing-client case short-circuits without an eviction
+        # attempt. Without this, the store raises
+        # ``RuntimeError("Redis client not available ...")``, the
+        # eviction raises the same, and the recovery path would
+        # mistakenly log "orphan may be in buffer" when nothing was
+        # actually written.
+        redis = await get_redis_client()
+        if redis is None:
+            raise BusBackendError(f"Redis client not available — cannot publish event for session {session_id}")
+        # Pre-generate the event id so the Pub/Sub payload can
+        # reference it, and so we have a fixed id to evict if the
+        # EVAL reply never reaches us (EVAL completed server-side but
+        # the reply was lost).
+        event_id = str(uuid.uuid4())
+        payload = orjson.dumps({"event_id": event_id})
+        try:
+            await self._store.store_event_with_notify(
+                session_id,
+                message,
+                channel=_channel(session_id),
+                payload=payload,
+                event_id_override=event_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — re-raise as typed bus error for the caller
+            await self._evict_after_publish_failure(session_id, event_id, exc)
+            raise BusBackendError(f"Atomic store+publish failed for session {session_id}: {exc}") from exc
+        return event_id
+
+    async def _evict_after_publish_failure(self, session_id: str, event_id: str, exc: BaseException) -> None:
+        """Best-effort eviction of an event the EVAL may have written server-side.
+
+        Three outcomes, three log levels:
+
+        * ``evict_event`` returns ``True`` → we found and removed an
+          orphan (EVAL completed server-side; reply was lost). Log at
+          warning so operators can correlate with the upstream
+          failure.
+        * ``evict_event`` returns ``False`` → the event never landed.
+          Silent; the raise downstream tells the caller.
+        * ``evict_event`` raises → we couldn't verify state. That's
+          NOT "nothing to clean up" — the EVAL may have landed and we
+          just can't reach Redis to find out. Log at error so the
+          operator sees the potential orphan.
+        """
+        try:
+            evicted = await self._store.evict_event(session_id, event_id)
+        except Exception as evict_exc:  # noqa: BLE001 — already recovering from a publish failure
+            logger.error(
+                "Server-event-bus could not verify/evict event %s for session %s after publish error (%s): %s — orphan may be in the buffer; operator should investigate",
+                event_id,
+                session_id,
+                exc,
+                evict_exc,
+                exc_info=evict_exc,
+            )
+            return
+        if evicted:
+            logger.warning(
+                "Server-event-bus rolled back event %s for session %s (publish EVAL reply lost: %s)",
+                event_id,
+                session_id,
+                exc,
+            )
+
+    async def subscribe(  # pylint: disable=invalid-overridden-method
+        self,
+        session_id: str,
+        *,
+        last_event_id: Optional[str] = None,
+    ) -> AsyncIterator[BusEvent]:
+        """Replay from ``last_event_id`` then tail the session's Pub/Sub channel."""
+        redis = await get_redis_client()
+        if redis is None:
+            raise BusBackendError(f"Redis client not available for session {session_id}")
+
+        # Distinct sentinel for backend failure, separate from the overflow
+        # ``None`` sentinel — lets the consumer raise ``BusBackendError``
+        # instead of misleadingly raising ``ListenerBacklogOverflow`` when
+        # the real cause is a Redis hiccup.
+        pump_failure: dict[str, str] = {}
+        queue: asyncio.Queue[BusEvent | None] = asyncio.Queue(maxsize=self._queue_depth)
+        seen: set[str] = set()
+
+        # Subscribe BEFORE replay so events landed between the replay's last
+        # seq and the live tail's first message aren't dropped.
+        # The ``await pubsub.subscribe(...)`` lives inside its own
+        # try/aclose because a transient disconnect, auth rotation or
+        # eval failure during subscribe would otherwise leak the
+        # ``pubsub`` connection — the cleanup below only fires once we
+        # enter the outer try/finally.
+        pubsub = redis.pubsub()
+        try:
+            await pubsub.subscribe(_channel(session_id))
+        except Exception:
+            try:
+                await pubsub.aclose()
+            except Exception as close_exc:  # noqa: BLE001 — best-effort cleanup; preserve original
+                logger.debug("pubsub.aclose during subscribe-failure cleanup raised for %s: %s", session_id, close_exc)
+            raise
+
+        def _force_sentinel() -> None:
+            """Guarantee the consumer wakes up by enqueueing ``None``.
+
+            Without a sentinel reaching the queue, a consumer blocked on
+            ``queue.get()`` waits forever for a pump task that has already
+            exited. If the queue is full we drop the oldest event to make
+            room — losing one event is strictly better than wedging the
+            stream until the client times out and reconnects.
+            """
+            for _ in range(2):
+                try:
+                    queue.put_nowait(None)
+                    return
+                except asyncio.QueueFull:
+                    try:
+                        queue.get_nowait()
+                    except asyncio.QueueEmpty:
+                        # Consumer drained between our check and now — retry put.
+                        continue
+            # Should never reach here for a single-producer queue, but log
+            # if it does so the wedge has a forensic trail.
+            logger.error(
+                "Pub/Sub pump for %s could not enqueue cancel sentinel (queue depth=%d)",
+                session_id,
+                queue.qsize(),
+            )
+
+        async def pump() -> None:
+            """Read Pub/Sub notifications and feed event ids into the subscriber's queue."""
+            try:
+                async for raw in pubsub.listen():
+                    if raw.get("type") != "message":
+                        continue
+                    data = raw.get("data") or b""
+                    try:
+                        info = orjson.loads(data)
+                        event_id = info["event_id"]
+                    except (orjson.JSONDecodeError, KeyError, TypeError) as exc:
+                        # Malformed payload (schema drift, foreign publisher, encoding bug).
+                        # Log so a payload-format regression doesn't silently nuke every
+                        # event for every session.
+                        logger.debug(
+                            "Discarding malformed Pub/Sub payload for %s: %s (%r)",
+                            session_id,
+                            exc,
+                            data[:128],
+                        )
+                        continue
+                    # Validate event_id type and length BEFORE letting it
+                    # become a Redis hash key. An attacker with Redis-write
+                    # could otherwise pass non-strings or pathological
+                    # values into ``_fetch_event`` → ``redis.hget``.
+                    if not isinstance(event_id, str) or not event_id or len(event_id) > 256:
+                        logger.debug(
+                            "Discarding malformed Pub/Sub event_id for %s: %r",
+                            session_id,
+                            event_id,
+                        )
+                        continue
+                    if event_id in seen:
+                        continue
+                    msg = await self._store.fetch_event(session_id, event_id)
+                    if msg is None:
+                        continue
+                    try:
+                        queue.put_nowait(BusEvent(event_id=event_id, message=msg))
+                    except asyncio.QueueFull:
+                        # Subscriber too slow — overflow path (NOT backend failure).
+                        # Force a sentinel through so the consumer wakes and
+                        # raises ListenerBacklogOverflow instead of blocking
+                        # forever after draining the (now sentinel-less) queue.
+                        _force_sentinel()
+                        return
+            except asyncio.CancelledError:
+                # External cancellation (subscribe() finally cancels us on
+                # consumer exit). Wake the consumer if it's blocked on
+                # queue.get(); without a sentinel it would wait forever
+                # for a pump that's gone.
+                _force_sentinel()
+                raise
+            except Exception as exc:
+                # Backend failure (Redis dropped, listen() raised, etc.).
+                # Record reason so the consumer can raise BusBackendError.
+                logger.warning("Pub/Sub pump for session %s exited: %s", session_id, exc)
+                pump_failure["reason"] = f"{type(exc).__name__}: {exc}"
+                _force_sentinel()
+
+        pump_task = asyncio.create_task(pump(), name=f"server-event-bus-pump:{session_id[:8]}")
+
+        try:
+            # Replay buffered events regardless of whether a Last-Event-Id
+            # was supplied. With a cursor we yield events strictly after
+            # it; without a cursor we yield everything in the surviving
+            # ring buffer. The latter case matters for reconnects that
+            # drop before any event id reached the client — the buffered
+            # server-initiated requests would otherwise be silently lost
+            # and the gateway-side ``RequestResponder`` would TTL out.
+            async for event in self._iter_events_after(session_id, last_event_id):
+                seen.add(event.event_id)
+                yield event
+            while True:
+                event = await queue.get()
+                if event is None:
+                    # Distinguish backend failure (typed BusBackendError)
+                    # from overflow (ListenerBacklogOverflow). The GET
+                    # handler logs each case differently — operators
+                    # tracing reconnect storms would otherwise chase
+                    # queue-depth metrics for what is really a Redis
+                    # outage.
+                    if pump_failure:
+                        raise BusBackendError(f"Bus backend failed for session {session_id}: {pump_failure['reason']}")
+                    raise ListenerBacklogOverflow(f"Listener queue overflowed for session {session_id}")
+                if event.event_id in seen:
+                    continue
+                seen.add(event.event_id)
+                yield event
+        finally:
+            # Cancel pump first, then await it so its `pubsub.listen()`
+            # await unwinds before we close the pubsub. Without this
+            # ordering, some redis-py versions raise teardown-time
+            # RuntimeErrors because aclose() runs while listen() still
+            # holds the connection.
+            pump_task.cancel()
+            try:
+                await pump_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001 — connection-pool leak indicator; log at warning so default LOG_LEVEL=ERROR operators still see it
+                logger.warning(
+                    "Pub/Sub pump drain raised for %s during teardown: %s",
+                    session_id,
+                    exc,
+                )
+            try:
+                await pubsub.unsubscribe(_channel(session_id))
+            except Exception as exc:  # noqa: BLE001 — leak indicator; see rationale above
+                logger.warning(
+                    "pubsub.unsubscribe raised for %s during teardown: %s",
+                    session_id,
+                    exc,
+                )
+            try:
+                await pubsub.aclose()
+            except Exception as exc:  # noqa: BLE001 — leak indicator; see rationale above
+                logger.warning(
+                    "pubsub.aclose raised for %s during teardown: %s",
+                    session_id,
+                    exc,
+                )
+
+    async def _iter_events_after(
+        self,
+        session_id: str,
+        last_event_id: str,
+    ) -> AsyncIterator[BusEvent]:
+        """Yield stored events after ``last_event_id`` with original ids preserved.
+
+        Delegates to ``RedisEventStore.replay_after_with_ids`` so the
+        Redis-key schema stays encapsulated in the event store.
+        """
+        async for ev_id, msg in self._store.replay_after_with_ids(session_id, last_event_id):
+            yield BusEvent(event_id=ev_id, message=msg)
+
+    async def close(self) -> None:
+        """No-op; Pub/Sub subscriptions and queues are scoped to ``subscribe()``."""
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+_bus_singleton: Optional[ServerEventBus] = None
+_bus_lock = asyncio.Lock()
+
+
+async def get_server_event_bus() -> ServerEventBus:
+    """Return the process-wide singleton bus.
+
+    Backend is chosen on first call from ``settings.cache_type`` and reused
+    for the lifetime of the process. Multi-node deployments
+    (``cache_type == "redis"``) get the Redis bus; everything else gets the
+    in-memory bus.
+
+    Returns:
+        The singleton ``ServerEventBus``.
+    """
+    global _bus_singleton  # pylint: disable=global-statement
+    if _bus_singleton is not None:
+        return _bus_singleton
+    async with _bus_lock:
+        if _bus_singleton is None:
+            if settings.cache_type == "redis" and settings.redis_url:
+                logger.info("ServerEventBus: using Redis backend")
+                _bus_singleton = RedisServerEventBus()
+            else:
+                logger.info(
+                    "ServerEventBus: using in-memory backend (cache_type=%s)",
+                    settings.cache_type,
+                )
+                _bus_singleton = InMemoryServerEventBus(
+                    max_events_per_stream=settings.streamable_http_max_events_per_stream,
+                )
+    return _bus_singleton
+
+
+async def reset_server_event_bus() -> None:
+    """Drop the singleton — for tests only."""
+    global _bus_singleton  # pylint: disable=global-statement
+    async with _bus_lock:
+        if _bus_singleton is not None:
+            await _bus_singleton.close()
+        _bus_singleton = None

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -38,7 +38,7 @@ import contextvars
 from dataclasses import dataclass
 from enum import Enum
 import re
-from typing import Any, AsyncGenerator, ContextManager, Dict, List, Optional, Pattern, Tuple, Union
+from typing import Any, AsyncGenerator, ContextManager, Dict, List, Optional, Pattern, Tuple, Union, assert_never
 from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
@@ -72,7 +72,13 @@ from mcpgateway.observability import create_span
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.http_client_service import get_http_client, get_http_limits
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.metrics import mcp_auth_cache_events_counter, oauth_verify_events_counter, transport_get_rejected_counter
+from mcpgateway.services.metrics import (
+    mcp_auth_cache_events_counter,
+    oauth_verify_events_counter,
+    transport_get_active_listeners_gauge,
+    transport_get_events_delivered_counter,
+    transport_get_rejected_counter,
+)
 from mcpgateway.services.oauth_manager import OAuthEnforcementUnavailableError, OAuthRequiredError
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptService
@@ -2732,6 +2738,816 @@ async def complete(
         return types.Completion(values=[], total=0, hasMore=False)
 
 
+# ----------------------------- POST response interception (ADR-052) ----------------------------
+
+
+@dataclass(frozen=True)
+class _BodyPeekResult:
+    """Result of buffering a POST body for response or notification interception.
+
+    ``body`` is ``None`` when the body cannot be replayed safely — either
+    the client disconnected before ``more_body`` went False or the ASGI
+    transport raised while we were reading. Callers must NOT replay in
+    those cases.
+
+    When ``too_large`` is True, ``body`` holds only the chunks we had
+    already accepted before the cap-busting chunk arrived (so its size
+    is at most ``mcp_body_peek_max_bytes``, and may be less). The
+    cap-busting chunk itself is passed through to the SDK verbatim via
+    ``replay_tail`` — we do **not** slice it into ``body`` and a
+    remainder, since that would duplicate the chunk's bytes in memory
+    and effectively double the peak footprint we were trying to bound.
+    With the no-slice design the over-cap path holds at most
+    ``cap + chunk`` bytes (the chunk reference uvicorn already
+    allocated, plus whatever we'd buffered before it).
+
+    ``replay_tail_more_body`` records whether further chunks are still
+    pending on the original receive after the tail. Interception is
+    skipped on the ``too_large`` path because we couldn't fit the whole
+    body in memory to inspect it.
+    """
+
+    body: Optional[bytes]
+    intercepted: bool
+    disconnected: bool = False
+    too_large: bool = False
+    replay_tail: bytes = b""
+    replay_tail_more_body: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject construction sites that build a meaningless combination of fields.
+
+        Enforces the five invariants the dataclass would otherwise leave
+        to convention:
+
+        1. ``body is None`` ⇔ the body cannot be replayed (``disconnected``
+           must be True; ``intercepted`` and ``too_large`` must be False;
+           there cannot be a ``replay_tail``).
+        2. ``intercepted=True`` ⇒ we matched a held responder, so ``body``
+           must be set and ``too_large`` must be False.
+        3. ``too_large=True`` ⇒ ``body`` is set, ``intercepted`` is False
+           (we couldn't parse), and the cap-busting chunk is carried in
+           ``replay_tail`` (otherwise the SDK would silently lose data).
+        4. ``replay_tail_more_body=True`` ⇒ ``replay_tail`` is non-empty.
+        """
+        if self.body is None:
+            if not self.disconnected:
+                raise ValueError("_BodyPeekResult.body=None is only valid when disconnected=True")
+            if self.intercepted or self.too_large or self.replay_tail or self.replay_tail_more_body:
+                raise ValueError("_BodyPeekResult: disconnected result must not carry intercepted/too_large/replay_tail")
+            return
+        # body is not None
+        if self.intercepted and self.too_large:
+            raise ValueError("_BodyPeekResult: intercepted and too_large are mutually exclusive")
+        if self.intercepted and (self.replay_tail or self.replay_tail_more_body):
+            # An intercepted POST already short-circuited with 202; the
+            # dispatcher never wraps the receive with a replay, so any
+            # replay_tail would be silently swallowed.
+            raise ValueError("_BodyPeekResult: intercepted result must not carry replay_tail")
+        if self.too_large and not self.replay_tail:
+            raise ValueError("_BodyPeekResult: too_large result must carry the replay_tail (cap-busting chunk)")
+        if self.replay_tail_more_body and not self.replay_tail:
+            raise ValueError("_BodyPeekResult: replay_tail_more_body=True requires a non-empty replay_tail")
+
+
+async def _drain_request_body(receive: Receive) -> _BodyPeekResult:
+    """Drain ASGI request events into a body buffer with a soft peek cap.
+
+    Cap (``settings.mcp_body_peek_max_bytes``) bounds the memory the
+    body-peek path holds while inspecting. When the buffered prefix
+    reaches the cap we stop reading, return what we have with
+    ``too_large=True``, and let the caller fall through to the SDK via a
+    replay-and-defer wrapper. The SDK's normal streaming receive then
+    drains the rest of the body — no traffic is dropped, interception is
+    just skipped for that one request. This matters for legitimate large
+    payloads such as ``sampling/createMessage`` model output, which can
+    exceed the cap and would otherwise be lost if we 413'd.
+
+    ASGI transport-level errors (``anyio.EndOfStream``,
+    ``ClosedResourceError``, ``OSError``) are translated to
+    ``disconnected=True`` so the body-peek path stays transparent to
+    the SDK fallback. Without this translation a transport hiccup
+    here would surface as a 500 from the gateway instead of the
+    SDK's normal disconnect handling.
+    """
+    cap = settings.mcp_body_peek_max_bytes
+    body = bytearray()
+    try:
+        while True:
+            message = await receive()
+            if message.get("type") != "http.request":
+                return _BodyPeekResult(body=None, intercepted=False, disconnected=True)
+            chunk = message.get("body", b"")
+            chunk_is_final = not message.get("more_body", False)
+            if len(body) + len(chunk) > cap:
+                # Soft cap: stop peeking, hand the prefix back so the
+                # caller can replay-and-defer to the SDK. Don't 413 —
+                # legitimate sampling responses can exceed the cap.
+                #
+                # Pass the cap-busting chunk through verbatim instead
+                # of slicing it into ``body`` and a remainder. Slicing
+                # would copy the whole chunk into two new bytes objects,
+                # duplicating it in memory — the very amplification the
+                # cap is meant to prevent. With the no-slice design the
+                # peak footprint stays at ``len(body) + chunk`` bytes
+                # (the chunk reference uvicorn already allocated, plus
+                # whatever we'd buffered before it).
+                return _BodyPeekResult(
+                    body=bytes(body),
+                    intercepted=False,
+                    too_large=True,
+                    replay_tail=chunk,
+                    replay_tail_more_body=not chunk_is_final,
+                )
+            body.extend(chunk)
+            if chunk_is_final:
+                return _BodyPeekResult(body=bytes(body), intercepted=False)
+    except (anyio.EndOfStream, anyio.ClosedResourceError, OSError) as exc:
+        logger.debug("body-peek receive() aborted: %s", exc)
+        return _BodyPeekResult(body=None, intercepted=False, disconnected=True)
+
+
+async def _maybe_intercept_response_post(
+    *,
+    receive: Receive,
+    mcp_session_id: str,
+    notification_service: Any,
+) -> _BodyPeekResult:
+    """Drain the POST body and try to route it to a held server-initiated request.
+
+    Args:
+        receive: ASGI receive callable for the in-flight POST.
+        mcp_session_id: Validated downstream session id.
+        notification_service: Live ``NotificationService`` singleton; the
+            holder of the per-session pending-request dict.
+
+    Returns:
+        ``_BodyPeekResult``. ``intercepted=True`` when a held responder
+        was matched and resolved (caller should respond 202).
+        ``disconnected=True`` when the client dropped mid-body (caller
+        should NOT replay; the SDK's disconnect handling will fire on
+        its own first ``receive()``).
+    """
+    drained = await _drain_request_body(receive)
+    if drained.disconnected or drained.body is None:
+        return drained
+    if drained.too_large:
+        # Prefix-only body — can't parse for interception. Pass the
+        # drained result through so the dispatch falls through to the
+        # SDK with replay-and-defer (preserving too_large).
+        return drained
+    body = drained.body
+    try:
+        payload = orjson.loads(body)
+    except orjson.JSONDecodeError:
+        return _BodyPeekResult(body=body, intercepted=False)
+    # Single-message JSON-RPC response (the spec allows batches; for v1 we
+    # only intercept the single-message shape — batches fall through).
+    if not isinstance(payload, dict):
+        return _BodyPeekResult(body=body, intercepted=False)
+    if "method" in payload or "id" not in payload:
+        return _BodyPeekResult(body=body, intercepted=False)
+    if "result" not in payload and "error" not in payload:
+        return _BodyPeekResult(body=body, intercepted=False)
+    request_id = str(payload["id"])
+    handled = await notification_service.complete_request(mcp_session_id, request_id, payload)
+    return _BodyPeekResult(body=body, intercepted=handled)
+
+
+async def _maybe_short_circuit_notification(receive: Receive) -> _BodyPeekResult:
+    """Drain a POST body and detect a JSON-RPC notification (no ``id`` field).
+
+    Spec: a notification is fire-and-forget — the server MUST NOT return
+    a JSON-RPC response body. Per the Streamable HTTP spec the prescribed
+    HTTP-level acknowledgment is ``202 Accepted`` with an empty body,
+    which is what the caller emits when we return ``intercepted=True``.
+    Anything else (a request with an ``id``, a malformed body, or
+    anything we can't parse) returns ``intercepted=False`` and the
+    caller should replay the body to the SDK for normal handling.
+
+    Returns ``disconnected=True`` when the client dropped mid-body so the
+    caller can avoid feeding the SDK a truncated payload.
+    """
+    drained = await _drain_request_body(receive)
+    if drained.disconnected or drained.body is None:
+        return drained
+    if drained.too_large:
+        # Prefix-only body — can't parse for short-circuit. Pass the
+        # drained result through so the dispatch falls through to the
+        # SDK with replay-and-defer (preserving too_large).
+        return drained
+    body = drained.body
+    try:
+        payload = orjson.loads(body)
+    except orjson.JSONDecodeError:
+        return _BodyPeekResult(body=body, intercepted=False)
+    # Only short-circuit single-message notifications. A batch or anything
+    # without a ``method`` falls through to the SDK.
+    if not isinstance(payload, dict):
+        return _BodyPeekResult(body=body, intercepted=False)
+    if "method" not in payload or "id" in payload:
+        return _BodyPeekResult(body=body, intercepted=False)
+    return _BodyPeekResult(body=body, intercepted=True)
+
+
+def _make_replay_receive(
+    body: bytes,
+    downstream_receive: Receive,
+    *,
+    replay_tail: bytes = b"",
+    replay_tail_more_body: bool = False,
+) -> Receive:
+    """Return an ASGI receive that yields ``body`` once, then defers to ``downstream_receive``.
+
+    Used after we have peeked at a POST body for response interception but
+    decided not to short-circuit — the SDK still needs to see the body, so
+    we replay it before relinquishing receive duty back to the original
+    callable for any subsequent disconnect signals.
+
+    When the peek truncated at the cap, ``replay_tail`` holds the chunk
+    bytes we consumed but did not store in ``body``; the replay yields
+    them as a second ASGI message before deferring. ``replay_tail_more_body``
+    indicates whether more chunks still need draining from
+    ``downstream_receive`` after the tail. Without this, truncating the
+    peek would silently drop the unstored chunk bytes from the SDK's
+    view of the body.
+
+    Args:
+        body: Buffered request body (≤ peek cap).
+        downstream_receive: The original ASGI receive callable to fall back
+            to once the buffered messages have been replayed.
+        replay_tail: Chunk bytes consumed from receive but not stored in
+            ``body`` (over-cap remainder). Empty when no truncation.
+        replay_tail_more_body: ``True`` when ``downstream_receive`` still
+            has further chunks to deliver after the tail; the SDK then
+            keeps calling ``receive()`` to drain them.
+    """
+    pending: list[Dict[str, Any]] = [{"type": "http.request", "body": body, "more_body": bool(replay_tail) or replay_tail_more_body}]
+    if replay_tail:
+        pending.append({"type": "http.request", "body": replay_tail, "more_body": replay_tail_more_body})
+    queue = iter(pending)
+
+    async def replay_receive() -> Dict[str, Any]:
+        """Yield the buffered prefix (and tail if any), then defer to original receive."""
+        try:
+            return next(queue)
+        except StopIteration:
+            return await downstream_receive()
+
+    return replay_receive
+
+
+# Lazy-populated on first request to avoid the import cycle at module
+# load time; caches the MODULE rather than the function so
+# ``monkeypatch.setattr(module, "get_notification_service", ...)`` in
+# tests still takes effect (the per-call attribute lookup on the
+# cached module sees the patched value).
+_notification_service_module: Optional[Any] = None
+
+
+def _get_notification_service() -> Any:
+    """Return the current ``notification_service.get_notification_service()`` result.
+
+    The first call imports the module (resolving the cycle that makes a
+    top-level import unsafe); subsequent calls re-read the module
+    attribute so test monkeypatching continues to work.
+    """
+    global _notification_service_module  # pylint: disable=global-statement
+    if _notification_service_module is None:
+        # First-Party
+        import mcpgateway.services.notification_service as ns_module  # pylint: disable=import-outside-toplevel
+
+        _notification_service_module = ns_module
+    return _notification_service_module.get_notification_service()
+
+
+def _resolve_intercept_target(method: str, mcp_session_id: str) -> Optional[Any]:
+    """Return the NotificationService when response interception should run, else None.
+
+    Response interception applies only to POST requests with a session
+    id where the service has at least one pending server-initiated
+    request. The service's "not initialized" RuntimeError is treated as
+    "no interception" (test bootstrap / early startup); other
+    exceptions are intentionally not caught — a narrow catch keeps
+    bugs in ``has_pending_request`` from silently disabling interception
+    for every in-flight responder.
+
+    Args:
+        method: HTTP method.
+        mcp_session_id: ``"not-provided"`` when no Mcp-Session-Id header
+            was present, else the validated session id.
+
+    Returns:
+        The ``NotificationService`` instance to pass into
+        ``_maybe_intercept_response_post``, or ``None`` to skip
+        interception entirely.
+    """
+    if method != "POST" or mcp_session_id == "not-provided":
+        return None
+    try:
+        svc = _get_notification_service()
+    except RuntimeError:
+        return None
+    if svc.has_pending_request(mcp_session_id):
+        return svc
+    return None
+
+
+class _PeekDispatchOutcome(Enum):
+    """Outcome of dispatching a body-peek result back into the request loop."""
+
+    HANDLED = "handled"
+    """Helper sent the 202 response; caller should ``return``."""
+    ABORTED = "aborted"
+    """Client disconnected mid-body; caller should ``return`` without further action."""
+    FALLTHROUGH = "fallthrough"
+    """Caller should continue with the (possibly replay-wrapped) ``receive`` callable."""
+
+
+async def _dispatch_peek_outcome(
+    peek: "_BodyPeekResult",
+    receive: Receive,
+    send: Send,
+    *,
+    accepted_body: bytes,
+    log_label: str,
+    log_context: str,
+) -> tuple[_PeekDispatchOutcome, Receive]:
+    """Translate a ``_BodyPeekResult`` into the next action for ``handle_streamable_http``.
+
+    Both the response-interception and notification-short-circuit paths
+    follow the same shape:
+
+    * ``intercepted`` → emit 202 + return
+    * ``disconnected`` → log + return
+    * ``too_large`` → log and fall through
+    * otherwise → wrap ``receive`` with the replay receive
+
+    Args:
+        peek: Result of the body-peek call.
+        receive: Original ASGI receive callable.
+        send: ASGI send callable used to emit the 202 response.
+        accepted_body: Body bytes for the 202 response (``b"{}"`` for
+            response interception, ``b""`` for notification
+            short-circuit).
+        log_label: Short identifier for the path emitting the log
+            (e.g. ``"response interception"`` or
+            ``"notification short-circuit"``).
+        log_context: Per-request identifier used in log lines (session
+            id, path, etc.).
+
+    Returns:
+        ``(outcome, receive)`` — the second value is meaningful only for
+        ``FALLTHROUGH`` and is the (possibly replay-wrapped) callable
+        the caller should pass to the SDK.
+
+    Raises:
+        RuntimeError: If the peek result violates the invariant that
+            ``body`` is non-None on the fall-through path. The
+            ``_BodyPeekResult.__post_init__`` validator should make this
+            unreachable; the explicit raise replaces the prior
+            ``assert`` so the check survives ``python -O``.
+    """
+    if peek.intercepted:
+        await send({"type": "http.response.start", "status": 202, "headers": [(b"content-type", b"application/json")]})
+        await send({"type": "http.response.body", "body": accepted_body})
+        return _PeekDispatchOutcome.HANDLED, receive
+    if peek.disconnected:
+        # Client dropped mid-body. Don't feed the SDK a truncated payload —
+        # let it observe the disconnect on its own next ``receive()`` call.
+        logger.debug("POST %s aborted by client mid-body (%s); not replaying", log_context, log_label)
+        return _PeekDispatchOutcome.ABORTED, receive
+    if peek.too_large:
+        # Body exceeded the peek cap. Skip interception and fall through to
+        # the SDK with a replay-and-defer wrapper — valid MCP traffic isn't
+        # dropped; only this one request misses interception.
+        logger.debug("POST %s body exceeds peek cap during %s; falling through to SDK", log_context, log_label)
+    if peek.body is None:  # type-narrow for mypy; invariant rules this out
+        raise RuntimeError("_BodyPeekResult invariant violation: body=None on fall-through")
+    new_receive = _make_replay_receive(
+        peek.body,
+        receive,
+        replay_tail=peek.replay_tail,
+        replay_tail_more_body=peek.replay_tail_more_body,
+    )
+    return _PeekDispatchOutcome.FALLTHROUGH, new_receive
+
+
+# ----------------------------- GET /mcp stream -----------------------------
+#
+# ADR-052: spec-conformant server→client SSE stream. Any node accepts the GET
+# (no affinity check); messages are delivered via the per-session event bus
+# which fans out across nodes when running on Redis. The single-listener
+# invariant is enforced via SessionAffinity.claim_listener.
+
+# How many heartbeats per TTL — gives us "lose at most TTL/N before
+# expiring" margin. 3 means a single missed beat is recoverable on the
+# next attempt without losing the claim. Floor of 1s prevents
+# pathological busy-looping if an operator sets the TTL very low.
+_GET_STREAM_HEARTBEAT_INTERVALS_PER_TTL = 3
+_GET_STREAM_HEARTBEAT_MIN_INTERVAL_SECONDS = 1.0
+
+
+def _heartbeat_interval_seconds() -> float:
+    """Derive the heartbeat refresh cadence from the configured listener TTL.
+
+    Returns ``ttl / _GET_STREAM_HEARTBEAT_INTERVALS_PER_TTL``, floored
+    at ``_GET_STREAM_HEARTBEAT_MIN_INTERVAL_SECONDS``. Deriving from
+    the TTL means an operator-configured TTL value lower than the
+    minimum interval still produces a sane cadence; a hard-coded
+    cadence would let the claim TTL expire before the next heartbeat
+    fired.
+    """
+    ttl = float(settings.mcp_get_stream_listener_ttl_seconds)
+    return max(_GET_STREAM_HEARTBEAT_MIN_INTERVAL_SECONDS, ttl / _GET_STREAM_HEARTBEAT_INTERVALS_PER_TTL)
+
+
+# How many consecutive heartbeat failures we tolerate before treating
+# the claim as lost. N=2 rides out one transient Redis hiccup at
+# heartbeat time without tearing down an otherwise-healthy stream.
+# Stays well under the TTL: with the default 30s TTL and ~10s heartbeat
+# cadence, 2 misses = 20s, comfortably below 30s.
+_GET_STREAM_HEARTBEAT_FAILURE_TOLERANCE = 2
+
+# Metric label used when the JSON-RPC method on the wire isn't a string —
+# defensive guard against malformed envelopes that nonetheless deliver.
+_UNKNOWN_METHOD_LABEL = "unknown"
+
+# Allowlist of MCP method labels that the events-delivered counter is
+# allowed to emit. Anything outside this set buckets to ``other``. The
+# method name comes from upstream JSON-RPC traffic, so an unbucketed
+# label would let a buggy or malicious upstream server explode
+# Prometheus cardinality and exhaust scrape memory. Keep this list
+# narrow — add new entries when a real MCP method graduates from
+# ``other`` and you want a dedicated bucket.
+_KNOWN_MCP_METHOD_LABELS: frozenset[str] = frozenset(
+    {
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/progress",
+        "notifications/message",
+        "notifications/tools/list_changed",
+        "notifications/resources/list_changed",
+        "notifications/resources/updated",
+        "notifications/prompts/list_changed",
+        "notifications/roots/list_changed",
+        "sampling/createMessage",
+        "elicitation/create",
+        "roots/list",
+        "logging/setLevel",
+        "ping",
+    }
+)
+_OTHER_METHOD_LABEL = "other"
+
+
+def _accepts_event_stream(accept_header: str) -> bool:
+    """Return True iff the Accept header allows ``text/event-stream``.
+
+    Case-insensitive media-type match, honours ``;q=0`` as
+    "explicitly not wanted", and treats an empty / missing header as
+    permissive (curl-style clients). Per RFC 7231 §5.3.2 — substring
+    matching gets both edge cases wrong: ``Text/Event-Stream`` rejected
+    and ``Accept: text/event-stream;q=0`` accepted.
+    """
+    if not accept_header:
+        return True  # absence of preference → no restriction
+    for entry in accept_header.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        media_type, _, params = entry.partition(";")
+        media_type = media_type.strip().lower()
+        if media_type not in ("text/event-stream", "text/*", "*/*"):
+            continue
+        # q-value defaults to 1.0; 0 means explicit refusal.
+        q_value = 1.0
+        for param in params.split(";"):
+            name, _, value = param.partition("=")
+            if name.strip().lower() == "q":
+                try:
+                    q_value = float(value.strip())
+                except ValueError:
+                    q_value = 0.0
+                break
+        if q_value > 0:
+            return True
+    return False
+
+
+def _bucket_method_label(method: Optional[str]) -> str:
+    """Map an MCP method name to a bounded Prometheus label value."""
+    if not isinstance(method, str) or not method:
+        return _UNKNOWN_METHOD_LABEL
+    if method in _KNOWN_MCP_METHOD_LABELS:
+        return method
+    return _OTHER_METHOD_LABEL
+
+
+async def _handle_get_stream(
+    *,
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    mcp_session_id: str,
+    last_event_id: Optional[str],
+    accept: str,
+) -> None:
+    """Serve a GET /mcp SSE stream for ``mcp_session_id``.
+
+    Negotiates the listener claim, opens an :class:`EventSourceResponse`
+    backed by the :class:`ServerEventBus`, and refreshes the claim while
+    the connection is held.
+
+    Args:
+        scope: ASGI scope for the inbound GET request.
+        receive: ASGI receive callable.
+        send: ASGI send callable.
+        mcp_session_id: Validated downstream session id from
+            ``Mcp-Session-Id``.
+        last_event_id: Value of the ``Last-Event-Id`` header, or None.
+        accept: Value of the ``Accept`` header (used for content negotiation).
+
+    Notes:
+        Per the MCP spec, GET requires ``Accept: text/event-stream``. We
+        return 406 if the client did not accept it; 409 if another
+        listener already holds the claim for this session; and 503 in
+        any of three cases — ``SessionAffinity`` singleton missing,
+        ``ListenerClaimResult.UNAVAILABLE`` (claim-storage backend
+        failed), or ``get_server_event_bus()`` raised. All three 503
+        paths share the same ``bus_unavailable`` label on
+        ``transport_get_rejected_total``; separating them would
+        require distinct outcome labels, filed as a potential
+        follow-up if operators need to split.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        ListenerClaimResult,
+        SessionAffinityNotInitializedError,
+        get_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        BusBackendError,
+        ListenerBacklogOverflow,
+        get_server_event_bus,
+    )
+
+    # Third-Party
+    from sse_starlette.sse import EventSourceResponse  # pylint: disable=import-outside-toplevel
+
+    if not _accepts_event_stream(accept):
+        transport_get_rejected_counter.labels(outcome="not_acceptable").inc()
+        await ORJSONResponse(
+            {"detail": "GET /mcp requires Accept: text/event-stream"},
+            status_code=406,
+        )(scope, receive, send)
+        return
+
+    # Resolve the process-wide SessionAffinity singleton. ADR-052: the
+    # listener-claim dict lives on the singleton regardless of whether
+    # cross-worker Redis affinity is enabled, so ``main.lifespan``
+    # always initializes it. A transient-fallback singleton would
+    # break the single-listener invariant: each request would get a
+    # fresh instance with its own dict, so two GETs on the same
+    # session both win the claim.
+    try:
+        affinity = get_session_affinity()
+    except SessionAffinityNotInitializedError:
+        # Early-boot / test-bootstrap race. Fail closed with 503 — we
+        # cannot enforce the invariant without the singleton, and in any
+        # real deployment lifespan initializes the service before the
+        # HTTP listener accepts traffic.
+        logger.warning("GET /mcp: SessionAffinity not initialized; returning 503")
+        transport_get_rejected_counter.labels(outcome="bus_unavailable").inc()
+        await ORJSONResponse(
+            {"detail": "Session affinity service not initialized; retry shortly."},
+            status_code=503,
+            headers={"Retry-After": "1"},
+        )(scope, receive, send)
+        return
+
+    connection_id = str(uuid4())
+    claim_result = await affinity.claim_listener(mcp_session_id, connection_id)
+    # match + assert_never makes the consumer exhaustive: a future
+    # ListenerClaimResult variant added without updating this branch
+    # is a type-checker error rather than a silent fall-through.
+    match claim_result:
+        case ListenerClaimResult.CONFLICT:
+            transport_get_rejected_counter.labels(outcome="listener_conflict").inc()
+            await ORJSONResponse(
+                {"detail": "Another GET /mcp stream is already open for this session."},
+                status_code=409,
+                headers={"Retry-After": "1"},
+            )(scope, receive, send)
+            return
+        case ListenerClaimResult.UNAVAILABLE:
+            # Distinct from CONFLICT: storage backing the claim failed
+            # (Redis unreachable, configured-but-no-client, eval errored).
+            # 503 lets operators distinguish backend outage from real
+            # listener races.
+            transport_get_rejected_counter.labels(outcome="bus_unavailable").inc()
+            await ORJSONResponse(
+                {"detail": "Listener-claim storage unavailable; retry shortly."},
+                status_code=503,
+                headers={"Retry-After": "1"},
+            )(scope, receive, send)
+            return
+        case ListenerClaimResult.WON:
+            pass  # fall through into the SSE stream setup below
+        case _ as _unreachable:
+            assert_never(_unreachable)
+
+    # The finally block below runs three independent cleanups: release
+    # the listener claim (always safe — release_listener is a no-op for
+    # non-owners), decrement the gauge (guarded by
+    # ``gauge_incremented`` so we only dec what we inc'd), and log the
+    # missing-response case. Each step has its own try/except so one
+    # failure doesn't skip the others.
+    bus = None
+    heartbeat_task: Optional[asyncio.Task[None]] = None
+    cancel_stream_event = asyncio.Event()
+    response_invoked = False
+    gauge_incremented = False
+    try:
+        transport_get_active_listeners_gauge.inc()
+        gauge_incremented = True
+        try:
+            bus = await get_server_event_bus()
+        except (RuntimeError, BusBackendError) as exc:
+            # Configured-but-unavailable backends raise these; broader
+            # exceptions (programming errors, misconfiguration) propagate
+            # to the outer except so the failure has a real traceback in
+            # the log instead of being smuggled into a 503.
+            logger.warning("GET /mcp: event bus unavailable for session %s: %s", mcp_session_id, exc)
+            transport_get_rejected_counter.labels(outcome="bus_unavailable").inc()
+            await ORJSONResponse(
+                {"detail": "Event bus unavailable; retry shortly."},
+                status_code=503,
+                headers={"Retry-After": "1"},
+            )(scope, receive, send)
+            return
+
+        heartbeat_interval = _heartbeat_interval_seconds()
+        consecutive_failures = 0
+
+        async def heartbeat_loop() -> None:
+            """Refresh the listener claim periodically; signal the event generator to close on loss.
+
+            Tolerates ``_GET_STREAM_HEARTBEAT_FAILURE_TOLERANCE``
+            consecutive failures before treating the claim as lost. Without
+            this, a single Redis hiccup at heartbeat time would tear down
+            the stream even though the Redis-side TTL hadn't actually
+            expired — letting an attacker who can perturb Redis disconnect
+            active streams on demand.
+            """
+            nonlocal consecutive_failures
+            while True:
+                await asyncio.sleep(heartbeat_interval)
+                still_ours = await affinity.heartbeat_listener(mcp_session_id, connection_id)
+                if still_ours:
+                    consecutive_failures = 0
+                    continue
+                consecutive_failures += 1
+                if consecutive_failures < _GET_STREAM_HEARTBEAT_FAILURE_TOLERANCE:
+                    logger.debug(
+                        "GET /mcp heartbeat for %s missed (%d/%d); will retry",
+                        mcp_session_id,
+                        consecutive_failures,
+                        _GET_STREAM_HEARTBEAT_FAILURE_TOLERANCE,
+                    )
+                    continue
+                # Lost the claim (preempted, TTL expired, or sustained
+                # heartbeat failure). The single-listener invariant says
+                # we must close THIS stream — otherwise a second GET that
+                # re-claims would coexist with us. Set the cancel event;
+                # event_gen exits and sse_starlette tears down the
+                # response.
+                logger.info(
+                    "GET /mcp listener claim for %s lost after %d consecutive heartbeat failures; ending stream",
+                    mcp_session_id,
+                    consecutive_failures,
+                )
+                cancel_stream_event.set()
+                return
+
+        heartbeat_task = asyncio.create_task(heartbeat_loop(), name=f"get-stream-heartbeat:{mcp_session_id[:8]}")
+
+        async def event_gen():
+            """Drain the event bus and yield SSE-shaped frames; signaled by ``cancel_stream_event`` on listener-claim loss."""
+            bus_iter = aiter(bus.subscribe(mcp_session_id, last_event_id=last_event_id))
+            try:
+                while True:
+                    next_event_task = asyncio.create_task(anext(bus_iter))
+                    cancel_wait_task = asyncio.create_task(cancel_stream_event.wait())
+                    try:
+                        done, _pending = await asyncio.wait(
+                            {next_event_task, cancel_wait_task},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                    finally:
+                        if not next_event_task.done():
+                            next_event_task.cancel()
+                        if not cancel_wait_task.done():
+                            cancel_wait_task.cancel()
+                    if cancel_wait_task in done:
+                        return
+                    try:
+                        event = next_event_task.result()
+                    except StopAsyncIteration:
+                        return
+                    root = getattr(event.message, "root", None)
+                    method_attr = getattr(root, "method", None) if root is not None else None
+                    transport_get_events_delivered_counter.labels(method=_bucket_method_label(method_attr)).inc()
+                    yield {
+                        "id": event.event_id,
+                        "event": "message",
+                        "data": event.message.model_dump_json(by_alias=True, exclude_none=True),
+                    }
+            except ListenerBacklogOverflow:
+                logger.info(
+                    "GET /mcp listener for %s dropped: backlog overflow (client should reconnect with Last-Event-Id)",
+                    mcp_session_id,
+                )
+            except BusBackendError as exc:
+                logger.warning(
+                    "GET /mcp listener for %s dropped: bus backend error: %s",
+                    mcp_session_id,
+                    exc,
+                )
+            except Exception as exc:  # noqa: BLE001 — catch-all guards the SSE response; log with traceback (CancelledError is a BaseException and already propagates)
+                # The named branches above cover the documented bus
+                # failure modes; anything else is a programming error
+                # (label-cardinality bug, SDK shape change, etc.) and
+                # would silently terminate the stream every time
+                # without a traceback. ``exc_info`` preserves the stack
+                # so the cause survives in operator logs / Sentry.
+                logger.warning(
+                    "GET /mcp event generator for %s exited unexpectedly: %s",
+                    mcp_session_id,
+                    exc,
+                    exc_info=exc,
+                )
+            finally:
+                # Close the bus iterator so its own finally block runs
+                # immediately — that's what cancels the Pub/Sub pump task
+                # and aclose's the redis pubsub. Without this aclose, the
+                # bus generator only finalizes on GC, leaking the pubsub
+                # connection and pump task in the meantime.
+                try:
+                    await bus_iter.aclose()
+                except Exception as exc:  # noqa: BLE001 — best-effort, log so leaks are visible
+                    logger.debug("bus_iter.aclose raised for %s: %s", mcp_session_id, exc)
+
+        response = EventSourceResponse(
+            event_gen(),
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+        response_invoked = True
+        await response(scope, receive, send)
+    finally:
+        # Each cleanup step gets its own try/except so a failure in one
+        # doesn't skip the others. A single bare ``await
+        # release_listener`` would skip the gauge decrement on a Redis
+        # hiccup and let the gauge drift upward forever; in Redis mode
+        # the orphaned claim would also block subsequent GETs on that
+        # session until TTL expiry.
+        if heartbeat_task is not None:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # noqa: BLE001 — log so a regression in heartbeat_loop has a forensic trail
+                logger.warning(
+                    "Heartbeat task drain raised for %s during GET /mcp cleanup: %s",
+                    mcp_session_id,
+                    exc,
+                    exc_info=exc,
+                )
+        try:
+            await affinity.release_listener(mcp_session_id, connection_id)
+        except Exception as exc:  # noqa: BLE001 — log, don't skip the gauge dec below
+            logger.warning(
+                "release_listener raised for %s during GET /mcp cleanup: %s",
+                mcp_session_id,
+                exc,
+            )
+        if gauge_incremented:
+            try:
+                transport_get_active_listeners_gauge.dec()
+            except Exception as exc:  # noqa: BLE001 — Prometheus client failures shouldn't propagate
+                logger.debug("gauge.dec raised for %s: %s", mcp_session_id, exc)
+        if not response_invoked:
+            logger.debug(
+                "GET /mcp for %s exited before response was constructed",
+                mcp_session_id,
+            )
+
+
 class SessionManagerWrapper:
     """
     Wrapper class for managing the lifecycle of a StreamableHTTPSessionManager instance.
@@ -2873,7 +3689,9 @@ class SessionManagerWrapper:
 
         return None  # Legitimate unscoped /mcp path
 
-    async def handle_streamable_http(self, scope: Scope, receive: Receive, send: Send) -> None:
+    async def handle_streamable_http(  # noqa: PLR0911,PLR0912,PLR0915 — pylint: disable=too-many-return-statements,too-many-branches,too-many-statements,too-many-locals
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
         """
         Forwards an incoming ASGI request to the streamable HTTP session manager.
 
@@ -2988,47 +3806,85 @@ class SessionManagerWrapper:
         if validated is _REJECT:
             return
 
-        # #4205: Passive GET SSE stream fallback. The MCP spec allows servers
-        # to return 405 on GET when they cannot anchor a passive stream to a
-        # session. Two branches land here:
-        #   (a) stateful sessions disabled globally (no session infrastructure);
-        #   (b) no Mcp-Session-Id — the sentinel "not-provided" covers both a
-        #       missing header and an invalid id that the affinity check reset.
-        # Why 405 rather than 404/400: the `/mcp` path exists and the GET is
-        # syntactically valid; 405 + `Allow: POST, DELETE` tells the client the
-        # resource is real and which verbs it supports, which is exactly what
-        # the MCP Streamable HTTP spec (2025-03-26 rev.) sanctions here.
-        # Placed after server-id validation and RBAC so bogus server IDs still
-        # 404 and unauthorized callers still 403 before we advertise the
-        # endpoint via the Allow header.
-        if method == "GET" and (not settings.use_stateful_sessions or mcp_session_id == "not-provided"):
+        # GET /mcp: server→client stream per MCP Streamable HTTP spec
+        # ("Listening for messages from the server"). Three short-circuit
+        # rejections live here, then the spec-conformant SSE handler takes
+        # over (ADR-052).
+        #
+        # Rejections preserved from the #4205 era:
+        #   * stateful sessions disabled globally → 405
+        #     (no event-store infrastructure to anchor a stream against)
+        #   * no Mcp-Session-Id → 405
+        #     (the spec requires a session for the GET stream)
+        # Plus one operator kill switch:
+        #   * mcp_get_stream_enabled=False → 405 (deliberate disable)
+        #
+        # All emit `Allow: POST, DELETE` so the client knows the resource is
+        # real. Placed after server-id validation and RBAC so bogus server
+        # IDs still 404 and unauthorized callers still 403 before we
+        # advertise the endpoint.
+        if method == "GET" and (not settings.use_stateful_sessions or not settings.mcp_get_stream_enabled or mcp_session_id == "not-provided"):
             if not settings.use_stateful_sessions:
                 detail = "Stateful sessions disabled on this gateway; passive SSE stream is not available."
                 reject_outcome = "stateful_disabled"
+            elif not settings.mcp_get_stream_enabled:
+                detail = "GET /mcp stream disabled by operator (MCP_GET_STREAM_ENABLED=False)."
+                reject_outcome = "feature_disabled"
             else:
                 detail = "Passive SSE stream requires an Mcp-Session-Id from a prior initialize."
                 reject_outcome = "no_session_id"
             transport_get_rejected_counter.labels(outcome=reject_outcome).inc()
-            # Log level split by reason: stateful-disabled is an operator-facing
-            # config condition (warn); missing session id is routine probing
-            # from strict MCP clients before `initialize` and would flood
-            # info-level logs (debug).
+            # Log level split by reason: stateful-disabled and feature-disabled
+            # are operator-facing config conditions (warn); missing session id
+            # is routine probing from strict MCP clients before `initialize`
+            # and would flood info-level logs (debug).
             if reject_outcome == "stateful_disabled":
-                logger.warning(
-                    "Rejecting GET %s with 405 — stateful sessions disabled",
-                    path,
-                )
+                logger.warning("Rejecting GET %s with 405 — stateful sessions disabled", path)
+            elif reject_outcome == "feature_disabled":
+                logger.warning("Rejecting GET %s with 405 — GET stream feature disabled (mcp_get_stream_enabled=False)", path)
             else:
-                logger.debug(
-                    "Rejecting GET %s with 405 — no session id presented",
-                    path,
-                )
+                logger.debug("Rejecting GET %s with 405 — no session id presented", path)
             response = ORJSONResponse(
                 {"detail": detail},
                 status_code=405,
                 headers={"Allow": "POST, DELETE"},
             )
             await response(scope, receive, send)
+            return
+
+        # GET /mcp with a valid session — spec-conformant SSE stream.
+        if method == "GET":
+            # Gate on session ownership before opening the SSE channel.
+            # Without this, any authenticated caller who knows another
+            # user's Mcp-Session-Id can subscribe to that session's
+            # server-initiated traffic (notifications, sampling, progress
+            # events) — and can also pin the rightful owner out of the
+            # single-listener slot until TTL expiry. Mirrors the gate
+            # that POST and DELETE already apply downstream.
+            session_allowed, deny_status, deny_detail = await _validate_streamable_session_access(
+                mcp_session_id=mcp_session_id,
+                user_context=user_context,
+                rpc_method=None,
+            )
+            if not session_allowed:
+                transport_get_rejected_counter.labels(outcome="session_denied").inc()
+                logger.warning(
+                    "Rejecting GET %s with %s — session ownership check failed for %s",
+                    path,
+                    deny_status,
+                    mcp_session_id,
+                )
+                response = ORJSONResponse({"detail": deny_detail}, status_code=deny_status)
+                await response(scope, receive, send)
+                return
+            await _handle_get_stream(
+                scope=scope,
+                receive=receive,
+                send=send,
+                mcp_session_id=mcp_session_id,
+                last_event_id=headers.get("last-event-id"),
+                accept=headers.get("accept", ""),
+            )
             return
 
         if is_internally_forwarded:
@@ -3380,6 +4236,88 @@ class SessionManagerWrapper:
                         initialize_span_active = True
             return message
 
+        # ADR-052: server-initiated request response interception.
+        # When this session has any pending RequestResponder waiting for a
+        # downstream reply, peek at this POST body. If it's a JSON-RPC
+        # response whose id matches a pending entry, route it directly to
+        # NotificationService.complete_request and short-circuit the SDK.
+        # Otherwise replay the buffered body to the SDK transparently.
+        # Only triggered when there's at least one pending request — the
+        # common case (zero pending) takes the streaming-receive fast path.
+        _notif_svc = _resolve_intercept_target(method, mcp_session_id)
+        if _notif_svc is not None:
+            # Authorize the caller against the session BEFORE touching the
+            # body or matching the held responder. Without this, an
+            # authenticated user who knows the victim's ``Mcp-Session-Id``
+            # plus a pending JSON-RPC ``id`` could POST a forged response
+            # here and ``complete_request`` would accept it (202) — the
+            # SDK's normal POST validation runs only when interception
+            # falls through, so the bypass would never reach it.
+            session_allowed, deny_status, deny_detail = await _validate_streamable_session_access(
+                mcp_session_id=mcp_session_id,
+                user_context=user_context,
+                rpc_method=None,
+            )
+            if not session_allowed:
+                logger.warning(
+                    "POST %s denied by session-ownership check during interception (%s)",
+                    mcp_session_id,
+                    deny_status,
+                )
+                response = ORJSONResponse({"detail": deny_detail}, status_code=deny_status)
+                await response(scope, receive, send)
+                return
+            peek = await _maybe_intercept_response_post(
+                receive=receive,
+                mcp_session_id=mcp_session_id,
+                notification_service=_notif_svc,
+            )
+            outcome, receive = await _dispatch_peek_outcome(
+                peek,
+                receive,
+                send,
+                accepted_body=b"{}",
+                log_label="response interception",
+                log_context=mcp_session_id,
+            )
+            if outcome is not _PeekDispatchOutcome.FALLTHROUGH:
+                return
+
+        # Spec-mandated notification short-circuit. JSON-RPC 2.0 + MCP
+        # Streamable HTTP: a notification (a request without an ``id``) is
+        # fire-and-forget — the server MUST NOT respond to it, and the spec
+        # acknowledges receipt with 202 Accepted regardless of session state.
+        # The MCP SDK's ``_validate_session`` enforces session-id presence
+        # for *every* POST and 400s here, which violates the notification
+        # rule. We peek the body only when no session id was presented (the
+        # common notification case is the post-init `notifications/initialized`
+        # round trip) on an MCP path — POSTs with a session id keep the
+        # streaming-receive fast path; non-MCP paths are not ours to peek
+        # (and may legitimately have no body / non-JSON body). Single-message
+        # bodies only; batches fall through to the SDK in case it ever grows
+        # proper batch handling.
+        is_mcp_path = path == "/mcp" or path.endswith("/mcp") or _SERVER_SCOPED_PATH_RE.search(path) is not None
+        # Skip when the affinity-forwarded path has already consumed the
+        # receive (it reads the body itself for the /rpc forward and
+        # falls through to the SDK on failure). Re-reading would observe
+        # an http.disconnect from the now-exhausted original receive and
+        # short-circuit the SDK fallback that the trusted-internal flow
+        # depends on. Forwarded requests already carry an Mcp-Session-Id
+        # in production, but tests exercise the no-session forwarded path
+        # so the gate is needed.
+        if method == "POST" and mcp_session_id == "not-provided" and is_mcp_path and not is_internally_forwarded:
+            peek = await _maybe_short_circuit_notification(receive)
+            outcome, receive = await _dispatch_peek_outcome(
+                peek,
+                receive,
+                send,
+                accepted_body=b"",
+                log_label="notification short-circuit",
+                log_context=path,
+            )
+            if outcome is not _PeekDispatchOutcome.FALLTHROUGH:
+                return
+
         span_exit_exc: tuple[Any, Any, Any] = (None, None, None)
 
         try:
@@ -3396,22 +4334,34 @@ class SessionManagerWrapper:
                 captured_session_id,
                 mcp_session_id,
             )
-            if settings.mcpgateway_session_affinity_enabled and settings.use_stateful_sessions:
-                session_to_register: Optional[str] = None
-
-                # Only server-emitted session IDs (from successful initialize) can
-                # establish new ownership state for affinity.
+            # Two distinct writes happen here:
+            #
+            #   * Claim the *logical owner* in the shared session registry.
+            #     This is what `_validate_streamable_session_access` reads on
+            #     subsequent POST/DELETE/GET requests, so it MUST fire whether
+            #     or not multi-worker affinity is enabled — single-node
+            #     deployments still need ownership recorded for the GET-stream
+            #     gate to recognise the legitimate owner.
+            #
+            #   * Register the *worker-affinity* mapping. This only matters
+            #     when multi-worker affinity is on and stays gated.
+            session_to_register: Optional[str] = None
+            requester_email = user_context.get("email") if isinstance(user_context, dict) else None
+            if settings.use_stateful_sessions:
                 if captured_session_id:
                     session_to_register = captured_session_id
-
-                    requester_email = user_context.get("email") if isinstance(user_context, dict) else None
                     if requester_email:
                         effective_owner = await _claim_streamable_session_owner(captured_session_id, requester_email)
                         if effective_owner and effective_owner != requester_email and not bool(user_context.get("is_admin", False)):
-                            logger.warning("Session owner mismatch for %s... (requester=%s, owner=%s)", captured_session_id[:8], requester_email, effective_owner)
+                            logger.warning(
+                                "Session owner mismatch for %s... (requester=%s, owner=%s)",
+                                captured_session_id[:8],
+                                requester_email,
+                                effective_owner,
+                            )
                 elif mcp_session_id != "not-provided":
-                    # Existing client-provided IDs may only refresh affinity when they
-                    # are already bound to the caller's principal.
+                    # Existing client-provided IDs may only refresh ownership
+                    # when they are already bound to the caller's principal.
                     session_allowed, _deny_status, _deny_detail = await _validate_streamable_session_access(
                         mcp_session_id=mcp_session_id,
                         user_context=user_context,
@@ -3420,19 +4370,30 @@ class SessionManagerWrapper:
                     if session_allowed:
                         session_to_register = mcp_session_id
 
-                logger.debug("[HTTP_AFFINITY_DEBUG] session_to_register=%s", session_to_register)
-                if session_to_register:
-                    try:
-                        # First-Party - lazy import to avoid circular dependencies
-                        # First-Party
-                        from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
+            logger.debug(
+                "[HTTP_AFFINITY_DEBUG] affinity_enabled=%s stateful=%s captured=%s mcp_session_id=%s session_to_register=%s",
+                settings.mcpgateway_session_affinity_enabled,
+                settings.use_stateful_sessions,
+                captured_session_id,
+                mcp_session_id,
+                session_to_register,
+            )
+            if session_to_register and settings.mcpgateway_session_affinity_enabled:
+                try:
+                    # First-Party - lazy import to avoid circular dependencies
+                    # First-Party
+                    from mcpgateway.services.session_affinity import get_session_affinity, WORKER_ID  # pylint: disable=import-outside-toplevel
 
-                        pool = get_session_affinity()
-                        await pool.register_session_owner(session_to_register)
-                        logger.debug("[HTTP_AFFINITY_SDK] Worker %s | Session %s... | Registered ownership after SDK handling", WORKER_ID, session_to_register[:8])
-                    except Exception as e:
-                        logger.debug("[HTTP_AFFINITY_DEBUG] Exception during registration: %s", e)
-                        logger.warning("Failed to register session ownership: %s", e)
+                    pool = get_session_affinity()
+                    await pool.register_session_owner(session_to_register)
+                    logger.debug(
+                        "[HTTP_AFFINITY_SDK] Worker %s | Session %s... | Registered ownership after SDK handling",
+                        WORKER_ID,
+                        session_to_register[:8],
+                    )
+                except Exception as e:
+                    logger.debug("[HTTP_AFFINITY_DEBUG] Exception during registration: %s", e)
+                    logger.warning("Failed to register session ownership: %s", e)
 
         except anyio.ClosedResourceError:
             # Expected when client closes one side of the stream (normal lifecycle)

--- a/tests/unit/mcpgateway/services/test_notification_service.py
+++ b/tests/unit/mcpgateway/services/test_notification_service.py
@@ -158,9 +158,7 @@ class TestNotificationDispatch:
 
         await notification_service._handle_notification("gw-1", mock_notification)
 
-        notification_service._enqueue_refresh.assert_called_once_with(
-            "gw-1", NotificationType.TOOLS_LIST_CHANGED
-        )
+        notification_service._enqueue_refresh.assert_called_once_with("gw-1", NotificationType.TOOLS_LIST_CHANGED)
         assert notification_service._notifications_received == 1
 
     @pytest.mark.asyncio
@@ -175,9 +173,7 @@ class TestNotificationDispatch:
 
         await notification_service._handle_notification("gw-1", mock_notification)
 
-        notification_service._enqueue_refresh.assert_called_once_with(
-            "gw-1", NotificationType.RESOURCES_LIST_CHANGED
-        )
+        notification_service._enqueue_refresh.assert_called_once_with("gw-1", NotificationType.RESOURCES_LIST_CHANGED)
 
     @pytest.mark.asyncio
     async def test_handle_notification_prompts(self, notification_service):
@@ -191,9 +187,7 @@ class TestNotificationDispatch:
 
         await notification_service._handle_notification("gw-1", mock_notification)
 
-        notification_service._enqueue_refresh.assert_called_once_with(
-            "gw-1", NotificationType.PROMPTS_LIST_CHANGED
-        )
+        notification_service._enqueue_refresh.assert_called_once_with("gw-1", NotificationType.PROMPTS_LIST_CHANGED)
 
     @pytest.mark.asyncio
     async def test_handle_notification_unknown(self, notification_service):
@@ -229,7 +223,6 @@ class TestDebouncing:
         assert notification_service._notifications_debounced == 1
         assert notification_service._notifications_debounced == 1
         await notification_service.shutdown()
-
 
     @pytest.mark.asyncio
     async def test_enqueue_refresh_queue_full(self, notification_service):
@@ -318,9 +311,7 @@ class TestRefreshExecution:
     async def test_execute_refresh_with_gateway_service(self, notification_service):
         """Test refresh execution calls gateway service."""
         mock_gateway_service = AsyncMock()
-        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(
-            return_value={"success": True, "tools_added": 2, "tools_removed": 1}
-        )
+        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(return_value={"success": True, "tools_added": 2, "tools_removed": 1})
         # _get_refresh_lock is synchronous and returns an asyncio.Lock
         mock_gateway_service._get_refresh_lock = MagicMock(return_value=asyncio.Lock())
 
@@ -346,9 +337,7 @@ class TestRefreshExecution:
     async def test_execute_refresh_handles_failure(self, notification_service):
         """Test refresh execution handles failures gracefully."""
         mock_gateway_service = AsyncMock()
-        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(
-            side_effect=Exception("Connection failed")
-        )
+        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(side_effect=Exception("Connection failed"))
         # _get_refresh_lock is synchronous and returns an asyncio.Lock
         mock_gateway_service._get_refresh_lock = MagicMock(return_value=asyncio.Lock())
 
@@ -364,9 +353,7 @@ class TestRefreshExecution:
     async def test_execute_refresh_logical_failure(self, notification_service):
         """Test refresh execution handles logical failures (success=False)."""
         mock_gateway_service = AsyncMock()
-        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(
-            return_value={"success": False, "error": "Something went wrong"}
-        )
+        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(return_value={"success": False, "error": "Something went wrong"})
         # _get_refresh_lock is synchronous and returns an asyncio.Lock
         mock_gateway_service._get_refresh_lock = MagicMock(return_value=asyncio.Lock())
 
@@ -382,9 +369,7 @@ class TestRefreshExecution:
     async def test_execute_refresh_skips_when_lock_held(self, notification_service):
         """Test refresh execution skips when lock is already held."""
         mock_gateway_service = AsyncMock()
-        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(
-            return_value={"success": True}
-        )
+        mock_gateway_service._refresh_gateway_tools_resources_prompts = AsyncMock(return_value={"success": True})
         # Create a lock that's already held
         held_lock = asyncio.Lock()
         await held_lock.acquire()  # Lock is now held
@@ -491,12 +476,14 @@ class TestGlobalSingleton:
     def teardown_method(self):
         """Ensure global service is cleared."""
         import mcpgateway.services.notification_service as ns_module
+
         ns_module._notification_service = None
 
     def test_get_without_init_raises(self):
         """Test get_notification_service raises if not initialized."""
         # Ensure it's None first (teardown handles, but be safe)
         import mcpgateway.services.notification_service as ns_module
+
         ns_module._notification_service = None
 
         with pytest.raises(RuntimeError, match="not initialized"):
@@ -522,3 +509,1166 @@ class TestGlobalSingleton:
         # Should be cleared
         with pytest.raises(RuntimeError):
             get_notification_service()
+
+
+# --------------------------------------------------------------------------
+# Server-initiated request correlation (ADR-052)
+# --------------------------------------------------------------------------
+
+
+class TestServerInitiatedRequestCorrelation:
+    """Cover the message-handler ``RequestResponder`` path and ``complete_request``."""
+
+    @staticmethod
+    def _make_responder(request_id: str, method: str = "roots/list"):
+        """Build a fake ``RequestResponder`` with respond/cancel captured."""
+        # Third-Party
+        from mcp.shared.session import RequestResponder
+        from mcp.types import ListRootsRequest, ServerRequest
+
+        request = ServerRequest(ListRootsRequest(method=method, params=None))
+        responder = RequestResponder(
+            request_id=request_id,
+            request_meta=None,
+            request=request,
+            session=MagicMock(_send_response=MagicMock()),
+            on_complete=lambda r: None,
+        )
+        captured: dict[str, object] = {"responded": None, "cancelled": False}
+
+        async def captured_respond(payload):
+            captured["responded"] = payload
+            responder._completed = True
+
+        async def captured_cancel():
+            captured["cancelled"] = True
+            responder._completed = True
+
+        responder.respond = captured_respond
+        responder.cancel = captured_cancel
+        return responder, captured
+
+    @pytest.mark.asyncio
+    async def test_request_responder_published_and_response_round_trips(self, monkeypatch):
+        """End-to-end: message handler publishes the request; complete_request resolves the responder."""
+        # First-Party
+        from mcp.types import ClientResult
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-corr"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        bus = await get_server_event_bus()
+        received: list[object] = []
+
+        async def consume() -> None:
+            async for evt in bus.subscribe(sid):
+                received.append(evt)
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.05)
+
+        responder, captured = self._make_responder("req-1")
+        await handler(responder)
+
+        await asyncio.wait_for(consumer, timeout=2.0)
+        assert len(received) == 1
+        envelope = received[0].message.root  # type: ignore[union-attr]
+        assert envelope.method == "roots/list"
+        assert envelope.id == "req-1"
+
+        # Downstream POSTs the response — complete_request resolves the future.
+        assert svc.has_pending_request(sid) is True
+        completed = await svc.complete_request(sid, "req-1", {"jsonrpc": "2.0", "id": "req-1", "result": {"roots": []}})
+        assert completed is True
+
+        # Holder task converts the payload into a ClientResult.
+        await asyncio.sleep(0.1)
+        assert isinstance(captured["responded"], ClientResult)
+        assert svc.has_pending_request(sid) is False
+        await reset_server_event_bus()
+
+    @pytest.mark.asyncio
+    async def test_request_responder_times_out_and_cancels(self, monkeypatch):
+        """If no downstream response arrives within the TTL, the responder is cancelled."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        # Squeeze the timeout to make the test fast.
+        svc._pending_request_ttl_seconds = 0.1
+
+        sid = "sess-timeout"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        # Drain the published request so the bus is happy (no listener
+        # required for the test, but we attach one for cleanliness).
+        bus = await get_server_event_bus()
+
+        async def consume() -> None:
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.05)
+
+        responder, captured = self._make_responder("req-2")
+        await handler(responder)
+        await consumer
+
+        # Wait past TTL.
+        await asyncio.sleep(0.3)
+        assert captured["cancelled"] is True
+        assert svc.has_pending_request(sid) is False
+        await reset_server_event_bus()
+
+    @pytest.mark.asyncio
+    async def test_complete_request_returns_false_when_no_match(self):
+        """Unmatched ids fall through (so the POST handler hands off to the SDK)."""
+        # First-Party
+        from mcpgateway.services.notification_service import NotificationService
+
+        svc = NotificationService()
+        result = await svc.complete_request("sess-x", "missing-id", {"id": "missing-id", "result": {}})
+        assert result is False
+        assert svc.has_pending_request("sess-x") is False
+
+    @pytest.mark.asyncio
+    async def test_complete_request_after_holder_timeout_is_noop(self, monkeypatch):
+        """A late ``complete_request`` after the TTL fires must not double-resolve.
+
+        Race shape: holder times out, cancels responder, pops the pending
+        entry. The downstream client then POSTs back the long-overdue
+        response. The lookup must return False (no double-resolve, no
+        crash) so the POST handler falls back to the SDK.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        svc._pending_request_ttl_seconds = 0.05  # tight TTL for the race window
+
+        sid = "sess-late"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        bus = await get_server_event_bus()
+
+        async def consume() -> None:
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        responder, _captured = self._make_responder("req-late")
+        await handler(responder)
+        await consumer
+        # Wait past TTL — holder should have cancelled and dropped the entry.
+        await asyncio.sleep(0.2)
+        assert svc.has_pending_request(sid) is False
+        # Late POST: must return False, not crash and not re-resolve.
+        result = await svc.complete_request(sid, "req-late", {"id": "req-late", "result": {}})
+        assert result is False
+        await reset_server_event_bus()
+
+    @pytest.mark.asyncio
+    async def test_respond_with_payload_routes_error_envelope(self):
+        """Downstream-supplied ``error`` envelope is forwarded as-is via ``responder.respond``."""
+        # Third-Party
+        from mcp.types import ErrorData
+
+        responder, captured = self._make_responder("req-err")
+        with responder:
+            await NotificationService._respond_with_payload(
+                responder,
+                {"jsonrpc": "2.0", "id": "req-err", "error": {"code": -32000, "message": "downstream said no"}},
+            )
+        assert isinstance(captured["responded"], ErrorData)
+        assert captured["responded"].code == -32000
+
+    @pytest.mark.asyncio
+    async def test_respond_with_payload_falls_back_on_unparseable_result(self):
+        """Garbage in ``result`` becomes an INTERNAL_ERROR ErrorData, not a crash."""
+        # Third-Party
+        from mcp.types import ErrorData, INTERNAL_ERROR
+
+        responder, captured = self._make_responder("req-bad")
+        # ClientResult is a discriminated union; an empty dict won't validate
+        # against any member and triggers the fallback path.
+        with responder:
+            await NotificationService._respond_with_payload(
+                responder,
+                {"jsonrpc": "2.0", "id": "req-bad", "result": {"this": "matches no known result type"}},
+            )
+        # Either a ClientResult validated (very lenient discriminator) OR
+        # the fallback INTERNAL_ERROR path fired. Both are spec-acceptable;
+        # the contract this test pins is "the responder is always answered,
+        # never left hung".
+        assert captured["responded"] is not None
+        if isinstance(captured["responded"], ErrorData):
+            assert captured["responded"].code == INTERNAL_ERROR
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_pending_holder_tasks(self, monkeypatch):
+        """``shutdown()`` cancels in-flight holder tasks instead of leaking them past process death (ADR-052)."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        await svc.initialize()
+        sid = "sess-shutdown"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        # Drain bus so the request publish doesn't block.
+        bus = await get_server_event_bus()
+
+        async def consume() -> None:
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        responder, _captured = self._make_responder("req-pending")
+        await handler(responder)
+        await consumer
+        assert svc.has_pending_request(sid) is True
+        held_tasks = list(svc._pending_holder_tasks)
+        assert held_tasks, "holder task should be tracked"
+
+        await svc.shutdown()
+
+        # All holder tasks resolved (cancelled); pending dict cleared.
+        for task in held_tasks:
+            assert task.done()
+        assert svc.has_pending_request(sid) is False
+        await reset_server_event_bus()
+
+    @pytest.mark.asyncio
+    async def test_pending_request_id_collision_logs_warning_and_cancels_prior(self, monkeypatch, caplog):
+        """Upstream protocol violation: same request id reused mid-flight must log + cancel prior holder."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-collision"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        # Drain the bus so publishes don't block.
+        bus = await get_server_event_bus()
+        drained: list[object] = []
+
+        async def drain() -> None:
+            async for evt in bus.subscribe(sid):
+                drained.append(evt)
+                if len(drained) >= 2:
+                    break
+
+        consumer = asyncio.create_task(drain())
+        await asyncio.sleep(0.02)
+
+        # First responder for "req-X" lands the holder.
+        first_responder, first_captured = self._make_responder("req-X")
+        await handler(first_responder)
+        await asyncio.sleep(0.05)
+
+        # Second responder reusing the same id triggers the collision branch.
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            second_responder, _second_captured = self._make_responder("req-X")
+            await handler(second_responder)
+            await asyncio.sleep(0.05)
+        await consumer
+        await reset_server_event_bus()
+
+        # Prior responder must have been cancelled by the collision logic.
+        assert first_captured["cancelled"] is True
+        # Operator-visible warning fired.
+        assert "id collision" in caplog.text.lower() or "reused id" in caplog.text.lower()
+        # Pending entry now belongs to the second responder, not the first.
+        assert svc.has_pending_request(sid) is True
+
+        # Cleanup so subsequent tests don't see a hanging holder.
+        await svc.complete_request(sid, "req-X", {"jsonrpc": "2.0", "id": "req-X", "result": {"roots": []}})
+
+    @pytest.mark.asyncio
+    async def test_forward_notification_to_stream_publishes_typed_envelope(self, monkeypatch):
+        """ServerNotification fanout has its own envelope construction; regression guard."""
+        # First-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-notif"
+        bus = await get_server_event_bus()
+
+        received: list[object] = []
+
+        async def consume() -> None:
+            async for evt in bus.subscribe(sid):
+                received.append(evt)
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        await svc._forward_notification_to_stream(sid, notif)
+
+        await asyncio.wait_for(consumer, timeout=2.0)
+        await reset_server_event_bus()
+
+        assert len(received) == 1
+        envelope = received[0].message.root  # type: ignore[union-attr]
+        assert envelope.method == "notifications/tools/list_changed"
+
+    @pytest.mark.asyncio
+    async def test_forward_request_publish_backend_unavailable_classifies_and_cancels(self, monkeypatch):
+        """BusBackendError from bus.publish → ``backend_unavailable`` label + holder future cancelled."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import BusBackendError
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+        sid = "sess-publish-fail-backend"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        # Stub the bus to raise BusBackendError on publish.
+        class BrokenBus:
+            async def publish(self, _sid, _msg):
+                raise BusBackendError("redis down")
+
+        async def _bus():
+            return BrokenBus()
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        # Capture counter increments before / after.
+        # First-Party
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+
+        before = server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get()
+        responder, _captured = self._make_responder("req-pub-fail")
+        await handler(responder)
+        await asyncio.sleep(0.05)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get() == before + 1
+        # Holder future was cancelled; pending dict cleared.
+        assert svc.has_pending_request(sid) is False
+
+    @pytest.mark.asyncio
+    async def test_forward_request_publish_transport_error_classifies_with_traceback(self, monkeypatch, caplog):
+        """ConnectionError from bus.publish → ``transport_error`` label + error-level log with traceback."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+        sid = "sess-publish-fail-transport"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        class BrokenBus:
+            async def publish(self, _sid, _msg):
+                raise ConnectionError("broken pipe")
+
+        async def _bus():
+            return BrokenBus()
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        # First-Party
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+
+        before = server_event_bus_publish_failed_counter.labels(reason="transport_error")._value.get()
+        responder, _captured = self._make_responder("req-pub-transport")
+        with caplog.at_level("ERROR", logger="mcpgateway.services.notification_service"):
+            await handler(responder)
+            await asyncio.sleep(0.05)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="transport_error")._value.get() == before + 1
+        assert "transport_error" in caplog.text
+        assert svc.has_pending_request(sid) is False
+
+    @pytest.mark.asyncio
+    async def test_shutdown_logs_warning_when_holder_drain_times_out(self, monkeypatch, caplog):
+        """If a holder task ignores cancellation, shutdown must bound itself + log the abandonment.
+
+        The bounded ``asyncio.wait_for`` is the only guard against a
+        ``responder.__exit__`` that hangs forever — without it, a
+        broken upstream session could pin shutdown indefinitely.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import reset_server_event_bus
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        # Squeeze the timeout so the test doesn't wait the default 5s.
+        svc._shutdown_drain_timeout_seconds = 0.1
+
+        # Holder that swallows cancellation and waits on an unsettable event,
+        # forcing the bounded wait_for to TimeoutError.
+        never_set = asyncio.Event()
+
+        async def _swallows_cancel():
+            try:
+                await never_set.wait()
+            except asyncio.CancelledError:
+                # Wait again on the unsettable event so the task doesn't terminate.
+                # This shields the task from the first cancel; shutdown won't
+                # call cancel a second time.
+                await never_set.wait()
+
+        task = asyncio.create_task(_swallows_cancel(), name="hung-holder")
+        svc._pending_holder_tasks.add(task)
+        # Yield once so the task starts and reaches its first await.
+        await asyncio.sleep(0)
+
+        try:
+            with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+                await svc.shutdown()
+        finally:
+            never_set.set()
+            try:
+                await asyncio.wait_for(task, timeout=0.2)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+        assert "did not drain" in caplog.text
+        assert "abandoning" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Additional edge-case coverage (ADR-052 error branches)
+# --------------------------------------------------------------------------
+
+
+class TestRecordPublishFailure:
+    """Cover ``_record_publish_failure`` edge cases."""
+
+    def test_counter_labels_exception_is_swallowed(self, caplog):
+        """If the counter itself raises, the helper logs at DEBUG and does not propagate."""
+        # First-Party
+        from mcpgateway.services.notification_service import _record_publish_failure
+
+        class BrokenCounter:
+            def labels(self, **_kwargs):
+                raise RuntimeError("prometheus broken")
+
+        # Must not raise.
+        with caplog.at_level("DEBUG", logger="mcpgateway.services.notification_service"):
+            _record_publish_failure(
+                "sess",
+                "req-1",
+                reason="transport_error",
+                exc=ConnectionError("boom"),
+                counter=BrokenCounter(),
+            )
+        assert "publish-failed counter raised" in caplog.text
+
+
+class TestInitializeIdempotency:
+    """Cover the double-init short-circuit branch."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_is_idempotent_when_worker_running(self, caplog):
+        """Calling initialize twice must not spawn a second worker task."""
+        svc = NotificationService()
+        try:
+            await svc.initialize()
+            first_task = svc._worker_task
+            assert first_task is not None and not first_task.done()
+
+            # Second call: worker already running; must short-circuit and keep the same task.
+            mock_gw = MagicMock()
+            with caplog.at_level("DEBUG", logger="mcpgateway.services.notification_service"):
+                await svc.initialize(gateway_service=mock_gw)
+            assert svc._worker_task is first_task
+            # gateway_service reference refreshed even on the short-circuit path.
+            assert svc._gateway_service is mock_gw
+        finally:
+            await svc.shutdown()
+
+
+class TestSafeCancel:
+    """Cover the exception branch of ``_safe_cancel``."""
+
+    @pytest.mark.asyncio
+    async def test_safe_cancel_swallows_responder_exception(self, caplog):
+        """A raising ``responder.cancel`` must be logged at WARNING, not propagated."""
+        responder = MagicMock()
+
+        async def boom():
+            raise RuntimeError("broken transport")
+
+        responder.cancel = boom
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await NotificationService._safe_cancel(responder, "sess-1", "req-1")
+
+        assert "responder.cancel() raised" in caplog.text
+        assert "sess-1" in caplog.text
+
+
+class TestShutdownPendingFutures:
+    """Cover the pending-futures cleanup branch in ``shutdown``."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_unfinished_pending_futures(self):
+        """``shutdown`` must cancel any futures still in ``_pending_requests``."""
+        svc = NotificationService()
+        loop = asyncio.get_running_loop()
+        pending_future = loop.create_future()
+        completed_future = loop.create_future()
+        completed_future.set_result({"ok": True})
+
+        svc._pending_requests[("sess-a", "1")] = pending_future
+        svc._pending_requests[("sess-a", "2")] = completed_future
+
+        await svc.shutdown()
+
+        assert pending_future.cancelled()
+        # Already-done futures are left alone (not re-cancelled) but popped.
+        assert completed_future.done() and not completed_future.cancelled()
+        assert svc._pending_requests == {}
+
+
+class TestForwardRequestPayloadFailures:
+    """Cover ``_forward_request_to_stream`` error branches pre-publish."""
+
+    @pytest.mark.asyncio
+    async def test_payload_build_failure_cancels_responder(self, monkeypatch, caplog):
+        """``model_dump`` raising a TypeError triggers the payload-build except branch."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+
+        # Fake responder: exposes request.root whose model_dump raises.
+        responder = MagicMock()
+        responder.request_id = "req-bad-payload"
+        root = MagicMock()
+        root.model_dump = MagicMock(side_effect=TypeError("shape drift"))
+        responder.request = MagicMock()
+        responder.request.root = root
+        cancelled = {"called": False}
+
+        async def _cancel():
+            cancelled["called"] = True
+
+        responder.cancel = _cancel
+        responder.__enter__ = MagicMock(return_value=responder)
+        responder.__exit__ = MagicMock(return_value=False)
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await svc._forward_request_to_stream("sess-p1", responder)
+
+        assert cancelled["called"] is True
+        assert "Failed to build request payload" in caplog.text
+        # No pending entry was created.
+        assert svc.has_pending_request("sess-p1") is False
+
+    @pytest.mark.asyncio
+    async def test_empty_method_refuses_to_publish_and_cancels(self, monkeypatch, caplog):
+        """Payload with empty ``method`` triggers the defense-in-depth branch."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+
+        responder = MagicMock()
+        responder.request_id = "req-empty-method"
+        root = MagicMock()
+        # method missing from payload entirely.
+        root.model_dump = MagicMock(return_value={"params": {"x": 1}})
+        responder.request = MagicMock()
+        responder.request.root = root
+        cancelled = {"called": False}
+
+        async def _cancel():
+            cancelled["called"] = True
+
+        responder.cancel = _cancel
+        responder.__enter__ = MagicMock(return_value=responder)
+        responder.__exit__ = MagicMock(return_value=False)
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await svc._forward_request_to_stream("sess-empty", responder)
+
+        assert cancelled["called"] is True
+        assert "empty method" in caplog.text
+        assert svc.has_pending_request("sess-empty") is False
+
+
+class TestForwardRequestBusGetFailure:
+    """Cover the ``get_server_event_bus`` raising branches for the request path."""
+
+    @pytest.mark.asyncio
+    async def test_get_bus_runtime_error_cancels_future(self, monkeypatch):
+        """RuntimeError from bus construction → backend_unavailable + cancelled future."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+        sid = "sess-bus-runtime"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        async def _bus():
+            raise RuntimeError("bus config broken")
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        before = server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get()
+
+        responder, _captured = TestServerInitiatedRequestCorrelation._make_responder("req-bus-rt")
+        await handler(responder)
+        await asyncio.sleep(0.05)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get() == before + 1
+        # Pending dict is cleaned up by the holder's finally.
+        assert svc.has_pending_request(sid) is False
+
+
+class TestForwardRequestHolderBranches:
+    """Cover ``hold()`` inner error branches: respond-raises, done-callback logging."""
+
+    @pytest.mark.asyncio
+    async def test_responder_respond_raises_is_logged(self, monkeypatch, caplog):
+        """If ``responder.respond`` raises inside the holder, log it and don't crash the task."""
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-respond-raises"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        bus = await get_server_event_bus()
+
+        async def consume():
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        responder, _captured = TestServerInitiatedRequestCorrelation._make_responder("req-resp-raises")
+
+        async def bad_respond(_payload):
+            raise RuntimeError("respond blew up")
+
+        responder.respond = bad_respond
+        await handler(responder)
+        await consumer
+
+        # Complete the request so the holder calls respond (which raises).
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await svc.complete_request(sid, "req-resp-raises", {"jsonrpc": "2.0", "id": "req-resp-raises", "result": {}})
+            await asyncio.sleep(0.1)
+
+        assert "responder.respond() raised" in caplog.text
+        await reset_server_event_bus()
+
+    @pytest.mark.asyncio
+    async def test_holder_done_callback_logs_unexpected_exception(self, monkeypatch, caplog):
+        """If ``on_complete`` raises during ``__exit__``, the done-callback logs it.
+
+        The context manager's ``__exit__`` invokes ``on_complete`` inside a
+        try/finally; a raising ``on_complete`` propagates out of ``with
+        responder:`` and is captured by ``_on_holder_done``.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-exit-shadow"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        bus = await get_server_event_bus()
+
+        async def consume():
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        # Build a responder with an on_complete that raises — this will
+        # escape the ``with responder:`` block in hold() after a successful
+        # respond() sets _completed=True.
+        # Third-Party
+        from mcp.shared.session import RequestResponder
+        from mcp.types import ListRootsRequest, ServerRequest
+
+        def _boom_on_complete(_resp):
+            raise RuntimeError("on_complete blew up")
+
+        responder = RequestResponder(
+            request_id="req-exit-shadow",
+            request_meta=None,
+            request=ServerRequest(ListRootsRequest(method="roots/list", params=None)),
+            session=MagicMock(_send_response=MagicMock()),
+            on_complete=_boom_on_complete,
+        )
+
+        async def captured_respond(_payload):
+            responder._completed = True
+
+        async def captured_cancel():
+            responder._completed = True
+
+        responder.respond = captured_respond
+        responder.cancel = captured_cancel
+
+        await handler(responder)
+        await consumer
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            # Resolve the future → respond sets _completed → __exit__ calls on_complete → raises.
+            await svc.complete_request(sid, "req-exit-shadow", {"jsonrpc": "2.0", "id": "req-exit-shadow", "result": {}})
+            # Give the holder + done-callback time to run.
+            await asyncio.sleep(0.1)
+
+        assert "Request-holder task" in caplog.text and "exited with exception" in caplog.text
+        await reset_server_event_bus()
+
+
+class TestHolderExitShadowsPrimary:
+    """Cover the ``__exit__ shadowing primary`` log branch (line 682)."""
+
+    @pytest.mark.asyncio
+    async def test_exit_shadow_logged_when_cancel_path_exits_raise(self, monkeypatch, caplog):
+        """External task cancel → primary_exc=CancelledError → ``__exit__`` raises → shadow log fires."""
+        # First-Party
+        from mcp.shared.session import RequestResponder
+        from mcp.types import ListRootsRequest, ServerRequest
+        from mcpgateway.config import settings
+        from mcpgateway.services.notification_service import NotificationService
+        from mcpgateway.transports.server_event_bus import (
+            get_server_event_bus,
+            reset_server_event_bus,
+        )
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        sid = "sess-exit-shadow2"
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id=sid)
+
+        bus = await get_server_event_bus()
+
+        async def consume():
+            async for _ in bus.subscribe(sid):
+                break
+
+        consumer = asyncio.create_task(consume())
+        await asyncio.sleep(0.02)
+
+        # on_complete raises — triggers __exit__ failure after _completed is set.
+        def _boom(_resp):
+            raise RuntimeError("exit boom")
+
+        responder = RequestResponder(
+            request_id="req-shadow",
+            request_meta=None,
+            request=ServerRequest(ListRootsRequest(method="roots/list", params=None)),
+            session=MagicMock(_send_response=MagicMock()),
+            on_complete=_boom,
+        )
+
+        async def captured_cancel():
+            # Set _completed so __exit__'s on_complete path runs.
+            responder._completed = True
+
+        async def captured_respond(_payload):
+            responder._completed = True
+
+        responder.cancel = captured_cancel
+        responder.respond = captured_respond
+
+        await handler(responder)
+        await consumer
+
+        # Snapshot the holder task, then cancel it → wait_for raises CancelledError.
+        held = list(svc._pending_holder_tasks)
+        assert held, "expected an in-flight holder"
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            for t in held:
+                t.cancel()
+            # Give the holder time to run the cancel path + __exit__ + done-callback.
+            await asyncio.sleep(0.1)
+
+        assert "shadowing primary" in caplog.text
+        await reset_server_event_bus()
+
+
+class TestRespondWithPayloadValidationBranches:
+    """Cover the ValidationError branches in ``_respond_with_payload``."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_error_payload_substitutes_internal_error(self, caplog):
+        """A non-validating ``error`` payload falls back to INTERNAL_ERROR."""
+        # Third-Party
+        from mcp.types import ErrorData, INTERNAL_ERROR
+
+        responder, captured = TestServerInitiatedRequestCorrelation._make_responder("req-bad-err")
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            with responder:
+                # Missing required "code" field → ValidationError.
+                await NotificationService._respond_with_payload(
+                    responder,
+                    {"jsonrpc": "2.0", "id": "req-bad-err", "error": {"no_code": True}},
+                )
+        assert isinstance(captured["responded"], ErrorData)
+        assert captured["responded"].code == INTERNAL_ERROR
+        assert "Malformed error from downstream" in captured["responded"].message
+        assert "substituting INTERNAL_ERROR" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unvalidatable_result_falls_back_to_error(self, monkeypatch, caplog):
+        """If ClientResult validation fails, respond with an ErrorData containing the message."""
+        # Third-Party
+        import mcp.types as mcp_types
+        from mcp.types import ErrorData, INTERNAL_ERROR
+        from pydantic import ValidationError
+
+        # Force ClientResult.model_validate to raise.
+        class StubValidationError(Exception):
+            pass
+
+        def raise_validation(*_args, **_kwargs):
+            # Construct a real ValidationError via pydantic for accurate typing.
+            try:
+                mcp_types.ErrorData.model_validate({})
+            except ValidationError as e:
+                raise e
+
+        monkeypatch.setattr(mcp_types.ClientResult, "model_validate", classmethod(lambda cls, *a, **k: raise_validation()))
+
+        responder, captured = TestServerInitiatedRequestCorrelation._make_responder("req-bad-result")
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            with responder:
+                await NotificationService._respond_with_payload(
+                    responder,
+                    {"jsonrpc": "2.0", "id": "req-bad-result", "result": {"whatever": 1}},
+                )
+
+        assert isinstance(captured["responded"], ErrorData)
+        assert captured["responded"].code == INTERNAL_ERROR
+        assert "Could not validate downstream result" in caplog.text
+
+
+class TestCompleteRequestAlreadyDone:
+    """Cover the ``future.done()`` branch in ``complete_request``."""
+
+    @pytest.mark.asyncio
+    async def test_complete_request_returns_false_when_future_already_done(self, caplog):
+        """A pre-completed / cancelled future under the key must yield a False return."""
+        svc = NotificationService()
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        fut.cancel()  # done via cancel
+        svc._pending_requests[("sess-done", "req-done")] = fut
+
+        with caplog.at_level("DEBUG", logger="mcpgateway.services.notification_service"):
+            result = await svc.complete_request("sess-done", "req-done", {"id": "req-done", "result": {}})
+
+        assert result is False
+        assert "already done" in caplog.text
+
+
+class TestForwardNotificationErrorBranches:
+    """Cover the error branches of ``_forward_notification_to_stream``."""
+
+    @pytest.mark.asyncio
+    async def test_notification_payload_build_failure_is_logged(self, monkeypatch, caplog):
+        """A notification whose ``root.model_dump`` raises is logged and dropped."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+
+        notif = MagicMock()
+        notif.root = MagicMock()
+        notif.root.model_dump = MagicMock(side_effect=ValueError("shape drift"))
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await svc._forward_notification_to_stream("sess-np", notif)
+
+        assert "Failed to build notification payload" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_notification_empty_method_refuses_publish(self, monkeypatch, caplog):
+        """Empty ``method`` in a notification payload is dropped with a warning."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        svc = NotificationService()
+
+        notif = MagicMock()
+        notif.root = MagicMock()
+        notif.root.model_dump = MagicMock(return_value={"params": None})  # no method
+
+        with caplog.at_level("WARNING", logger="mcpgateway.services.notification_service"):
+            await svc._forward_notification_to_stream("sess-nm", notif)
+
+        assert "empty method" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_notification_get_bus_runtime_error(self, monkeypatch):
+        """``get_server_event_bus`` raising during notification fanout → backend_unavailable metric."""
+        # First-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+        from mcpgateway.config import settings
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        async def _bus():
+            raise RuntimeError("bus config broken")
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        svc = NotificationService()
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        before = server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get()
+
+        await svc._forward_notification_to_stream("sess-nb", notif)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get() == before + 1
+
+    @pytest.mark.asyncio
+    async def test_notification_publish_transport_error(self, monkeypatch):
+        """``bus.publish`` raising ConnectionError → transport_error metric."""
+        # First-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+        from mcpgateway.config import settings
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        class BrokenBus:
+            async def publish(self, _sid, _msg):
+                raise ConnectionError("pipe gone")
+
+        async def _bus():
+            return BrokenBus()
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        svc = NotificationService()
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        before = server_event_bus_publish_failed_counter.labels(reason="transport_error")._value.get()
+
+        await svc._forward_notification_to_stream("sess-nt", notif)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="transport_error")._value.get() == before + 1
+
+    @pytest.mark.asyncio
+    async def test_notification_publish_backend_error(self, monkeypatch):
+        """``bus.publish`` raising BusBackendError → backend_unavailable metric."""
+        # First-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+        from mcpgateway.config import settings
+        from mcpgateway.services.metrics import server_event_bus_publish_failed_counter
+        from mcpgateway.transports.server_event_bus import BusBackendError
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+
+        class BrokenBus:
+            async def publish(self, _sid, _msg):
+                raise BusBackendError("redis down")
+
+        async def _bus():
+            return BrokenBus()
+
+        monkeypatch.setattr("mcpgateway.transports.server_event_bus.get_server_event_bus", _bus)
+
+        svc = NotificationService()
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+        before = server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get()
+
+        await svc._forward_notification_to_stream("sess-nbe", notif)
+
+        assert server_event_bus_publish_failed_counter.labels(reason="backend_unavailable")._value.get() == before + 1
+
+
+class TestEnqueueRefreshDebounceEdge:
+    """Cover the ``debounce window but no pending`` branch (lines 1080-1086)."""
+
+    @pytest.mark.asyncio
+    async def test_debounce_without_pending_entry_counts_as_debounced(self, notification_service):
+        """When ``_last_refresh_enqueued`` is recent but no ``_pending_refresh_flags`` entry exists,
+        the notification is counted as debounced and the log-debug branch runs.
+        """
+        # Simulate: refresh was recently enqueued and then processed (flags popped),
+        # but debounce window still applies.
+        notification_service._last_refresh_enqueued["gw-x"] = time.time()
+        # Deliberately DO NOT add a _pending_refresh_flags entry.
+
+        before = notification_service._notifications_debounced
+        await notification_service._enqueue_refresh("gw-x", NotificationType.TOOLS_LIST_CHANGED)
+        assert notification_service._notifications_debounced == before + 1
+        assert notification_service._refresh_queue.qsize() == 0
+
+
+class TestMessageHandlerServerNotification:
+    """Cover the ServerNotification branch of ``create_message_handler`` (lines 513-517)."""
+
+    @pytest.mark.asyncio
+    async def test_server_notification_dispatched_and_fanned_out(self, monkeypatch):
+        """A ServerNotification arriving at the handler triggers both handle and fanout."""
+        # Third-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+
+        # First-Party
+        from mcpgateway.config import settings
+        from mcpgateway.transports.server_event_bus import reset_server_event_bus
+
+        monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+        await reset_server_event_bus()
+
+        svc = NotificationService()
+        svc._handle_notification = AsyncMock()  # type: ignore[assignment]
+        svc._forward_notification_to_stream = AsyncMock()  # type: ignore[assignment]
+
+        handler = svc.create_message_handler("gw-1", "http://u", downstream_session_id="sess-sn")
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+
+        await handler(notif)
+
+        svc._handle_notification.assert_awaited_once_with("gw-1", notif, "http://u")
+        svc._forward_notification_to_stream.assert_awaited_once_with("sess-sn", notif)
+
+    @pytest.mark.asyncio
+    async def test_server_notification_without_session_id_skips_fanout(self):
+        """No downstream_session_id → only internal handling, no fanout."""
+        # Third-Party
+        from mcp.types import ServerNotification, ToolListChangedNotification
+
+        svc = NotificationService()
+        svc._handle_notification = AsyncMock()  # type: ignore[assignment]
+        svc._forward_notification_to_stream = AsyncMock()  # type: ignore[assignment]
+
+        handler = svc.create_message_handler("gw-1")
+        notif = ServerNotification(ToolListChangedNotification(method="notifications/tools/list_changed"))
+
+        await handler(notif)
+
+        svc._handle_notification.assert_awaited_once()
+        svc._forward_notification_to_stream.assert_not_awaited()
+
+
+class TestRefreshWorkerErrorPath:
+    """Cover the generic-exception branch inside ``_process_refresh_queue`` (lines 1139-1142)."""
+
+    @pytest.mark.asyncio
+    async def test_worker_logs_and_continues_on_execute_exception(self, notification_service, caplog):
+        """If ``_execute_refresh`` raises, the worker logs and keeps running."""
+        call_count = {"n": 0}
+
+        async def flaky_execute(_pending):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom in executor")
+
+        notification_service._execute_refresh = flaky_execute  # type: ignore[assignment]
+
+        await notification_service.initialize()
+        try:
+            # Enqueue a refresh — worker will pick it up, executor raises.
+            await notification_service._refresh_queue.put(PendingRefresh(gateway_id="gw-err"))
+            with caplog.at_level("ERROR", logger="mcpgateway.services.notification_service"):
+                # Give the worker time to process + log.
+                await asyncio.sleep(0.2)
+            assert call_count["n"] >= 1
+            assert "Error in refresh worker" in caplog.text
+            # Worker should still be running after the logged exception.
+            assert notification_service._worker_task is not None
+            assert not notification_service._worker_task.done()
+        finally:
+            await notification_service.shutdown()

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1648,7 +1648,7 @@ def test_init_session_affinity_with_notifications_enabled_wires_handler_factory(
     # Exercising the handler factory exposes it to coverage on
     # `default_handler_factory` closure.
     assert affinity._message_handler_factory is not None  # pylint: disable=protected-access
-    affinity._message_handler_factory("http://u", "gw-1")  # pylint: disable=protected-access
+    affinity._message_handler_factory("http://u", "gw-1", downstream_session_id="sess-test")  # pylint: disable=protected-access
     mock_notif_svc.create_message_handler.assert_called_once()
 
 
@@ -2260,3 +2260,377 @@ async def test_execute_forwarded_http_request_logs_debug_when_error_publish_also
         await affinity._execute_forwarded_http_request(request, _FailingPublishRedis())  # pylint: disable=protected-access
 
     assert any("Failed to publish error response" in rec.getMessage() for rec in caplog.records)
+
+
+# --------------------------------------------------------------------------
+# GET-stream listener claims (ADR-052)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_first_wins_second_loses(monkeypatch):
+    """Two GETs for the same session: first claim wins, second sees CONFLICT (ADR-052)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 30, raising=False)
+    affinity = SessionAffinity()
+    sid = "sess-listener-1"
+
+    assert await affinity.claim_listener(sid, "conn-A") is ListenerClaimResult.WON
+    assert await affinity.claim_listener(sid, "conn-B") is ListenerClaimResult.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_listener_heartbeat_refreshes_only_for_owner(monkeypatch):
+    """Heartbeat must succeed for the holder and fail for any other connection."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 30, raising=False)
+    affinity = SessionAffinity()
+    sid = "sess-listener-2"
+
+    await affinity.claim_listener(sid, "conn-owner")
+    assert await affinity.heartbeat_listener(sid, "conn-owner") is True
+    assert await affinity.heartbeat_listener(sid, "conn-intruder") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_release_only_owner_then_new_can_claim(monkeypatch):
+    """Release is owner-conditional; after release, a new connection can claim."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 30, raising=False)
+    affinity = SessionAffinity()
+    sid = "sess-listener-3"
+
+    await affinity.claim_listener(sid, "conn-A")
+    # Wrong connection-id can't release someone else's claim.
+    assert await affinity.release_listener(sid, "conn-other") is False
+    assert await affinity.claim_listener(sid, "conn-other") is ListenerClaimResult.CONFLICT
+    # Owner releases successfully and a new claim can land.
+    assert await affinity.release_listener(sid, "conn-A") is True
+    assert await affinity.claim_listener(sid, "conn-B") is ListenerClaimResult.WON
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_expires_with_ttl(monkeypatch):
+    """An expired in-memory claim is reclaimable without explicit release."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 0, raising=False)
+    affinity = SessionAffinity()
+    sid = "sess-listener-4"
+
+    assert await affinity.claim_listener(sid, "conn-old") is ListenerClaimResult.WON
+    # ttl=0 → claim expires immediately on the next purge sweep.
+    await asyncio.sleep(0.05)
+    assert await affinity.claim_listener(sid, "conn-new") is ListenerClaimResult.WON
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_concurrent_race_exactly_one_winner(monkeypatch):
+    """Concurrent claim_listener calls on the same session: exactly one returns WON.
+
+    Pins the in-memory backend's ``asyncio.Lock`` contract — accidentally
+    removing the lock would only break under load, which a sequential test
+    would never catch.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 30, raising=False)
+    affinity = SessionAffinity()
+    sid = "sess-race"
+
+    results = await asyncio.gather(
+        affinity.claim_listener(sid, "conn-A"),
+        affinity.claim_listener(sid, "conn-B"),
+        affinity.claim_listener(sid, "conn-C"),
+    )
+    won = [r for r in results if r is ListenerClaimResult.WON]
+    conflict = [r for r in results if r is ListenerClaimResult.CONFLICT]
+    assert len(won) == 1, f"expected exactly one WON, got {results}"
+    assert len(conflict) == 2, f"expected two CONFLICT, got {results}"
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_invalid_session_id_rejected(monkeypatch):
+    """Malformed session ids return UNAVAILABLE (defence-in-depth — caller shouldn't 409 a bad input)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    affinity = SessionAffinity()
+
+    assert await affinity.claim_listener("bad/id!", "conn-X") is ListenerClaimResult.UNAVAILABLE
+    assert await affinity.heartbeat_listener("bad/id!", "conn-X") is False
+    assert await affinity.release_listener("bad/id!", "conn-X") is False
+
+
+def test_log_redis_listener_error_classifies_by_exception_type(caplog):
+    """Operator-facing log levels: transient/config/unknown classification matrix.
+
+    The classifier is the operator's only signal during a Redis incident
+    — a regression that conflated config errors with transient blips
+    would quietly mute the warning needed to spot credential rotations
+    or Lua script drift.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity  # pylint: disable=import-outside-toplevel
+
+    pytest.importorskip("redis")
+    # Third-Party
+    from redis import exceptions as redis_exc  # pylint: disable=import-outside-toplevel
+
+    sid = "sess-classify"
+
+    # Transient errors stay at debug — should NOT appear in WARNING capture.
+    with caplog.at_level("WARNING", logger="mcpgateway.services.session_affinity"):
+        SessionAffinity._log_redis_listener_error("claim", sid, redis_exc.ConnectionError("conn refused"))
+        SessionAffinity._log_redis_listener_error("heartbeat", sid, redis_exc.TimeoutError("redis timeout"))
+    assert "ConnectionError" not in caplog.text
+    assert "TimeoutError" not in caplog.text
+    caplog.clear()
+
+    # Config / protocol errors escalate to warning.
+    with caplog.at_level("WARNING", logger="mcpgateway.services.session_affinity"):
+        SessionAffinity._log_redis_listener_error("claim", sid, redis_exc.AuthenticationError("invalid creds"))
+        SessionAffinity._log_redis_listener_error("release", sid, redis_exc.ResponseError("WRONGTYPE"))
+        SessionAffinity._log_redis_listener_error("heartbeat", sid, redis_exc.NoScriptError("script unknown"))
+    assert "AuthenticationError" in caplog.text
+    assert "ResponseError" in caplog.text
+    assert "NoScriptError" in caplog.text
+    caplog.clear()
+
+    # Unknown / programming errors get warning + traceback.
+    with caplog.at_level("WARNING", logger="mcpgateway.services.session_affinity"):
+        SessionAffinity._log_redis_listener_error("claim", sid, OSError("unexpected"))
+    assert "OSError" in caplog.text or "unexpected" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Redis-backed listener-claim coverage. The earlier listener-claim tests
+# all use cache_type=memory; the Redis branches (the authoritative
+# multi-node path) had zero coverage. Stub out get_redis_client so we
+# exercise the SET-NX / Lua-eval call shapes without a real Redis.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_redis_won_when_set_nx_returns_true(monkeypatch):
+    """Redis SET NX returning truthy → WON."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+    monkeypatch.setattr(settings, "mcp_get_stream_listener_ttl_seconds", 30, raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.claim_listener("sess-x", "conn-1") is ListenerClaimResult.WON
+    fake_redis.set.assert_awaited_once()
+    args, kwargs = fake_redis.set.call_args
+    assert kwargs.get("nx") is True
+    assert kwargs.get("ex") == 30
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_redis_conflict_when_set_nx_returns_false(monkeypatch):
+    """Redis SET NX returning falsy → CONFLICT (slot already held)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=None)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.claim_listener("sess-y", "conn-2") is ListenerClaimResult.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_redis_unavailable_when_client_missing(monkeypatch):
+    """``cache_type=redis`` but ``get_redis_client`` returns None → UNAVAILABLE."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+
+    affinity = SessionAffinity()
+    assert await affinity.claim_listener("sess-z", "conn-3") is ListenerClaimResult.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_listener_claim_redis_unavailable_when_set_raises(monkeypatch):
+    """Any exception from ``redis.set`` → UNAVAILABLE (NOT CONFLICT). Critical: 503 vs 409 split."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import ListenerClaimResult, SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(side_effect=ConnectionError("redis down"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.claim_listener("sess-q", "conn-4") is ListenerClaimResult.UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_listener_heartbeat_redis_eval_round_trips(monkeypatch):
+    """Redis heartbeat eval returning 1 → True (still owner); 0 → False (lost)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.eval = AsyncMock(return_value=1)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.heartbeat_listener("sess-h", "conn-1") is True
+
+    fake_redis.eval = AsyncMock(return_value=0)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+    assert await affinity.heartbeat_listener("sess-h", "conn-1") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_heartbeat_redis_returns_false_on_exception(monkeypatch):
+    """A heartbeat that raises returns False (caller closes the stream)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.eval = AsyncMock(side_effect=ConnectionError("redis down"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.heartbeat_listener("sess-h", "conn-1") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_release_redis_eval_round_trips(monkeypatch):
+    """Redis release eval returning 1 → True (released); 0 → False (not owner)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.eval = AsyncMock(return_value=1)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.release_listener("sess-r", "conn-1") is True
+
+    fake_redis.eval = AsyncMock(return_value=0)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+    assert await affinity.release_listener("sess-r", "conn-1") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_release_redis_returns_false_on_exception(monkeypatch):
+    """A release that raises returns False (best-effort cleanup)."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+
+    fake_redis = MagicMock()
+    fake_redis.eval = AsyncMock(side_effect=ConnectionError("redis down"))
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake_redis))
+
+    affinity = SessionAffinity()
+    assert await affinity.release_listener("sess-r", "conn-1") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_heartbeat_returns_false_when_redis_client_none(monkeypatch):
+    """``get_redis_client`` returning ``None`` short-circuits heartbeat to False."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+
+    affinity = SessionAffinity()
+    assert await affinity.heartbeat_listener("sess-none", "conn-1") is False
+
+
+@pytest.mark.asyncio
+async def test_listener_release_returns_false_when_redis_client_none(monkeypatch):
+    """``get_redis_client`` returning ``None`` short-circuits release to False."""
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+    monkeypatch.setattr("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=None))
+
+    affinity = SessionAffinity()
+    assert await affinity.release_listener("sess-none", "conn-1") is False
+
+
+def test_log_redis_listener_error_falls_back_when_redis_module_absent(monkeypatch, caplog):
+    """If the ``redis`` package is not importable, fall back to a plain warning.
+
+    This branch fires only on a degraded install where redis-py was removed
+    but cache_type=redis was left configured — an operator-visible edge case
+    that still needs to surface the original exception.
+    """
+    # Standard
+    import builtins
+    import sys
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "redis" and fromlist and "exceptions" in fromlist:
+            raise ImportError("redis not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setitem(sys.modules, "redis", None)
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+
+    sid = "sess-noredis"
+    with caplog.at_level("WARNING", logger="mcpgateway.services.session_affinity"):
+        SessionAffinity._log_redis_listener_error("claim", sid, RuntimeError("boom"))
+    assert "Listener-claim" in caplog.text
+    assert sid in caplog.text

--- a/tests/unit/mcpgateway/services/test_upstream_session_registry.py
+++ b/tests/unit/mcpgateway/services/test_upstream_session_registry.py
@@ -1181,15 +1181,15 @@ async def test_default_session_factory_passes_httpx_factory(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_default_session_factory_message_handler_factory_success(monkeypatch):
-    """A provided message_handler_factory is called with (url, gateway_id) and its result flows into ClientSession."""
+    """A provided message_handler_factory is called with (url, gateway_id, downstream_session_id) and its result flows into ClientSession."""
     # First-Party
     from mcpgateway.services import upstream_session_registry as usr
 
     sentinel_handler = object()
     factory_calls = []
 
-    def handler_factory(url, gateway_id):
-        factory_calls.append((url, gateway_id))
+    def handler_factory(url, gateway_id, *, downstream_session_id):
+        factory_calls.append((url, gateway_id, downstream_session_id))
         return sentinel_handler
 
     monkeypatch.setattr(usr, "streamablehttp_client", lambda **_kw: _FakeTransportCtx(streams=("r", "w", object())))
@@ -1198,7 +1198,7 @@ async def test_default_session_factory_message_handler_factory_success(monkeypat
     req = _make_request(message_handler_factory=handler_factory)
     await usr._default_session_factory(req)  # pylint: disable=protected-access
 
-    assert factory_calls == [(req.url, req.gateway_id)]
+    assert factory_calls == [(req.url, req.gateway_id, req.downstream_session_id)]
     assert _FakeClientSessionCM.last_message_handler is sentinel_handler
 
 
@@ -1208,7 +1208,7 @@ async def test_default_session_factory_message_handler_factory_failure_is_logged
     # First-Party
     from mcpgateway.services import upstream_session_registry as usr
 
-    def bad_factory(_url, _gw):
+    def bad_factory(_url, _gw, *, downstream_session_id):  # pylint: disable=unused-argument
         raise ValueError("handler factory boom")
 
     monkeypatch.setattr(usr, "streamablehttp_client", lambda **_kw: _FakeTransportCtx(streams=("r", "w", object())))

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -4641,6 +4641,12 @@ class TestLifespanAdvanced:
             def set(self):
                 self._set = True
 
+            def clear(self):
+                # ADR-052 added an early `await NotificationService.initialize()`
+                # in lifespan, which calls `self._shutdown_event.clear()`. The
+                # FakeEvent must answer it.
+                self._set = False
+
             async def wait(self):
                 self._set = True
                 return True
@@ -12152,8 +12158,16 @@ class TestRemainingCoverageGaps:
         log_aggregator.aggregate_all_components = MagicMock()
         monkeypatch.setattr(main_mod, "get_log_aggregator", MagicMock(return_value=log_aggregator))
 
-        # Force TimeoutError in wait_for and ensure the coroutine is closed to avoid warnings.
+        # Force TimeoutError only for the aggregation loop's wait (interval_seconds=60
+        # when window_minutes=0). Delegate every other wait_for (e.g. NotificationService's
+        # refresh-queue worker that uses timeout=1.0) to the real implementation; otherwise
+        # those loops spin without yielding and deadlock the event loop, since a synchronous
+        # TimeoutError-only fake never hits an await point.
+        real_wait_for = asyncio.wait_for
+
         async def fake_wait_for(awaitable, timeout=None):  # noqa: ANN001
+            if timeout != 60:
+                return await real_wait_for(awaitable, timeout=timeout)
             if hasattr(awaitable, "close"):
                 awaitable.close()
             raise asyncio.TimeoutError()
@@ -12252,6 +12266,104 @@ class TestRemainingCoverageGaps:
         async with main_mod.lifespan(main_mod.app):
             # Give the aggregation loop a chance to hit wait_for at least once.
             await asyncio.sleep(0.05)
+
+    async def test_lifespan_wires_notification_handler_factory(self, monkeypatch):
+        """Capture the factory passed to ``init_upstream_session_registry`` and invoke it.
+
+        The inline factory is only exercised when a new upstream session is wired,
+        so we capture it at init time and call it directly to cover the
+        ``create_message_handler`` hand-off.
+        """
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        def make_service():  # noqa: ANN001 - local test helper
+            service = MagicMock()
+            service.initialize = AsyncMock()
+            service.shutdown = AsyncMock()
+            return service
+
+        monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "enable_header_passthrough", False)
+        monkeypatch.setattr(main_mod.settings, "mcpgateway_tool_cancellation_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "mcpgateway_elicitation_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "metrics_buffer_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "metrics_cleanup_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "metrics_rollup_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "sso_enabled", False)
+        monkeypatch.setattr(main_mod.settings, "metrics_aggregation_enabled", False)
+
+        monkeypatch.setattr(main_mod, "logging_service", make_service())
+        monkeypatch.setattr(main_mod.logging_service, "configure_uvicorn_after_startup", MagicMock())
+        for attr in (
+            "tool_service",
+            "resource_service",
+            "prompt_service",
+            "gateway_service",
+            "root_service",
+            "completion_service",
+            "sampling_handler",
+            "resource_cache",
+            "streamable_http_session",
+            "session_registry",
+            "export_service",
+            "import_service",
+        ):
+            monkeypatch.setattr(main_mod, attr, make_service())
+        monkeypatch.setattr(main_mod, "a2a_service", None)
+
+        monkeypatch.setattr(main_mod, "get_redis_client", AsyncMock())
+        monkeypatch.setattr(main_mod, "close_redis_client", AsyncMock())
+        monkeypatch.setattr(main_mod, "validate_security_configuration", MagicMock())
+        monkeypatch.setattr(main_mod, "init_telemetry", MagicMock())
+        monkeypatch.setattr(main_mod, "refresh_slugs_on_startup", MagicMock())
+        monkeypatch.setattr("mcpgateway.routers.llmchat_router.init_redis", AsyncMock())
+        monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.get_instance", AsyncMock())
+        monkeypatch.setattr("mcpgateway.services.http_client_service.SharedHttpClient.shutdown", AsyncMock())
+
+        subscriber = MagicMock()
+        subscriber.start = AsyncMock()
+        subscriber.stop = AsyncMock()
+        # First-Party
+        import mcpgateway.cache.registry_cache as registry_cache_mod
+
+        monkeypatch.setattr(registry_cache_mod, "get_cache_invalidation_subscriber", MagicMock(return_value=subscriber))
+
+        sentinel_handler = MagicMock(name="message_handler")
+        notification_svc = MagicMock()
+        notification_svc.initialize = AsyncMock()
+        notification_svc.create_message_handler = MagicMock(return_value=sentinel_handler)
+        monkeypatch.setattr("mcpgateway.services.notification_service.init_notification_service", MagicMock(return_value=notification_svc))
+
+        captured = {}
+
+        def capture_registry(*, message_handler_factory):  # noqa: ANN001
+            captured["factory"] = message_handler_factory
+
+        monkeypatch.setattr(
+            "mcpgateway.services.upstream_session_registry.init_upstream_session_registry",
+            capture_registry,
+        )
+
+        async with main_mod.lifespan(main_mod.app):
+            factory = captured["factory"]
+            handler = factory("https://peer.example/mcp", "gw-1", downstream_session_id="sess-123")
+
+        assert handler is sentinel_handler
+        notification_svc.create_message_handler.assert_called_once_with(
+            "gw-1",
+            "https://peer.example/mcp",
+            downstream_session_id="sess-123",
+        )
+
+        # And the gateway_id-falsy branch: factory should fall back to the URL.
+        notification_svc.create_message_handler.reset_mock()
+        factory("https://peer.example/mcp", None, downstream_session_id="sess-456")
+        notification_svc.create_message_handler.assert_called_once_with(
+            "https://peer.example/mcp",
+            "https://peer.example/mcp",
+            downstream_session_id="sess-456",
+        )
 
     async def test_lifespan_reraises_unexpected_startup_error(self, monkeypatch):
         # First-Party

--- a/tests/unit/mcpgateway/transports/test_redis_event_store.py
+++ b/tests/unit/mcpgateway/transports/test_redis_event_store.py
@@ -608,3 +608,480 @@ class TestRedisEventStore:
         callback = AsyncMock()
         assert await store.replay_events_after("event-id", callback) == stream_id
         callback.assert_awaited_once()
+
+    async def test_replay_after_with_ids_drops_cross_stream_index_entry(self, monkeypatch: pytest.MonkeyPatch):
+        """Tenancy guard: a stale Last-Event-Id whose index points at another session must NOT replay.
+
+        Without this gate, a forged or collision-recycled Last-Event-Id could be used
+        to read another session's buffered events.
+        """
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:cross")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                # Index says event "ev-victim" lives on stream "victim", but the caller
+                # asks to replay it on stream "attacker".
+                self.get = AsyncMock(return_value=orjson.dumps({"stream_id": "victim", "seq_num": 5}))
+                self.hget = AsyncMock(side_effect=AssertionError("must NOT touch any data after the cross-stream check"))
+                self.zrangebyscore = AsyncMock(side_effect=AssertionError("must NOT enumerate the buffer"))
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids("attacker", "ev-victim")]
+        assert results == [], "cross-stream index entry must yield no events"
+
+    async def test_replay_after_with_ids_returns_empty_when_cursor_evicted(self, monkeypatch: pytest.MonkeyPatch):
+        """Codex P2 regression: stale Last-Event-Id below start_seq must NOT replay only the surviving tail.
+
+        Without the start_seq check, a reconnect with an evicted cursor would
+        silently miss the gap between the cursor and the buffer head.
+        """
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:evict")
+        stream_id = "s"
+        meta_key = store._get_stream_meta_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.get = AsyncMock(return_value=orjson.dumps({"stream_id": stream_id, "seq_num": 1}))
+                self.hget = AsyncMock(side_effect=self._hget)
+                self.zrangebyscore = AsyncMock(side_effect=AssertionError("must NOT enumerate the buffer when cursor evicted"))
+
+            async def _hget(self, key: str, field: str):
+                if key == meta_key and field == "start_seq":
+                    return b"10"  # cursor seq=1 < start_seq=10 → evicted
+                raise AssertionError(f"Unexpected hget: {key=} {field=}")
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids(stream_id, "ev-stale")]
+        assert results == [], "evicted cursor must yield no events (caller treats as 'too old')"
+
+    async def test_replay_after_with_ids_replays_entire_buffer_when_cursor_is_none(self, monkeypatch: pytest.MonkeyPatch):
+        """Codex P1 regression: ``last_event_id=None`` must yield every buffered event.
+
+        Reconnect-without-cursor path: a client whose connection dropped
+        before any event ids reached it has no Last-Event-Id, but the
+        ring buffer holds events (most importantly server-initiated
+        requests) that we MUST deliver — otherwise the gateway-side
+        ``RequestResponder`` TTLs out and the request silently disappears.
+        """
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:nocursor")
+        stream_id = "s"
+        events_key = store._get_stream_events_key(stream_id)
+        messages_key = store._get_stream_messages_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                # No index lookup — None cursor skips that path entirely.
+                self.get = AsyncMock(side_effect=AssertionError("must NOT touch the event-id index when cursor is None"))
+                self.zrangebyscore = AsyncMock(return_value=[b"ev-1", b"ev-2"])
+                self.hget = AsyncMock(side_effect=self._hget)
+
+            async def _hget(self, key: str, field: str):
+                if key == messages_key and field == "ev-1":
+                    return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/before"})
+                if key == messages_key and field == "ev-2":
+                    return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/after"})
+                raise AssertionError(f"Unexpected hget: {key=} {field=}")
+
+        dummy = DummyRedis()
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=dummy),
+        )
+
+        results = [item async for item in store.replay_after_with_ids(stream_id, None)]
+        assert len(results) == 2
+        assert [eid for eid, _ in results] == ["ev-1", "ev-2"]
+        # Used the -inf score range, not the cursor index.
+        dummy.zrangebyscore.assert_awaited_once_with(events_key, "-inf", "+inf")
+
+    async def test_replay_after_with_ids_replays_when_start_seq_missing(self, monkeypatch: pytest.MonkeyPatch):
+        """Missing start_seq (no metadata yet) is treated as 'no eviction recorded' — replay proceeds."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:nostart")
+        stream_id = "s"
+        messages_key = store._get_stream_messages_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.get = AsyncMock(return_value=orjson.dumps({"stream_id": stream_id, "seq_num": 1}))
+                self.zrangebyscore = AsyncMock(return_value=[b"ev-2"])
+                self.hget = AsyncMock(side_effect=self._hget)
+
+            async def _hget(self, key: str, field: str):
+                if field == "start_seq":
+                    return None
+                if key == messages_key and field == "ev-2":
+                    return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/test"})
+                raise AssertionError(f"Unexpected hget: {key=} {field=}")
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids(stream_id, "ev-stale")]
+        assert len(results) == 1
+        assert results[0][0] == "ev-2"
+
+    # ----------------------------------------------------------------------
+    # store_event_with_notify
+    # ----------------------------------------------------------------------
+
+    async def test_store_event_with_notify_raises_when_redis_client_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        """RuntimeError when Redis client is unavailable on the notify path."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:notify-nored")
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=None),
+        )
+
+        with pytest.raises(RuntimeError, match="Redis client not available"):
+            await store.store_event_with_notify(
+                "stream",
+                {"jsonrpc": "2.0", "method": "notifications/test"},
+                channel="chan",
+                payload=b"evid",
+            )
+
+    async def test_store_event_with_notify_happy_path_generates_event_id(self, monkeypatch: pytest.MonkeyPatch):
+        """Happy path: EVAL is invoked with the 12-arg store-and-notify signature and a UUID event id."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:notify-gen")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.eval = AsyncMock(return_value=1)
+
+        dummy = DummyRedis()
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=dummy),
+        )
+
+        stream_id = "stream-notify"
+        msg = {"jsonrpc": "2.0", "method": "notifications/test"}
+        event_id = await store.store_event_with_notify(stream_id, msg, channel="ch", payload=b"pl")
+
+        # Generated event ids are uuid4 hex-with-dashes; just validate shape.
+        uuid.UUID(event_id)
+
+        # Inspect EVAL call: 3 keys + 8 argv = 11 positional args after the script.
+        dummy.eval.assert_awaited_once()
+        call_args = dummy.eval.call_args
+        script = call_args.args[0]
+        assert "PUBLISH" in script, "must use the store-and-notify Lua variant"
+        num_keys = call_args.args[1]
+        assert num_keys == 3
+        meta_key = call_args.args[2]
+        events_key = call_args.args[3]
+        messages_key = call_args.args[4]
+        assert meta_key == store._get_stream_meta_key(stream_id)
+        assert events_key == store._get_stream_events_key(stream_id)
+        assert messages_key == store._get_stream_messages_key(stream_id)
+        argv_event_id = call_args.args[5]
+        assert argv_event_id == event_id
+        argv_message_json = call_args.args[6]
+        assert orjson.loads(argv_message_json) == msg
+        assert call_args.args[7] == 60  # ttl
+        assert call_args.args[8] == 10  # max_events
+        assert call_args.args[9] == store._event_index_prefix()
+        assert call_args.args[10] == stream_id
+        assert call_args.args[11] == "ch"
+        assert call_args.args[12] == b"pl"
+
+    async def test_store_event_with_notify_uses_event_id_override(self, monkeypatch: pytest.MonkeyPatch):
+        """event_id_override is passed through to the EVAL ARGV."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:notify-override")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.eval = AsyncMock(return_value=1)
+
+        dummy = DummyRedis()
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=dummy),
+        )
+
+        forced = "00000000-0000-0000-0000-0000000000aa"
+        returned = await store.store_event_with_notify(
+            "stream-x",
+            {"jsonrpc": "2.0", "method": "notifications/test"},
+            channel="chan",
+            payload=b"pl",
+            event_id_override=forced,
+        )
+        assert returned == forced
+        # ARGV[1] must be the override
+        assert dummy.eval.call_args.args[5] == forced
+
+    async def test_store_event_with_notify_handles_dict_like_message_without_model_dump(self, monkeypatch: pytest.MonkeyPatch):
+        """Messages that don't expose model_dump fall back to dict(message)."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:notify-dict")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.eval = AsyncMock(return_value=1)
+
+        dummy = DummyRedis()
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=dummy),
+        )
+
+        # Plain dict has no model_dump; dict() of a dict returns a copy.
+        msg = {"jsonrpc": "2.0", "method": "notifications/plain"}
+        await store.store_event_with_notify("s", msg, channel="c", payload=b"p")
+
+        assert orjson.loads(dummy.eval.call_args.args[6]) == msg
+
+    # ----------------------------------------------------------------------
+    # replay_after_with_ids: remaining edge cases
+    # ----------------------------------------------------------------------
+
+    async def test_replay_after_with_ids_returns_when_redis_client_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 430: redis=None yields nothing."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:ri-nored")
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=None),
+        )
+        results = [item async for item in store.replay_after_with_ids("s", "evid")]
+        assert results == []
+
+        # None cursor path also short-circuits cleanly with no Redis.
+        results = [item async for item in store.replay_after_with_ids("s", None)]
+        assert results == []
+
+    async def test_replay_after_with_ids_none_cursor_skips_missing_and_malformed_entries(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 441 (hget returns None → continue) and 444-446 (malformed JSON → log + continue)."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:ri-none-edge")
+        stream_id = "s"
+        messages_key = store._get_stream_messages_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.zrangebyscore = AsyncMock(return_value=[b"gone", b"bad", b"ok"])
+                self.hget = AsyncMock(side_effect=self._hget)
+
+            async def _hget(self, key: str, field: str):
+                assert key == messages_key
+                if field == "gone":
+                    return None  # 441 continue
+                if field == "bad":
+                    return b"{"  # malformed JSON -> 444-446
+                if field == "ok":
+                    return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/ok"})
+                raise AssertionError("unexpected field")
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids(stream_id, None)]
+        assert len(results) == 1
+        assert results[0][0] == "ok"
+
+    async def test_replay_after_with_ids_returns_when_index_missing(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 451: index lookup returns nothing → yield nothing."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:ri-idx-missing")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.get = AsyncMock(return_value=None)
+                self.hget = AsyncMock(side_effect=AssertionError("must not read meta/messages"))
+                self.zrangebyscore = AsyncMock(side_effect=AssertionError("must not enumerate"))
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids("s", "evid")]
+        assert results == []
+
+    async def test_replay_after_with_ids_returns_when_index_malformed(self, monkeypatch: pytest.MonkeyPatch):
+        """Lines 456-463: malformed index JSON is logged and yields nothing."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:ri-idx-bad")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                # Non-JSON bytes triggers orjson.loads failure -> warning path
+                self.get = AsyncMock(return_value=b"{not json")
+                self.hget = AsyncMock(side_effect=AssertionError("must not read meta/messages"))
+                self.zrangebyscore = AsyncMock(side_effect=AssertionError("must not enumerate"))
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids("s", "evid")]
+        assert results == []
+
+    async def test_replay_after_with_ids_handles_bad_start_seq_and_edge_messages(self, monkeypatch: pytest.MonkeyPatch):
+        """Lines 489-490 (start_seq parse error), 504 (hget None), 507-509 (malformed JSON)."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:ri-badstart")
+        stream_id = "s"
+        meta_key = store._get_stream_meta_key(stream_id)
+        messages_key = store._get_stream_messages_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.get = AsyncMock(return_value=orjson.dumps({"stream_id": stream_id, "seq_num": 1}))
+                self.zrangebyscore = AsyncMock(return_value=[b"gone", b"bad", b"ok"])
+                self.hget = AsyncMock(side_effect=self._hget)
+
+            async def _hget(self, key: str, field: str):
+                if key == meta_key and field == "start_seq":
+                    return b"not-an-int"  # 489-490: except TypeError/ValueError
+                if key == messages_key and field == "gone":
+                    return None  # 504 continue
+                if key == messages_key and field == "bad":
+                    return b"{"  # 507-509 warning path
+                if key == messages_key and field == "ok":
+                    return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/ok"})
+                raise AssertionError(f"Unexpected hget: {key=} {field=}")
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        results = [item async for item in store.replay_after_with_ids(stream_id, "ev-cursor")]
+        assert len(results) == 1
+        assert results[0][0] == "ok"
+
+    # ----------------------------------------------------------------------
+    # evict_event
+    # ----------------------------------------------------------------------
+
+    async def test_evict_event_raises_when_redis_client_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 538-540: missing Redis client raises RuntimeError so callers can log the orphan."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:evict-nored")
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=None),
+        )
+        with pytest.raises(RuntimeError, match="Redis client not available"):
+            await store.evict_event("s", "evid")
+
+    async def test_evict_event_returns_true_when_event_removed(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 544-553 happy path: EVAL returns 1 → True."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:evict-hit")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.eval = AsyncMock(return_value=1)
+
+        dummy = DummyRedis()
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=dummy),
+        )
+
+        stream_id = "s"
+        event_id = "evid"
+        result = await store.evict_event(stream_id, event_id)
+        assert result is True
+
+        dummy.eval.assert_awaited_once()
+        call_args = dummy.eval.call_args
+        # 3 keys + 2 argv
+        assert call_args.args[1] == 3
+        assert call_args.args[2] == store._get_stream_meta_key(stream_id)
+        assert call_args.args[3] == store._get_stream_events_key(stream_id)
+        assert call_args.args[4] == store._get_stream_messages_key(stream_id)
+        assert call_args.args[5] == event_id
+        assert call_args.args[6] == store._event_index_prefix()
+
+    async def test_evict_event_returns_false_when_event_absent(self, monkeypatch: pytest.MonkeyPatch):
+        """EVAL returns 0 → False (idempotent no-op)."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:evict-miss")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.eval = AsyncMock(return_value=0)
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        assert await store.evict_event("s", "evid") is False
+
+    # ----------------------------------------------------------------------
+    # fetch_event
+    # ----------------------------------------------------------------------
+
+    async def test_fetch_event_returns_none_when_redis_client_unavailable(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 568-570: redis=None returns None, no exception."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:fetch-nored")
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=None),
+        )
+        assert await store.fetch_event("s", "evid") is None
+
+    async def test_fetch_event_returns_none_when_hash_entry_missing(self, monkeypatch: pytest.MonkeyPatch):
+        """Line 573-574: hget returns None → returns None."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:fetch-miss")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.hget = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+        assert await store.fetch_event("s", "evid") is None
+
+    async def test_fetch_event_returns_none_when_payload_is_malformed(self, monkeypatch: pytest.MonkeyPatch):
+        """Lines 575-579: orjson/model_validate failure returns None and logs a warning."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:fetch-bad")
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.hget = AsyncMock(return_value=b"{")  # invalid JSON
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+        assert await store.fetch_event("s", "evid") is None
+
+    async def test_fetch_event_returns_validated_message(self, monkeypatch: pytest.MonkeyPatch):
+        """Happy path: valid JSON-RPC payload validates into a JSONRPCMessage."""
+        store = RedisEventStore(max_events_per_stream=10, ttl=60, key_prefix="mcpgw:eventstore:test:fetch-ok")
+        stream_id = "s"
+        event_id = "evid"
+        messages_key = store._get_stream_messages_key(stream_id)
+
+        class DummyRedis:
+            def __init__(self) -> None:
+                self.hget = AsyncMock(side_effect=self._hget)
+
+            async def _hget(self, key: str, field: str):
+                assert key == messages_key
+                assert field == event_id
+                return orjson.dumps({"jsonrpc": "2.0", "method": "notifications/ok"})
+
+        monkeypatch.setattr(
+            "mcpgateway.transports.redis_event_store.get_redis_client",
+            AsyncMock(return_value=DummyRedis()),
+        )
+
+        result = await store.fetch_event(stream_id, event_id)
+        assert result is not None
+        # JSONRPCMessage wraps the underlying model; confirm it round-trips.
+        dumped = result.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["jsonrpc"] == "2.0"
+        assert dumped["method"] == "notifications/ok"

--- a/tests/unit/mcpgateway/transports/test_server_event_bus.py
+++ b/tests/unit/mcpgateway/transports/test_server_event_bus.py
@@ -1,0 +1,1214 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the server-to-client event bus (ADR-052).
+
+Covers the in-memory backend end-to-end (publish/subscribe/replay/overflow)
+and the factory's backend selection. The Redis backend's network-bound paths
+are exercised in integration tests under compose.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import asyncio
+from unittest.mock import AsyncMock
+
+# Third-Party
+from mcp.types import JSONRPCMessage, JSONRPCNotification
+import pytest
+
+# First-Party
+from mcpgateway.transports.server_event_bus import (
+    BusEvent,
+    InMemoryServerEventBus,
+    ListenerBacklogOverflow,
+    RedisServerEventBus,
+    _events_after,
+    get_server_event_bus,
+    reset_server_event_bus,
+)
+
+
+def _notif(i: int) -> JSONRPCMessage:
+    return JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test", params={"i": i}))
+
+
+@pytest.mark.asyncio
+async def test_publish_then_subscribe_replays_after_last_event_id():
+    """Replay: subscribe with Last-Event-Id yields events strictly after it, then tails."""
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+    sid = "sess-replay"
+
+    eid_1 = await bus.publish(sid, _notif(1))
+    eid_2 = await bus.publish(sid, _notif(2))
+
+    received: list[str] = []
+
+    async def consume() -> None:
+        async for evt in bus.subscribe(sid, last_event_id=eid_1):
+            received.append(evt.event_id)
+            if len(received) == 2:
+                break
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    eid_3 = await bus.publish(sid, _notif(3))
+    await asyncio.wait_for(consumer, timeout=2.0)
+
+    assert received == [eid_2, eid_3]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_without_last_event_id_replays_buffered_events():
+    """Reconnect-without-cursor: every event in the buffer must be delivered.
+
+    Codex P1 regression: a reconnecting client whose connection dropped
+    before any event ids reached it has no Last-Event-Id to resume from,
+    but the buffer holds events that arrived during the disconnect —
+    most importantly server-initiated requests whose ``RequestResponder``
+    on the gateway side will TTL out if we silently drop them. With the
+    fix, the consumer receives the buffered backlog *and* the new
+    event published after subscription.
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+    sid = "sess-replay-no-cursor"
+
+    await bus.publish(sid, _notif(1))  # buffered before subscribe
+
+    received: list[int] = []
+
+    async def consume() -> None:
+        async for evt in bus.subscribe(sid):
+            received.append(evt.message.root.params["i"])
+            if len(received) >= 2:
+                break
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    await bus.publish(sid, _notif(2))
+    await asyncio.wait_for(consumer, timeout=2.0)
+
+    assert received == [1, 2], "must replay buffered backlog AND tail future events"
+
+
+@pytest.mark.asyncio
+async def test_unknown_last_event_id_starts_at_head():
+    """An unknown Last-Event-Id behaves as if no resume was requested."""
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+    sid = "sess-unknown"
+    await bus.publish(sid, _notif(1))
+
+    received: list[int] = []
+
+    async def consume() -> None:
+        async for evt in bus.subscribe(sid, last_event_id="bogus"):
+            received.append(evt.message.root.params["i"])
+            break
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    await bus.publish(sid, _notif(2))
+    await asyncio.wait_for(consumer, timeout=2.0)
+
+    assert received == [2]
+
+
+@pytest.mark.asyncio
+async def test_multiple_subscribers_each_get_every_event():
+    """Two listeners on the same session both receive published events."""
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+    sid = "sess-fanout"
+
+    received_a: list[int] = []
+    received_b: list[int] = []
+
+    async def consume(target: list[int]) -> None:
+        async for evt in bus.subscribe(sid):
+            target.append(evt.message.root.params["i"])
+            break
+
+    a = asyncio.create_task(consume(received_a))
+    b = asyncio.create_task(consume(received_b))
+    await asyncio.sleep(0.05)
+    await bus.publish(sid, _notif(99))
+    await asyncio.gather(a, b)
+
+    assert received_a == [99]
+    assert received_b == [99]
+
+
+@pytest.mark.asyncio
+async def test_listener_queue_overflow_raises_backlog_overflow():
+    """A subscriber that can't keep up gets ListenerBacklogOverflow on the next get."""
+    bus = InMemoryServerEventBus(max_events_per_stream=10, listener_queue_depth=2)
+    sid = "sess-overflow"
+
+    started = asyncio.Event()
+    received: list[int] = []
+
+    async def driver() -> None:
+        with pytest.raises(ListenerBacklogOverflow):
+            started.set()
+            async for evt in bus.subscribe(sid):
+                received.append(evt.message.root.params["i"])
+
+    consumer = asyncio.create_task(driver())
+    await started.wait()
+    await asyncio.sleep(0.05)
+    # Publish well past the queue depth without yielding to the consumer.
+    # The drain+sentinel path injects None; the consumer raises on its next
+    # get. Note we don't await each publish — they're all synchronous from
+    # the bus's perspective (in-memory put_nowait).
+    for i in range(20):
+        await bus.publish(sid, _notif(i))
+    await asyncio.wait_for(consumer, timeout=2.0)
+    # Whether any events landed before the sentinel depends on scheduling;
+    # the contract this test pins is "raises ListenerBacklogOverflow".
+
+
+@pytest.mark.asyncio
+async def test_subscribe_unregisters_on_aclose():
+    """Closing the async-iterator (explicitly) removes the listener from the bus's registry.
+
+    Note: async-for ``break`` does NOT auto-aclose generators in Python — the
+    generator is finalized on garbage collection. Call sites that need
+    deterministic cleanup (e.g. the GET handler's response generator) get
+    it for free because the SSE response wrapper closes its source generator
+    on disconnect. We mirror that contract here with an explicit aclose.
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+    sid = "sess-cleanup"
+
+    sub = bus.subscribe(sid)
+    started = asyncio.Event()
+    received: list[int] = []
+
+    async def consume() -> None:
+        started.set()
+        async for evt in sub:
+            received.append(evt.message.root.params["i"])
+            break
+
+    task = asyncio.create_task(consume())
+    await started.wait()
+    await asyncio.sleep(0.05)
+
+    # While subscribed: exactly one entry on the listeners list.
+    assert sid in bus._listeners and len(bus._listeners[sid]) == 1
+
+    await bus.publish(sid, _notif(1))
+    await task
+
+    # Explicit aclose runs the generator's finally and unregisters the queue.
+    await sub.aclose()
+    assert sid not in bus._listeners or not bus._listeners[sid]
+    assert received == [1]
+
+
+def test_events_after_helper():
+    """Pure helper — exhaustive coverage of the cursor edge cases."""
+    e1 = BusEvent(event_id="a", message=_notif(1))
+    e2 = BusEvent(event_id="b", message=_notif(2))
+    e3 = BusEvent(event_id="c", message=_notif(3))
+    assert _events_after([e1, e2, e3], "a") == [e2, e3]
+    assert _events_after([e1, e2, e3], "c") == []
+    assert _events_after([e1, e2, e3], "missing") == [], "evicted/unknown cursor → no events (force resync)"
+    # Codex P1 fix: None cursor replays the whole buffer so reconnects
+    # without Last-Event-Id still receive pending server-initiated requests.
+    assert _events_after([e1, e2, e3], None) == [e1, e2, e3]
+    assert _events_after([], "a") == []
+    assert _events_after([], None) == []
+
+
+@pytest.mark.asyncio
+async def test_factory_picks_in_memory_backend_for_non_redis_cache_type(monkeypatch):
+    """When cache_type != 'redis', the factory binds InMemoryServerEventBus."""
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    await reset_server_event_bus()
+    bus = await get_server_event_bus()
+    assert isinstance(bus, InMemoryServerEventBus)
+    await reset_server_event_bus()
+
+
+@pytest.mark.asyncio
+async def test_factory_picks_redis_backend_for_redis_cache_type(monkeypatch):
+    """When cache_type=='redis' AND redis_url is set, the factory binds RedisServerEventBus."""
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "cache_type", "redis", raising=False)
+    monkeypatch.setattr(settings, "redis_url", "redis://localhost:6379/0", raising=False)
+    await reset_server_event_bus()
+    bus = await get_server_event_bus()
+    assert isinstance(bus, RedisServerEventBus)
+    await reset_server_event_bus()
+
+
+@pytest.mark.asyncio
+async def test_inmemory_close_signals_active_subscribers_with_sentinel():
+    """Graceful shutdown path: close() must inject the None sentinel into every listener queue.
+
+    Without this, an active subscriber blocked on ``queue.get()`` would
+    wait forever after the bus was closed (e.g. on process shutdown
+    before the SSE response had a chance to drain).
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10)
+
+    sub = bus.subscribe("sid-close-signal")
+    # Pull once so the subscribe registers its queue under _listeners.
+    await asyncio.sleep(0)
+
+    # Track what the consumer sees after close().
+    received: list[object] = []
+
+    async def consume() -> None:
+        try:
+            async for evt in sub:
+                received.append(evt)
+        except Exception as exc:  # noqa: BLE001 — sentinel surfaces as ListenerBacklogOverflow
+            received.append(exc)
+
+    consumer = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)  # let the iterator block on queue.get()
+
+    await bus.close()
+    await asyncio.wait_for(consumer, timeout=1.0)
+
+    # The sentinel propagates as ListenerBacklogOverflow (the in-memory
+    # backend's "queue closed by producer" signal).
+    assert received, "consumer must wake up after bus.close()"
+    # Either the iterator stopped cleanly or raised the backlog signal —
+    # both are acceptable graceful-shutdown outcomes; a hung consumer
+    # would have timed out above.
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_singleton(monkeypatch):
+    """Repeated calls return the same instance until reset_server_event_bus."""
+    # First-Party
+    from mcpgateway.config import settings
+
+    monkeypatch.setattr(settings, "cache_type", "memory", raising=False)
+    await reset_server_event_bus()
+    bus_a = await get_server_event_bus()
+    bus_b = await get_server_event_bus()
+    assert bus_a is bus_b
+    await reset_server_event_bus()
+    bus_c = await get_server_event_bus()
+    assert bus_c is not bus_a
+    await reset_server_event_bus()
+
+
+@pytest.mark.asyncio
+async def test_redis_publish_uses_atomic_store_and_notify(monkeypatch):
+    """Store + PUBLISH happen inside a single Lua eval — no separate ``redis.publish`` call path.
+
+    Codex stop-hook escalation: even with best-effort rollback, a
+    concurrent ``replay_after_with_ids`` could observe the event
+    between ``store_event`` and the failing ``PUBLISH``/rollback
+    window. Atomic Lua closes that race — Redis runs the script
+    without any other client command interleaving.
+    """
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    store_and_notify_calls: list[dict] = []
+
+    class FakeStore:
+        async def store_event_with_notify(self, sid, _msg, *, channel, payload, event_id_override=None):
+            store_and_notify_calls.append({"sid": sid, "channel": channel, "payload": payload, "event_id": event_id_override})
+            return event_id_override or "generated-id"
+
+        async def store_event(self, _sid, _msg):  # unused on atomic fast path
+            raise AssertionError("atomic publish must NOT fall back to store_event")
+
+    # A fake client that would raise on a standalone publish — proves
+    # we never take that path.
+    class SentinelRedis:
+        async def publish(self, *_args, **_kwargs):
+            raise AssertionError("atomic path must use the store's Lua, not redis.publish directly")
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=SentinelRedis()),
+    )
+
+    bus = RedisServerEventBus(store=FakeStore())
+    msg = JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+    event_id = await bus.publish("sid-atomic", msg)
+
+    assert len(store_and_notify_calls) == 1
+    call = store_and_notify_calls[0]
+    assert call["sid"] == "sid-atomic"
+    assert "sid-atomic" in call["channel"]
+    assert call["event_id"] == event_id
+    # Payload round-trips the event id for subscribers.
+    import orjson  # local so the test doesn't pull orjson at import time for non-Redis runs
+
+    assert orjson.loads(call["payload"]) == {"event_id": event_id}
+
+
+@pytest.mark.asyncio
+async def test_redis_publish_atomic_failure_evicts_when_server_side_completed(monkeypatch, caplog):
+    """EVAL reply lost mid-network → best-effort evict uncovers the orphan and logs it.
+
+    Codex stop-hook: atomic Lua protects concurrent readers, but it
+    does NOT protect against "EVAL completed server-side, TCP drops,
+    client sees an error." In that window the event IS in the buffer
+    and the PUBLISH DID fire. Without best-effort eviction we'd
+    orphan it for the next reconnect-without-cursor to replay.
+    """
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    evict_calls: list[tuple[str, str]] = []
+
+    class FakeStore:
+        async def store_event_with_notify(self, *_args, **_kwargs):
+            raise ConnectionError("EVAL reply lost")
+
+        async def evict_event(self, sid, event_id):
+            evict_calls.append((sid, event_id))
+            return True  # simulates "server ran the script; our evict caught the orphan"
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=object()),
+    )
+
+    bus = RedisServerEventBus(store=FakeStore())
+    msg = JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.server_event_bus"):
+        with pytest.raises(BusBackendError, match="Atomic store\\+publish failed"):
+            await bus.publish("sid-reply-lost", msg)
+
+    assert len(evict_calls) == 1, "must attempt eviction after a publish exception"
+    assert evict_calls[0][0] == "sid-reply-lost"
+    assert "rolled back event" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_publish_atomic_failure_no_orphan_to_evict(monkeypatch):
+    """EVAL never reached Redis → evict returns False → no noisy log, just raise."""
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    class FakeStore:
+        async def store_event_with_notify(self, *_args, **_kwargs):
+            raise ConnectionError("never reached Redis")
+
+        async def evict_event(self, _sid, _event_id):
+            return False  # nothing was stored → nothing to evict
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=object()),
+    )
+
+    bus = RedisServerEventBus(store=FakeStore())
+    msg = JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+    with pytest.raises(BusBackendError, match="Atomic store\\+publish failed"):
+        await bus.publish("sid-never-sent", msg)
+
+
+@pytest.mark.asyncio
+async def test_redis_publish_eviction_failure_logs_error(monkeypatch, caplog):
+    """If the eviction itself fails after a publish error, log at error so operators can investigate."""
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    class FakeStore:
+        async def store_event_with_notify(self, *_args, **_kwargs):
+            raise ConnectionError("publish failed")
+
+        async def evict_event(self, _sid, _event_id):
+            raise ConnectionError("and the evict is broken too")
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=object()),
+    )
+
+    bus = RedisServerEventBus(store=FakeStore())
+    msg = JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+    with caplog.at_level("ERROR", logger="mcpgateway.transports.server_event_bus"):
+        with pytest.raises(BusBackendError):
+            await bus.publish("sid-evict-broken", msg)
+    assert "could not verify/evict event" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_publish_missing_client_raises_without_eviction(monkeypatch, caplog):
+    """When ``get_redis_client`` returns None, short-circuit with ``BusBackendError`` — no eviction attempt.
+
+    Codex stop-hook escalation: the store's atomic Lua method also
+    raises on missing-client, and evict_event ALSO raises on
+    missing-client. Going through the eviction path would log
+    "orphan may be in buffer" at error level even though the store
+    never attempted a write. Pre-check at the bus layer so the
+    missing-client case is crisp: raise ``BusBackendError``, no
+    eviction, no misleading orphan warning.
+    """
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    class SentinelStore:
+        async def store_event_with_notify(self, *_args, **_kwargs):
+            raise AssertionError("bus must short-circuit before calling the store")
+
+        async def evict_event(self, *_args, **_kwargs):
+            raise AssertionError("bus must NOT attempt eviction when client is missing")
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=None),
+    )
+
+    bus = RedisServerEventBus(store=SentinelStore())
+    msg = JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/test"))
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.server_event_bus"):
+        with pytest.raises(BusBackendError, match="Redis client not available"):
+            await bus.publish("sid-no-client", msg)
+    # Crucially, no "orphan may be in buffer" chatter — nothing was written.
+    assert "orphan may be in the buffer" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# In-memory backend — edge cases for overflow drain / listener removal / close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inmemory_overflow_drain_handles_queueempty_race():
+    """QueueEmpty mid-drain (lines 220-221) must break the drain loop cleanly.
+
+    Simulated by substituting a queue whose ``empty()`` lies: reports
+    False but ``get_nowait()`` raises QueueEmpty — mirrors a producer/
+    consumer race where the consumer drains between our ``empty()``
+    check and our ``get_nowait()``.
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10, listener_queue_depth=1)
+    sid = "sess-drain-race"
+
+    class LyingQueue:
+        def __init__(self) -> None:
+            self._items: list[object] = []
+            self._empty_calls = 0
+            self.put_nowaits: list[object] = []
+
+        def put_nowait(self, item):  # noqa: D401 — mimic asyncio.Queue API
+            self.put_nowaits.append(item)
+            if item is None:
+                self._items.append(item)
+                return
+            # First put_nowait fills up; second raises QueueFull to hit overflow branch.
+            if self._items:
+                raise asyncio.QueueFull()
+            self._items.append(item)
+
+        def empty(self):
+            # Lie once: report non-empty so the drain loop enters, then raise QueueEmpty.
+            self._empty_calls += 1
+            if self._empty_calls == 1:
+                return False
+            return len(self._items) == 0
+
+        def get_nowait(self):
+            raise asyncio.QueueEmpty()
+
+    fake_q = LyingQueue()
+    # Inject directly under the lock-free path; publish will hold the lock.
+    bus._listeners[sid] = [fake_q]  # type: ignore[list-item]
+
+    # First publish fills the fake queue; second triggers overflow → drain → QueueEmpty → break.
+    await bus.publish(sid, _notif(1))
+    await bus.publish(sid, _notif(2))
+
+    # Sentinel must still have been enqueued after the break.
+    assert None in fake_q.put_nowaits, "None sentinel must be enqueued after drain QueueEmpty break"
+
+
+@pytest.mark.asyncio
+async def test_inmemory_subscribe_finally_handles_valueerror_on_remove():
+    """listener.remove raising ValueError (lines 254-255) must be swallowed.
+
+    Replace the subscriber's registered queue with a different queue
+    between the yield and the finally block. The finally's
+    ``listeners.remove(queue)`` will then raise ValueError (the
+    original queue is no longer in the list) — the contract is to
+    swallow it and continue cleanup.
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10, listener_queue_depth=4)
+    sid = "sess-remove-race"
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe(sid):
+            pass  # pragma: no cover — we cancel before any events flow
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+
+    # Swap the registered queue for a different object so remove() can't find it.
+    # The list stays truthy (keeps the ``if listeners:`` branch live) so the
+    # ValueError fallback is exercised.
+    async with bus._lock:
+        bus._listeners[sid] = [asyncio.Queue()]  # type: ignore[list-item]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The ValueError branch swallowed the error; our stand-in queue is still
+    # there (remove() didn't touch it), proving the swallow-and-continue path.
+    assert sid in bus._listeners
+    assert len(bus._listeners[sid]) == 1
+
+
+@pytest.mark.asyncio
+async def test_inmemory_close_swallows_queuefull_when_sentinel_cant_enqueue():
+    """close() with a full listener queue (lines 267-268) must swallow QueueFull.
+
+    If a subscriber's queue is already full when ``close()`` runs, the
+    None sentinel ``put_nowait`` raises QueueFull — the contract is to
+    swallow and continue, since forcing a wake-up is best-effort at
+    shutdown.
+    """
+    bus = InMemoryServerEventBus(max_events_per_stream=10, listener_queue_depth=1)
+    sid = "sess-close-full"
+
+    # Register a full queue directly so close() hits the QueueFull branch.
+    full_queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+    full_queue.put_nowait(BusEvent(event_id="x", message=_notif(0)))
+    bus._listeners[sid] = [full_queue]  # type: ignore[list-item]
+
+    # Must not raise.
+    await bus.close()
+
+    # close() clears state even when the sentinel couldn't be enqueued.
+    assert sid not in bus._listeners
+
+
+# ---------------------------------------------------------------------------
+# Redis backend — subscribe() paths
+# ---------------------------------------------------------------------------
+
+
+class _FakePubSub:
+    """Controllable pubsub double for RedisServerEventBus tests.
+
+    ``listen`` yields whatever dicts are put into ``_listen_queue``.
+    A ``None`` item closes the async generator (clean exit). An
+    ``Exception`` instance causes ``listen`` to raise it (simulates
+    connection drops mid-stream).
+    """
+
+    def __init__(self) -> None:
+        self._listen_queue: asyncio.Queue = asyncio.Queue()
+        self.subscribe_calls: list[str] = []
+        self.unsubscribe_calls: list[str] = []
+        self.aclose_calls = 0
+        self.subscribe_exc: Exception | None = None
+        self.unsubscribe_exc: Exception | None = None
+        self.aclose_exc: Exception | None = None
+
+    async def subscribe(self, channel: str) -> None:
+        self.subscribe_calls.append(channel)
+        if self.subscribe_exc is not None:
+            raise self.subscribe_exc
+
+    async def unsubscribe(self, channel: str) -> None:
+        self.unsubscribe_calls.append(channel)
+        if self.unsubscribe_exc is not None:
+            raise self.unsubscribe_exc
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        if self.aclose_exc is not None:
+            raise self.aclose_exc
+
+    async def listen(self):
+        while True:
+            item = await self._listen_queue.get()
+            if item is None:
+                return
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    def feed(self, item) -> None:
+        self._listen_queue.put_nowait(item)
+
+
+class _FakeRedis:
+    def __init__(self, pubsub_obj: _FakePubSub) -> None:
+        self._pubsub = pubsub_obj
+
+    def pubsub(self) -> _FakePubSub:
+        return self._pubsub
+
+
+class _FakeStore:
+    """Minimal RedisEventStore double for subscribe() tests."""
+
+    def __init__(self, replay: list[tuple[str, JSONRPCMessage]] | None = None, fetch_map: dict[str, JSONRPCMessage] | None = None) -> None:
+        self._replay = replay or []
+        self._fetch_map = fetch_map or {}
+
+    async def replay_after_with_ids(self, _sid: str, _last_event_id):
+        for ev_id, msg in self._replay:
+            yield ev_id, msg
+
+    async def fetch_event(self, _sid: str, event_id: str):
+        return self._fetch_map.get(event_id)
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_missing_client_raises(monkeypatch):
+    """subscribe() short-circuits with BusBackendError when get_redis_client is None."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=None),
+    )
+    bus = RedisServerEventBus(store=_FakeStore())
+    sub = bus.subscribe("sid-nc")
+    with pytest.raises(BusBackendError, match="Redis client not available"):
+        await sub.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_subscribe_failure_calls_aclose(monkeypatch):
+    """pubsub.subscribe raising must propagate AND invoke aclose cleanup."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    fake_pubsub.subscribe_exc = ConnectionError("subscribe boom")
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=_FakeStore())
+    sub = bus.subscribe("sid-subfail")
+    with pytest.raises(ConnectionError, match="subscribe boom"):
+        await sub.__anext__()
+    assert fake_pubsub.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_subscribe_failure_aclose_also_raises(monkeypatch, caplog):
+    """Subscribe-failure cleanup: aclose raising is logged at debug, original exc propagates."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    fake_pubsub.subscribe_exc = ConnectionError("subscribe boom")
+    fake_pubsub.aclose_exc = RuntimeError("aclose boom")
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=_FakeStore())
+    sub = bus.subscribe("sid-subfail-acloseboom")
+    with caplog.at_level("DEBUG", logger="mcpgateway.transports.server_event_bus"):
+        with pytest.raises(ConnectionError, match="subscribe boom"):
+            await sub.__anext__()
+    assert fake_pubsub.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_replay_then_tail_happy_path(monkeypatch):
+    """Replay yields stored events (covers _iter_events_after 615-616), then tail via Pub/Sub."""
+    # Standard
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    m1 = _notif(1)
+    m2 = _notif(2)
+    fake_pubsub = _FakePubSub()
+    store = _FakeStore(
+        replay=[("ev-1", m1)],
+        fetch_map={"ev-2": m2},
+    )
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+    sub = bus.subscribe("sid-happy", last_event_id="ev-0")
+
+    received: list[str] = []
+
+    async def consume() -> None:
+        async for evt in sub:
+            received.append(evt.event_id)
+            if len(received) == 2:
+                break
+
+    task = asyncio.create_task(consume())
+    # Give the consumer a chance to process the replay item and start tailing.
+    await asyncio.sleep(0.05)
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-2"})})
+    await asyncio.wait_for(task, timeout=1.0)
+    await sub.aclose()
+
+    assert received == ["ev-1", "ev-2"]
+    assert fake_pubsub.subscribe_calls == ["mcp:session:sid-happy:events"]
+    assert fake_pubsub.unsubscribe_calls == ["mcp:session:sid-happy:events"]
+    assert fake_pubsub.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_pump_discards_malformed_payloads(monkeypatch):
+    """Pump discards non-JSON and non-string event_id payloads without dying."""
+    # Standard
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    good_msg = _notif(42)
+    store = _FakeStore(fetch_map={"ev-good": good_msg})
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+    sub = bus.subscribe("sid-malformed")
+
+    received: list[str] = []
+
+    async def consume() -> None:
+        async for evt in sub:
+            received.append(evt.event_id)
+            break
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+
+    # 1) Non-"message" type — skipped by the ``if raw.get("type") != "message"`` branch.
+    fake_pubsub.feed({"type": "subscribe", "data": b"ignored"})
+    # 2) Invalid JSON — JSONDecodeError branch.
+    fake_pubsub.feed({"type": "message", "data": b"{"})
+    # 3) JSON without event_id key — KeyError branch.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"not_event": 1})})
+    # 4) event_id present but wrong type — isinstance(event_id, str) branch.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": 12345})})
+    # 5) event_id empty string — len check.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": ""})})
+    # 6) event_id too long — len > 256 check.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "x" * 300})})
+    # 7) Unknown event_id — _store.fetch_event returns None branch.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-missing"})})
+    # 8) Good event.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-good"})})
+
+    await asyncio.wait_for(task, timeout=1.0)
+    await sub.aclose()
+    assert received == ["ev-good"]
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_pump_skips_duplicate_event_ids(monkeypatch):
+    """event_id in seen → skip (covers seen-set branch)."""
+    # Standard
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    m1 = _notif(1)
+    m2 = _notif(2)
+    # Replay puts "ev-1" into seen, so a later pubsub message with "ev-1"
+    # must be skipped by the ``if event_id in seen`` branch in pump.
+    store = _FakeStore(replay=[("ev-1", m1)], fetch_map={"ev-2": m2})
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+    sub = bus.subscribe("sid-dedup", last_event_id="ev-0")
+
+    received: list[str] = []
+
+    async def consume() -> None:
+        async for evt in sub:
+            received.append(evt.event_id)
+            if len(received) == 2:
+                break
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    # Duplicate of replay event — skipped.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-1"})})
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-2"})})
+    await asyncio.wait_for(task, timeout=1.0)
+    await sub.aclose()
+    assert received == ["ev-1", "ev-2"]
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_pump_queue_full_raises_overflow(monkeypatch):
+    """queue_full inside pump → _force_sentinel → consumer raises ListenerBacklogOverflow."""
+    # Standard
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.server_event_bus import ListenerBacklogOverflow, RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    m1 = _notif(1)
+    m2 = _notif(2)
+    m3 = _notif(3)
+    store = _FakeStore(fetch_map={"ev-1": m1, "ev-2": m2, "ev-3": m3})
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    # Queue depth 1: first event fills it, second triggers QueueFull → _force_sentinel.
+    bus = RedisServerEventBus(store=store, listener_queue_depth=1)
+    sub = bus.subscribe("sid-overflow")
+
+    async def driver() -> None:
+        # Start iteration but never drain the pump.
+        agen = sub.__aiter__()
+        await agen.__anext__()  # consume replay (none) → wait for queue
+        # Consumer hasn't called get() again when we feed; the pump will
+        # fill the queue and then get QueueFull on next feed.
+        raise AssertionError("should not reach here — replay is empty")
+
+    # Simpler approach: consume events until ListenerBacklogOverflow.
+    async def consume() -> None:
+        async for _evt in sub:
+            # Stay around so queue depth fills up in pump.
+            await asyncio.sleep(0.5)
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    # Feed 3 messages; pump puts first in queue (consumer picks up), then
+    # pump fills depth=1 and the next put_nowait raises QueueFull
+    # → _force_sentinel() enqueues None → consumer sees None → ListenerBacklogOverflow.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-1"})})
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-2"})})
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-3"})})
+
+    with pytest.raises(ListenerBacklogOverflow, match="Listener queue overflowed"):
+        await asyncio.wait_for(task, timeout=2.0)
+    await sub.aclose()
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_pump_backend_failure_raises_bus_backend_error(monkeypatch):
+    """listen() raising mid-stream → pump_failure set → consumer raises BusBackendError."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import BusBackendError, RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+    sub = bus.subscribe("sid-backend-fail")
+
+    async def consume() -> None:
+        async for _evt in sub:
+            pass  # pragma: no cover — no events will be delivered
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    # listen() raises mid-stream → pump's except Exception path fires.
+    fake_pubsub.feed(ConnectionError("redis dropped"))
+
+    with pytest.raises(BusBackendError, match="Bus backend failed"):
+        await asyncio.wait_for(task, timeout=2.0)
+    await sub.aclose()
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_cancellation_path_force_sentinel(monkeypatch):
+    """Consumer task cancelled while blocked on queue → subscribe finally cancels pump → CancelledError branch runs."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe("sid-cancel"):
+            pass  # pragma: no cover — no events
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    # Cancelling the consumer task unwinds subscribe's generator → finally block
+    # cancels the pump → pump's CancelledError branch fires _force_sentinel →
+    # teardown unsubscribes and acloses.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_pubsub.unsubscribe_calls == ["mcp:session:sid-cancel:events"]
+    assert fake_pubsub.aclose_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_teardown_unsubscribe_raises_logs_warning(monkeypatch, caplog):
+    """pubsub.unsubscribe raising during teardown is logged at warning, exit is clean."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    fake_pubsub.unsubscribe_exc = ConnectionError("unsubscribe boom")
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe("sid-td-unsub"):
+            pass  # pragma: no cover
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.server_event_bus"):
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    assert "pubsub.unsubscribe raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_teardown_aclose_raises_logs_warning(monkeypatch, caplog):
+    """pubsub.aclose raising during teardown is logged at warning, exit is clean."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    fake_pubsub.aclose_exc = ConnectionError("aclose boom")
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe("sid-td-aclose"):
+            pass  # pragma: no cover
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.server_event_bus"):
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    assert "pubsub.aclose raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_force_sentinel_fallback_logs_error(monkeypatch, caplog):
+    """_force_sentinel fallback (lines 471-476): repeated QueueFull+QueueEmpty logs error.
+
+    Pathological queue double: ``put_nowait`` always raises QueueFull,
+    ``get_nowait`` always raises QueueEmpty. Both retries fall through
+    to the forensic-trail error log. The normal single-producer
+    contract can't reach this branch, but defensive code deserves a
+    regression test for when it does.
+    """
+    # First-Party
+    from mcpgateway.transports import server_event_bus as bus_mod
+
+    class PathologicalQueue:
+        def __init__(self, maxsize: int = 0) -> None:  # noqa: D401
+            self._maxsize = maxsize
+
+        def put_nowait(self, _item):
+            raise asyncio.QueueFull()
+
+        def get_nowait(self):
+            raise asyncio.QueueEmpty()
+
+        def qsize(self) -> int:
+            return 0
+
+        async def get(self):
+            # Consumer blocks forever; we cancel the consumer task.
+            await asyncio.Event().wait()
+
+        def empty(self) -> bool:
+            return True
+
+    fake_pubsub = _FakePubSub()
+    fake_pubsub.subscribe_exc = None
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    # Swap asyncio.Queue in the module namespace so subscribe() uses our double.
+    monkeypatch.setattr(bus_mod.asyncio, "Queue", PathologicalQueue)
+
+    bus = bus_mod.RedisServerEventBus(store=store)
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe("sid-force-sentinel"):
+            pass  # pragma: no cover
+
+    task = asyncio.create_task(consume())
+    await asyncio.sleep(0.05)
+    with caplog.at_level("ERROR", logger="mcpgateway.transports.server_event_bus"):
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    assert "could not enqueue cancel sentinel" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_consumer_skips_already_seen_event(monkeypatch):
+    """Race: pump delivers an event the consumer will later add to ``seen`` during replay.
+
+    The pump's ``if event_id in seen: continue`` short-circuit doesn't
+    add to seen — only the consumer's replay loop does. So if the
+    pump enqueues an event *before* replay yields it, the consumer
+    yields the replay copy, then reads the pub/sub copy from its
+    queue, sees it in ``seen`` and ``continue`` — that is the
+    dedup branch at line 568.
+    """
+    # Standard
+    import orjson
+
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    m1 = _notif(1)
+    m2 = _notif(2)
+    # Replay will yield ev-1 FIRST; we'll also feed pubsub ev-1 before
+    # replay consumer yields it so pump enqueues a duplicate into the
+    # consumer queue. Consumer then reads ev-1 from queue after it's
+    # already in seen → the line-568 ``continue`` branch fires.
+    store = _FakeStore(replay=[("ev-1", m1)], fetch_map={"ev-1": m1, "ev-2": m2})
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+    bus = RedisServerEventBus(store=store)
+
+    received: list[str] = []
+
+    async def consume() -> None:
+        async for evt in bus.subscribe("sid-dedup-race", last_event_id="ev-0"):
+            received.append(evt.event_id)
+            if len(received) == 2:
+                break
+
+    # Prime the pump with ev-1 BEFORE starting the consumer so pump has it
+    # queued by the time replay runs. Ordering is deterministic: pump
+    # task is created and starts running when subscribe() enters its try
+    # block, and its listen() generator yields from the pre-filled queue.
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-1"})})
+    fake_pubsub.feed({"type": "message", "data": orjson.dumps({"event_id": "ev-2"})})
+
+    # Slow down the replay iterator so the pump has time to enqueue the
+    # duplicate ev-1 BEFORE the consumer yields it from replay.
+    orig_replay = store.replay_after_with_ids
+
+    async def slow_replay(sid, last_id):
+        async for item in orig_replay(sid, last_id):
+            await asyncio.sleep(0.05)
+            yield item
+
+    store.replay_after_with_ids = slow_replay  # type: ignore[assignment]
+
+    task = asyncio.create_task(consume())
+    await asyncio.wait_for(task, timeout=2.0)
+    assert received == ["ev-1", "ev-2"], "duplicate ev-1 must be skipped by consumer"
+
+
+@pytest.mark.asyncio
+async def test_redis_subscribe_teardown_pump_drain_exception_logs_warning(monkeypatch, caplog):
+    """If awaiting the pump_task after cancel raises a non-CancelledError, it is logged at warning.
+
+    We reach this branch by letting the pump's backend-failure path
+    complete (recording pump_failure + _force_sentinel) and wrapping
+    the pump task so ``await pump_task`` re-raises during teardown.
+    The normal pump ``except Exception`` handler *absorbs* the error
+    so the task exits normally — to hit the teardown-time re-raise
+    branch we patch asyncio.create_task to wrap the pump coroutine in
+    a task whose result will raise on await.
+    """
+    # First-Party
+    from mcpgateway.transports.server_event_bus import RedisServerEventBus
+
+    fake_pubsub = _FakePubSub()
+    store = _FakeStore()
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_redis_client",
+        AsyncMock(return_value=_FakeRedis(fake_pubsub)),
+    )
+
+    # Patch create_task so the pump coroutine is wrapped in a task that
+    # raises a non-CancelledError when awaited.
+    orig_create_task = asyncio.create_task
+    marker = {"replaced": False}
+
+    def spy_create_task(coro, *, name=None):
+        if name and name.startswith("server-event-bus-pump:") and not marker["replaced"]:
+            marker["replaced"] = True
+
+            async def failing_pump():
+                try:
+                    await coro  # drive original pump so its finally/sentinel fires
+                except BaseException:
+                    pass
+                raise RuntimeError("drain boom")
+
+            return orig_create_task(failing_pump(), name=name)
+        return orig_create_task(coro, name=name)
+
+    monkeypatch.setattr(asyncio, "create_task", spy_create_task)
+
+    bus = RedisServerEventBus(store=store)
+
+    async def consume() -> None:
+        async for _evt in bus.subscribe("sid-td-pump-drain"):
+            pass  # pragma: no cover
+
+    task = orig_create_task(consume())
+    await asyncio.sleep(0.05)
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.server_event_bus"):
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    assert "Pub/Sub pump drain raised" in caplog.text

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -22,6 +22,7 @@ have no heavy dependencies.
 from __future__ import annotations
 
 # Standard
+import asyncio
 from contextlib import asynccontextmanager
 import json
 from types import SimpleNamespace
@@ -6583,23 +6584,1233 @@ async def test_handle_streamable_http_get_returns_405_when_no_session_id(monkeyp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("header_name", [b"mcp-session-id", b"x-mcp-session-id"])
-async def test_handle_streamable_http_get_passes_through_with_session(monkeypatch, header_name):
-    """GET on /mcp with either Mcp-Session-Id alias reaches the SDK in stateful mode (#4205)."""
+async def test_handle_streamable_http_get_returns_sse_with_session(monkeypatch, header_name):
+    """GET on /mcp with a valid session opens the spec-defined SSE stream (ADR-052).
+
+    The SDK session manager is NOT consulted — the GET stream is served by the
+    gateway's own ``_handle_get_stream`` so server-initiated messages can be
+    fanned out via the per-session event bus.
+    """
+    # Reset the event bus singleton so a clean in-memory backend is used.
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    # ADR-052 / fix #1: production main.lifespan always inits the affinity
+    # singleton so the listener-claim dict is process-wide. The handler
+    # now 503s if the singleton is missing — mirror lifespan in the test.
+    init_session_affinity(enable_notifications=False)
+
     sdk = _CountingSessionManager()
     monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
     monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
 
     wrapper = SessionManagerWrapper()
     await wrapper.initialize()
     send, messages = _make_send_collector()
-    scope = _make_scope("/mcp", method="GET", headers=[(header_name, b"abc-123-valid-session")])
-    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(header_name, b"abc-123-valid-session"), (b"accept", b"text/event-stream")],
+    )
+
+    async def receive_with_disconnect():
+        # Let the SSE handler start, then signal client disconnect so the
+        # response generator unwinds cleanly.
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, receive_with_disconnect, send),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pass  # Acceptable — the heartbeat loop keeps the stream alive
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called, "GET with session must NOT route to the SDK manager"
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts, "expected an http.response.start"
+    assert starts[0]["status"] == 200
+    headers = dict(starts[0]["headers"])
+    assert headers.get(b"content-type", b"").startswith(b"text/event-stream")
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_denies_non_owner_session(monkeypatch, caplog):
+    """ADR-052 / Codex P1: GET /mcp must enforce session ownership before opening SSE.
+
+    Without this gate, any authenticated caller who knows another user's
+    Mcp-Session-Id can subscribe to that session's server-initiated traffic
+    and pin the rightful owner out of the single-listener slot.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    # The validate function returns deny when the session belongs to someone else.
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._validate_streamable_session_access",
+        AsyncMock(return_value=(False, 403, "Session access denied")),
+    )
+
+    counter = tr.transport_get_rejected_counter.labels(outcome="session_denied")
+    before = counter._value.get()
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"someone-elses-session"), (b"accept", b"text/event-stream")],
+    )
+
+    u_token = user_context_var.set({"email": "intruder@example.com", "is_authenticated": True, "is_admin": False, "teams": ["t1"]})
+    try:
+        with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+            await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    finally:
+        user_context_var.reset(u_token)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called, "SDK must not be reached on a denied GET"
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 403
+    assert counter._value.get() == before + 1
+    assert "session ownership check failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_denies_unknown_session(monkeypatch):
+    """ADR-052 / Codex P1: GET /mcp with a well-formed but nonexistent session id must 404.
+
+    Mirrors the POST behavior — without this, GET returns 200 SSE for any
+    session id the caller invents.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._validate_streamable_session_access",
+        AsyncMock(return_value=(False, 404, "Session not found")),
+    )
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"made-up-session-id"), (b"accept", b"text/event-stream")],
+    )
+
+    u_token = user_context_var.set({"email": "user@example.com", "is_authenticated": True, "is_admin": False, "teams": ["t1"]})
+    try:
+        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    finally:
+        user_context_var.reset(u_token)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 404
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_post_response_interception_validates_ownership(monkeypatch, caplog):
+    """Codex P1: response-interception path must validate session ownership before complete_request.
+
+    Without this gate, an authenticated caller who knows the victim's
+    Mcp-Session-Id plus a pending JSON-RPC ``id`` can POST a forged
+    response and complete_request returns 202 — the SDK's normal POST
+    auth would never get a chance to reject the cross-session forgery.
+    """
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    # Force interception path: notification service has a pending request for the victim's session.
+    fake_svc = MagicMock(spec=NotificationService)
+    fake_svc.has_pending_request = MagicMock(return_value=True)
+    fake_svc.complete_request = AsyncMock(side_effect=AssertionError("complete_request must NOT be reached on a denied POST"))
+    monkeypatch.setattr(
+        "mcpgateway.services.notification_service.get_notification_service",
+        lambda: fake_svc,
+    )
+
+    # Owner says caller doesn't own the session.
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._validate_streamable_session_access",
+        AsyncMock(return_value=(False, 403, "Session access denied")),
+    )
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    body = b'{"jsonrpc":"2.0","id":"victim-req-7","result":{"content":[]}}'
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[(b"mcp-session-id", b"victims-session"), (b"content-type", b"application/json")],
+    )
+    u_token = user_context_var.set({"email": "intruder@example.com", "is_authenticated": True, "is_admin": False, "teams": ["t1"]})
+    try:
+        with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+            await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+    finally:
+        user_context_var.reset(u_token)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called, "SDK must not be reached on a denied interception POST"
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 403, "interception path must 403 on ownership failure, not 202"
+    assert "interception" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_returns_405_when_feature_disabled(monkeypatch, caplog):
+    """ADR-052: ``mcp_get_stream_enabled=False`` keeps the 405 path even with a valid session.
+
+    Operator kill switch must override the spec-conformant SSE handler.
+    """
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    counter = tr.transport_get_rejected_counter.labels(outcome="feature_disabled")
+    before = counter._value.get()
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="GET", headers=[(b"mcp-session-id", b"abc-123-valid")])
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
     await wrapper.shutdown()
 
-    assert sdk.called
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 405
+    assert _allow_header(starts[0]) == "POST, DELETE"
+    assert counter._value.get() == before + 1
+    assert "mcp_get_stream_enabled=False" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_second_listener_returns_409(monkeypatch):
+    """ADR-052 single-listener invariant: a second concurrent GET on the same session 409s."""
+    # First-Party
+    from mcpgateway.services.session_affinity import get_session_affinity, init_session_affinity
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus
+
+    await reset_server_event_bus()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    # Pre-claim the listener slot using the singleton affinity service.
+    # First-Party
+    from mcpgateway.services.session_affinity import ListenerClaimResult  # pylint: disable=import-outside-toplevel
+
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+    sid = "abc-123-listener"
+    assert await affinity.claim_listener(sid, "incumbent-conn") is ListenerClaimResult.WON
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", sid.encode()), (b"accept", b"text/event-stream")],
+    )
+    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 409
+    headers = dict(starts[0]["headers"])
+    assert headers.get(b"retry-after") == b"1"
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_wrong_accept_returns_406(monkeypatch):
+    """ADR-052: GET /mcp without ``Accept: text/event-stream`` returns 406."""
+    # First-Party
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus
+
+    await reset_server_event_bus()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    counter = tr.transport_get_rejected_counter.labels(outcome="not_acceptable")
+    before = counter._value.get()
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"abc-123-wrong-accept"), (b"accept", b"application/json")],
+    )
+    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 406
+    assert counter._value.get() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_bus_unavailable_returns_503(monkeypatch):
+    """ADR-052: when the event bus raises after the listener is claimed, return 503 and release the claim."""
+    # First-Party
+    from mcpgateway.services.session_affinity import (
+        ListenerClaimResult,
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus
+
+    await reset_server_event_bus()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    sid = "sess-bus-down"
+
+    async def boom():
+        raise RuntimeError("simulated bus failure")
+
+    # Lazy-imported inside _handle_get_stream — patch the source module.
+    monkeypatch.setattr(
+        "mcpgateway.transports.server_event_bus.get_server_event_bus",
+        boom,
+    )
+    counter = tr.transport_get_rejected_counter.labels(outcome="bus_unavailable")
+    before = counter._value.get()
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", sid.encode()), (b"accept", b"text/event-stream")],
+    )
+    await wrapper.handle_streamable_http(scope, _make_receive(b""), send)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 503
+    assert counter._value.get() == before + 1
+    # Listener claim must have been released so a follow-up GET can succeed.
+    assert await affinity.claim_listener(sid, "follow-up") is ListenerClaimResult.WON
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_falls_through_for_request_payloads():
+    """Response interceptor must not swallow JSON-RPC request payloads (id present + method present)."""
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post
+
+    svc = NotificationService()
+    body = b'{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{}}'
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-passthrough",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+    assert result.disconnected is False
+    assert result.body == body, "body must be preserved for SDK replay"
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_too_large_returns_prefix_for_replay(monkeypatch):
+    """Codex stop-hook regression: over-cap body must fall through to SDK, not 413.
+
+    Large legitimate sampling/createMessage responses can exceed
+    ``mcp_body_peek_max_bytes``. The peek path must return the buffered
+    prefix with ``too_large=True`` so the dispatch can replay-and-defer
+    to the SDK. Hard-rejecting with 413 would strand the upstream
+    ``RequestResponder`` AND drop a valid downstream response.
+    """
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    # Settings are pydantic-validated; patch via the module attribute path.
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_body_peek_max_bytes", 64)
+
+    svc = NotificationService()
+    chunks = [
+        ({"type": "http.request", "body": b"a" * 50, "more_body": True},),
+        ({"type": "http.request", "body": b"b" * 50, "more_body": True},),  # 100 > 64 cap → too_large
+        ({"type": "http.request", "body": b"c" * 50, "more_body": False},),
+    ]
+    idx = [0]
+
+    async def receive():
+        msg = chunks[idx[0]][0]
+        idx[0] += 1
+        return msg
+
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-large-response",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+    assert result.too_large is True
+    assert result.disconnected is False
+    assert result.body is not None, "must return prefix for SDK replay-and-defer"
+    # The over-cap path passes the cap-busting chunk through to the SDK
+    # *verbatim* via ``replay_tail`` instead of slicing it into ``body``.
+    # Slicing would copy the chunk into two new bytes objects and double
+    # peak memory — defeating the cap as a memory bound. ``body`` only
+    # holds the chunks accepted before the cap-busting one arrived.
+    assert result.body == b"a" * 50
+    # Chunk had more_body=True, so more chunks still need draining
+    # from the wire after the replay tail.
+    assert result.replay_tail_more_body is True
+    assert result.replay_tail == b"b" * 50
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_too_large_on_final_chunk_preserves_tail(monkeypatch):
+    """Edge case: the chunk that pushes over the cap is also the last chunk.
+
+    The cap still bounds ``body`` to ``mcp_body_peek_max_bytes`` and the
+    over-cap remainder is stashed in ``replay_tail`` with
+    ``replay_tail_more_body=False`` (no further chunks pending on the
+    original receive).
+    """
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_body_peek_max_bytes", 64)
+
+    svc = NotificationService()
+    chunks = [
+        ({"type": "http.request", "body": b"a" * 50, "more_body": True},),
+        ({"type": "http.request", "body": b"b" * 50, "more_body": False},),  # over cap AND final
+    ]
+    idx = [0]
+
+    async def receive():
+        msg = chunks[idx[0]][0]
+        idx[0] += 1
+        return msg
+
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-large-final",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+    assert result.too_large is True
+    assert result.body == b"a" * 50
+    assert result.replay_tail_more_body is False
+    assert result.replay_tail == b"b" * 50
+
+
+@pytest.mark.asyncio
+async def test_drain_request_body_does_not_double_buffer_oversize_chunk(monkeypatch):
+    """Codex P2 regression: a single multi-MB ASGI chunk must not be double-buffered.
+
+    uvicorn/h11 commonly hands the entire request body over in one
+    ``http.request`` event. The peek path must not slice that chunk
+    into ``body`` plus a remainder — slicing copies the chunk into two
+    new bytes objects and doubles peak memory, defeating the cap as a
+    memory bound. Instead, ``body`` stays at whatever was buffered
+    *before* the cap-busting chunk arrived (``b""`` here, since the
+    huge chunk is the first one), and the chunk is passed through
+    verbatim via ``replay_tail`` so the SDK still sees the full body.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _drain_request_body  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_body_peek_max_bytes", 1024)
+
+    huge = b"x" * (4 * 1024 * 1024)  # 4 MB single chunk
+    delivered = [{"type": "http.request", "body": huge, "more_body": False}]
+    idx = [0]
+
+    async def receive():
+        msg = delivered[idx[0]]
+        idx[0] += 1
+        return msg
+
+    result = await _drain_request_body(receive)
+    assert result.too_large is True
+    assert result.body == b"", "body must not absorb any bytes from the cap-busting chunk"
+    assert result.replay_tail is huge, "the original chunk must pass through verbatim, not via a slice copy"
+    assert result.replay_tail_more_body is False
+
+
+@pytest.mark.asyncio
+async def test_make_replay_receive_replays_prefix_tail_then_defers():
+    """Replay receive yields prefix, then truncated tail, then defers to downstream."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _make_replay_receive  # pylint: disable=import-outside-toplevel
+
+    downstream_chunks = [
+        {"type": "http.request", "body": b"WIRE", "more_body": False},
+    ]
+    idx = [0]
+
+    async def downstream_receive():
+        msg = downstream_chunks[idx[0]]
+        idx[0] += 1
+        return msg
+
+    replay = _make_replay_receive(
+        b"PREFIX",
+        downstream_receive,
+        replay_tail=b"TAIL",
+        replay_tail_more_body=True,
+    )
+
+    first = await replay()
+    assert first == {"type": "http.request", "body": b"PREFIX", "more_body": True}
+
+    second = await replay()
+    assert second == {"type": "http.request", "body": b"TAIL", "more_body": True}
+
+    third = await replay()
+    assert third == {"type": "http.request", "body": b"WIRE", "more_body": False}
+
+
+@pytest.mark.asyncio
+async def test_make_replay_receive_signals_complete_when_prefix_is_whole_body():
+    """No-truncation path keeps the existing fast-path semantics.
+
+    When the peek captured the full body, the replay yields a single
+    complete chunk and downstream receive only fires for later
+    disconnect signals.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _make_replay_receive  # pylint: disable=import-outside-toplevel
+
+    async def downstream_receive():
+        return {"type": "http.disconnect"}
+
+    replay = _make_replay_receive(b"WHOLE", downstream_receive)
+
+    first = await replay()
+    assert first == {"type": "http.request", "body": b"WHOLE", "more_body": False}
+
+    second = await replay()
+    assert second == {"type": "http.disconnect"}
+
+
+def test_accepts_event_stream_handles_q_values_and_case():
+    """Codex P3 regression: Accept parser must honour ``q=0`` and case-insensitive media types.
+
+    Substring matching gets both edges wrong: ``Text/Event-Stream`` is
+    rejected and ``text/event-stream;q=0`` is accepted.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _accepts_event_stream  # pylint: disable=import-outside-toplevel
+
+    # Permissive cases.
+    assert _accepts_event_stream("text/event-stream") is True
+    assert _accepts_event_stream("text/event-stream;charset=utf-8") is True
+    assert _accepts_event_stream("Text/Event-Stream") is True, "case-insensitive per RFC 7231"
+    assert _accepts_event_stream("text/event-stream;q=0.9") is True
+    assert _accepts_event_stream("application/json, text/event-stream") is True
+    assert _accepts_event_stream("*/*") is True
+    assert _accepts_event_stream("text/*") is True
+    assert _accepts_event_stream("") is True, "empty header → no preference"
+
+    # Rejection cases.
+    assert _accepts_event_stream("text/event-stream;q=0") is False, "q=0 means explicit refusal"
+    assert _accepts_event_stream("application/json") is False
+    assert _accepts_event_stream("text/html, application/xml") is False
+    assert _accepts_event_stream("*/*;q=0") is False, "wildcard with q=0 is still refusal"
+
+
+def test_bucket_method_label_caps_cardinality():
+    """Codex P2 regression: events-delivered metric label must come from a finite allowlist.
+
+    Without bucketing, ``method`` flows straight from upstream JSON-RPC
+    traffic and a buggy/malicious MCP server can explode Prometheus
+    cardinality. The allowlist bucket guarantees a bounded label set.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _bucket_method_label  # pylint: disable=import-outside-toplevel
+
+    # Known MCP methods round-trip verbatim.
+    assert _bucket_method_label("notifications/initialized") == "notifications/initialized"
+    assert _bucket_method_label("sampling/createMessage") == "sampling/createMessage"
+    assert _bucket_method_label("ping") == "ping"
+
+    # Unknown / arbitrary upstream methods fall into a single bucket.
+    assert _bucket_method_label("custom.attacker.method") == "other"
+    assert _bucket_method_label("notifications/custom_namespace") == "other"
+    assert _bucket_method_label("a" * 4096) == "other", "unbounded-length input must NOT pass through"
+
+    # Missing / non-string input falls into the explicit unknown bucket.
+    assert _bucket_method_label(None) == "unknown"
+    assert _bucket_method_label("") == "unknown"
+    assert _bucket_method_label(123) == "unknown"  # type: ignore[arg-type]
+
+
+def test_resolve_intercept_target_swallows_service_not_initialized():
+    """Early-boot path: NotificationService not initialized → return None, never raise.
+
+    Locks in the narrow ``except RuntimeError``: if a future change
+    started swallowing arbitrary exceptions here, it would silently
+    disable interception for every in-flight server-initiated
+    request response. The narrow catch is a deliberate guard.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _resolve_intercept_target  # pylint: disable=import-outside-toplevel
+    import mcpgateway.transports.streamablehttp_transport as transport_mod  # pylint: disable=import-outside-toplevel
+
+    # Bypass the cached module ref so the test patches the live import.
+    transport_mod._notification_service_module = None
+
+    def _raise_not_init():
+        raise RuntimeError("NotificationService not initialized")
+
+    with patch("mcpgateway.services.notification_service.get_notification_service", side_effect=_raise_not_init):
+        assert _resolve_intercept_target("POST", "sess-x") is None
+
+    # Non-RuntimeError exceptions must propagate (locking in the narrow catch).
+    def _raise_value():
+        raise ValueError("bug in has_pending_request")
+
+    with patch("mcpgateway.services.notification_service.get_notification_service", side_effect=_raise_value):
+        with pytest.raises(ValueError, match="bug in has_pending_request"):
+            _resolve_intercept_target("POST", "sess-x")
+
+
+def test_body_peek_result_invariant_validator_rejects_invalid_combinations():
+    """The __post_init__ validator must catch every combination its docstring promises.
+
+    The dataclass is the load-bearing safety net for the dispatch
+    helper's "body is None on fall-through is impossible" assumption.
+    A regression that quietly weakens any of these checks would let an
+    invalid result reach _dispatch_peek_outcome and cascade.
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _BodyPeekResult  # pylint: disable=import-outside-toplevel
+
+    # body=None ⇒ disconnected=True
+    with pytest.raises(ValueError, match="body=None"):
+        _BodyPeekResult(body=None, intercepted=False, disconnected=False)
+
+    # body=None must not carry intercepted/too_large/replay_tail
+    with pytest.raises(ValueError, match="disconnected result"):
+        _BodyPeekResult(body=None, intercepted=False, disconnected=True, too_large=True)
+    with pytest.raises(ValueError, match="disconnected result"):
+        _BodyPeekResult(body=None, intercepted=True, disconnected=True)
+
+    # intercepted ⇒ NOT too_large
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _BodyPeekResult(body=b"x", intercepted=True, too_large=True, replay_tail=b"y")
+
+    # intercepted ⇒ no replay_tail (would be silently swallowed by 202 path)
+    with pytest.raises(ValueError, match="intercepted result must not carry replay_tail"):
+        _BodyPeekResult(body=b"x", intercepted=True, replay_tail=b"y")
+
+    # too_large ⇒ replay_tail non-empty
+    with pytest.raises(ValueError, match="too_large result must carry the replay_tail"):
+        _BodyPeekResult(body=b"x", intercepted=False, too_large=True, replay_tail=b"")
+
+    # replay_tail_more_body ⇒ replay_tail non-empty
+    with pytest.raises(ValueError, match="replay_tail_more_body=True requires"):
+        _BodyPeekResult(body=b"x", intercepted=False, replay_tail=b"", replay_tail_more_body=True)
+
+    # Valid shapes round-trip without raising
+    _BodyPeekResult(body=None, intercepted=False, disconnected=True)
+    _BodyPeekResult(body=b"hello", intercepted=False)
+    _BodyPeekResult(body=b"hello", intercepted=True)
+    _BodyPeekResult(body=b"prefix", intercepted=False, too_large=True, replay_tail=b"tail", replay_tail_more_body=True)
+
+
+def _make_chunked_receive(*chunks):
+    """Build an ASGI receive() that yields each chunk in turn."""
+    state = {"i": 0}
+
+    async def receive():
+        msg = chunks[state["i"]]
+        state["i"] += 1
+        return msg
+
+    return receive
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_intercepts_real_notification():
+    """A single-message JSON-RPC notification (no ``id``) → 202 short-circuit."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"notifications/initialized"}', "more_body": False},
+    )
+    result = await _maybe_short_circuit_notification(receive)
+    assert result.intercepted is True
+    assert result.disconnected is False
+    assert result.too_large is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_falls_through_for_request_with_id():
+    """A request (has ``id``) must NOT be intercepted — silently 202'ing it would strand the caller forever."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'{"jsonrpc":"2.0","id":"1","method":"tools/list"}', "more_body": False},
+    )
+    result = await _maybe_short_circuit_notification(receive)
+    assert result.intercepted is False
+    assert result.body is not None, "body must be returned for SDK replay"
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_falls_through_for_batch():
+    """A JSON-RPC batch array must NOT be short-circuited; the SDK handles batches."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'[{"jsonrpc":"2.0","method":"a"},{"jsonrpc":"2.0","method":"b"}]', "more_body": False},
+    )
+    result = await _maybe_short_circuit_notification(receive)
+    assert result.intercepted is False
+    assert result.body is not None
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_falls_through_for_malformed_json():
+    """A body that doesn't parse as JSON must NOT be intercepted."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b"not json at all }{[", "more_body": False},
+    )
+    result = await _maybe_short_circuit_notification(receive)
+    assert result.intercepted is False
+    assert result.body is not None
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_falls_through_when_too_large():
+    """Over-cap bodies must NOT be intercepted — fall through to SDK with the cap-busting chunk preserved."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    monkey_settings = tr.settings  # capture so we can restore
+    original_cap = monkey_settings.mcp_body_peek_max_bytes
+    monkey_settings.mcp_body_peek_max_bytes = 32
+    try:
+        receive = _make_chunked_receive(
+            {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"a"}' * 5, "more_body": False},
+        )
+        result = await _maybe_short_circuit_notification(receive)
+        assert result.intercepted is False
+        assert result.too_large is True
+        assert result.replay_tail, "cap-busting chunk preserved for SDK replay"
+    finally:
+        monkey_settings.mcp_body_peek_max_bytes = original_cap
+
+
+@pytest.mark.asyncio
+async def test_maybe_short_circuit_notification_returns_disconnected_on_client_drop():
+    """Client disconnect mid-body must NOT replay a truncated body to the SDK."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _maybe_short_circuit_notification  # pylint: disable=import-outside-toplevel
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"par', "more_body": True},
+        {"type": "http.disconnect"},
+    )
+    result = await _maybe_short_circuit_notification(receive)
+    assert result.disconnected is True
+    assert result.body is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_intercepts_held_responder(monkeypatch):
+    """Held server-initiated request → matched response → ``intercepted=True``.
+
+    Covers the transport-side dispatch path where the body-peek matches a
+    held responder via NotificationService.complete_request — no transport
+    test previously exercised the ``intercepted=True`` path (only the
+    fall-through and disconnect branches were covered).
+    """
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    svc = NotificationService()
+    monkeypatch.setattr(svc, "complete_request", AsyncMock(return_value=True))
+
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'{"jsonrpc":"2.0","id":"req-7","result":{"content":[]}}', "more_body": False},
+    )
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-intercept",
+        notification_service=svc,
+    )
+    assert result.intercepted is True
+    assert result.disconnected is False
+    assert result.too_large is False
+    svc.complete_request.assert_awaited_once()
+    args, _kwargs = svc.complete_request.await_args
+    assert args[0] == "sess-intercept"
+    assert args[1] == "req-7"
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_signals_disconnect_without_replay():
+    """ADR-052 (silent-failure fix): ``http.disconnect`` mid-body must NOT replay a truncated body."""
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post
+
+    svc = NotificationService()
+    chunks = [
+        ({"type": "http.request", "body": b'{"jsonrpc":"2.0","id":"1","resu', "more_body": True},),
+        ({"type": "http.disconnect"},),
+    ]
+    idx = [0]
+
+    async def receive():
+        msg = chunks[idx[0]][0]
+        idx[0] += 1
+        return msg
+
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-disconnect",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+    assert result.disconnected is True
+    assert result.body is None, "must NOT return truncated body for replay"
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_heartbeat_loss_closes_stream_then_reclaim_succeeds(monkeypatch):
+    """ADR-052: heartbeat-induced claim loss must close the SSE response so a second listener can re-claim.
+
+    Regression test for the single-listener invariant: if the heartbeat
+    loop reports the claim is no longer ours (Redis preemption, TTL
+    expiry, or sustained heartbeat failure), the active SSE stream
+    must close before another GET can take the slot. Otherwise the
+    original stream and a new claimant would coexist and both would
+    receive every server-initiated message.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        ListenerClaimResult,
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+    # Tight TTL so the heartbeat fires inside the test window.
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_listener_ttl_seconds", 1)
+
+    sid = "sess-heartbeat-loss"
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", sid.encode()), (b"accept", b"text/event-stream")],
+    )
+
+    # Forcibly drop the listener claim from under the active GET.
+    # The heartbeat loop's next refresh attempt will see it's gone,
+    # tolerate the configured number of misses, then signal close.
+    async def kick_claim_out():
+        await asyncio.sleep(0.4)
+        # Simulate a Redis-side preemption: clear the in-memory dict
+        # outright. The original GET's connection_id is now orphaned.
+        affinity._listener_claims.clear()  # noqa: SLF001 — test preemption simulation
+
+    kicker = asyncio.create_task(kick_claim_out())
+
+    async def receive_keepalive():
+        # Hold the connection open longer than the heartbeat window so
+        # the heartbeat actually runs and detects the loss.
+        await asyncio.sleep(3.0)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, receive_keepalive, send),
+            timeout=5.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await kicker
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    # After the original stream closed, a second client must be able to
+    # claim the now-vacated slot.
+    assert await affinity.claim_listener(sid, "second-client") is ListenerClaimResult.WON
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_replays_from_last_event_id(monkeypatch):
+    """ADR-052 resume: ``Last-Event-Id`` causes replay of buffered events on connect."""
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification
+    from mcpgateway.transports.server_event_bus import (
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    sid = "abc-123-resume"
+    bus = await get_server_event_bus()
+    eid_a = await bus.publish(sid, JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/a")))
+    eid_b = await bus.publish(sid, JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/b")))
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[
+            (b"mcp-session-id", sid.encode()),
+            (b"accept", b"text/event-stream"),
+            (b"last-event-id", eid_a.encode()),
+        ],
+    )
+
+    async def disconnect_after_replay():
+        # Hold the stream open just long enough for the replay events to flush
+        # through SSE serialization, then signal client disconnect.
+        await asyncio.sleep(0.2)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, disconnect_after_replay, send),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
     starts = [m for m in messages if m["type"] == "http.response.start"]
     assert starts and starts[0]["status"] == 200
+    body_chunks = b"".join(m.get("body", b"") for m in messages if m["type"] == "http.response.body")
+    # Replay must include eid_b but NOT eid_a (Last-Event-Id is exclusive).
+    assert eid_b.encode() in body_chunks
+    assert b"notifications/b" in body_chunks
+    assert eid_a.encode() not in body_chunks
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_closes_bus_subscription_on_disconnect(monkeypatch):
+    """ADR-052 cleanup: client disconnect must aclose() the bus subscription.
+
+    Without this, every cancelled GET stream leaks the per-listener
+    queue (in-memory) or the pubsub connection (Redis). The cleanup is
+    silenced behind try/except so a regression that drops the
+    aclose() call would be invisible — this test wraps the bus to
+    assert the call actually fires.
+    """
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    bus = await get_server_event_bus()
+    aclose_calls: list[str] = []
+
+    # Wrap the bus's subscribe() so we can intercept the async iterator's aclose.
+    original_subscribe = bus.subscribe
+
+    def wrapped_subscribe(session_id, *, last_event_id=None):
+        underlying = original_subscribe(session_id, last_event_id=last_event_id)
+
+        class _TrackingIter:
+            """Forwards iteration to the real bus iterator, records aclose."""
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return await underlying.__anext__()
+
+            async def aclose(self):
+                aclose_calls.append(session_id)
+                await underlying.aclose()
+
+        return _TrackingIter()
+
+    monkeypatch.setattr(bus, "subscribe", wrapped_subscribe)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-aclose-check"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_after_start():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, disconnect_after_start, send),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert aclose_calls == ["sid-aclose-check"], "bus_iter.aclose must fire exactly once on client disconnect"
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_get_preempt_then_reclaim_replays_gap_event(monkeypatch):
+    """ADR-052 fanout: an event published between preemption and reclaim must reach the next listener.
+
+    The single-listener invariant means at most one stream is live at a
+    time, but published events buffer in the bus's event store. A
+    second listener that resumes with ``Last-Event-Id`` must see events
+    that landed during the gap — otherwise multi-node fanout silently
+    loses messages whenever a heartbeat-loss preemption races with a
+    publish.
+    """
+    # First-Party
+    from mcp.types import JSONRPCMessage, JSONRPCNotification  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    sid = "sid-preempt-gap"
+    bus = await get_server_event_bus()
+    # Pre-existing event the first listener saw (we'll resume after this id).
+    eid_before = await bus.publish(sid, JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/before")))
+
+    # Simulate a previous listener having held the slot, then losing it
+    # via heartbeat preemption. The transport's heartbeat-loss test
+    # already exercises that preemption path; here we just leave the
+    # claim slot vacant and publish a "gap" event before the second
+    # listener resumes.
+    eid_gap = await bus.publish(sid, JSONRPCMessage(JSONRPCNotification(jsonrpc="2.0", method="notifications/gap")))
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[
+            (b"mcp-session-id", sid.encode()),
+            (b"accept", b"text/event-stream"),
+            (b"last-event-id", eid_before.encode()),
+        ],
+    )
+
+    async def disconnect_after_replay():
+        await asyncio.sleep(0.2)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, disconnect_after_replay, send),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    # Sanity: the in-memory backend assigned distinct event ids and the
+    # affinity slot is reusable for the next listener.
+    assert eid_before != eid_gap
+    assert affinity is not None  # singleton resolved cleanly
+    body_chunks = b"".join(m.get("body", b"") for m in messages if m["type"] == "http.response.body")
+    # The gap event published *between* the previous listener's last
+    # seen event and this listener's claim must replay through.
+    assert eid_gap.encode() in body_chunks, "gap event must reach the second listener via Last-Event-Id replay"
+    assert b"notifications/gap" in body_chunks
+    # The pre-resume event must NOT replay (Last-Event-Id is exclusive).
+    assert eid_before.encode() not in body_chunks
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_allows_authenticated_oauth_server_on_get(monkeypatch):
+    """Symmetric to the unauthenticated 401 case: a valid token on GET /mcp must reach the handler.
+
+    The unauthenticated 401 case is covered by
+    ``test_streamable_http_auth_rejects_unauthenticated_oauth_server_on_get``.
+    Without this symmetric check, a future change that gated GET on
+    OAuth incorrectly (e.g. checking method != "GET") would silently
+    block legitimate authenticated streams.
+    """
+
+    async def fake_verify(token):
+        return {
+            "sub": "user@example.com",
+            "teams": ["team1"],
+            "user": {"is_admin": False},
+        }
+
+    monkeypatch.setattr(tr, "verify_credentials", fake_verify)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", False)
+
+    mock_auth_cache = MagicMock()
+    mock_auth_cache.get_team_membership_valid_sync.return_value = True
+
+    scope = _make_scope("/servers/abc123def/mcp", method="GET", headers=[(b"authorization", b"Bearer valid-token")])
+    called = []
+
+    async def send(msg):
+        called.append(msg)
+
+    with patch("mcpgateway.cache.auth_cache.get_auth_cache", return_value=mock_auth_cache):
+        result = await streamable_http_auth(scope, None, send)
+    assert result is True, "auth middleware must allow authenticated GET to oauth_enabled server"
+    assert called == [], "no error response should be sent"
+
+    user_ctx = tr.user_context_var.get()
+    assert user_ctx.get("is_authenticated") is True
 
 
 @pytest.mark.asyncio
@@ -14172,3 +15383,952 @@ class TestDirectProxyValidatesMeta:
         hidden_depth = {"k": [{"l2": {"l3": "x"}}]}
         with pytest.raises(ValueError, match="maximum nesting depth"):
             _validate_meta_data(hidden_depth)
+
+
+# ---------------------------------------------------------------------------
+# Coverage gap closers for the ADR-052 GET /mcp stream and body-peek helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_request_body_translates_end_of_stream_to_disconnected():
+    """Lines 2865-2867: ASGI transport errors map to ``disconnected=True`` instead of propagating."""
+    # Third-Party
+    import anyio  # pylint: disable=import-outside-toplevel
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _drain_request_body  # pylint: disable=import-outside-toplevel
+
+    async def bad_receive():
+        raise anyio.EndOfStream()
+
+    result = await _drain_request_body(bad_receive)
+    assert result.disconnected is True
+    assert result.body is None
+
+
+@pytest.mark.asyncio
+async def test_drain_request_body_translates_closed_resource_error():
+    """Lines 2865-2867: ClosedResourceError also maps to a disconnected result."""
+    # Third-Party
+    import anyio  # pylint: disable=import-outside-toplevel
+
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _drain_request_body  # pylint: disable=import-outside-toplevel
+
+    async def bad_receive():
+        raise anyio.ClosedResourceError()
+
+    result = await _drain_request_body(bad_receive)
+    assert result.disconnected is True
+    assert result.body is None
+
+
+@pytest.mark.asyncio
+async def test_drain_request_body_translates_os_error():
+    """Lines 2865-2867: OSError from the underlying transport becomes a disconnected result."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _drain_request_body  # pylint: disable=import-outside-toplevel
+
+    async def bad_receive():
+        raise OSError("socket broken")
+
+    result = await _drain_request_body(bad_receive)
+    assert result.disconnected is True
+    assert result.body is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_invalid_json_falls_through():
+    """Lines 2902-2903: malformed JSON body must fall through, not crash."""
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    svc = NotificationService()
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b"not json at all", "more_body": False},
+    )
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-bad-json",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+    assert result.body == b"not json at all"
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_non_dict_payload_falls_through():
+    """Line 2907: top-level array (batch) payload must fall through."""
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    svc = NotificationService()
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'[{"id":"1","result":{}}]', "more_body": False},
+    )
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-batch",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_intercept_response_post_missing_result_and_error_falls_through():
+    """Line 2911: a dict with ``id`` but no ``result``/``error`` is not a JSON-RPC response."""
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _maybe_intercept_response_post  # pylint: disable=import-outside-toplevel
+
+    svc = NotificationService()
+    # Has `id` but no `result`/`error` and no `method` → falls through via the
+    # no-result/no-error guard.
+    receive = _make_chunked_receive(
+        {"type": "http.request", "body": b'{"jsonrpc":"2.0","id":"1"}', "more_body": False},
+    )
+    result = await _maybe_intercept_response_post(
+        receive=receive,
+        mcp_session_id="sess-id-only",
+        notification_service=svc,
+    )
+    assert result.intercepted is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_peek_outcome_intercepted_emits_202():
+    """Lines 3112-3114: ``intercepted=True`` → 202 + HANDLED."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (  # pylint: disable=import-outside-toplevel
+        _BodyPeekResult,
+        _PeekDispatchOutcome,
+        _dispatch_peek_outcome,
+    )
+
+    send, messages = _make_send_collector()
+
+    async def dummy_receive():
+        return {"type": "http.disconnect"}
+
+    peek = _BodyPeekResult(body=b"{}", intercepted=True)
+    outcome, _new_recv = await _dispatch_peek_outcome(
+        peek,
+        dummy_receive,
+        send,
+        accepted_body=b"{}",
+        log_label="t",
+        log_context="sess",
+    )
+    assert outcome is _PeekDispatchOutcome.HANDLED
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 202
+
+
+@pytest.mark.asyncio
+async def test_dispatch_peek_outcome_disconnected_returns_aborted(caplog):
+    """Lines 3118-3119: disconnected result logs and returns ABORTED without touching send."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (  # pylint: disable=import-outside-toplevel
+        _BodyPeekResult,
+        _PeekDispatchOutcome,
+        _dispatch_peek_outcome,
+    )
+
+    send, messages = _make_send_collector()
+
+    async def dummy_receive():
+        return {"type": "http.disconnect"}
+
+    peek = _BodyPeekResult(body=None, intercepted=False, disconnected=True)
+    with caplog.at_level("DEBUG", logger="mcpgateway.transports.streamablehttp_transport"):
+        outcome, _new_recv = await _dispatch_peek_outcome(
+            peek,
+            dummy_receive,
+            send,
+            accepted_body=b"",
+            log_label="notification short-circuit",
+            log_context="/mcp",
+        )
+    assert outcome is _PeekDispatchOutcome.ABORTED
+    assert messages == []  # no response was sent
+    assert "aborted by client mid-body" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_peek_outcome_too_large_logs_and_falls_through(caplog):
+    """Line 3124: too_large result logs debug and falls through with a replay-wrapped receive."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (  # pylint: disable=import-outside-toplevel
+        _BodyPeekResult,
+        _PeekDispatchOutcome,
+        _dispatch_peek_outcome,
+    )
+
+    send, _messages = _make_send_collector()
+
+    async def dummy_receive():
+        return {"type": "http.disconnect"}
+
+    peek = _BodyPeekResult(
+        body=b"prefix",
+        intercepted=False,
+        too_large=True,
+        replay_tail=b"tail",
+    )
+    with caplog.at_level("DEBUG", logger="mcpgateway.transports.streamablehttp_transport"):
+        outcome, new_recv = await _dispatch_peek_outcome(
+            peek,
+            dummy_receive,
+            send,
+            accepted_body=b"",
+            log_label="response interception",
+            log_context="sess-big",
+        )
+    assert outcome is _PeekDispatchOutcome.FALLTHROUGH
+    assert "exceeds peek cap" in caplog.text
+    first = await new_recv()
+    assert first["body"] == b"prefix"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_peek_outcome_body_none_on_fallthrough_raises_runtime_error(monkeypatch):
+    """Line 3126: the invariant guard raises ``RuntimeError`` when body is None on the fall-through path."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (  # pylint: disable=import-outside-toplevel
+        _BodyPeekResult,
+        _dispatch_peek_outcome,
+    )
+
+    send, _messages = _make_send_collector()
+
+    async def dummy_receive():
+        return {"type": "http.disconnect"}
+
+    # Build a valid disconnected result, then bypass __post_init__ with
+    # object.__setattr__ to craft the impossible "body=None on fall-through"
+    # shape that the invariant guard must reject.
+    peek = _BodyPeekResult(body=None, intercepted=False, disconnected=True)
+    object.__setattr__(peek, "disconnected", False)
+    with pytest.raises(RuntimeError, match="_BodyPeekResult invariant violation"):
+        await _dispatch_peek_outcome(
+            peek,
+            dummy_receive,
+            send,
+            accepted_body=b"",
+            log_label="t",
+            log_context="x",
+        )
+
+
+def test_accepts_event_stream_skips_empty_entries_in_list():
+    """Line 3218: empty list entries in Accept header are skipped (trailing/double commas)."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _accepts_event_stream  # pylint: disable=import-outside-toplevel
+
+    # Leading/trailing/double commas produce empty entries the parser must skip
+    # without tripping on the media_type.partition(";") step.
+    assert _accepts_event_stream(",text/event-stream") is True
+    assert _accepts_event_stream("text/event-stream,,application/json") is True
+    assert _accepts_event_stream(",,,") is False
+
+
+def test_accepts_event_stream_invalid_q_value_rejects():
+    """Lines 3230-3231: malformed q-value treated as 0 (explicit refusal)."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _accepts_event_stream  # pylint: disable=import-outside-toplevel
+
+    # Non-numeric q value — per spec / defensive choice — treated as q=0 refusal.
+    assert _accepts_event_stream("text/event-stream;q=not-a-number") is False
+    # But a different media type with a busted q shouldn't save us.
+    assert _accepts_event_stream("application/json;q=xyz") is False
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_session_affinity_not_initialized_returns_503(monkeypatch, caplog):
+    """Lines 3315, 3320-3327: SessionAffinityNotInitializedError → 503."""
+    # First-Party
+    import mcpgateway.services.session_affinity as sa_mod  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.streamablehttp_transport import _handle_get_stream  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    # Force the "not initialized" condition by clearing the singleton.
+    monkeypatch.setattr(sa_mod, "_mcp_session_pool", None, raising=False)
+
+    counter = tr.transport_get_rejected_counter.labels(outcome="bus_unavailable")
+    before = counter._value.get()
+
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sess-no-affinity"), (b"accept", b"text/event-stream")],
+    )
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        await _handle_get_stream(
+            scope=scope,
+            receive=_make_receive(b""),
+            send=send,
+            mcp_session_id="sess-no-affinity",
+            last_event_id=None,
+            accept="text/event-stream",
+        )
+
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 503
+    headers = dict(starts[0]["headers"])
+    assert headers.get(b"retry-after") == b"1"
+    assert counter._value.get() == before + 1
+    assert "SessionAffinity not initialized" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_claim_unavailable_returns_503(monkeypatch):
+    """Lines 3348-3354: ListenerClaimResult.UNAVAILABLE → 503 with retry hint."""
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        ListenerClaimResult,
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.streamablehttp_transport import _handle_get_stream  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+    monkeypatch.setattr(
+        affinity,
+        "claim_listener",
+        AsyncMock(return_value=ListenerClaimResult.UNAVAILABLE),
+    )
+
+    counter = tr.transport_get_rejected_counter.labels(outcome="bus_unavailable")
+    before = counter._value.get()
+
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sess-claim-unavail"), (b"accept", b"text/event-stream")],
+    )
+    await _handle_get_stream(
+        scope=scope,
+        receive=_make_receive(b""),
+        send=send,
+        mcp_session_id="sess-claim-unavail",
+        last_event_id=None,
+        accept="text/event-stream",
+    )
+    await reset_server_event_bus()
+
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 503
+    headers = dict(starts[0]["headers"])
+    assert headers.get(b"retry-after") == b"1"
+    assert counter._value.get() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_unreachable_claim_variant_triggers_assert_never(monkeypatch):
+    """Lines 3357-3358: a sentinel ListenerClaimResult the match does not handle trips ``assert_never``."""
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.streamablehttp_transport import _handle_get_stream  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    # Return a sentinel that is none of {WON, CONFLICT, UNAVAILABLE}. The
+    # defensive ``case _ as _unreachable: assert_never(...)`` should raise.
+    monkeypatch.setattr(affinity, "claim_listener", AsyncMock(return_value="bogus-variant"))
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid"), (b"accept", b"text/event-stream")],
+    )
+    # assert_never raises some form of exception (AssertionError / TypeError
+    # depending on implementation); either way the handler must NOT silently
+    # fall through to return without emitting a response.
+    with pytest.raises(Exception):  # noqa: BLE001
+        await _handle_get_stream(
+            scope=scope,
+            receive=_make_receive(b""),
+            send=send,
+            mcp_session_id="sid",
+            last_event_id=None,
+            accept="text/event-stream",
+        )
+    await reset_server_event_bus()
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_event_gen_handles_backlog_overflow(monkeypatch, caplog):
+    """Line 3467: ListenerBacklogOverflow in event_gen logs info and exits cleanly."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        ListenerBacklogOverflow,
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    bus = await get_server_event_bus()
+
+    async def overflowing_subscribe(session_id, *, last_event_id=None):  # pylint: disable=unused-argument
+        # An async generator that immediately raises ListenerBacklogOverflow on
+        # first anext — exercises the dedicated except branch in event_gen.
+        if False:
+            yield  # pragma: no cover — keep this a valid async generator
+        raise ListenerBacklogOverflow(f"queue overflowed for session {session_id}")
+
+    monkeypatch.setattr(bus, "subscribe", overflowing_subscribe)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-overflow"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("INFO", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "backlog overflow" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_event_gen_handles_bus_backend_error(monkeypatch, caplog):
+    """Line 3472: BusBackendError in event_gen logs a warning and exits cleanly."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        BusBackendError,
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    bus = await get_server_event_bus()
+
+    async def failing_subscribe(session_id, *, last_event_id=None):  # pylint: disable=unused-argument
+        if False:
+            yield  # pragma: no cover
+        raise BusBackendError(f"backend dead for {session_id}")
+
+    monkeypatch.setattr(bus, "subscribe", failing_subscribe)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-backend-err"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "bus backend error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_event_gen_logs_unexpected_exception(monkeypatch, caplog):
+    """Line 3484: programming-error exceptions in event_gen log a warning with traceback."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    bus = await get_server_event_bus()
+
+    async def explosive_subscribe(session_id, *, last_event_id=None):  # pylint: disable=unused-argument
+        if False:
+            yield  # pragma: no cover
+        raise ValueError(f"boom for {session_id}")
+
+    monkeypatch.setattr(bus, "subscribe", explosive_subscribe)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-boom"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "exited unexpectedly" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_stop_async_iteration_ends_stream_cleanly(monkeypatch):
+    """Lines 3456-3457: StopAsyncIteration from the bus iterator ends the event generator cleanly."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import (  # pylint: disable=import-outside-toplevel
+        get_server_event_bus,
+        reset_server_event_bus,
+    )
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    bus = await get_server_event_bus()
+
+    # An async generator that yields zero events and immediately returns —
+    # the first anext raises StopAsyncIteration which the event_gen captures
+    # and treats as a clean end-of-stream.
+    async def empty_subscribe(session_id, *, last_event_id=None):  # pylint: disable=unused-argument
+        return
+        yield  # pragma: no cover — keeps the function an async generator
+
+    monkeypatch.setattr(bus, "subscribe", empty_subscribe)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-empty"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    # SSE 200 must have been opened before the empty generator exited.
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_heartbeat_success_resets_failure_counter(monkeypatch):
+    """Lines 3408-3409: a successful heartbeat clears ``consecutive_failures``."""
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    # Count how many times heartbeat_listener was invoked (to confirm the
+    # loop ran at least one successful iteration → reset-branch covered).
+    real_hb = affinity.heartbeat_listener
+    call_count = {"n": 0}
+
+    async def tracking_hb(session_id, conn_id):
+        call_count["n"] += 1
+        return await real_hb(session_id, conn_id)
+
+    monkeypatch.setattr(affinity, "heartbeat_listener", tracking_hb)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+    # Drive the heartbeat to fire inside the test window — TTL of 3 produces
+    # a 1s cadence (floored); hold the stream open slightly longer.
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_listener_ttl_seconds", 3)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-hb"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_after_heartbeat():
+        await asyncio.sleep(1.3)
+        return {"type": "http.disconnect"}
+
+    try:
+        await asyncio.wait_for(
+            wrapper.handle_streamable_http(scope, disconnect_after_heartbeat, send),
+            timeout=3.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert call_count["n"] >= 1, "heartbeat must have fired at least once to exercise the success branch"
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_release_listener_exception_is_logged(monkeypatch, caplog):
+    """Lines 3533-3534: release_listener raising during cleanup must be logged, not propagated."""
+    # First-Party
+    from mcpgateway.services.session_affinity import (  # pylint: disable=import-outside-toplevel
+        get_session_affinity,
+        init_session_affinity,
+    )
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+    affinity = get_session_affinity()
+
+    async def boom_release(session_id, conn_id):  # pylint: disable=unused-argument
+        raise RuntimeError("simulated release failure")
+
+    monkeypatch.setattr(affinity, "release_listener", boom_release)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-release-fail"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "release_listener raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_gauge_dec_exception_is_logged(monkeypatch, caplog):
+    """Lines 3542-3543: Prometheus gauge decrement failures during cleanup are logged at debug."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    # Swap the module-level gauge for a fake whose dec() raises.
+    class _BrokenGauge:
+        def inc(self):
+            return None
+
+        def dec(self):
+            raise RuntimeError("prometheus broken")
+
+    monkeypatch.setattr(tr, "transport_get_active_listeners_gauge", _BrokenGauge())
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-gauge"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("DEBUG", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "gauge.dec raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_get_stream_heartbeat_task_drain_exception_is_logged(monkeypatch, caplog):
+    """Lines 3524-3525: a heartbeat-task failure during cleanup is logged, not propagated."""
+    # First-Party
+    import mcpgateway.transports.streamablehttp_transport as tr_mod  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    # Replace ``asyncio.create_task`` just for the heartbeat path so it returns
+    # a task that raises a non-CancelledError when awaited. We only intercept
+    # tasks whose name starts with "get-stream-heartbeat:" to avoid breaking
+    # the sse_starlette internal tasks.
+    real_create_task = asyncio.create_task
+
+    class _FailingTask:
+        def __init__(self):
+            self._cancelled = False
+
+        def cancel(self):
+            self._cancelled = True
+
+        def __await__(self):
+            async def _raise():
+                raise RuntimeError("hb drain fail")
+
+            return _raise().__await__()
+
+    def fake_create_task(coro, *args, name=None, **kwargs):
+        if name and name.startswith("get-stream-heartbeat:"):
+            # Ensure the real coroutine is still scheduled so the handler runs
+            # it (and we close it to avoid "coroutine never awaited" warnings),
+            # then return our fake task.
+            coro.close()
+            return _FailingTask()
+        return real_create_task(coro, *args, name=name, **kwargs)
+
+    monkeypatch.setattr(tr_mod.asyncio, "create_task", fake_create_task)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, _messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="GET",
+        headers=[(b"mcp-session-id", b"sid-hb-drain"), (b"accept", b"text/event-stream")],
+    )
+
+    async def disconnect_quickly():
+        await asyncio.sleep(0.1)
+        return {"type": "http.disconnect"}
+
+    with caplog.at_level("WARNING", logger="mcpgateway.transports.streamablehttp_transport"):
+        try:
+            await asyncio.wait_for(
+                wrapper.handle_streamable_http(scope, disconnect_quickly, send),
+                timeout=2.0,
+            )
+        except asyncio.TimeoutError:
+            pass
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+    assert "Heartbeat task drain raised" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_post_interception_allowed_intercepts_held_responder(monkeypatch):
+    """Lines 4270, 4275, 4283-4284: POST interception path when session access passes → HANDLED 202.
+
+    Covers the full happy-path inside the interception block: after
+    ``_validate_streamable_session_access`` allows the caller, the peek
+    completes and ``_dispatch_peek_outcome`` returns HANDLED (not
+    FALLTHROUGH), so the handler must early-return without touching the
+    SDK.
+    """
+    # First-Party
+    from mcpgateway.services.notification_service import NotificationService  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    # Force interception path: has_pending_request=True, complete_request returns True.
+    fake_svc = MagicMock(spec=NotificationService)
+    fake_svc.has_pending_request = MagicMock(return_value=True)
+    fake_svc.complete_request = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "mcpgateway.services.notification_service.get_notification_service",
+        lambda: fake_svc,
+    )
+    # Owner check allows the caller.
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport._validate_streamable_session_access",
+        AsyncMock(return_value=(True, 200, "")),
+    )
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    body = b'{"jsonrpc":"2.0","id":"req-x","result":{"content":[]}}'
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[(b"mcp-session-id", b"owned-session"), (b"content-type", b"application/json")],
+    )
+    u_token = user_context_var.set({"email": "owner@example.com", "is_authenticated": True, "is_admin": False, "teams": ["t1"]})
+    try:
+        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+    finally:
+        user_context_var.reset(u_token)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called, "SDK must be skipped on HANDLED interception"
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 202
+    fake_svc.complete_request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_post_notification_short_circuit_returns_202(monkeypatch):
+    """Line 4319: short-circuit path on a notification POST without session id returns HANDLED 202."""
+    # First-Party
+    from mcpgateway.services.session_affinity import init_session_affinity  # pylint: disable=import-outside-toplevel
+    from mcpgateway.transports.server_event_bus import reset_server_event_bus  # pylint: disable=import-outside-toplevel
+
+    await reset_server_event_bus()
+    init_session_affinity(enable_notifications=False)
+
+    sdk = _CountingSessionManager()
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: sdk)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_get_stream_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", False)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.cache_type", "memory")
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+    send, messages = _make_send_collector()
+    # Notification body (no `id`) and no Mcp-Session-Id header → short-circuit path.
+    body = b'{"jsonrpc":"2.0","method":"notifications/initialized"}'
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[(b"content-type", b"application/json")],
+    )
+    await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+    await wrapper.shutdown()
+    await reset_server_event_bus()
+
+    assert not sdk.called, "SDK must not be reached on a short-circuited notification"
+    starts = [m for m in messages if m["type"] == "http.response.start"]
+    assert starts and starts[0]["status"] == 202


### PR DESCRIPTION
## Summary

- Restores the MCP-spec GET /mcp server→client SSE stream on both Python and Rust gateways, with multi-node fanout via Redis Pub/Sub.
- Introduces `ServerEventBus` (in-memory + Redis backends), per-session single-listener claim, server-initiated request correlation with holder tasks, body-peek + replay-and-defer, and a session-ownership gate on GET/POST-interception paths.
- Adds ~1.8k lines of focused unit coverage (~828 tests) across 23 files / +6,197 / -196.

Design: `docs/docs/architecture/adr/052-get-stream-and-server-initiated-requests.md`  
Operator quickstart: `docs/docs/architecture/get-stream-quickstart.md`

## Test plan
- [x] `uv run pytest tests/unit/mcpgateway/transports/ tests/unit/mcpgateway/services/test_notification_service.py tests/unit/mcpgateway/services/test_session_affinity.py` — 828 tests pass
- [x] ADR-052 deny-path tests (non-owner 403, unknown 404, response-interception ownership gate)
- [x] Body-peek over-cap no-double-buffer (`replay_tail is huge` identity check)
- [x] Atomic store+publish via Lua (reconnect-replay race closed)
- [x] Best-effort evict after publish failure with three-way log classification (orphan cleaned / nothing to clean / couldn't verify)
- [x] Cross-stream-id replay rejection, evicted-cursor, no-cursor buffer replay
- [x] Heartbeat-loss preemption + reclaim, preempt-then-late-claim gap delivery
- [x] `bus_iter.aclose` fires on disconnect
- [x] Authenticated + unauthenticated GET to `oauth_enabled` server
- [x] SessionAffinity Redis branches (claim / heartbeat / release × success / conflict / unavailable / exception)
- [x] Bounded `NotificationService.shutdown` timeout branch
- [x] `_bucket_method_label` allowlist caps Prometheus cardinality
- [x] `_accepts_event_stream` RFC-7231 Accept parser
- [ ] Integration: verify against docker-compose edge-mode protocol-compliance matrix
- [ ] Integration: observe `server_event_bus_publish_failed_total{reason}` during a simulated Redis outage

## Out of scope (filed for follow-up)

- [#4332](https://github.com/IBM/mcp-context-forge/issues/4332) — `RedisServerEventBus` pump / sentinel / dedup fakeredis coverage
- [#4334](https://github.com/IBM/mcp-context-forge/issues/4334) — Split listener-claim methods out of `SessionAffinity` into `SessionPresence`
- [#4344](https://github.com/IBM/mcp-context-forge/issues/4344) — `SessionFactory` typed-handle refactor