### PR TITLE
Chore: Add client build output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,6 +278,7 @@ mcpgateway/static/vendor/
 mcpgateway/static/bundle-*.js
 mcpgateway/static/.vite/
 mcpgateway/static/app/
+mcpgateway/static/css/
 public/
 
 # Export & SBOM files


### PR DESCRIPTION
Does what is says on the ~tin~ title.