### PR TITLE
feat: add flexibility for docker compose image selection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-21T11:15:36Z",
+  "generated_at": "2026-04-21T22:06:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -318,7 +318,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -326,7 +326,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 929,
+        "line_number": 951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -334,7 +334,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 931,
+        "line_number": 953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1622,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6256,
+        "line_number": 6263,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6753,
+        "line_number": 6760,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6765,
+        "line_number": 6772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6837,
+        "line_number": 6844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7916,
+        "line_number": 7923,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,28 @@ CONTAINER_CPUS   = 2
 # The -r flag for xargs is GNU-specific and will fail on macOS
 XARGS_FLAGS := $(shell [ "$$(uname)" = "Darwin" ] && echo "" || echo "-r")
 
+# -----------------------------------------------------------------------------
+#  Allow override of the image to be used in various docker compose
+#  up and down actions
+# -----------------------------------------------------------------------------
+ifndef IMAGE_LOCAL
+  # Base image name (without any prefix)
+  IMAGE_BASE := mcpgateway/mcpgateway
+  IMAGE_TAG := latest
+
+  # Handle runtime-specific image naming
+  ifeq ($(CONTAINER_RUNTIME),podman)
+    # Podman adds localhost/ prefix for local builds
+    IMAGE_LOCAL := localhost/$(IMAGE_BASE):$(IMAGE_TAG)
+    IMAGE_LOCAL_DEV := localhost/$(IMAGE_BASE)-dev:$(IMAGE_TAG)
+    IMAGE_PUSH := $(IMAGE_BASE):$(IMAGE_TAG)
+  else
+    # Docker doesn't add prefix
+    IMAGE_LOCAL := $(IMAGE_BASE):$(IMAGE_TAG)
+    IMAGE_LOCAL_DEV := $(IMAGE_BASE)-dev:$(IMAGE_TAG)
+    IMAGE_PUSH := $(IMAGE_BASE):$(IMAGE_TAG)
+  endif
+endif
 
 # =============================================================================
 # 📖 DYNAMIC HELP
@@ -1653,6 +1675,7 @@ testing-up:                                ## Start testing stack (Locust + A2A 
 	@echo "🧪 Starting testing stack (fast_test_server)..."
 	@echo "   🦗 Locust workers: $(TESTING_LOCUST_WORKERS) (override: TESTING_LOCUST_WORKERS=4 make testing-up)"
 	@mkdir -p reports
+	@echo "   Using image $${IMAGE_LOCAL}"
 	HOST_UID=$(HOST_UID) HOST_GID=$(HOST_GID) \
 	LOCUST_EXPECT_WORKERS=$(TESTING_LOCUST_WORKERS) \
 	$(COMPOSE_CMD_MONITOR) --profile testing --profile inspector --profile sso up -d --scale locust_worker=$(TESTING_LOCUST_WORKERS)
@@ -5152,22 +5175,6 @@ CONTAINER_RUNTIME ?= $(shell command -v docker >/dev/null 2>&1 && echo docker ||
 
 print-runtime:
 	@echo Using container runtime: $(CONTAINER_RUNTIME)
-# Base image name (without any prefix)
-IMAGE_BASE := mcpgateway/mcpgateway
-IMAGE_TAG := latest
-
-# Handle runtime-specific image naming
-ifeq ($(CONTAINER_RUNTIME),podman)
-  # Podman adds localhost/ prefix for local builds
-  IMAGE_LOCAL := localhost/$(IMAGE_BASE):$(IMAGE_TAG)
-  IMAGE_LOCAL_DEV := localhost/$(IMAGE_BASE)-dev:$(IMAGE_TAG)
-  IMAGE_PUSH := $(IMAGE_BASE):$(IMAGE_TAG)
-else
-  # Docker doesn't add prefix
-  IMAGE_LOCAL := $(IMAGE_BASE):$(IMAGE_TAG)
-  IMAGE_LOCAL_DEV := $(IMAGE_BASE)-dev:$(IMAGE_TAG)
-  IMAGE_PUSH := $(IMAGE_BASE):$(IMAGE_TAG)
-endif
 
 print-image:
 	@echo "🐳 Container Runtime: $(CONTAINER_RUNTIME)"


### PR DESCRIPTION
## Summary

This PR adds flexibility for bringing up docker compose environments with custom images via commands like `make testing-up IMAGE_LOCAL=custom-image:tag`.

## Changes

- Wrap `IMAGE_LOCAL` definition in `ifndef` block to allow external override
- Add echo statement in `testing-up` target to show which image is being used
- Maintains backward compatibility with existing workflows

## Benefits

- Enables easy testing with different image builds without modifying the Makefile
- Improves developer experience for local development and testing
- Supports flexible environment setup for various testing scenarios

## Usage Example

```bash
# Use default image
make testing-up

# Use custom image
make testing-up IMAGE_LOCAL=my-custom-image:dev

# Use locally built image
make testing-up IMAGE_LOCAL=mcpgateway/mcpgateway:local-build
```

## Testing

- Verified backward compatibility with existing `make testing-up` command
- Tested override functionality with custom image specification