### PR TITLE
fix(data-analysis): use SHA-256 for dataset content fingerprint

### DIFF
--- a/mcp-servers/python/data_analysis_server/src/data_analysis_server/storage/dataset_manager.py
+++ b/mcp-servers/python/data_analysis_server/src/data_analysis_server/storage/dataset_manager.py
@@ -194,7 +194,7 @@ class DatasetManager:
         if source:
             content += f"_{source}"
 
-        hash_obj = hashlib.md5(content.encode())
+        hash_obj = hashlib.sha256(content.encode())
         return f"dataset_{hash_obj.hexdigest()[:8]}"
 
     def _evict_if_necessary(self) -> None:


### PR DESCRIPTION
Replace MD5 with SHA-256 when deriving internal dataset IDs from content metadata (not a security boundary, but aligns with weak-crypto hygiene and static analysis expectations).
