### PR TITLE
fix(oauth): auto-learn IdP audience and persist as resource for token validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-23T06:18:21Z",
+  "generated_at": "2026-04-27T14:14:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5000,7 +5000,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 629,
+        "line_number": 643,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T12:40:08Z",
+  "generated_at": "2026-04-23T05:50:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5000,7 +5000,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 625,
+        "line_number": 644,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7290,7 +7290,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 259,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-23T05:50:51Z",
+  "generated_at": "2026-04-23T06:18:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5000,7 +5000,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 644,
+        "line_number": 629,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7290,7 +7290,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 259,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -73,6 +73,42 @@ def _normalize_resource_url(url: str | None, *, preserve_query: bool = False) ->
     return normalized
 
 
+async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, Any], db: Session) -> None:
+    """Learn the IdP's audience identifier from the token and persist it.
+
+    Many IdPs (ServiceNow, Authentik, etc.) do not honor RFC 8707 and set the
+    ``aud`` claim to an abstract identifier (often the ``client_id``) rather than
+    the ``resource`` URL sent in the authorization request.  By persisting the
+    actual ``aud`` value as ``resource`` in the gateway's ``oauth_config``, we
+    ensure that subsequent token validation in ``_validate_audience`` succeeds
+    and that future OAuth requests use the IdP's preferred audience identifier.
+
+    This is a best-effort operation: opaque tokens and missing aud claims are
+    silently ignored.
+
+    Args:
+        gateway: The gateway ORM object (will be mutated and flushed).
+        oauth_result: The result dict from ``complete_authorization_code_flow``,
+            expected to contain ``token_aud``.
+        db: Active database session.
+    """
+    token_aud = oauth_result.get("token_aud")
+    if token_aud is None:
+        return
+
+    # Store aud as-is (string or list) -- RFC 7519 allows both forms.
+    current_resource = (gateway.oauth_config or {}).get("resource")
+    if current_resource == token_aud:
+        return  # Already correct
+
+    # Persist the learned audience as resource
+    updated_config = dict(gateway.oauth_config) if gateway.oauth_config else {}
+    updated_config["resource"] = token_aud
+    gateway.oauth_config = updated_config
+    db.flush()
+    logger.debug("Learned OAuth audience from IdP token for gateway %s; persisted as resource", gateway.name)
+
+
 oauth_router = APIRouter(prefix="/oauth", tags=["oauth"])
 
 
