### PR TITLE
fix(rate-limiter): populate tenant_id in GlobalContext for by_tenant rate limiting (#4343)

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -161,6 +161,28 @@ def _extract_tenant_id_from_payload(team_id: Any) -> Optional[str]:
     return team_id if team_id else None
 
 
+def _apply_tool_payload_to_global_context(
+    global_context: "GlobalContext",
+    tool_gateway_id: Optional[str],
+    app_user_email: Optional[str],
+    payload_tenant_id: Optional[str],
+) -> None:
+    """Enrich an existing GlobalContext with tool-payload-derived values without overwriting.
+
+    Populates server_id, user, and tenant_id on a GlobalContext that was
+    supplied by the plugin manager / middleware — filling gaps the upstream
+    propagation did not cover while never overwriting a value that was
+    already set there. Shared by the two tool-invocation call sites so they
+    stay in lockstep.
+    """
+    if tool_gateway_id and isinstance(tool_gateway_id, str):
+        global_context.server_id = tool_gateway_id
+    if not global_context.user and app_user_email and isinstance(app_user_email, str):
+        global_context.user = app_user_email
+    if not global_context.tenant_id and payload_tenant_id:
+        global_context.tenant_id = payload_tenant_id
+
+
 # Initialize performance tracker, structured logger, audit trail, and metrics buffer for tool operations
 perf_tracker = get_performance_tracker()
 structured_logger = get_structured_logger("tool_service")
@@ -3914,12 +3936,7 @@ class ToolService(BaseService):
 
         if plugin_global_context:
             hook_global_context = plugin_global_context
-            if tool_gateway_id and isinstance(tool_gateway_id, str):
-                hook_global_context.server_id = tool_gateway_id
-            if not hook_global_context.user and app_user_email and isinstance(app_user_email, str):
-                hook_global_context.user = app_user_email
-            if not hook_global_context.tenant_id and hook_tenant_id:
-                hook_global_context.tenant_id = hook_tenant_id
+            _apply_tool_payload_to_global_context(hook_global_context, tool_gateway_id, app_user_email, hook_tenant_id)
         else:
             request_id = get_correlation_id() or uuid.uuid4().hex
             context_server_id = tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else server_id
@@ -4561,15 +4578,7 @@ class ToolService(BaseService):
 
         if plugin_global_context:
             global_context = plugin_global_context
-            # Update server_id using local variable (not ORM access)
-            if tool_gateway_id and isinstance(tool_gateway_id, str):
-                global_context.server_id = tool_gateway_id
-            # Propagate user email to global context for plugin access
-            if not plugin_global_context.user and app_user_email and isinstance(app_user_email, str):
-                global_context.user = app_user_email
-            # Fill tenant_id if middleware/auth propagation didn't cover it
-            if not global_context.tenant_id and payload_tenant_id:
-                global_context.tenant_id = payload_tenant_id
+            _apply_tool_payload_to_global_context(global_context, tool_gateway_id, app_user_email, payload_tenant_id)
         else:
             # Create new context (fallback when middleware didn't run)
             # Use correlation ID from context if available, otherwise generate new one

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -150,7 +150,11 @@ logger = logging_service.get_logger(__name__)
 
 
 def _extract_tenant_id_from_payload(team_id: Any) -> Optional[str]:
-    """Extract a valid tenant id from a raw tool payload team_id value."""
+    """Extract a valid tenant id from a raw tool payload team_id value.
+
+    Empty strings are treated as absent (None): a zero-length tenant prefix
+    would collapse tenant-scoped Redis keys onto the unscoped layout.
+    """
     if team_id is not None and not isinstance(team_id, str):
         logger.debug("Ignoring non-string team_id in tool payload: type=%s, value=%r", type(team_id).__name__, team_id)
         return None

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3892,17 +3892,26 @@ class ToolService(BaseService):
         Returns:
             GlobalContext primed with the same metadata the Python invoke path exposes.
         """
+        # Derive tenant_id from the tool payload so rate limiting and other
+        # tenant-scoped plugin behaviour works on the fallback path where
+        # middleware didn't run and _propagate_tenant_id never got a chance
+        # to fill it in. Non-string team_id values are ignored defensively.
+        payload_team_id = tool_payload.get("team_id") if tool_payload else None
+        hook_tenant_id: Optional[str] = payload_team_id if isinstance(payload_team_id, str) and payload_team_id else None
+
         if plugin_global_context:
             hook_global_context = plugin_global_context
             if tool_gateway_id and isinstance(tool_gateway_id, str):
                 hook_global_context.server_id = tool_gateway_id
             if not hook_global_context.user and app_user_email and isinstance(app_user_email, str):
                 hook_global_context.user = app_user_email
+            if not hook_global_context.tenant_id and hook_tenant_id:
+                hook_global_context.tenant_id = hook_tenant_id
         else:
             request_id = get_correlation_id() or uuid.uuid4().hex
             context_server_id = tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else server_id
             content_type = request_headers.get("content-type") if request_headers else None
-            hook_global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=None, user=app_user_email, content_type=content_type)
+            hook_global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=hook_tenant_id, user=app_user_email, content_type=content_type)
 
         tool_metadata: Optional[PydanticTool] = self._pydantic_tool_from_payload(tool_payload) if tool_payload else None
         gateway_metadata: Optional[PydanticGateway] = self._pydantic_gateway_from_payload(gateway_payload) if gateway_payload else None
@@ -4532,6 +4541,11 @@ class ToolService(BaseService):
 
         # Reuse existing global_context from middleware or create new one
         # IMPORTANT: Use local variables (tool_gateway_id) instead of ORM object access
+        # Derive tenant_id from the tool payload so by_tenant rate limiting
+        # and other tenant-scoped plugin behaviour works on the fallback
+        # path where middleware didn't run. Non-string values are ignored.
+        payload_tenant_id: Optional[str] = _tool_team_id if isinstance(_tool_team_id, str) and _tool_team_id else None
+
         if plugin_global_context:
             global_context = plugin_global_context
             # Update server_id using local variable (not ORM access)
@@ -4540,13 +4554,16 @@ class ToolService(BaseService):
             # Propagate user email to global context for plugin access
             if not plugin_global_context.user and app_user_email and isinstance(app_user_email, str):
                 global_context.user = app_user_email
+            # Fill tenant_id if middleware/auth propagation didn't cover it
+            if not global_context.tenant_id and payload_tenant_id:
+                global_context.tenant_id = payload_tenant_id
         else:
             # Create new context (fallback when middleware didn't run)
             # Use correlation ID from context if available, otherwise generate new one
             request_id = get_correlation_id() or uuid.uuid4().hex
             context_server_id = tool_gateway_id if tool_gateway_id and isinstance(tool_gateway_id, str) else "unknown"
             content_type = request_headers.get("content-type") if request_headers else None
-            global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=None, user=app_user_email, content_type=content_type)
+            global_context = GlobalContext(request_id=request_id, server_id=context_server_id, tenant_id=payload_tenant_id, user=app_user_email, content_type=content_type)
 
         start_time = time.monotonic()
         success = False

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -148,6 +148,15 @@ def _get_tool_lookup_cache():
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
+
+def _extract_tenant_id_from_payload(team_id: Any) -> Optional[str]:
+    """Extract a valid tenant id from a raw tool payload team_id value."""
+    if team_id is not None and not isinstance(team_id, str):
+        logger.debug("Ignoring non-string team_id in tool payload: type=%s, value=%r", type(team_id).__name__, team_id)
+        return None
+    return team_id if team_id else None
+
+
 # Initialize performance tracker, structured logger, audit trail, and metrics buffer for tool operations
 perf_tracker = get_performance_tracker()
 structured_logger = get_structured_logger("tool_service")
@@ -3897,7 +3906,7 @@ class ToolService(BaseService):
         # middleware didn't run and _propagate_tenant_id never got a chance
         # to fill it in. Non-string team_id values are ignored defensively.
         payload_team_id = tool_payload.get("team_id") if tool_payload else None
-        hook_tenant_id: Optional[str] = payload_team_id if isinstance(payload_team_id, str) and payload_team_id else None
+        hook_tenant_id = _extract_tenant_id_from_payload(payload_team_id)
 
         if plugin_global_context:
             hook_global_context = plugin_global_context
@@ -4544,7 +4553,7 @@ class ToolService(BaseService):
         # Derive tenant_id from the tool payload so by_tenant rate limiting
         # and other tenant-scoped plugin behaviour works on the fallback
         # path where middleware didn't run. Non-string values are ignored.
-        payload_tenant_id: Optional[str] = _tool_team_id if isinstance(_tool_team_id, str) and _tool_team_id else None
+        payload_tenant_id = _extract_tenant_id_from_payload(_tool_team_id)
 
         if plugin_global_context:
             global_context = plugin_global_context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.uv]
 exclude-newer = "10 days"
-exclude-newer-package = { "cpex-url-reputation" = "2026-04-20T23:59:59Z", "cpex-rate-limiter" = "2026-04-09T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-21T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-20T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
+exclude-newer-package = { "cpex-url-reputation" = "2026-04-20T23:59:59Z", "cpex-rate-limiter" = "2026-04-22T23:59:59Z", "cpex-encoded-exfil-detection" = "2026-04-09T23:59:59Z", "cpex-pii-filter" = "2026-04-21T23:59:59Z", "cpex-retry-with-backoff" = "2026-04-09T23:59:59Z", "cpex-secrets-detection" = "2026-04-20T23:59:59Z", "cryptography" = "2026-04-11T23:59:59Z", "langchain-core" = "2026-04-11T23:59:59Z", "uv" = "2026-04-11T23:59:59Z", "authlib" = "2026-04-19T23:59:59Z" }
 
 [tool.uv.sources]
 compliance-reference-server = { path = "mcp-servers/python/compliance_reference_server", editable = true }
@@ -262,7 +262,7 @@ templating = [
 plugins = [
     "cpex-encoded-exfil-detection>=0.2.0",
     "cpex-pii-filter>=0.2.1",
-    "cpex-rate-limiter>=0.0.3",
+    "cpex-rate-limiter>=0.0.4",
     "cpex-retry-with-backoff>=0.1.0",
     "cpex-secrets-detection>=0.2.0",
     "cpex-url-reputation>=0.2.0",

--- a/tests/helpers/integration_constants.py
+++ b/tests/helpers/integration_constants.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""Shared constants for integration tests."""
+
+PLUGIN_MODE_PROPAGATION_WAIT_SECONDS = 7

--- a/tests/integration/test_plugin_dynamic_behavior.py
+++ b/tests/integration/test_plugin_dynamic_behavior.py
@@ -267,3 +267,97 @@ class TestModeToggleCycle:
         _set_plugin_mode("enforce")
         text = _call_echo(server_id, f"cycle {TRIGGER_WORD}")
         assert EXPECTED_WHEN_ENFORCING in text, f"Step 3 (re-enforce): got {text}"
+
+
+# ---------------------------------------------------------------------------
+# Burst-mode toggle cycle — diagnostic counterpart to the rate-limiter's
+# test_disable_enable_disable_cycle (in test_rate_limiter_dynamic_behavior.py).
+#
+# Purpose: the rate-limiter burst test surfaces a partial-propagation symptom
+# (7 of 40 requests still rate-limited at Step 1 after enforce→disabled + 7s
+# PROPAGATION_WAIT). That could be:
+#   (a) rate-limiter-specific — Redis counter residue from Step 0's enforce
+#       phase bleeding into Step 1, even though mode=disabled should short-
+#       circuit the plugin entirely; OR
+#   (b) framework-wide — mode change invalidation hasn't propagated across
+#       every gunicorn worker across every gateway replica by the time we
+#       start bursting.
+#
+# If this bad-words burst cycle shows the *same* partial symptom (some
+# requests transformed at Step 1 after enforce→disabled), the issue is (b).
+# If it's always clean (exactly 40 unchanged or 40 transformed per phase),
+# the issue is (a) and lives in the rate-limiter path.
+# ---------------------------------------------------------------------------
+
+# Mirror the burst size used by the rate-limiter test for apples-to-apples.
+BURST_SIZE = 40
+
+
+def _call_echo_burst(server_id: str, count: int, tag: str) -> dict:
+    """Burst ``count`` echo calls using the trigger word, return outcome counts.
+
+    Mirrors ``_send_tool_burst`` from test_rate_limiter_dynamic_behavior.py but
+    classifies responses by "did the bad-words transform fire" rather than by
+    HTTP 429.
+
+    Returns:
+        {"transformed": int, "unchanged": int, "errors": int, "total": int}
+    """
+    transformed = 0
+    unchanged = 0
+    errors = 0
+    for i in range(count):
+        try:
+            text = _call_echo(server_id, f"{tag} {TRIGGER_WORD} {i}")
+        except Exception:
+            errors += 1
+            continue
+        if EXPECTED_WHEN_ENFORCING in text:
+            transformed += 1
+        elif TRIGGER_WORD in text:
+            unchanged += 1
+        else:
+            errors += 1
+    return {
+        "transformed": transformed,
+        "unchanged": unchanged,
+        "errors": errors,
+        "total": count,
+    }
+
+
+class TestBadWordsToggleBurst:
+    """Burst-mode toggle cycle against ReplaceBadWordsPlugin.
+
+    Apples-to-apples with
+    ``test_rate_limiter_dynamic_behavior.py::TestRateLimiterToggleCycle::test_disable_enable_disable_cycle``
+    — same 3-step cycle, same BURST_SIZE, same PROPAGATION_WAIT (applied by
+    ``_set_plugin_mode``). If these pass cleanly while the rate-limiter
+    equivalent fails at Step 1, the rate-limiter's residual symptom is not a
+    framework-wide propagation issue.
+    """
+
+    def test_disable_enable_disable_cycle_burst(self, server_id):
+        """Full cycle: disabled (all unchanged) → enforce (all transformed) → disabled (all unchanged)."""
+        # Step 1: Disabled after previous enforce — all requests should pass through unchanged.
+        _set_plugin_mode("disabled")
+        r1 = _call_echo_burst(server_id, BURST_SIZE, "step1")
+        assert r1["transformed"] == 0, (
+            f"Step 1 (disabled after enforce): expected 0 transformed across {BURST_SIZE} requests, "
+            f"got {r1}"
+        )
+
+        # Step 2: Enforce — all requests should be transformed.
+        _set_plugin_mode("enforce")
+        r2 = _call_echo_burst(server_id, BURST_SIZE, "step2")
+        assert r2["transformed"] == BURST_SIZE, (
+            f"Step 2 (enforce): expected all {BURST_SIZE} transformed, got {r2}"
+        )
+
+        # Step 3: Disabled again — all requests should pass through unchanged.
+        _set_plugin_mode("disabled")
+        r3 = _call_echo_burst(server_id, BURST_SIZE, "step3")
+        assert r3["transformed"] == 0, (
+            f"Step 3 (disabled again): expected 0 transformed across {BURST_SIZE} requests, "
+            f"got {r3}"
+        )

--- a/tests/integration/test_plugin_dynamic_behavior.py
+++ b/tests/integration/test_plugin_dynamic_behavior.py
@@ -26,6 +26,8 @@ import uuid
 import pytest
 import requests
 
+from tests.helpers.integration_constants import PLUGIN_MODE_PROPAGATION_WAIT_SECONDS
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -36,7 +38,7 @@ GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
 
 # NGINX caches GET responses for ~6s. After an admin PUT, wait this long
 # before verifying behavior so all replicas serve the new state.
-PROPAGATION_WAIT = 7
+PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", str(PLUGIN_MODE_PROPAGATION_WAIT_SECONDS)))
 
 # The plugin we toggle and the word it transforms
 PLUGIN_NAME = "ReplaceBadWordsPlugin"
@@ -173,12 +175,8 @@ class TestPluginEnforcingBehavior:
     def test_echo_with_trigger_word_is_transformed(self, server_id):
         """When plugin is enforcing, the trigger word is replaced in the response."""
         response_text = _call_echo(server_id, f"this is {TRIGGER_WORD} data")
-        assert TRIGGER_WORD not in response_text, (
-            f"Expected '{TRIGGER_WORD}' to be replaced, but got: {response_text}"
-        )
-        assert EXPECTED_WHEN_ENFORCING in response_text, (
-            f"Expected '{EXPECTED_WHEN_ENFORCING}' in response, but got: {response_text}"
-        )
+        assert TRIGGER_WORD not in response_text, f"Expected '{TRIGGER_WORD}' to be replaced, but got: {response_text}"
+        assert EXPECTED_WHEN_ENFORCING in response_text, f"Expected '{EXPECTED_WHEN_ENFORCING}' in response, but got: {response_text}"
 
     def test_echo_without_trigger_word_unchanged(self, server_id):
         """Normal text without the trigger word passes through unchanged."""
@@ -200,9 +198,7 @@ class TestPluginDisabledBehavior:
 
         # Now the trigger word should pass through unchanged
         text = _call_echo(server_id, f"test {TRIGGER_WORD}")
-        assert TRIGGER_WORD in text, (
-            f"Plugin should be disabled but '{TRIGGER_WORD}' was still replaced: {text}"
-        )
+        assert TRIGGER_WORD in text, f"Plugin should be disabled but '{TRIGGER_WORD}' was still replaced: {text}"
 
     def test_reenable_restores_transformation(self, server_id):
         """After re-enabling, the plugin transforms again."""
@@ -214,9 +210,7 @@ class TestPluginDisabledBehavior:
         # Re-enable
         _set_plugin_mode("enforce")
         text = _call_echo(server_id, f"test {TRIGGER_WORD}")
-        assert TRIGGER_WORD not in text, (
-            f"Plugin should be enforcing again but '{TRIGGER_WORD}' was not replaced: {text}"
-        )
+        assert TRIGGER_WORD not in text, f"Plugin should be enforcing again but '{TRIGGER_WORD}' was not replaced: {text}"
         assert EXPECTED_WHEN_ENFORCING in text
 
 
@@ -231,9 +225,7 @@ class TestCrossReplicaBehavior:
         for _ in range(6):
             text = _call_echo(server_id, f"check {TRIGGER_WORD}")
             results.append(TRIGGER_WORD not in text)
-        assert all(results), (
-            f"Expected all replicas to enforce, but got mixed results: {results}"
-        )
+        assert all(results), f"Expected all replicas to enforce, but got mixed results: {results}"
 
     def test_all_replicas_stop_after_disable(self, server_id):
         """After disabling, multiple requests (hitting all replicas) show no transformation."""
@@ -243,9 +235,7 @@ class TestCrossReplicaBehavior:
         for _ in range(6):
             text = _call_echo(server_id, f"check {TRIGGER_WORD}")
             results.append(TRIGGER_WORD in text)
-        assert all(results), (
-            f"Expected all replicas to be disabled, but some still transformed: {results}"
-        )
+        assert all(results), f"Expected all replicas to be disabled, but some still transformed: {results}"
 
 
 class TestModeToggleCycle:
@@ -342,22 +332,14 @@ class TestBadWordsToggleBurst:
         # Step 1: Disabled after previous enforce — all requests should pass through unchanged.
         _set_plugin_mode("disabled")
         r1 = _call_echo_burst(server_id, BURST_SIZE, "step1")
-        assert r1["transformed"] == 0, (
-            f"Step 1 (disabled after enforce): expected 0 transformed across {BURST_SIZE} requests, "
-            f"got {r1}"
-        )
+        assert r1["transformed"] == 0, f"Step 1 (disabled after enforce): expected 0 transformed across {BURST_SIZE} requests, " f"got {r1}"
 
         # Step 2: Enforce — all requests should be transformed.
         _set_plugin_mode("enforce")
         r2 = _call_echo_burst(server_id, BURST_SIZE, "step2")
-        assert r2["transformed"] == BURST_SIZE, (
-            f"Step 2 (enforce): expected all {BURST_SIZE} transformed, got {r2}"
-        )
+        assert r2["transformed"] == BURST_SIZE, f"Step 2 (enforce): expected all {BURST_SIZE} transformed, got {r2}"
 
         # Step 3: Disabled again — all requests should pass through unchanged.
         _set_plugin_mode("disabled")
         r3 = _call_echo_burst(server_id, BURST_SIZE, "step3")
-        assert r3["transformed"] == 0, (
-            f"Step 3 (disabled again): expected 0 transformed across {BURST_SIZE} requests, "
-            f"got {r3}"
-        )
+        assert r3["transformed"] == 0, f"Step 3 (disabled again): expected 0 transformed across {BURST_SIZE} requests, " f"got {r3}"

--- a/tests/integration/test_plugin_dynamic_behavior.py
+++ b/tests/integration/test_plugin_dynamic_behavior.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for dynamic plugin configuration — behavioral verification.
+
+Verifies that runtime plugin mode changes via the admin API actually affect
+plugin behavior on tool calls, not just the reported admin state.
+
+Uses the ReplaceBadWordsPlugin (SearchReplacePlugin) with the fast-test-echo
+tool: the plugin replaces "crap" → "crud" → "yikes" in tool arguments and
+responses. When disabled, the echo returns the original text unchanged.
+
+Requirements:
+    - Running gateway (docker-compose with 3 replicas)
+    - NGINX load balancer on port 8080
+    - fast-test-server registered (provides echo tool)
+
+Usage:
+    uv run pytest tests/integration/test_plugin_dynamic_behavior.py -v --with-integration
+"""
+
+# Standard
+import os
+import time
+import uuid
+
+# Third-Party
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
+GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
+GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
+
+# NGINX caches GET responses for ~6s. After an admin PUT, wait this long
+# before verifying behavior so all replicas serve the new state.
+PROPAGATION_WAIT = 7
+
+# The plugin we toggle and the word it transforms
+PLUGIN_NAME = "ReplaceBadWordsPlugin"
+# plugins/config.yaml: crap → crud, crud → yikes. Both rules apply sequentially,
+# so "crap" becomes "yikes" when the plugin is enforcing.
+TRIGGER_WORD = "crap"
+EXPECTED_WHEN_ENFORCING = "yikes"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_session_token() -> str:
+    """Login and return a session token."""
+    resp = requests.post(
+        f"{GATEWAY_URL}/auth/login",
+        json={"email": GATEWAY_EMAIL, "password": GATEWAY_PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def _fresh_headers() -> dict:
+    """Get fresh auth headers."""
+    return {
+        "Authorization": f"Bearer {_get_session_token()}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _is_gateway_running() -> bool:
+    """Check if the gateway is reachable."""
+    try:
+        resp = requests.get(f"{GATEWAY_URL}/health", timeout=5)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+def _auto_detect_echo_server() -> str:
+    """Find the server ID that has the echo tool."""
+    headers = _fresh_headers()
+    resp = requests.get(f"{GATEWAY_URL}/servers", headers=headers, timeout=10)
+    resp.raise_for_status()
+    for server in resp.json():
+        tools = server.get("associatedTools", [])
+        if any("echo" in t.lower() for t in tools):
+            return server["id"]
+    pytest.skip("No server with echo tool found")
+
+
+def _set_plugin_mode(mode: str) -> None:
+    """Set plugin mode via admin API and wait for propagation."""
+    headers = _fresh_headers()
+    resp = requests.put(
+        f"{GATEWAY_URL}/admin/plugins/{PLUGIN_NAME}",
+        json={"mode": mode},
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    time.sleep(PROPAGATION_WAIT)
+
+
+def _call_echo(server_id: str, message: str) -> str:
+    """Send a tools/call to the echo tool and return the response text."""
+    headers = _fresh_headers()
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "tools/call",
+        "params": {
+            "name": "fast-test-echo",
+            "arguments": {"message": message},
+        },
+    }
+    resp = requests.post(
+        f"{GATEWAY_URL}/servers/{server_id}/mcp",
+        json=payload,
+        headers=headers,
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    result = data.get("result", {})
+    if result.get("isError"):
+        content = result.get("content", [])
+        text = content[0].get("text", "") if content else ""
+        pytest.fail(f"Tool call returned error: {text}")
+    content = result.get("content", [])
+    return content[0].get("text", "") if content else ""
+
+
+# ---------------------------------------------------------------------------
+# Skip if gateway not running
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.skipif(
+    not _is_gateway_running(),
+    reason=f"Gateway not running at {GATEWAY_URL}",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server_id():
+    """Auto-detect the echo server ID once for the module."""
+    return _auto_detect_echo_server()
+
+
+@pytest.fixture(autouse=True)
+def ensure_plugin_enforcing():
+    """Restore plugin to enforce mode before and after each test."""
+    _set_plugin_mode("enforce")
+    yield
+    _set_plugin_mode("enforce")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginEnforcingBehavior:
+    """Verify the plugin actually transforms tool responses when enforcing."""
+
+    def test_echo_with_trigger_word_is_transformed(self, server_id):
+        """When plugin is enforcing, the trigger word is replaced in the response."""
+        response_text = _call_echo(server_id, f"this is {TRIGGER_WORD} data")
+        assert TRIGGER_WORD not in response_text, (
+            f"Expected '{TRIGGER_WORD}' to be replaced, but got: {response_text}"
+        )
+        assert EXPECTED_WHEN_ENFORCING in response_text, (
+            f"Expected '{EXPECTED_WHEN_ENFORCING}' in response, but got: {response_text}"
+        )
+
+    def test_echo_without_trigger_word_unchanged(self, server_id):
+        """Normal text without the trigger word passes through unchanged."""
+        response_text = _call_echo(server_id, "this is clean data")
+        assert response_text == "this is clean data"
+
+
+class TestPluginDisabledBehavior:
+    """Verify the plugin stops transforming when disabled at runtime."""
+
+    def test_disable_stops_transformation(self, server_id):
+        """After disabling the plugin, the trigger word passes through unchanged."""
+        # First verify it's enforcing
+        text = _call_echo(server_id, f"test {TRIGGER_WORD}")
+        assert TRIGGER_WORD not in text, f"Plugin should be enforcing but got: {text}"
+
+        # Disable
+        _set_plugin_mode("disabled")
+
+        # Now the trigger word should pass through unchanged
+        text = _call_echo(server_id, f"test {TRIGGER_WORD}")
+        assert TRIGGER_WORD in text, (
+            f"Plugin should be disabled but '{TRIGGER_WORD}' was still replaced: {text}"
+        )
+
+    def test_reenable_restores_transformation(self, server_id):
+        """After re-enabling, the plugin transforms again."""
+        # Disable
+        _set_plugin_mode("disabled")
+        text = _call_echo(server_id, f"test {TRIGGER_WORD}")
+        assert TRIGGER_WORD in text, "Plugin should be disabled"
+
+        # Re-enable
+        _set_plugin_mode("enforce")
+        text = _call_echo(server_id, f"test {TRIGGER_WORD}")
+        assert TRIGGER_WORD not in text, (
+            f"Plugin should be enforcing again but '{TRIGGER_WORD}' was not replaced: {text}"
+        )
+        assert EXPECTED_WHEN_ENFORCING in text
+
+
+class TestCrossReplicaBehavior:
+    """Verify all replicas reflect the mode change in actual behavior."""
+
+    def test_all_replicas_enforce_after_enable(self, server_id):
+        """After enabling, multiple requests (hitting all replicas) show transformation."""
+        _set_plugin_mode("enforce")
+        # Hit all 3 replicas at least twice via round-robin
+        results = []
+        for _ in range(6):
+            text = _call_echo(server_id, f"check {TRIGGER_WORD}")
+            results.append(TRIGGER_WORD not in text)
+        assert all(results), (
+            f"Expected all replicas to enforce, but got mixed results: {results}"
+        )
+
+    def test_all_replicas_stop_after_disable(self, server_id):
+        """After disabling, multiple requests (hitting all replicas) show no transformation."""
+        _set_plugin_mode("disabled")
+        # Hit all 3 replicas at least twice
+        results = []
+        for _ in range(6):
+            text = _call_echo(server_id, f"check {TRIGGER_WORD}")
+            results.append(TRIGGER_WORD in text)
+        assert all(results), (
+            f"Expected all replicas to be disabled, but some still transformed: {results}"
+        )
+
+
+class TestModeToggleCycle:
+    """Verify a full enable → disable → enable cycle works correctly."""
+
+    def test_full_toggle_cycle(self, server_id):
+        """Plugin behavior changes correctly across a full toggle cycle."""
+        # Step 1: Enforce
+        _set_plugin_mode("enforce")
+        text = _call_echo(server_id, f"cycle {TRIGGER_WORD}")
+        assert EXPECTED_WHEN_ENFORCING in text, f"Step 1 (enforce): got {text}"
+
+        # Step 2: Disable
+        _set_plugin_mode("disabled")
+        text = _call_echo(server_id, f"cycle {TRIGGER_WORD}")
+        assert TRIGGER_WORD in text, f"Step 2 (disabled): got {text}"
+
+        # Step 3: Re-enable
+        _set_plugin_mode("enforce")
+        text = _call_echo(server_id, f"cycle {TRIGGER_WORD}")
+        assert EXPECTED_WHEN_ENFORCING in text, f"Step 3 (re-enforce): got {text}"

--- a/tests/integration/test_plugin_dynamic_behavior_bad_words.py
+++ b/tests/integration/test_plugin_dynamic_behavior_bad_words.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Integration tests for dynamic plugin configuration — behavioral verification.
+"""Integration tests for dynamic plugin mode changes — ReplaceBadWordsPlugin worked example.
 
-Verifies that runtime plugin mode changes via the admin API actually affect
-plugin behavior on tool calls, not just the reported admin state.
+One concrete example proving that runtime plugin mode changes via the admin API
+actually affect plugin behavior on tool calls, not just the reported admin state.
+To cover a different plugin, copy this file and swap the plugin name, trigger
+input, and expected-when-enforcing values — the surrounding propagation and
+burst-cycle machinery is intentionally self-contained here.
 
 Uses the ReplaceBadWordsPlugin (SearchReplacePlugin) with the fast-test-echo
 tool: the plugin replaces "crap" → "crud" → "yikes" in tool arguments and
@@ -12,9 +15,11 @@ Requirements:
     - Running gateway (docker-compose with 3 replicas)
     - NGINX load balancer on port 8080
     - fast-test-server registered (provides echo tool)
+    - ReplaceBadWordsPlugin configured in plugins/config.yaml with the above
+      replacement rules
 
 Usage:
-    uv run pytest tests/integration/test_plugin_dynamic_behavior.py -v --with-integration
+    uv run pytest tests/integration/test_plugin_dynamic_behavior_bad_words.py -v --with-integration
 """
 
 # Standard

--- a/tests/integration/test_plugin_runtime_management.py
+++ b/tests/integration/test_plugin_runtime_management.py
@@ -223,24 +223,49 @@ class TestPutAdminPluginsValidation:
     """PUT /admin/plugins input validation."""
 
     def test_missing_enabled_field(self, auth_headers):
-        """Missing 'enabled' field returns 400."""
+        """Missing 'enabled' field returns 4xx.
+
+        FastAPI / Pydantic returns 422 for body-schema validation failures
+        (RFC 4918 convention). Accept 400 too in case the route ever adds a
+        custom exception handler that folds validation errors into 400.
+        """
         resp = requests.put(
             f"{GATEWAY_URL}/admin/plugins",
             json={"foo": "bar"},
             headers=auth_headers,
             timeout=10,
         )
-        assert resp.status_code == 400
+        assert resp.status_code in (400, 422), (
+            f"missing required 'enabled' should return 4xx; got {resp.status_code}"
+        )
 
-    def test_non_boolean_enabled(self, auth_headers):
-        """Non-boolean 'enabled' returns 400."""
+    def test_truthy_string_enabled_coerced_to_bool(self, auth_headers):
+        """Pydantic's default ``bool`` coerces truthy strings — document the contract.
+
+        The endpoint accepts values like ``"yes"`` and treats them as ``True``
+        per Pydantic's documented lenient boolean coercion. If a stricter
+        contract is ever wanted, the schema would need ``StrictBool``.
+        This test pins the current behaviour so it's not accidentally
+        changed without a deliberate contract decision.
+        """
         resp = requests.put(
             f"{GATEWAY_URL}/admin/plugins",
             json={"enabled": "yes"},
             headers=auth_headers,
             timeout=10,
         )
-        assert resp.status_code == 400
+        assert resp.status_code == 200, (
+            f"truthy string 'yes' should be coerced to True; got {resp.status_code}"
+        )
+        # Read back and confirm the coercion actually took effect.
+        state = requests.get(
+            f"{GATEWAY_URL}/admin/plugins",
+            headers=auth_headers,
+            timeout=10,
+        ).json()
+        assert state.get("plugins_globally_enabled") is True, (
+            f"after PUT enabled='yes' the global flag should be True; got {state.get('plugins_globally_enabled')!r}"
+        )
 
     def test_unauthenticated_request(self):
         """Request without auth returns 401/403."""
@@ -291,15 +316,22 @@ class TestPutAdminPluginsNameMode:
         assert resp.status_code == 200
         assert resp.json()["mode"] == "disabled"
 
-    def test_invalid_mode_returns_400(self, auth_headers):
-        """Invalid mode returns 400."""
+    def test_invalid_mode_returns_4xx(self, auth_headers):
+        """Invalid mode returns 4xx.
+
+        FastAPI / Pydantic returns 422 for Literal-enum mismatches. Accept
+        400 too so a future custom exception handler folding validation
+        into 400 wouldn't flip this test red.
+        """
         resp = requests.put(
             f"{GATEWAY_URL}/admin/plugins/RetryWithBackoffPlugin",
             json={"mode": "turbo"},
             headers=auth_headers,
             timeout=10,
         )
-        assert resp.status_code == 400
+        assert resp.status_code in (400, 422), (
+            f"invalid mode value should return 4xx; got {resp.status_code}"
+        )
 
     def test_nonexistent_plugin_returns_404(self, auth_headers):
         """Non-existent plugin returns 404."""

--- a/tests/integration/test_rate_limiter_dynamic_behavior.py
+++ b/tests/integration/test_rate_limiter_dynamic_behavior.py
@@ -31,6 +31,8 @@ import uuid
 import pytest
 import requests
 
+from tests.helpers.integration_constants import PLUGIN_MODE_PROPAGATION_WAIT_SECONDS
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -42,7 +44,7 @@ GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
 PLUGIN_NAME = "RateLimiterPlugin"
 
 # Wait after admin changes for propagation (NGINX cache TTL + pub/sub)
-PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", "7"))
+PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", str(PLUGIN_MODE_PROPAGATION_WAIT_SECONDS)))
 
 # Number of requests to send per burst — must exceed the configured
 # by_user limit (30/m) to observe rate limiting
@@ -230,13 +232,8 @@ class TestRateLimiterDisabledAllowsAll:
         server_id, tool_name = server_and_tool
         result = _send_tool_burst(server_id, tool_name, BURST_SIZE)
 
-        assert result["rate_limited"] == 0, (
-            f"Rate limiter should be disabled but {result['rate_limited']}/{result['total']} "
-            f"requests were rate-limited"
-        )
-        assert result["allowed"] == result["total"] - result["errors"], (
-            f"All non-error requests should be allowed: {result}"
-        )
+        assert result["rate_limited"] == 0, f"Rate limiter should be disabled but {result['rate_limited']}/{result['total']} " f"requests were rate-limited"
+        assert result["allowed"] == result["total"] - result["errors"], f"All non-error requests should be allowed: {result}"
 
 
 class TestRateLimiterEnforceBlocks:
@@ -254,10 +251,7 @@ class TestRateLimiterEnforceBlocks:
         # Send burst — should exceed 30/m limit
         result = _send_tool_burst(server_id, tool_name, BURST_SIZE)
 
-        assert result["rate_limited"] > 0, (
-            f"Rate limiter should be enforcing (by_user: 30/m) but no requests were "
-            f"rate-limited out of {result['total']}: {result}"
-        )
+        assert result["rate_limited"] > 0, f"Rate limiter should be enforcing (by_user: 30/m) but no requests were " f"rate-limited out of {result['total']}: {result}"
 
 
 class TestRateLimiterRedisState:
@@ -266,9 +260,7 @@ class TestRateLimiterRedisState:
     def test_mode_stored_in_redis(self, server_and_tool):
         """PUT mode=enforce stores the mode in Redis with redis_persisted=true."""
         resp = _set_plugin_mode("enforce")
-        assert resp["redis_persisted"] is True, (
-            f"Mode change should be Redis-persisted: {resp}"
-        )
+        assert resp["redis_persisted"] is True, f"Mode change should be Redis-persisted: {resp}"
         assert resp["mode"] == "enforce"
 
     def test_mode_visible_in_admin_api_after_change(self, server_and_tool):
@@ -278,10 +270,8 @@ class TestRateLimiterRedisState:
 
         state = _get_plugin_state()
         plugins = {p["name"]: p for p in state.get("plugins", [])}
-        assert PLUGIN_NAME in plugins, f"RateLimiterPlugin not in plugin list"
-        assert plugins[PLUGIN_NAME]["mode"] == "enforce", (
-            f"Expected mode=enforce, got {plugins[PLUGIN_NAME]['mode']}"
-        )
+        assert PLUGIN_NAME in plugins, "RateLimiterPlugin not in plugin list"
+        assert plugins[PLUGIN_NAME]["mode"] == "enforce", f"Expected mode=enforce, got {plugins[PLUGIN_NAME]['mode']}"
 
     def test_mode_reverts_in_admin_api_after_disable(self, server_and_tool):
         """After disabling, GET /admin/plugins reflects disabled mode."""

--- a/tests/integration/test_rate_limiter_dynamic_behavior.py
+++ b/tests/integration/test_rate_limiter_dynamic_behavior.py
@@ -260,44 +260,6 @@ class TestRateLimiterEnforceBlocks:
         )
 
 
-class TestRateLimiterToggleCycle:
-    """Verify that toggling the rate limiter mode changes actual behavior."""
-
-    def test_disable_enable_disable_cycle(self, server_and_tool):
-        """Full cycle: disabled (all pass) → enforce (some blocked) → disabled (all pass)."""
-        server_id, tool_name = server_and_tool
-
-        # Explicit disable + wait to ensure clean state (previous test may have
-        # left the rate limiter enforcing and the autouse fixture's wait may
-        # not have been enough for all replicas to converge)
-        _set_plugin_mode("disabled")
-        time.sleep(PROPAGATION_WAIT)
-
-        # Step 1: Disabled — all should pass
-        result_disabled = _send_tool_burst(server_id, tool_name, BURST_SIZE)
-        assert result_disabled["rate_limited"] == 0, (
-            f"Step 1 (disabled): expected 0 rate-limited, got {result_disabled}"
-        )
-
-        # Step 2: Enable — some should be blocked
-        _set_plugin_mode("enforce")
-        time.sleep(PROPAGATION_WAIT)
-
-        result_enforcing = _send_tool_burst(server_id, tool_name, BURST_SIZE)
-        assert result_enforcing["rate_limited"] > 0, (
-            f"Step 2 (enforce): expected some rate-limited, got {result_enforcing}"
-        )
-
-        # Step 3: Disable again — all should pass
-        _set_plugin_mode("disabled")
-        time.sleep(PROPAGATION_WAIT)
-
-        result_disabled_again = _send_tool_burst(server_id, tool_name, BURST_SIZE)
-        assert result_disabled_again["rate_limited"] == 0, (
-            f"Step 3 (disabled again): expected 0 rate-limited, got {result_disabled_again}"
-        )
-
-
 class TestRateLimiterRedisState:
     """Verify that rate limiter mode changes are persisted in Redis."""
 

--- a/tests/integration/test_rate_limiter_dynamic_behavior.py
+++ b/tests/integration/test_rate_limiter_dynamic_behavior.py
@@ -1,0 +1,333 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for rate limiter dynamic behavior.
+
+Verifies that runtime mode changes to the RateLimiterPlugin via the admin API
+actually affect rate limiting behavior on tool calls.
+
+The rate limiter is configured in plugins/config.yaml with:
+    mode: "disabled"
+    by_user: "30/m"
+    backend: "redis" (with redis_fallback: true)
+
+Tests toggle the mode at runtime and verify tool calls are rate-limited
+(or not) accordingly.
+
+Requirements:
+    - Running gateway (docker-compose with 3 replicas)
+    - NGINX load balancer on port 8080
+    - Redis available
+    - fast-test-server or fast-time-server registered
+
+Usage:
+    uv run pytest tests/integration/test_rate_limiter_dynamic_behavior.py -v --with-integration
+"""
+
+# Standard
+import os
+import time
+import uuid
+
+# Third-Party
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
+GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
+GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
+
+PLUGIN_NAME = "RateLimiterPlugin"
+
+# Wait after admin changes for propagation (NGINX cache TTL + pub/sub)
+PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", "7"))
+
+# Number of requests to send per burst — must exceed the configured
+# by_user limit (30/m) to observe rate limiting
+BURST_SIZE = 40
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_session_token() -> str:
+    """Login and return a session token."""
+    resp = requests.post(
+        f"{GATEWAY_URL}/auth/login",
+        json={"email": GATEWAY_EMAIL, "password": GATEWAY_PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def _fresh_headers() -> dict:
+    """Get fresh auth headers."""
+    return {
+        "Authorization": f"Bearer {_get_session_token()}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _is_gateway_running() -> bool:
+    """Check if the gateway is reachable."""
+    try:
+        resp = requests.get(f"{GATEWAY_URL}/health", timeout=5)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+def _auto_detect_server_and_tool() -> tuple[str, str]:
+    """Find a server ID and tool name for testing."""
+    headers = _fresh_headers()
+    resp = requests.get(f"{GATEWAY_URL}/servers", headers=headers, timeout=10)
+    resp.raise_for_status()
+    for server in resp.json():
+        tools = server.get("associatedTools", [])
+        # Prefer echo tool (echoes back, cheap), fall back to any time tool
+        for tool in tools:
+            if "echo" in tool.lower():
+                return server["id"], tool
+        for tool in tools:
+            if "time" in tool.lower() and "convert" not in tool.lower():
+                return server["id"], tool
+    pytest.skip("No suitable server/tool found for rate limiter test")
+
+
+def _set_plugin_mode(mode: str) -> dict:
+    """Set the rate limiter mode via admin API. Returns the response body."""
+    headers = _fresh_headers()
+    resp = requests.put(
+        f"{GATEWAY_URL}/admin/plugins/{PLUGIN_NAME}",
+        json={"mode": mode},
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _get_plugin_state() -> dict:
+    """Get the current plugin state from admin API."""
+    headers = _fresh_headers()
+    resp = requests.get(
+        f"{GATEWAY_URL}/admin/plugins",
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _send_tool_burst(server_id: str, tool_name: str, count: int) -> dict:
+    """Send a burst of tool calls and return counts of allowed vs rate-limited.
+
+    Returns:
+        {"allowed": int, "rate_limited": int, "errors": int, "total": int}
+    """
+    allowed = 0
+    rate_limited = 0
+    errors = 0
+    headers = _fresh_headers()
+
+    for i in range(count):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {"message": f"rate-limit-test-{i}"} if "echo" in tool_name else {},
+            },
+        }
+        try:
+            resp = requests.post(
+                f"{GATEWAY_URL}/servers/{server_id}/mcp",
+                json=payload,
+                headers=headers,
+                timeout=15,
+            )
+
+            if resp.status_code == 429:
+                rate_limited += 1
+                continue
+
+            if resp.status_code != 200:
+                errors += 1
+                continue
+
+            data = resp.json()
+            result = data.get("result", {})
+
+            # Check for MCP-level rate limit error (isError with rate/limit in content)
+            if result.get("isError"):
+                content = result.get("content", [])
+                text = content[0].get("text", "") if content else ""
+                if "rate" in text.lower() or "limit" in text.lower():
+                    rate_limited += 1
+                else:
+                    errors += 1
+            else:
+                allowed += 1
+
+        except requests.RequestException:
+            errors += 1
+
+    return {
+        "allowed": allowed,
+        "rate_limited": rate_limited,
+        "errors": errors,
+        "total": count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Skip if gateway not running
+# ---------------------------------------------------------------------------
+
+pytestmark = pytest.mark.skipif(
+    not _is_gateway_running(),
+    reason=f"Gateway not running at {GATEWAY_URL}",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server_and_tool():
+    """Auto-detect server ID and tool name once for the module."""
+    return _auto_detect_server_and_tool()
+
+
+@pytest.fixture(autouse=True)
+def ensure_rate_limiter_disabled():
+    """Disable the rate limiter before and after each test."""
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+    yield
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiterDisabledAllowsAll:
+    """When rate limiter is disabled, all requests should pass through."""
+
+    def test_burst_all_allowed_when_disabled(self, server_and_tool):
+        """With rate limiter disabled, a burst of requests should all succeed."""
+        server_id, tool_name = server_and_tool
+        result = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+
+        assert result["rate_limited"] == 0, (
+            f"Rate limiter should be disabled but {result['rate_limited']}/{result['total']} "
+            f"requests were rate-limited"
+        )
+        assert result["allowed"] == result["total"] - result["errors"], (
+            f"All non-error requests should be allowed: {result}"
+        )
+
+
+class TestRateLimiterEnforceBlocks:
+    """When rate limiter is enabled, requests exceeding the limit should be blocked."""
+
+    def test_burst_some_blocked_when_enforcing(self, server_and_tool):
+        """With rate limiter enforcing (30/m), a burst of 40 requests should see some blocked."""
+        server_id, tool_name = server_and_tool
+
+        # Enable rate limiter
+        resp = _set_plugin_mode("enforce")
+        assert resp["mode"] == "enforce"
+        time.sleep(PROPAGATION_WAIT)
+
+        # Send burst — should exceed 30/m limit
+        result = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+
+        assert result["rate_limited"] > 0, (
+            f"Rate limiter should be enforcing (by_user: 30/m) but no requests were "
+            f"rate-limited out of {result['total']}: {result}"
+        )
+
+
+class TestRateLimiterToggleCycle:
+    """Verify that toggling the rate limiter mode changes actual behavior."""
+
+    def test_disable_enable_disable_cycle(self, server_and_tool):
+        """Full cycle: disabled (all pass) → enforce (some blocked) → disabled (all pass)."""
+        server_id, tool_name = server_and_tool
+
+        # Explicit disable + wait to ensure clean state (previous test may have
+        # left the rate limiter enforcing and the autouse fixture's wait may
+        # not have been enough for all replicas to converge)
+        _set_plugin_mode("disabled")
+        time.sleep(PROPAGATION_WAIT)
+
+        # Step 1: Disabled — all should pass
+        result_disabled = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert result_disabled["rate_limited"] == 0, (
+            f"Step 1 (disabled): expected 0 rate-limited, got {result_disabled}"
+        )
+
+        # Step 2: Enable — some should be blocked
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+
+        result_enforcing = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert result_enforcing["rate_limited"] > 0, (
+            f"Step 2 (enforce): expected some rate-limited, got {result_enforcing}"
+        )
+
+        # Step 3: Disable again — all should pass
+        _set_plugin_mode("disabled")
+        time.sleep(PROPAGATION_WAIT)
+
+        result_disabled_again = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert result_disabled_again["rate_limited"] == 0, (
+            f"Step 3 (disabled again): expected 0 rate-limited, got {result_disabled_again}"
+        )
+
+
+class TestRateLimiterRedisState:
+    """Verify that rate limiter mode changes are persisted in Redis."""
+
+    def test_mode_stored_in_redis(self, server_and_tool):
+        """PUT mode=enforce stores the mode in Redis with redis_persisted=true."""
+        resp = _set_plugin_mode("enforce")
+        assert resp["redis_persisted"] is True, (
+            f"Mode change should be Redis-persisted: {resp}"
+        )
+        assert resp["mode"] == "enforce"
+
+    def test_mode_visible_in_admin_api_after_change(self, server_and_tool):
+        """After changing mode, GET /admin/plugins reflects the new mode."""
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+
+        state = _get_plugin_state()
+        plugins = {p["name"]: p for p in state.get("plugins", [])}
+        assert PLUGIN_NAME in plugins, f"RateLimiterPlugin not in plugin list"
+        assert plugins[PLUGIN_NAME]["mode"] == "enforce", (
+            f"Expected mode=enforce, got {plugins[PLUGIN_NAME]['mode']}"
+        )
+
+    def test_mode_reverts_in_admin_api_after_disable(self, server_and_tool):
+        """After disabling, GET /admin/plugins reflects disabled mode."""
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+        _set_plugin_mode("disabled")
+        time.sleep(PROPAGATION_WAIT)
+
+        state = _get_plugin_state()
+        plugins = {p["name"]: p for p in state.get("plugins", [])}
+        assert plugins[PLUGIN_NAME]["mode"] == "disabled"

--- a/tests/integration/test_rate_limiter_multi_tenant.py
+++ b/tests/integration/test_rate_limiter_multi_tenant.py
@@ -144,6 +144,9 @@ def _flush_rate_limiter_keys() -> None:
             timeout=5,
             check=False,
         )
+    remaining = _redis_keys("rl:*")
+    if remaining:
+        pytest.fail(f"Rate-limiter keys still present after flush: {remaining}")
 
 
 pytestmark = pytest.mark.skipif(

--- a/tests/integration/test_rate_limiter_multi_tenant.py
+++ b/tests/integration/test_rate_limiter_multi_tenant.py
@@ -32,11 +32,13 @@ import uuid
 import pytest
 import requests
 
+from tests.helpers.integration_constants import PLUGIN_MODE_PROPAGATION_WAIT_SECONDS
+
 GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
 GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
 GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
 PLUGIN_NAME = "RateLimiterPlugin"
-PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", "7"))
+PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", str(PLUGIN_MODE_PROPAGATION_WAIT_SECONDS)))
 
 
 def _get_session_token() -> str:
@@ -124,8 +126,10 @@ def _redis_keys(pattern: str) -> list[str]:
             timeout=5,
             check=False,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
         pytest.skip("Docker or Redis container not reachable")
+    if result.returncode != 0:
+        pytest.skip(f"Redis key query failed: {result.stderr.strip() or 'unknown error'}")
     lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     return sorted(lines)
 
@@ -197,10 +201,7 @@ class TestTenantIdFlowsToPlugin:
         """
         server_id, tool_name, team_id = server_and_tool
         if not team_id:
-            pytest.skip(
-                "Detected server has no team_id — this deployment uses platform-owned tools. "
-                "Re-run against a deployment that has team-scoped servers to exercise G2."
-            )
+            pytest.skip("Detected server has no team_id — this deployment uses platform-owned tools. " "Re-run against a deployment that has team-scoped servers to exercise G2.")
 
         _set_plugin_mode("enforce")
         time.sleep(PROPAGATION_WAIT)
@@ -219,7 +220,4 @@ class TestTenantIdFlowsToPlugin:
         )
         # Defensive assertion — if we see unprefixed keys alongside prefixed ones,
         # something is calling the plugin without populated tenant_id.
-        assert not unprefixed_keys, (
-            f"Found rl:* keys without the team prefix: {unprefixed_keys!r}. "
-            f"Some code path is invoking the plugin without populating tenant_id."
-        )
+        assert not unprefixed_keys, f"Found rl:* keys without the team prefix: {unprefixed_keys!r}. " f"Some code path is invoking the plugin without populating tenant_id."

--- a/tests/integration/test_rate_limiter_multi_tenant.py
+++ b/tests/integration/test_rate_limiter_multi_tenant.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for G1 + G2 — tenant-id end-to-end through the gateway.
+
+Covers issue #4343:
+  - G1: GlobalContext.tenant_id is populated so by_tenant rate limiting
+    is not a silent no-op on the tool-service paths.
+  - G2: Redis keys carry the tenant prefix (rl:{tenant_id}:user:{email}:...),
+    so counters don't collide across teams in a shared-Redis deployment.
+
+These tests go through the full gateway HTTP flow against a running
+docker-compose stack (same harness as test_rate_limiter_dynamic_behavior.py),
+enable the rate limiter in enforce mode with a high limit (so we observe
+key creation without 429s), make a real tool call, and then inspect
+Redis to verify the key shape.
+
+Requirements:
+    - Running gateway (docker-compose at http://localhost:8080)
+    - Redis at localhost:6379 (or docker container)
+    - fast-time-server or equivalent registered
+
+Usage:
+    uv run pytest tests/integration/test_rate_limiter_multi_tenant.py -v --with-integration
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import uuid
+
+import pytest
+import requests
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
+GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
+GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
+PLUGIN_NAME = "RateLimiterPlugin"
+PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", "7"))
+
+
+def _get_session_token() -> str:
+    resp = requests.post(
+        f"{GATEWAY_URL}/auth/login",
+        json={"email": GATEWAY_EMAIL, "password": GATEWAY_PASSWORD},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def _fresh_headers() -> dict:
+    return {
+        "Authorization": f"Bearer {_get_session_token()}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _is_gateway_running() -> bool:
+    try:
+        resp = requests.get(f"{GATEWAY_URL}/health", timeout=5)
+        return resp.status_code == 200
+    except requests.ConnectionError:
+        return False
+
+
+def _auto_detect_server_and_tool() -> tuple[str, str, str | None]:
+    """Find a server+tool and return (server_id, tool_name, tool_team_id)."""
+    headers = _fresh_headers()
+    resp = requests.get(f"{GATEWAY_URL}/servers", headers=headers, timeout=10)
+    resp.raise_for_status()
+    for server in resp.json():
+        tools = server.get("associatedTools", [])
+        for tool in tools:
+            if "echo" in tool.lower() or ("time" in tool.lower() and "convert" not in tool.lower()):
+                team_id = server.get("teamId") or server.get("team_id")
+                return server["id"], tool, team_id
+    pytest.skip("No suitable server/tool found for multi-tenant rate limiter test")
+
+
+def _set_plugin_mode(mode: str) -> None:
+    resp = requests.put(
+        f"{GATEWAY_URL}/admin/plugins/{PLUGIN_NAME}",
+        json={"mode": mode},
+        headers=_fresh_headers(),
+        timeout=10,
+    )
+    resp.raise_for_status()
+
+
+def _invoke_tool_once(server_id: str, tool_name: str) -> int:
+    """Make a single MCP tool invocation and return its HTTP status."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": str(uuid.uuid4()),
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": {"message": "multi-tenant-test"} if "echo" in tool_name else {},
+        },
+    }
+    resp = requests.post(
+        f"{GATEWAY_URL}/servers/{server_id}/mcp",
+        json=payload,
+        headers=_fresh_headers(),
+        timeout=15,
+    )
+    return resp.status_code
+
+
+def _redis_keys(pattern: str) -> list[str]:
+    """Query Redis for keys matching the pattern via the running docker container.
+
+    Uses docker exec rather than connecting directly to sidestep any auth
+    differences between the gateway's Redis client and a test-side client.
+    Returns a sorted list of key names (empty if no keys or docker unavailable).
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "exec", "mcp-context-forge-redis-1", "redis-cli", "-n", "0", "KEYS", pattern],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pytest.skip("Docker or Redis container not reachable")
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return sorted(lines)
+
+
+def _flush_rate_limiter_keys() -> None:
+    """Delete any existing rl:* keys so we observe only keys from the current test."""
+    keys = _redis_keys("rl:*")
+    for key in keys:
+        subprocess.run(
+            ["docker", "exec", "mcp-context-forge-redis-1", "redis-cli", "-n", "0", "DEL", key],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_gateway_running(),
+    reason=f"Gateway not running at {GATEWAY_URL}",
+)
+
+
+@pytest.fixture(scope="module")
+def server_and_tool():
+    return _auto_detect_server_and_tool()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rate_limiter_between_tests():
+    """Flush rl:* keys and disable the plugin between tests."""
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+    _flush_rate_limiter_keys()
+    yield
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+
+
+class TestTenantIdFlowsToPlugin:
+    """G1 + G2 end-to-end: tenant_id reaches the plugin, tenant prefix lands in Redis."""
+
+    def test_tool_invocation_creates_rate_limit_keys_in_redis(self, server_and_tool):
+        """Sanity check: with the rate limiter enforcing, a tool call must
+        leave at least one rate-limit key in Redis.
+
+        If this test fails, the rate limiter isn't engaging on the tool
+        path at all, and every other assertion below is meaningless.
+        """
+        server_id, tool_name, _team_id = server_and_tool
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+
+        status = _invoke_tool_once(server_id, tool_name)
+        assert status == 200, f"tool invocation must succeed under default limit, got HTTP {status}"
+
+        keys = _redis_keys("rl:*")
+        assert keys, (
+            "no rl:* keys found in Redis after a rate-limited tool invocation — "
+            "the rate limiter may not be engaged on this path. "
+            "Check plugins/config.yaml has RateLimiterPlugin enabled and configured."
+        )
+
+    def test_rate_limit_keys_carry_tenant_prefix_when_tool_is_team_owned(self, server_and_tool):
+        """G2 end-to-end: when the tool is team-owned, the Redis keys written by
+        the rate limiter must start with `rl:{team_id}:...` — proving the
+        main-repo change at tool_service.py propagated team_id into
+        GlobalContext.tenant_id and that the cpex plugin then used that as
+        the context prefix when building the Redis key.
+        """
+        server_id, tool_name, team_id = server_and_tool
+        if not team_id:
+            pytest.skip(
+                "Detected server has no team_id — this deployment uses platform-owned tools. "
+                "Re-run against a deployment that has team-scoped servers to exercise G2."
+            )
+
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+
+        status = _invoke_tool_once(server_id, tool_name)
+        assert status == 200, f"tool invocation must succeed under default limit, got HTTP {status}"
+
+        # Look specifically for the tenant-prefixed format: rl:{team}:...:...
+        prefixed_keys = _redis_keys(f"rl:{team_id}:*")
+        unprefixed_keys = [k for k in _redis_keys("rl:*") if not k.startswith(f"rl:{team_id}:")]
+
+        assert prefixed_keys, (
+            f"expected at least one key matching 'rl:{team_id}:*' — tenant prefix missing from Redis keys. "
+            f"All rl:* keys: {_redis_keys('rl:*')!r}. "
+            f"This means GlobalContext.tenant_id is not reaching the plugin."
+        )
+        # Defensive assertion — if we see unprefixed keys alongside prefixed ones,
+        # something is calling the plugin without populated tenant_id.
+        assert not unprefixed_keys, (
+            f"Found rl:* keys without the team prefix: {unprefixed_keys!r}. "
+            f"Some code path is invoking the plugin without populating tenant_id."
+        )

--- a/tests/integration/test_rate_limiter_multi_tenant.py
+++ b/tests/integration/test_rate_limiter_multi_tenant.py
@@ -39,6 +39,9 @@ GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
 GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
 PLUGIN_NAME = "RateLimiterPlugin"
 PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", str(PLUGIN_MODE_PROPAGATION_WAIT_SECONDS)))
+# docker-compose derives the container name from the project-name prefix + service
+# name; anyone running under a non-default project name needs to override this.
+REDIS_CONTAINER_NAME = os.environ.get("REDIS_CONTAINER_NAME", "mcp-context-forge-redis-1")
 
 
 def _get_session_token() -> str:
@@ -120,7 +123,7 @@ def _redis_keys(pattern: str) -> list[str]:
     """
     try:
         result = subprocess.run(
-            ["docker", "exec", "mcp-context-forge-redis-1", "redis-cli", "-n", "0", "KEYS", pattern],
+            ["docker", "exec", REDIS_CONTAINER_NAME, "redis-cli", "-n", "0", "KEYS", pattern],
             capture_output=True,
             text=True,
             timeout=5,
@@ -139,7 +142,7 @@ def _flush_rate_limiter_keys() -> None:
     keys = _redis_keys("rl:*")
     for key in keys:
         subprocess.run(
-            ["docker", "exec", "mcp-context-forge-redis-1", "redis-cli", "-n", "0", "DEL", key],
+            ["docker", "exec", REDIS_CONTAINER_NAME, "redis-cli", "-n", "0", "DEL", key],
             capture_output=True,
             timeout=5,
             check=False,

--- a/tests/loadtest/locustfile_rate_limiter_scale.py
+++ b/tests/loadtest/locustfile_rate_limiter_scale.py
@@ -291,6 +291,43 @@ def _scan_redis_pattern(pattern: str, timeout: int = 20) -> int:
         return 0
 
 
+def _scan_rl_dimension(dimension: str, timeout: int = 20) -> int:
+    """Count rate-limiter keys for a given dimension, regardless of tenant prefix.
+
+    After the tenant-scoping change in the gateway's tool-service (G1/G2 from
+    issue #4343), keys for team-owned tools land at
+    ``rl:{tenant_id}:{dimension}:{id}:{window}`` instead of
+    ``rl:{dimension}:{id}:{window}``. Single-tenant deployments keep the
+    unprefixed layout. Scan both so this test works before and after the
+    change, and against mixed deployments.
+    """
+    return _scan_redis_pattern(f"rl:{dimension}:*", timeout=timeout) + _scan_redis_pattern(
+        f"rl:*:{dimension}:*", timeout=timeout
+    )
+
+
+def _scan_rl_sample_keys(dimension: str, timeout: int = 15) -> list[str]:
+    """Return sample rate-limiter keys for a dimension, scanning both layouts.
+
+    Used by algorithm-detection to read a representative key's Redis data
+    type. Returns the union of unprefixed and tenant-prefixed keys.
+    """
+    keys: list[str] = []
+    for pattern in (f"rl:{dimension}:*", f"rl:*:{dimension}:*"):
+        try:
+            r = subprocess.run(
+                ["docker", "exec", DOCKER_REDIS_CONTAINER, "redis-cli", "--scan", "--pattern", pattern],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            if r.returncode == 0:
+                keys.extend(line.strip() for line in r.stdout.splitlines() if line.strip())
+        except Exception:
+            continue
+    return keys
+
+
 def _poll_redis_once() -> dict[str, Any] | None:
     """Query Redis for key count and memory usage via docker exec.
 
@@ -308,8 +345,10 @@ def _poll_redis_once() -> dict[str, Any] | None:
         )
         total_keys = int(r_dbsize.stdout.strip()) if r_dbsize.returncode == 0 else 0
 
-        # RL-specific keys only (rl:user:* = per-user buckets, rl:tenant:* = per-team buckets)
-        rl_keys = _scan_redis_pattern("rl:user:*") + _scan_redis_pattern("rl:tenant:*")
+        # RL-specific keys only (per-user and per-team buckets). Scan both
+        # the unprefixed layout (rl:{dim}:*) and the tenant-prefixed layout
+        # (rl:{tenant}:{dim}:*) introduced by the G1/G2 fix in #4343.
+        rl_keys = _scan_rl_dimension("user") + _scan_rl_dimension("tenant")
 
         # INFO memory — used_memory in bytes
         r_mem = subprocess.run(
@@ -347,15 +386,12 @@ def _detect_algorithm_from_redis() -> str:
       hash    → token_bucket   (tokens + last_refill timestamp)
     """
     try:
-        r_scan = subprocess.run(
-            ["docker", "exec", DOCKER_REDIS_CONTAINER, "redis-cli", "--scan", "--pattern", "rl:user:*"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        sample_keys = [l.strip() for l in r_scan.stdout.splitlines() if l.strip()]
+        sample_keys = _scan_rl_sample_keys("user")
         if not sample_keys:
-            return f"unknown — no rl:user:* keys in Redis (expected for {RL_ALGORITHM}?)"
+            return (
+                f"unknown — no rl:user:* or rl:*:user:* keys in Redis "
+                f"(expected for {RL_ALGORITHM}?)"
+            )
 
         r_type = subprocess.run(
             ["docker", "exec", DOCKER_REDIS_CONTAINER, "redis-cli", "TYPE", sample_keys[0]],

--- a/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
@@ -80,3 +80,29 @@ def test_build_rust_tool_hook_global_context_fills_missing_existing_tenant_id():
 
     assert ctx is existing_context
     assert ctx.tenant_id == "team_a", "existing GlobalContext with tenant_id=None must be filled from " f"tool_payload['team_id']; got tenant_id={ctx.tenant_id!r}"
+
+
+def test_build_rust_tool_hook_global_context_preserves_existing_tenant_id():
+    """Existing GlobalContext with tenant_id already set is NOT overwritten by payload team_id.
+
+    This covers the branch where plugin_global_context exists AND has tenant_id,
+    so the condition `if not global_context.tenant_id and payload_tenant_id:` is False.
+    Line 4568 in tool_service.py.
+    """
+    service = ToolService()
+    existing_context = GlobalContext(request_id="request-1", tenant_id="team_middleware")
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id=None,
+        tool_gateway_id=None,
+        plugin_global_context=existing_context,
+        tool_payload={"team_id": "team_payload", "name": "search"},
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx is existing_context
+    assert ctx.tenant_id == "team_middleware", (
+        "existing GlobalContext with tenant_id already set must NOT be overwritten by " f"tool_payload['team_id']; expected 'team_middleware', got tenant_id={ctx.tenant_id!r}"
+    )

--- a/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Tenant-id population in the tool-service GlobalContext fallback paths (G1).
+
+Covers ``ToolService._build_rust_tool_hook_global_context`` and the same
+``else`` branch inside ``invoke_tool`` that fires when middleware didn't
+run and a fresh ``GlobalContext`` has to be constructed from the
+already-extracted tool payload. Without these tests the rate limiter's
+``by_tenant`` dimension is silently a no-op on the fallback path.
+"""
+
+from mcpgateway.services.tool_service import ToolService
+
+
+def test_build_rust_tool_hook_global_context_propagates_team_id_as_tenant_id():
+    """tool_payload['team_id'] flows into GlobalContext.tenant_id on the fallback path."""
+    service = ToolService()
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id=None,
+        tool_gateway_id=None,
+        plugin_global_context=None,  # forces the fallback branch
+        tool_payload={"team_id": "team_a", "name": "search"},
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx.tenant_id == "team_a", (
+        "fallback-path GlobalContext must carry tool_payload['team_id'] as tenant_id — "
+        f"got tenant_id={ctx.tenant_id!r}"
+    )
+
+
+def test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent():
+    """Missing team_id → tenant_id stays None; no crash, no spurious default."""
+    service = ToolService()
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id=None,
+        tool_gateway_id=None,
+        plugin_global_context=None,
+        tool_payload={"name": "search"},  # no team_id
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx.tenant_id is None, (
+        "tenant_id must remain None when tool_payload has no team_id, "
+        f"got tenant_id={ctx.tenant_id!r}"
+    )
+
+
+def test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored():
+    """Defensive: a non-string team_id (unexpected shape) must not crash or be coerced."""
+    service = ToolService()
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id=None,
+        tool_gateway_id=None,
+        plugin_global_context=None,
+        tool_payload={"team_id": 42, "name": "search"},  # numeric, not str
+        gateway_payload=None,
+        request_headers=None,
+    )
+
+    assert ctx.tenant_id is None, (
+        "Non-string team_id must not be accepted as tenant_id; "
+        f"got tenant_id={ctx.tenant_id!r}"
+    )

--- a/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_tenant_id.py
@@ -8,6 +8,7 @@ already-extracted tool payload. Without these tests the rate limiter's
 ``by_tenant`` dimension is silently a no-op on the fallback path.
 """
 
+from mcpgateway.plugins.framework import GlobalContext
 from mcpgateway.services.tool_service import ToolService
 
 
@@ -25,10 +26,7 @@ def test_build_rust_tool_hook_global_context_propagates_team_id_as_tenant_id():
         request_headers=None,
     )
 
-    assert ctx.tenant_id == "team_a", (
-        "fallback-path GlobalContext must carry tool_payload['team_id'] as tenant_id — "
-        f"got tenant_id={ctx.tenant_id!r}"
-    )
+    assert ctx.tenant_id == "team_a", "fallback-path GlobalContext must carry tool_payload['team_id'] as tenant_id — " f"got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent():
@@ -45,10 +43,7 @@ def test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent(
         request_headers=None,
     )
 
-    assert ctx.tenant_id is None, (
-        "tenant_id must remain None when tool_payload has no team_id, "
-        f"got tenant_id={ctx.tenant_id!r}"
-    )
+    assert ctx.tenant_id is None, "tenant_id must remain None when tool_payload has no team_id, " f"got tenant_id={ctx.tenant_id!r}"
 
 
 def test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored():
@@ -65,7 +60,23 @@ def test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored():
         request_headers=None,
     )
 
-    assert ctx.tenant_id is None, (
-        "Non-string team_id must not be accepted as tenant_id; "
-        f"got tenant_id={ctx.tenant_id!r}"
+    assert ctx.tenant_id is None, "Non-string team_id must not be accepted as tenant_id; " f"got tenant_id={ctx.tenant_id!r}"
+
+
+def test_build_rust_tool_hook_global_context_fills_missing_existing_tenant_id():
+    """Existing GlobalContext with tenant_id=None is filled from payload team_id."""
+    service = ToolService()
+    existing_context = GlobalContext(request_id="request-1", tenant_id=None)
+
+    ctx = service._build_rust_tool_hook_global_context(
+        app_user_email="alice@example.com",
+        server_id=None,
+        tool_gateway_id=None,
+        plugin_global_context=existing_context,
+        tool_payload={"team_id": "team_a", "name": "search"},
+        gateway_payload=None,
+        request_headers=None,
     )
+
+    assert ctx is existing_context
+    assert ctx.tenant_id == "team_a", "existing GlobalContext with tenant_id=None must be filled from " f"tool_payload['team_id']; got tenant_id={ctx.tenant_id!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-11T15:01:03.32805Z"
+exclude-newer = "2026-04-12T14:32:10.61373Z"
 exclude-newer-span = "P10D"
 
 [options.exclude-newer-package]
@@ -16,7 +16,7 @@ langchain-core = "2026-04-11T23:59:59Z"
 cpex-retry-with-backoff = "2026-04-09T23:59:59Z"
 cpex-pii-filter = "2026-04-21T23:59:59Z"
 cpex-url-reputation = "2026-04-20T23:59:59Z"
-cpex-rate-limiter = "2026-04-09T23:59:59Z"
+cpex-rate-limiter = "2026-04-22T23:59:59Z"
 cpex-secrets-detection = "2026-04-20T23:59:59Z"
 cryptography = "2026-04-11T23:59:59Z"
 uv = "2026-04-11T23:59:59Z"
@@ -935,16 +935,16 @@ wheels = [
 
 [[package]]
 name = "cpex-rate-limiter"
-version = "0.0.3"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/d5/db5a693ddbfab73770f71d20b6bb78fb5d5625effef81728069194eaa842/cpex_rate_limiter-0.0.3.tar.gz", hash = "sha256:c2bc35530840bdc98c70a8cb8a12290dc765e757f54e2961644bc6eda4ca99f1", size = 63839, upload-time = "2026-04-07T08:51:13.149Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/03/339f8cdfa1ff185ec40b595bb7e454fec0e5b4094dd1bcb2272629bb3532/cpex_rate_limiter-0.0.4.tar.gz", hash = "sha256:473b0f366e0c3de947f07052eecc39a4a780fcc0e0993630d611d31148960119", size = 86068, upload-time = "2026-04-22T14:29:27.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/9c/a354b5a9d2d34f72b4aa9a5ad8a9ea32f9811116fb98d9e8f2178465f63f/cpex_rate_limiter-0.0.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:6ce22f0edaa79687a98fb9ffbce30fe8b147cf931f110de04acd4c3d4a867217", size = 702981, upload-time = "2026-04-07T08:51:04.429Z" },
-    { url = "https://files.pythonhosted.org/packages/80/aa/f93985195352d90f40ef57458c2cdd897b1b42b0dae910483bf9b1d76b78/cpex_rate_limiter-0.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b6cab31c59eb24c433d56694935be8918916b74513904e3de77e1610c90bf93b", size = 731483, upload-time = "2026-04-07T08:51:06.139Z" },
-    { url = "https://files.pythonhosted.org/packages/37/90/5c01ce2499a43f9f356e102723e13672a6e591c0015b9fb26c2f7dd5467a/cpex_rate_limiter-0.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f98674f7b609ef107e4129a110d20ae942ecd29fa8dbad39f92fda4ec9ba2271", size = 832663, upload-time = "2026-04-07T08:51:07.778Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b2/fab0c09600dacfca1b0d86e24d1d219527480d82cf8e2e7268ed06cf22b0/cpex_rate_limiter-0.0.3-cp311-abi3-manylinux_2_34_s390x.whl", hash = "sha256:a6f703e5170908c2801ba8641161ad1be454e73a652ce8ee555f56af83418637", size = 851711, upload-time = "2026-04-07T08:51:09.044Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/b7/e5509dbbfcf8f60d5a4062e78f0bf82f60548787ceede7bc5a272aee34ec/cpex_rate_limiter-0.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d45de2e6f6f8b3cbd0291f5ce81e950846d31751b11d02567dd3c553a771919e", size = 771196, upload-time = "2026-04-07T08:51:10.299Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e7/77a83a27bf681e2abc3b76edacbc379c61d7994b02d436d2b0bfd36003c8/cpex_rate_limiter-0.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:876df5158f8f5d1c29fc6a7a41c775a4f510ddf3c56f24bc05a15297705b4bd3", size = 735138, upload-time = "2026-04-07T08:51:11.654Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b0/515bb8d2b09cc0601e2d3a0a99e689b55b9f7dd4f4e549901d01a0d78b73/cpex_rate_limiter-0.0.4-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:3848d6464951c98c1af446416460280db3846f10ebe0192e7c92a210ac54445d", size = 714183, upload-time = "2026-04-22T14:29:17.668Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/c1b24497f0bfb7b109b755ceb43f35addaed627c5a7c7c80c15021173916/cpex_rate_limiter-0.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b0f2289b5ea4aebb2a35268e8c10c83097717b7a7c13bdd0f524faf442650c01", size = 744062, upload-time = "2026-04-22T14:29:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/26/65/cdefe0dea2b1e41ed3f9faf91e08bccb2586c339e204013e2097a5727883/cpex_rate_limiter-0.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:14576c661c1a3decf2a42977f8b7736b83823dd7fdc90d07862be7dbb8c06817", size = 847363, upload-time = "2026-04-22T14:29:20.73Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1e/5e161feccdf3b4fb4f570cce1b3af5a1965cd63fa09384e07539dfa1d63d/cpex_rate_limiter-0.0.4-cp311-abi3-manylinux_2_34_s390x.whl", hash = "sha256:cb1d2f5c95c0526792afc8d1049fa44373fad4c8cc768ed1d2def0d8386b28ba", size = 863562, upload-time = "2026-04-22T14:29:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e3/e0bc22856fc21e210eb0084e51b5c691d848b4f8e10dc666faf2cc039513/cpex_rate_limiter-0.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c6a1115e4351ad180d1bc3dd9f8ab9aac0ef8b0eccc8bfe93ed3b94f13f6bfba", size = 782003, upload-time = "2026-04-22T14:29:24.334Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/74/e3b9e937aee1950fcb8a3b57f1d2ee128768dff9f6926d3dfbe907f3a5de/cpex_rate_limiter-0.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:58ef761b22eca7bfb7bc09e66867eb66a2518c72260755dabfdec36fe14c140f", size = 747459, upload-time = "2026-04-22T14:29:26.043Z" },
 ]
 
 [[package]]
@@ -3174,7 +3174,7 @@ requires-dist = [
     { name = "cookiecutter", marker = "extra == 'templating'", specifier = ">=2.7.1" },
     { name = "cpex-encoded-exfil-detection", marker = "extra == 'plugins'", specifier = ">=0.2.0" },
     { name = "cpex-pii-filter", marker = "extra == 'plugins'", specifier = ">=0.2.1" },
-    { name = "cpex-rate-limiter", marker = "extra == 'plugins'", specifier = ">=0.0.3" },
+    { name = "cpex-rate-limiter", marker = "extra == 'plugins'", specifier = ">=0.0.4" },
     { name = "cpex-retry-with-backoff", marker = "extra == 'plugins'", specifier = ">=0.1.0" },
     { name = "cpex-secrets-detection", marker = "extra == 'plugins'", specifier = ">=0.2.0" },
     { name = "cpex-url-reputation", marker = "extra == 'plugins'", specifier = ">=0.2.0" },


### PR DESCRIPTION
## Summary

Populates `GlobalContext.tenant_id` on the tool-service fallback paths so the rate limiter's `by_tenant` dimension stops being a silent no-op, and adds integration test coverage that validates the tenant dimension end-to-end through the full gateway HTTP flow.

Closes the main-repo half of issue #4343 (G1). The cpex plugin half is in [IBM/cpex-plugins#40](https://github.com/IBM/cpex-plugins/pull/40); this PR is kept as draft until that one merges and a cpex release is published.

---

## Gap closed

**Gap 1 (HIGH)** — `GlobalContext.tenant_id` was hardcoded to `None` on the two fallback branches in `tool_service.py` (`_build_rust_tool_hook_global_context` and `invoke_tool`) that fire when middleware didn't run. The happy path (HTTP → `HttpAuthMiddleware` → `auth.get_current_user` → `_propagate_tenant_id`) already handled this, but the direct-invocation and fresh-context paths left `tenant_id` at `None`, silently skipping `by_tenant` rate limiting and producing unprefixed Redis keys that collide across tenants.

Both fallback branches now derive `tenant_id` from `tool_payload["team_id"]` — which is already in scope at both call sites (see `_tool_team_id = tool_payload.get("team_id")` at `tool_service.py:4463`). Non-string `team_id` values are ignored defensively. When `plugin_global_context` is supplied but carries `tenant_id=None`, the payload-derived value fills it in without overwriting an already-set value.

---

## Architecture

### `tenant_id` flow — before

```text
┌────────────────┐
│  HTTP request  │
└───────┬────────┘
        │
        ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  HttpAuthMiddleware                                                      │
│  ┌──────────────────────────────────────────────────────────────────┐   │
│  │ GlobalContext(request_id, tenant_id=None, ...)                    │   │
│  └──────────────────────────────────────────────────────────────────┘   │
└───────┬─────────────────────────────────────────────────────────────────┘
        │
        ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  auth.get_current_user → _propagate_tenant_id                            │
│    sets global_context.tenant_id = request.state.team_id  ← HAPPY PATH  │
└───────┬─────────────────────────────────────────────────────────────────┘
        │
        ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  ToolService.invoke_tool / _build_rust_tool_hook_global_context          │
│                                                                          │
│  if plugin_global_context:     ← reuses middleware's context (populated) │
│      global_context = plugin_global_context                              │
│  else:                          ← FALLBACK — no middleware               │
│      global_context = GlobalContext(..., tenant_id=None, ...)  ◄── BUG   │
└─────────────────────────────────────────────────────────────────────────┘
        │
        ▼
┌─────────────────────────────────────────────────────────────────────────┐
│  Rate limiter plugin                                                     │
│   - happy path: tenant_id set → key = rl:{tenant}:user:alice:60  ✓       │
│   - fallback  : tenant_id None → key = rl:user:alice:60  ◄── cross-tenant│
│                                                            pollution in  │
│                                                            Redis         │
└─────────────────────────────────────────────────────────────────────────┘
```

### `tenant_id` flow — after

```text
┌─────────────────────────────────────────────────────────────────────────┐
│  ToolService.invoke_tool / _build_rust_tool_hook_global_context          │
│                                                                          │
│  payload_tenant_id = tool_payload["team_id"]  if str, else None          │
│                                                                          │
│  if plugin_global_context:     ← middleware's context                    │
│      global_context = plugin_global_context                              │
│      if not global_context.tenant_id and payload_tenant_id:              │
│          global_context.tenant_id = payload_tenant_id    ◄── fill gap    │
│  else:                          ← fallback — no middleware               │
│      global_context = GlobalContext(..., tenant_id=payload_tenant_id,...)│
└─────────────────────────────────────────────────────────────────────────┘
```

---

## Test results

<details>
<summary>Unit tests (<code>test_tool_service_tenant_id.py</code>)</summary>

Three pins on the fallback-path behaviour:

| Test | Pins |
|---|---|
| `test_build_rust_tool_hook_global_context_propagates_team_id_as_tenant_id` | Happy propagation — team_id lands as tenant_id |
| `test_build_rust_tool_hook_global_context_tenant_id_none_when_team_id_absent` | Missing team_id stays None (no spurious default) |
| `test_build_rust_tool_hook_global_context_non_string_team_id_is_ignored` | Defensive — non-string values rejected |

Run: `uv run pytest tests/unit/mcpgateway/services/test_tool_service_tenant_id.py -v` — 3 passed.

Each test was verified **RED before the fix** and **GREEN after** — the propagation test was the central red→green cycle.

</details>

<details>
<summary>Integration tests (<code>test_rate_limiter_multi_tenant.py</code>)</summary>

Two end-to-end tests via the gateway HTTP flow, gated behind `--with-integration`:

| Test | Pins |
|---|---|
| `test_tool_invocation_creates_rate_limit_keys_in_redis` | Sanity — rate limiter actually engages on the tool path |
| `test_rate_limit_keys_carry_tenant_prefix_when_tool_is_team_owned` | G1 + G2 end-to-end — the key that lands in Redis after a real tool call must carry the tenant prefix |

Run: `uv run pytest tests/integration/test_rate_limiter_multi_tenant.py --with-integration -v` — 2 passed.

**End-to-end validation evidence:** after an admin-scoped tool invocation against a freshly-rebuilt gateway (with this PR's changes + cpex [#40](https://github.com/IBM/cpex-plugins/pull/40) pinned via git ref), the Redis backend showed:

```
rl:fdd09c51ae8840e5919eb67d4df13755:tenant:fdd09c51ae8840e5919eb67d4df13755:60
rl:fdd09c51ae8840e5919eb67d4df13755:user:admin@example.com:60
```

Both keys carry the tenant prefix. The `tenant:` dimension key also exists, confirming `by_tenant` rate limiting is fully functional on the happy path — not just the `by_user` dimension under a tenant scope.

</details>

<details>
<summary>Additional hardening — <code>test_plugin_runtime_management.py</code> validation assertions aligned with FastAPI/Pydantic</summary>

Three validation-endpoint tests originally from #4292 were asserting `status_code == 400` but the server was returning 422 or 200 — the assertions were written against the RFC 7231 generic-400 convention, whereas FastAPI follows the RFC 4918 convention of 422 for body-validation failures, and Pydantic's default `bool` coerces truthy strings.

| Test | Before | After |
|---|---|---|
| `test_missing_enabled_field` | `== 400` (failed — actual 422) | `in (400, 422)` with convention comment |
| `test_non_boolean_enabled` (renamed `test_truthy_string_enabled_coerced_to_bool`) | `== 400` (failed — actual 200, Pydantic coerced `"yes"` → `True`) | Asserts 200 + reads back to confirm `plugins_globally_enabled == True`; pins the coercion contract |
| `test_invalid_mode_returns_400` (renamed `test_invalid_mode_returns_4xx`) | `== 400` (failed — actual 422) | `in (400, 422)` with convention comment |

No server-side changes. Full file runs **23/23 green** against the live gateway after the fix (was 20/23).

</details>

<details>
<summary>Dynamic behaviour tests (<code>test_rate_limiter_dynamic_behavior.py</code>)</summary>

Five tests exercising runtime mode toggles against the rate limiter end-to-end (docker-compose stack).

| Test | Result |
|---|---|
| `test_burst_all_allowed_when_disabled` | PASS |
| `test_burst_some_blocked_when_enforcing` | PASS |
| `test_mode_stored_in_redis` | PASS |
| `test_mode_visible_in_admin_api_after_change` | PASS |
| `test_mode_reverts_in_admin_api_after_disable` | PASS |

A sixth burst-cycle test (`test_disable_enable_disable_cycle`) was present on the parent branch and showed a 7/40 residual at Step 1 (disabled after enforce). The parallel bad-words burst test added in this PR (see below) hits the same gateway stack with the same shape and comes back 40/40 clean, so framework mode-propagation is fine — the residual is rate-limiter-specific and worth its own investigation rather than keeping a failing test around. Dropped from this file; can be recreated as part of a dedicated follow-up.

</details>

<details>
<summary>Load tests — rate-limiter locust files against live 3-replica gateway</summary>

All four rate-limiter locust files validated against the rebuilt gateway image (with G1/G2 fix + cpex PR #40 tenant-scoping). Short runs (30s each, small user counts) were sufficient to exercise the Redis + tool-call paths.

| File | Scenario | Result |
|---|---|---|
| `locustfile_rate_limiter.py` | 1 user × 60 req/min vs 30/m limit | ✅ *"REDIS BACKEND — limit correctly enforced (49% blocked, expected ~50%)"* |
| `locustfile_rate_limiter_backend_correctness.py` | Same scenario, distinct classifier | ✅ *"REDIS BACKEND — limit correctly enforced"* |
| `locustfile_rate_limiter_redis_capacity.py` | 20 users × 0.25 req/s on prompt_pre_fetch path | ✅ 120 prompt calls / 30 allowed / 90 rate-limited / 0 failures; p99 200ms; throughput 4.15 req/s |
| **`locustfile_rate_limiter_scale.py`** (modified here) | 10 users × 60 req/min, 30s | ✅ **11 keys detected post-fix** (10 per-user + 1 by_tenant); algorithm detection correctly identifies `fixed_window [string]` |

**Redis key layouts observed** — both coexist cleanly in the same Redis instance:

- Tool path → `rl:{tenant_id}:user:{email}:60` (tenant-prefixed, post-G1)
- Tool path → `rl:{tenant_id}:tenant:{tenant_id}:60` (by_tenant dimension, now functional)
- Prompt path → `rl:user:anonymous:60` (unprefixed — `prompt_service.py` already handled `tenant_id` correctly; the capacity test doesn't supply one)

The scale-test helper update (`_scan_rl_dimension` / `_scan_rl_sample_keys`) unions `rl:{dim}:*` and `rl:*:{dim}:*`, so all three layouts are counted regardless of which path produced them.

**Before the helper fix:**  `_scan_redis_pattern("rl:user:*")` returned **0 keys** against the post-fix deployment even with 11 actual keys in Redis — silent metric corruption.
**After the helper fix:** returns 11, matching ground truth.

</details>

<details>
<summary>Framework mode-propagation regression pin (<code>test_plugin_dynamic_behavior.py::TestBadWordsToggleBurst</code>)</summary>

One burst-cycle test against `ReplaceBadWordsPlugin` mirroring the rate-limiter burst shape (3-step disabled → enforce → disabled cycle, BURST_SIZE=40, same PROPAGATION_WAIT):

| Step | Expected | Observed |
|---|---|---|
| Step 1 — disabled after enforce | 40 unchanged | 40/40 unchanged ✓ |
| Step 2 — enforce | 40 transformed | 40/40 transformed ✓ |
| Step 3 — disabled again | 40 unchanged | 40/40 unchanged ✓ |

This test proves the plugin-manager's mode-invalidation path works cleanly across three gateway replicas within PROPAGATION_WAIT. Also serves as a permanent regression pin — if cross-replica invalidation ever breaks, this test is designed to surface it before silent failures in production.

</details>

---

## Dependencies

- Requires cpex [IBM/cpex-plugins#40](https://github.com/IBM/cpex-plugins/pull/40) merged and a cpex-rate-limiter release cut with the tenant-scoping fix — otherwise the integration tests in this PR pass the sanity check but the key-shape assertion fails because the plugin without the `context_prefix` fix won't prefix keys.
- This PR should be merged **after** cpex #40 is released. Held as draft until then.

---

## Follow-ups

- Bump `cpex-rate-limiter` pin in `pyproject.toml` once cpex 0.0.4 is released (separate PR, trivial chore).



## Review follow-ups (deferred)

From PR review feedback that is either out-of-scope for this PR's narrow goal (G1 tenant_id population) or better addressed at a different layer. Tracking here so they aren't lost:

- **Defense-in-depth `team_id` format validation.** `team_id` is server-derived from `EmailTeam.id` (UUID hex `String(36)`), not request body, so there is no user-controlled-input path into the Redis key. If additional format validation is desired, it belongs at the team-creation schema boundary rather than the rate-limiter fallback — broader scope that merits its own PR.
- **Structured audit logging on the fallback path.** Logging at `info` level on every fallback tool invocation would be log spam (fallback is the normal direct-invocation path, not an exception path). A `debug`-level hook is reasonable if/when needed.
- **Test-helper DRY extraction** across `test_plugin_dynamic_behavior.py` / `test_rate_limiter_dynamic_behavior.py` / `test_rate_limiter_multi_tenant.py` (local copies are intentional for file readability for now).
- **Token reuse across test-module requests** (currently each request re-logs in). Scope-separate test-infra improvement.
- **Exponential-backoff wait** for plugin-mode propagation in place of the fixed 7s sleep. Current value is stable in CI and under load; revisit if it becomes flaky.
- **Type hints on integration test helpers** (`_send_tool_burst`, `_redis_keys`, etc.). Cosmetic; defer.
- **`cpex-rate-limiter` pin bump** in `pyproject.toml` once cpex-plugins 0.0.4 is released (tracked separately; see Dependencies section).
