### PR TITLE
Align code default for LOG_LEVEL with docs

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1319,7 +1319,7 @@ class Settings(BaseSettings):
         return set(v)
 
     # Logging
-    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(default="ERROR")
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(default="INFO")
     log_requests: bool = Field(default=False, description="Enable request payload logging with sensitive data masking")
     log_format: Literal["json", "text"] = "json"  # json or text
     log_to_file: bool = False  # Enable file logging (default: stdout/stderr only)


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 80 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
_What problem does this PR fix and **why**?_

The docs state that INFO is the default log level, but ERROR is used here.

## 🔁 Reproduction Steps
_Link the issue and minimal steps to reproduce the bug._

1. Don't set LOG_LEVEL, observe logs
2. Set LOG_LEVEL=INFO, observe logs

Expected: No change

Actual: INFO logs now present

## 🐞 Root Cause
_What was wrong and where?_

The documentation states that the default level is different than what is actually applied

## 💡 Fix Description
_How did you solve it?  Key design points._

The documented default is now applied

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
