### PR TITLE
chore: update cpex-url-reputation to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,7 @@ plugins = [
     "cpex-rate-limiter>=0.0.3",
     "cpex-retry-with-backoff>=0.1.0",
     "cpex-secrets-detection>=0.2.0",
-    "cpex-url-reputation>=0.1.1",
+    "cpex-url-reputation>=0.2.0",
 ]
 
 # gRPC Support (EXPERIMENTAL - optional, disabled by default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 exclude-newer = "10 days"
-exclude-newer-package = { "cpex-rate-limiter" = "2026-04-09T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-09T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-20T23:59:59Z", "cpex-url-reputation" = "2026-04-09T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
+exclude-newer-package = { "cpex-url-reputation" = "2026-04-20T23:59:59Z", "cpex-rate-limiter" = "2026-04-09T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-09T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-20T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
 
 [tool.uv.sources]
 compliance-reference-server = { path = "mcp-servers/python/compliance_reference_server", editable = true }


### PR DESCRIPTION
## Description

Update the cpex-url-reputation plugin dependency from >=0.1.1 to >=0.2.0 to use the latest published version from the cpex-plugins repository.

## Changes

- Update pyproject.toml to require cpex-url-reputation>=0.2.0

## Context

The url_reputation plugin has been moved to the cpex-plugins repository and version 0.2.0 has been published to PyPI. This update ensures mcp-context-forge uses the latest stable version.

## Testing

- [ ] Dependency resolution works correctly
- [ ] No breaking changes in plugin API

## Related

Closes #4349

## Checklist

- [x] Code follows project style guidelines
- [x] Commit is signed with DCO
- [x] Changes are documented
- [x] Related issue created and linked