@@ -298,22 +334,10 @@ async def initiate_oauth_flow(
 
         oauth_config = gateway.oauth_config.copy()  # Work with a copy to avoid mutating the original
 
-        # RFC 8707: Set resource parameter for JWT access tokens
-        # Respect pre-configured resource (e.g., for providers requiring pre-registered resources)
-        # Only derive from gateway.url if not explicitly configured
-        if oauth_config.get("resource"):
-            # Normalize existing resource - preserve query for explicit config (RFC 8707 allows when necessary)
-            existing = oauth_config["resource"]
-            if isinstance(existing, list):
-                original_count = len(existing)
-                normalized = [_normalize_resource_url(r, preserve_query=True) for r in existing]
-                oauth_config["resource"] = [r for r in normalized if r]
-                if not oauth_config["resource"] and original_count > 0:
-                    logger.warning(f"All {original_count} configured resource values were invalid and removed")
-            else:
-                oauth_config["resource"] = _normalize_resource_url(existing, preserve_query=True)
-        else:
-            # Default to gateway.url as the resource (strip query per RFC 8707 SHOULD NOT)
+        # RFC 8707: Set resource parameter for JWT access tokens.
+        # If resource was previously learned from the IdP's token aud claim, use it as-is.
+        # Otherwise derive from gateway.url for the first authorization request.
+        if not oauth_config.get("resource"):
             oauth_config["resource"] = _normalize_resource_url(gateway.url)
 
         # Phase 1.4: Auto-trigger DCR if credentials are missing
@@ -541,29 +565,23 @@ async def oauth_callback(
 
         # Complete OAuth flow
 
-        # RFC 8707: Add resource parameter for JWT access tokens
-        # Must be set here in callback, not just in /authorize, because complete_authorization_code_flow
-        # needs it for the token exchange request
-        # Respect pre-configured resource; only derive from gateway.url if not explicitly configured
+        # RFC 8707: Set resource parameter for the token exchange request.
+        # If resource was previously learned from the IdP's token aud claim, use it as-is.
+        # Otherwise derive from gateway.url for the first authorization request.
         oauth_config_with_resource = gateway.oauth_config.copy()
-        if oauth_config_with_resource.get("resource"):
-            # Preserve query for explicit config (RFC 8707 allows when necessary)
-            existing = oauth_config_with_resource["resource"]
-            if isinstance(existing, list):
-                original_count = len(existing)
-                normalized = [_normalize_resource_url(r, preserve_query=True) for r in existing]
-                oauth_config_with_resource["resource"] = [r for r in normalized if r]
-                if not oauth_config_with_resource["resource"] and original_count > 0:
-                    logger.warning(f"All {original_count} configured resource values were invalid and removed")
-            else:
-                oauth_config_with_resource["resource"] = _normalize_resource_url(existing, preserve_query=True)
-        else:
-            # Strip query for auto-derived (RFC 8707 SHOULD NOT)
+        if not oauth_config_with_resource.get("resource"):
             oauth_config_with_resource["resource"] = _normalize_resource_url(gateway.url)
 
         result = await oauth_manager.complete_authorization_code_flow(
             gateway_id, code, state, oauth_config_with_resource, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key
         )
+
+        # Learn the IdP's audience mapping from the token and persist as resource.
+        # RFC 8707 Section 2: "The authorization server may use the exact resource value
+        # as the audience or it may map from that value to a more general URI or abstract
+        # identifier for the given resource."  We persist whatever the IdP chose so that
+        # subsequent token validation matches.
+        await _persist_learned_audience(gateway, result, db)
 
         logger.info(f"Completed OAuth flow for gateway {SecurityValidator.sanitize_log_message(gateway_id)}, user {SecurityValidator.sanitize_log_message(str(result.get('user_id')))}")
 

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -777,6 +777,10 @@ class OAuthManager:
         # Extract user information from token response
         user_id = self._extract_user_id(token_response, credentials)
 
+        # Extract audience from token (best-effort) for caller to persist as resource.
+        # This enables audience learning for IdPs that map resource to a different aud.
+        token_aud = self._extract_token_audience(token_response.get("access_token", ""))
+
         # Store tokens if storage service is available
         if self.token_storage:
             token_record = await self.token_storage.store_tokens(
@@ -789,8 +793,8 @@ class OAuthManager:
                 scopes=token_response.get("scope", "").split(),
             )
 
-            return {"success": True, "user_id": user_id, "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None}
-        return {"success": True, "user_id": user_id, "expires_at": None}
+            return {"success": True, "user_id": user_id, "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None, "token_aud": token_aud}
+        return {"success": True, "user_id": user_id, "expires_at": None, "token_aud": token_aud}
 
     async def get_access_token_for_user(self, gateway_id: str, app_user_email: str) -> Optional[str]:
         """Get valid access token for a specific user.
@@ -1590,6 +1594,34 @@ class OAuthManager:
 
         # Final fallback
         return "unknown_user"
+
+    @staticmethod
+    def _extract_token_audience(access_token: str) -> Any:
+        """Extract the ``aud`` claim from a JWT access token (best-effort).
+
+        Returns the raw ``aud`` value (string or list) or ``None`` for opaque
+        tokens or decode failures.  No signature verification is performed.
+
+        Args:
+            access_token: The raw access token string.
+
+        Returns:
+            The ``aud`` claim value, or None.
+        """
+        if not access_token:
+            return None
+        try:
+            # Third-Party
+            import jwt as pyjwt  # pylint: disable=import-outside-toplevel
+
+            claims = pyjwt.decode(
+                access_token,
+                options={"verify_signature": False, "verify_aud": False, "verify_iss": False, "verify_exp": False},
+                algorithms=["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "HS256", "HS384", "HS512", "EdDSA"],
+            )
+            return claims.get("aud")
+        except Exception:  # noqa: BLE001
+            return None
 
 
 class OAuthError(Exception):

--- a/mcpgateway/services/token_validation_service.py
+++ b/mcpgateway/services/token_validation_service.py
@@ -73,9 +73,9 @@ class TokenValidationResult:
             >>> r.blocking_errors
             []
             >>> r.audience_match = False
-            >>> r.warnings.append("Token audience mismatch: token aud=[api://wrong], expected 'api://correct'")
+            >>> r.warnings.append("Token audience mismatch: token aud does not match expected resource or gateway URL")
             >>> r.blocking_errors
-            ["Token audience mismatch: token aud=[api://wrong], expected 'api://correct'"]
+            ["Token audience mismatch: token aud does not match expected resource or gateway URL"]
         """
         if not self.warnings:
             return []
@@ -152,8 +152,8 @@ def _validate_audience(claims: Dict[str, Any], oauth_config: Dict[str, Any], gat
         gateway_name: Gateway name for log messages.
         result: Validation result to update in-place.
     """
-    expected_audience = oauth_config.get("resource") or gateway_url
-    if not expected_audience:
+    expected = oauth_config.get("resource") or gateway_url
+    if not expected:
         return
 
     token_aud = claims.get("aud")
@@ -161,14 +161,15 @@ def _validate_audience(claims: Dict[str, Any], oauth_config: Dict[str, Any], gat
         logger.debug("OAuth token for gateway %s has no 'aud' claim", gateway_name)
         return
 
+    # Normalize both sides to lists for a simple membership check.
+    # Per RFC 7519 Section 4.1.3, aud can be a string or array.
+    expected_list = expected if isinstance(expected, list) else [expected]
     aud_list = token_aud if isinstance(token_aud, list) else [token_aud]
-    if expected_audience in aud_list:
+    if any(a in expected_list for a in aud_list):
         result.audience_match = True
     else:
         result.audience_match = False
-        safe_aud = ", ".join(str(a)[:80] for a in aud_list[:3])
-        safe_expected = str(expected_audience)[:80]
-        result.warnings.append(f"Token audience mismatch: token aud=[{safe_aud}], expected '{safe_expected}'")
+        result.warnings.append("Token audience mismatch: token aud does not match expected resource or gateway URL")
 
 
 def _validate_scopes(claims: Dict[str, Any], oauth_config: Dict[str, Any], gateway_name: str, result: TokenValidationResult) -> None:

--- a/mcpgateway/services/token_validation_service.py
+++ b/mcpgateway/services/token_validation_service.py
@@ -75,7 +75,7 @@ class TokenValidationResult:
             >>> r.audience_match = False
             >>> r.warnings.append("Token audience mismatch: token aud does not match expected resource or gateway URL")
             >>> r.blocking_errors
-            ["Token audience mismatch: token aud does not match expected resource or gateway URL"]
+            ['Token audience mismatch: token aud does not match expected resource or gateway URL']
         """
         if not self.warnings:
             return []

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -101,6 +101,98 @@ class TestNormalizeResourceUrl:
         assert result == "https://example.com/path?x=1"
 
 
+class TestPersistLearnedAudience:
+    """Tests for _persist_learned_audience helper."""
+
+    @pytest.mark.asyncio
+    async def test_persists_string_aud_from_jwt(self):
+        """Persists the aud claim as resource when token_aud is a string."""
+        oauth_result = {"token_aud": "my-client-id", "user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "my-client-id", "grant_type": "authorization_code"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        assert gateway.oauth_config["resource"] == "my-client-id"
+        db.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persists_list_aud_from_jwt(self):
+        """Persists the full aud list when token_aud is an array."""
+        aud_list = ["https://api.example.com", "my-client-id"]
+        oauth_result = {"token_aud": aud_list, "user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "my-client-id"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        assert gateway.oauth_config["resource"] == aud_list
+        db.flush.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_resource_already_matches(self):
+        """Does not flush if the persisted resource already matches aud."""
+        oauth_result = {"token_aud": "my-client-id", "user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "my-client-id", "resource": "my-client-id"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        db.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_opaque_token(self):
+        """Gracefully skips when token_aud is None (opaque token)."""
+        oauth_result = {"token_aud": None, "user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "cid"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        db.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_token_aud(self):
+        """Gracefully skips when token_aud is missing from result."""
+        oauth_result = {"user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "cid"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        db.flush.assert_not_called()
+
+
 class TestOAuthRouter:
     """Test cases for OAuth router endpoints."""
 
@@ -279,8 +371,8 @@ class TestOAuthRouter:
             assert "incomplete" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
-    async def test_initiate_oauth_flow_normalizes_resource_list(self, mock_db, mock_request, mock_current_user):
-        """Test that resource list is normalized and invalid entries removed."""
+    async def test_initiate_oauth_flow_uses_persisted_resource_as_is(self, mock_db, mock_request, mock_current_user):
+        """Test that a persisted resource (learned from IdP aud) is used as-is."""
         mock_gateway = Mock(spec=Gateway)
         mock_gateway.id = "gateway123"
         mock_gateway.name = "Test Gateway"
@@ -294,7 +386,7 @@ class TestOAuthRouter:
             "authorization_url": "https://auth.example.com/authorize",
             "token_url": "https://auth.example.com/token",
             "redirect_uri": "https://gateway.example.com/oauth/callback",
-            "resource": ["https://api.example.com/path?x=1#frag", "invalid-resource"],
+            "resource": "my-client-id-from-idp",
         }
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
@@ -311,11 +403,11 @@ class TestOAuthRouter:
                 await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
 
         oauth_config_passed = mock_oauth_manager.initiate_authorization_code_flow.call_args[0][1]
-        assert oauth_config_passed["resource"] == ["https://api.example.com/path?x=1"]
+        assert oauth_config_passed["resource"] == "my-client-id-from-idp"
 
     @pytest.mark.asyncio
-    async def test_initiate_oauth_flow_resource_string_normalized(self, mock_db, mock_request, mock_current_user):
-        """Test that resource string is normalized preserving query."""
+    async def test_initiate_oauth_flow_resource_list_persisted_as_is(self, mock_db, mock_request, mock_current_user):
+        """Test that a persisted resource list (learned from IdP aud array) is used as-is."""
         mock_gateway = Mock(spec=Gateway)
         mock_gateway.id = "gateway123"
         mock_gateway.name = "Test Gateway"
@@ -329,7 +421,7 @@ class TestOAuthRouter:
             "authorization_url": "https://auth.example.com/authorize",
             "token_url": "https://auth.example.com/token",
             "redirect_uri": "https://gateway.example.com/oauth/callback",
-            "resource": "https://api.example.com/path?x=1#frag",
+            "resource": ["https://api.example.com", "my-client-id"],
         }
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
@@ -346,7 +438,7 @@ class TestOAuthRouter:
                 await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
 
         oauth_config_passed = mock_oauth_manager.initiate_authorization_code_flow.call_args[0][1]
-        assert oauth_config_passed["resource"] == "https://api.example.com/path?x=1"
+        assert oauth_config_passed["resource"] == ["https://api.example.com", "my-client-id"]
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_missing_client_id(self, mock_db, mock_request, mock_current_user):
@@ -447,7 +539,7 @@ class TestOAuthRouter:
 
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
-        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00"}
+        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00", "token_aud": None}
 
         with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
             mock_oauth_manager = Mock()
@@ -473,8 +565,8 @@ class TestOAuthRouter:
                 assert oauth_config_passed["resource"] == "https://mcp.example.com"  # Normalized URL
 
     @pytest.mark.asyncio
-    async def test_oauth_callback_resource_string_normalized(self, mock_db, mock_request):
-        """Test OAuth callback normalizes string resource value."""
+    async def test_oauth_callback_resource_string_persisted_as_is(self, mock_db, mock_request):
+        """Test OAuth callback uses persisted resource as-is (learned from IdP aud)."""
         import base64
         import json
 
@@ -494,11 +586,11 @@ class TestOAuthRouter:
             "authorization_url": "https://auth.example.com/authorize",
             "token_url": "https://auth.example.com/token",
             "redirect_uri": "https://gateway.example.com/oauth/callback",
-            "resource": "https://api.example.com/path?x=1#frag",
+            "resource": "my-client-id-from-idp",
         }
         mock_db.execute.return_value.scalar_one_or_none.return_value = mock_gateway
 
-        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00"}
+        token_result = {"user_id": "oauth_user_123", "app_user_email": "test@example.com", "expires_at": "2024-01-01T12:00:00", "token_aud": None}
 
         with patch("mcpgateway.routers.oauth_router.OAuthManager") as mock_oauth_manager_class:
             mock_oauth_manager = Mock()
@@ -513,7 +605,7 @@ class TestOAuthRouter:
 
         assert isinstance(result, HTMLResponse)
         oauth_config_passed = mock_oauth_manager.complete_authorization_code_flow.call_args[0][3]
-        assert oauth_config_passed["resource"] == "https://api.example.com/path?x=1"
+        assert oauth_config_passed["resource"] == "my-client-id-from-idp"
 
     @pytest.mark.asyncio
     async def test_oauth_callback_legacy_state_format(self, mock_db, mock_request, mock_gateway):
@@ -1407,7 +1499,8 @@ class TestOAuthRouterAdditionalCoverage:
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_initiate_oauth_flow_invalid_resource_list(self, mock_db, mock_request, mock_current_user):
+    async def test_initiate_oauth_flow_resource_list_used_as_is(self, mock_db, mock_request, mock_current_user):
+        """Resource lists (learned from IdP aud arrays) are passed through unchanged."""
         mock_gateway = Mock(spec=Gateway)
         mock_gateway.id = "gateway123"
         mock_gateway.name = "Gateway"
@@ -1433,11 +1526,11 @@ class TestOAuthRouterAdditionalCoverage:
             with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
                 from mcpgateway.routers.oauth_router import initiate_oauth_flow
 
-                with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                    result = await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
+                result = await initiate_oauth_flow("gateway123", mock_request, mock_current_user, mock_db)
 
         assert isinstance(result, RedirectResponse)
-        mock_logger.warning.assert_called()
+        oauth_config_passed = mock_mgr.initiate_authorization_code_flow.call_args[0][1]
+        assert oauth_config_passed["resource"] == ["not-a-url"]
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_dcr_decrypts_secret(self, mock_db, mock_request, mock_current_user):
@@ -1531,7 +1624,8 @@ class TestOAuthRouterAdditionalCoverage:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_oauth_callback_invalid_resource_list(self, mock_db, mock_request):
+    async def test_oauth_callback_resource_list_used_as_is(self, mock_db, mock_request):
+        """Resource lists (learned from IdP aud arrays) are passed through unchanged in callback."""
         import base64
         import orjson
 
@@ -1561,11 +1655,11 @@ class TestOAuthRouterAdditionalCoverage:
             with patch("mcpgateway.routers.oauth_router.TokenStorageService"):
                 from mcpgateway.routers.oauth_router import oauth_callback
 
-                with patch("mcpgateway.routers.oauth_router.logger") as mock_logger:
-                    response = await oauth_callback(code="code", state=state, request=mock_request, db=mock_db)
+                response = await oauth_callback(code="code", state=state, request=mock_request, db=mock_db)
 
         assert response.status_code == 200
-        mock_logger.warning.assert_called()
+        oauth_config_passed = mock_mgr.complete_authorization_code_flow.call_args[0][3]
+        assert oauth_config_passed["resource"] == ["not-a-url"]
 
     @pytest.mark.asyncio
     async def test_initiate_oauth_flow_dcr_error(self, mock_db, mock_request, mock_current_user):

--- a/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
@@ -770,7 +770,7 @@ class TestFetchToolsAfterOauthTokenValidation:
     @pytest.mark.asyncio
     async def test_sse_connection_401_diagnostic_error(self, gateway_service):
         """_connect_to_sse_server_without_validation produces diagnostic message on 401-like errors."""
-        validation_warnings = ["Token audience mismatch: token aud=[api://wrong], expected 'api://correct'"]
+        validation_warnings = ["Token audience mismatch: token aud does not match expected resource or gateway URL"]
 
         with patch("mcpgateway.services.gateway_service.sse_client", side_effect=Exception("HTTP 401 Unauthorized")):
             with pytest.raises(GatewayConnectionError, match="Possible causes.*audience mismatch"):

--- a/tests/unit/mcpgateway/services/test_token_validation_service.py
+++ b/tests/unit/mcpgateway/services/test_token_validation_service.py
@@ -58,7 +58,7 @@ class TestTokenValidationResult:
     def test_blocking_errors_audience_mismatch(self):
         r = TokenValidationResult(is_jwt=True)
         r.audience_match = False
-        r.warnings.append("Token audience mismatch: token aud=[api://wrong], expected 'api://correct'")
+        r.warnings.append("Token audience mismatch: token aud does not match expected resource or gateway URL")
         errors = r.blocking_errors
         assert len(errors) == 1
         assert "audience" in errors[0].lower()
@@ -85,7 +85,7 @@ class TestTokenValidationResult:
         r.scopes_sufficient = False
         r.issuer_match = False
         r.warnings = [
-            "Token audience mismatch: token aud=[wrong], expected 'right'",
+            "Token audience mismatch: token aud does not match expected resource or gateway URL",
             "Token may be missing required scopes: [write]",
             "Token issuer mismatch: token iss='wrong', expected 'right'",
         ]
@@ -96,7 +96,7 @@ class TestTokenValidationResult:
         r = TokenValidationResult(is_jwt=True)
         r.audience_match = False
         r.scopes_sufficient = None  # absent claim — must not block
-        r.warnings.append("Token audience mismatch: token aud=[wrong], expected 'right'")
+        r.warnings.append("Token audience mismatch: token aud does not match expected resource or gateway URL")
         errors = r.blocking_errors
         assert len(errors) == 1
         assert "audience" in errors[0].lower()
@@ -214,6 +214,22 @@ class TestValidateOauthTokenClaims:
 
         assert result.audience_match is None
         assert not any("audience" in w.lower() for w in result.warnings)
+
+    def test_audience_resource_list_matches(self):
+        """When resource is a list (learned from IdP aud array), any overlap is a match."""
+        token = _make_jwt({"aud": "my-client-id"})
+        oauth_config = {"resource": ["https://api.example.com", "my-client-id"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.audience_match is True
+
+    def test_audience_resource_takes_precedence_over_gateway_url(self):
+        """When resource is set, gateway_url is not used as fallback."""
+        token = _make_jwt({"aud": "https://gw.example.com"})
+        oauth_config = {"resource": "some-other-value"}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.audience_match is False
 
     # -- Scope mismatch --
 

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -1055,7 +1055,7 @@ class TestOAuthManager:
                         # This should work without token storage
                         result = await manager.complete_authorization_code_flow(gateway_id, code, state, credentials)
 
-                        expected = {"success": True, "user_id": "user123", "expires_at": None}  # No token storage means no expiration tracking
+                        expected = {"success": True, "user_id": "user123", "expires_at": None, "token_aud": None}  # No token storage means no expiration tracking
                         assert result == expected
 
                         # PKCE: Now includes code_verifier parameter and CA certificate parameters


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

OAuth token audience validation fails for IdPs (ServiceNow, Authentik, etc.) that do not honor RFC 8707 and set the `aud` claim to an abstract identifier (e.g. `client_id`) rather than the resource URL sent in the authorization request. Users see "Token audience mismatch" errors after a successful OAuth flow, with no way to fix it from the UI.

RFC 8707 Section 2 explicitly allows this behavior:

> The authorization server may use the exact `resource` value as the audience **or it may map from that value to a more general URI or abstract identifier** for the given resource.

## 🔁 Reproduction Steps

Closes #4384
Related: #4171

1. Register a gateway with OAuth (e.g. ServiceNow StreamableHTTP)
2. Complete OAuth authorization flow — succeeds
3. Click "Fetch Tools" — fails with: `Token audience mismatch: token aud=[<client_id>], expected '<gateway_url>'`

## 🐞 Root Cause

Two disconnected code paths:

1. `/oauth/authorize` and `/oauth/callback` (`oauth_router.py`) inject `resource = _normalize_resource_url(gateway.url)` into a **transient copy** of `oauth_config` and send it to the IdP. This copy is never persisted.

2. `_validate_audience` (`token_validation_service.py:155`) reads `oauth_config.get("resource")` from the **persisted** config (which has no `resource`), falls back to `gateway_url`, and fails because the IdP's `aud` doesn't match the gateway URL.

The system sends a `resource` to the IdP but never learns what the IdP actually mapped it to.

## 💡 Fix Description

**Auto-learn the audience from the token at callback time and persist it as `resource`.**

1. **`oauth_manager.py`**: Added `_extract_token_audience()` — decodes the access token (best-effort, no signature verification) and extracts the `aud` claim. Returns only the claim value, never the raw token. `complete_authorization_code_flow` now returns `token_aud` in its result dict.

2. **`oauth_router.py`**: Added `_persist_learned_audience()` — after `complete_authorization_code_flow` succeeds in the callback, persists the `token_aud` as `resource` in `gateway.oauth_config`. Skips gracefully for opaque tokens, missing aud, or when resource already matches.

3. **`oauth_router.py`**: Simplified resource injection in both `/oauth/authorize` and `/oauth/callback` — if `resource` is already set (learned from a previous token), use it as-is. If not set (first auth), use `_normalize_resource_url(gateway.url)`.

4. **`token_validation_service.py`**: Simplified `_validate_audience` — `expected = resource or gateway_url`, normalize both sides to lists, simple membership check. Removed token audience and expected values from warning messages to avoid leaking sensitive identifiers (client IDs, etc.) into logs and error responses.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests (6 affected files)         | `uv run pytest tests/unit/mcpgateway/routers/test_oauth_router.py tests/unit/mcpgateway/services/test_token_validation_service.py tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py tests/unit/mcpgateway/test_oauth_manager.py tests/unit/mcpgateway/services/test_oauth_manager_pkce.py` | ✅ 385 passed |
| Manual regression (ServiceNow)        | OAuth flow + Fetch Tools | ✅ Fixed via DB update, code fix matches |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
- [x] Sensitive token values removed from log/error messages