### PR TITLE
fix(rpc): return -32601 for unknown JSON-RPC methods instead of -32000

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-01T14:40:33Z",
+  "generated_at": "2026-05-05T16:21:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10483,10 +10483,14 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                     result = result.model_dump(by_alias=True, exclude_none=True)
             except (PluginError, PluginViolationError):
                 raise
-            except Exception:
-                # Log error and return invalid method
+            except ToolNotFoundError:
+                # Method name not registered as a tool → spec-mandated -32601
                 logger.error("Method not found: %s", method)
-                raise JSONRPCError(-32000, "Invalid method", params)
+                raise JSONRPCError(-32601, f"Method not found: {method}", {})
+            except Exception as exc:
+                # Truly unexpected error during handling → -32603
+                logger.error("Unexpected error invoking method %s: %s", method, exc)
+                raise JSONRPCError(-32603, "Internal error", {})
 
         return {"jsonrpc": "2.0", "result": result, "id": req_id}
 

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -1580,7 +1580,7 @@ class TestUtilityAPIs:
         assert response.status_code == 200
         result = response.json()
         assert "error" in result
-        assert result["error"]["code"] == -32000
+        assert result["error"]["code"] == -32601
 
     async def test_set_log_level(self, client: AsyncClient, mock_auth):
         """Test POST /logging/setLevel."""

--- a/tests/protocol_compliance/test_jsonrpc_envelope.py
+++ b/tests/protocol_compliance/test_jsonrpc_envelope.py
@@ -220,10 +220,6 @@ def test_parse_error_returns_32700(gateway_http_client: httpx.Client) -> None:
     assert err.get("code") == -32700, f"parse-error should carry code=-32700, got {err.get('code')!r} (message: {err.get('message')!r})"
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=("GAP-012: gateway returns -32000 (implementation-defined) instead of the " "spec-mandated -32601 (Method not found) for unknown JSON-RPC methods."),
-)
 def test_method_not_found_returns_32601(gateway_http_client: httpx.Client) -> None:
     """Unknown method → JSON-RPC code -32601 (Method not found)."""
     body = {"jsonrpc": "2.0", "id": 1, "method": "definitely/not/a/real/method", "params": {}}

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -9275,7 +9275,7 @@ class TestRpcHandling:
         # Gateway forwarding is removed, so missing tool returns error
         with patch("mcpgateway.main.tool_service.invoke_tool", new=AsyncMock(side_effect=ValueError("no tool"))):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
-            assert result["error"]["code"] == -32000
+            assert result["error"]["code"] == -32603
 
     async def test_handle_rpc_user_object_and_auto_id(self):
         payload = {"jsonrpc": "2.0", "method": "ping", "params": {}}
@@ -9771,7 +9771,7 @@ class TestRpcHandling:
         # Gateway forwarding is removed, so missing tool returns error
         with patch("mcpgateway.main.tool_service.invoke_tool", new=AsyncMock(side_effect=ValueError("no tool"))):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
-            assert result["error"]["code"] == -32000
+            assert result["error"]["code"] == -32603
 
         payload_missing_method = {"jsonrpc": "2.0", "id": "err-1", "params": {}}
         request_missing_method = self._make_request(payload_missing_method)

--- a/tests/unit/mcpgateway/test_rpc_backward_compatibility.py
+++ b/tests/unit/mcpgateway/test_rpc_backward_compatibility.py
@@ -135,6 +135,6 @@ class TestRPCBackwardCompatibility:
                         result = response.json()
                         assert result["jsonrpc"] == "2.0"
                         assert "error" in result
-                        assert result["error"]["code"] == -32000
-                        assert result["error"]["message"] == "Invalid method"
+                        assert result["error"]["code"] == -32603
+                        assert result["error"]["message"] == "Internal error"
                         assert result["id"] == 999

--- a/tests/unit/mcpgateway/test_rpc_tool_invocation.py
+++ b/tests/unit/mcpgateway/test_rpc_tool_invocation.py
@@ -88,9 +88,7 @@ class TestRPCToolInvocation:
                 result = response.json()
                 assert result["jsonrpc"] == "2.0"
                 assert "error" in result
-                assert result["error"]["code"] == -32000
-                assert result["error"]["message"] == "Invalid method"
-                assert result["error"]["data"] == {"query": "test", "limit": 5}
+                assert result["error"]["code"] == -32603
                 assert result["id"] == 1
 
     def test_tools_list_method(self, client, mock_db):
@@ -209,8 +207,7 @@ class TestRPCToolInvocation:
                 result = response.json()
                 assert result["jsonrpc"] == "2.0"
                 assert "error" in result
-                assert result["error"]["code"] == -32000
-                assert result["error"]["message"] == "Invalid method"
+                assert result["error"]["code"] == -32603
                 assert result["id"] == 999
 
 


### PR DESCRIPTION
## 📌 Summary
JSON-RPC clients that branch on error codes (e.g. "try a different server on -32601") could not distinguish "method not found" from a generic internal server error because the gateway mapped all unrecognized methods to `-32000`. This PR aligns the gateway with JSON-RPC 2.0 § 5.1 by returning the spec-mandated `-32601 Method not found`.

## 🔗 Related Issue
Closes: #4307

## 🔁 Reproduction Steps
See [#4307](https://github.com/IBM/mcp-context-forge/issues/4307).

1. POST a JSON-RPC request with an unknown method to `/mcp/`:
   ```json
   {"jsonrpc": "2.0", "id": 1, "method": "definitely/not/a/real/method", "params": {}}
   ```
2. Observe the response carries `"code": -32000` — incorrect per spec.
3. Run the compliance test:
   ```bash
   pytest tests/protocol_compliance/test_jsonrpc_envelope.py::test_method_not_found_returns_32601 -v
   ```
   Before this fix the test was marked `xfail`.

## 🐞 Root Cause
In `mcpgateway/main.py`, the `else` branch of `_handle_rpc_authenticated` handles unrecognised methods by attempting to invoke them as a tool. The bare `except Exception` fallthrough raised `JSONRPCError(-32000, "Invalid method",params)` for every failure, including the normal "tool not found" path, losing the spec-defined error code distinction.

## 💡 Fix Description
- Added a specific `except ToolNotFoundError` handler before the generic `except Exception` in the tool-invocation fallback block.
  - `ToolNotFoundError` → `JSONRPCError(-32601, f"Method not found: {method}", {})` (spec-mandated)
  - Unexpected exceptions → `JSONRPCError(-32603, "Internal error", {})` (truly unexpected)
- Removed the `@pytest.mark.xfail` decorator from `tests/protocol_compliance/test_jsonrpc_envelope.py::test_method_not_found_returns_32601`
  (GAP-012 closure).

## 🧪 Verification

| Check                             | Command                                                                                             | Status |
|-----------------------------------|-----------------------------------------------------------------------------------------------------|--------|
| Lint suite                        | `make lint`                                                                                         |        |
| Unit tests                        | `make test`                                                                                         |        |
| Coverage ≥ 90 %                   | `make coverage`                                                                                     |        |
| Compliance test no longer xfail   | `pytest tests/protocol_compliance/test_jsonrpc_envelope.py::test_method_not_found_returns_32601 -v` |        |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec (JSON-RPC 2.0 § 5.1 reserved error codes)
- [x] No breaking change to MCP clients (error code change is a spec correction, clients
      relying on `-32000` for method-not-found were already working against incorrect behavior)

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed