### PR TITLE
fix(build): docker build failure

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-21T22:06:48Z",
+  "generated_at": "2026-04-22T18:13:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -145,6 +145,11 @@ COPY --chown=1001:0 package.json package-lock.json ./
 # Install frontend dependencies
 RUN npm ci
 
+# Create directory structure with correct ownership before Vite build
+USER root
+RUN mkdir -p mcpgateway/static && chown -R 1001:0 mcpgateway
+USER 1001
+
 # Copy frontend source files
 COPY --chown=1001:0 mcpgateway/admin_ui/ mcpgateway/admin_ui/
 COPY --chown=1001:0 vite.config.js ./


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4367 

---

## 📝 Summary
Fix the docker build failure with error 

```bash 
error during build:
EACCES: permission denied, mkdir '/opt/app-root/src/mcpgateway/static'
    at async mkdir (node:internal/fs/promises:859:10)
    at async writeOutputFile (file:///opt/app-root/src/node_modules/rollup/dist/es/shared/node-entry.js:24012:5)
The command '/bin/sh -c npm run vite:build' returned a non-zero code: 1
```

Now with the fix, the image is built with `make docker-prod` or `make compose-build`

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
