### PR TITLE
fix(logging): reinitialize logging after bootstrap_db to recover from…

### DIFF
--- a/mcpgateway/alembic/env.py
+++ b/mcpgateway/alembic/env.py
@@ -42,6 +42,7 @@ Note:
 """
 
 # Standard
+import logging
 from importlib.resources import files
 from logging.config import fileConfig
 
@@ -110,9 +111,10 @@ def _inside_alembic() -> bool:
 
 config.set_main_option("script_location", str(files("mcpgateway").joinpath("alembic")))
 
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name is not None:
+# Only apply alembic.ini logging when root has no handlers (standalone CLI).
+# Skip when imported from the gateway lifespan to avoid fileConfig() resetting
+# root handlers/level (disable_existing_loggers does not protect root).
+if config.config_file_name is not None and not logging.getLogger().handlers:
     fileConfig(
         config.config_file_name,
         disable_existing_loggers=False,


### PR DESCRIPTION
fix(logging): reinitialize logging after bootstrap_db to recover from Alembic fileConfig reset

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #4378

---

## 📝 Summary

During gateway startup, `LoggingService.initialize()` correctly configures the root logger (adds `StreamHandler` + `StorageHandler`, sets level from `LOG_LEVEL`). Moments later, `bootstrap_db()` runs Alembic migrations, and `mcpgateway/alembic/env.py` calls `logging.config.fileConfig(alembic.ini, disable_existing_loggers=False)`. Even with `disable_existing_loggers=False`, `fileConfig` rebuilds the root logger's handler list and forces its level to whatever `[logger_root]` in `alembic.ini` declares (currently `WARNING`).

Net effect: for the remainder of the process, every application-level `INFO`/`DEBUG` log (plugin pub/sub events, service lifecycle, request logs, etc.) is silently dropped.

This PR re-invokes `await logging_service.initialize()` immediately after `await bootstrap_db()` in the FastAPI lifespan, which reinstalls the correct handlers and level so app logs flow through `docker compose logs` / stdout for the rest of the process. Minimal, targeted, low-risk.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

Manually verified on a 2-replica × 24-worker Docker Compose stack: before the fix, `Pub/sub:` and `Plugin manager initialized with N plugins` lines were absent from `docker compose logs` despite Redis confirming pub/sub delivery; after the fix, all application logs flow at both `LOG_LEVEL=INFO` and `LOG_LEVEL=DEBUG`.

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)