### PR TITLE
fix(rbac): enforce team-membership check on plugin binding DELETE endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-09T20:52:57Z",
+  "generated_at": "2026-05-09T21:04:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -29,7 +29,7 @@ from mcpgateway.plugins import get_plugin_manager_factory, publish_binding_chang
 from mcpgateway.plugins.gateway_plugin_manager import CONTEXT_ID_SEPARATOR, make_context_id
 from mcpgateway.schemas import ToolPluginBindingListResponse, ToolPluginBindingRequest, ToolPluginBindingResponse
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError, ToolPluginBindingService
+from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingForbiddenError, ToolPluginBindingNotFoundError, ToolPluginBindingService
 
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
@@ -208,6 +208,9 @@ async def delete_tool_plugin_bindings_by_reference(
 
     Returns the deleted records (empty list if none matched — not an error).
 
+    Non-admin callers may only delete bindings belonging to their own teams;
+    bindings on other teams are silently skipped.
+
     Args:
         binding_reference_id: The external reference ID whose bindings to delete.
         current_user_ctx: Authenticated user context.
@@ -221,7 +224,10 @@ async def delete_tool_plugin_bindings_by_reference(
         >>> asyncio.iscoroutinefunction(delete_tool_plugin_bindings_by_reference)
         True
     """
-    deleted: List[ToolPluginBindingResponse] = _service.delete_bindings_by_reference(db, binding_reference_id)
+    is_admin: bool = current_user_ctx.get("is_admin", False)
+    user_teams: list = current_user_ctx.get("teams", []) or []
+    allowed_teams = None if is_admin else set(user_teams)
+    deleted: List[ToolPluginBindingResponse] = _service.delete_bindings_by_reference(db, binding_reference_id, allowed_teams=allowed_teams)
     db.commit()
     await _invalidate_and_broadcast(deleted)
     return ToolPluginBindingListResponse(bindings=deleted, total=len(deleted))
@@ -253,6 +259,7 @@ async def delete_tool_plugin_binding(
         ToolPluginBindingResponse: The deleted binding record.
 
     Raises:
+        HTTPException: 403 if the caller is not a member of the binding's team.
         HTTPException: 404 if no binding with the given ID exists.
 
     Examples:
@@ -261,9 +268,14 @@ async def delete_tool_plugin_binding(
         True
     """
     try:
-        deleted = _service.delete_binding(db, binding_id)
+        is_admin: bool = current_user_ctx.get("is_admin", False)
+        user_teams: list = current_user_ctx.get("teams", []) or []
+        allowed_teams = None if is_admin else set(user_teams)
+        deleted = _service.delete_binding(db, binding_id, allowed_teams=allowed_teams)
         db.commit()
         await _invalidate_and_broadcast([deleted])
         return deleted
     except ToolPluginBindingNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except ToolPluginBindingForbiddenError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -39,6 +39,17 @@ router = APIRouter(prefix="/v1/tools/plugin_bindings", tags=["Tool Plugin Bindin
 _service = ToolPluginBindingService()
 
 
+def _allowed_teams_from_ctx(ctx: Dict[str, Any]) -> Optional[set[str]]:
+    """Derive the set of teams a caller is allowed to mutate.
+
+    Returns ``None`` for unrestricted admins (full bypass).
+    Returns an empty set for public-only callers (nothing allowed).
+    """
+    is_admin: bool = ctx.get("is_admin", False)
+    token_teams = ctx.get("token_teams")
+    return None if (is_admin and token_teams is None) else set(token_teams or [])
+
+
 async def _invalidate_and_broadcast(bindings: List[ToolPluginBindingResponse]) -> None:
     """Evict local caches and broadcast pub/sub frames for a batch of bindings.
 
@@ -101,10 +112,10 @@ async def upsert_tool_plugin_bindings(
     """
     try:
         caller_email: str = current_user_ctx["email"]
-        is_admin: bool = current_user_ctx.get("is_admin", False)
-        user_teams: list = current_user_ctx.get("teams", []) or []
+        allowed_teams = _allowed_teams_from_ctx(current_user_ctx)
+        user_teams: set = set() if allowed_teams is None else allowed_teams
 
-        if not is_admin:
+        if allowed_teams is not None:
             unauthorized = [tid for tid in request.teams if tid not in user_teams]
             if unauthorized:
                 raise HTTPException(
@@ -224,9 +235,7 @@ async def delete_tool_plugin_bindings_by_reference(
         >>> asyncio.iscoroutinefunction(delete_tool_plugin_bindings_by_reference)
         True
     """
-    is_admin: bool = current_user_ctx.get("is_admin", False)
-    user_teams: list = current_user_ctx.get("teams", []) or []
-    allowed_teams = None if is_admin else set(user_teams)
+    allowed_teams = _allowed_teams_from_ctx(current_user_ctx)
     deleted: List[ToolPluginBindingResponse] = _service.delete_bindings_by_reference(db, binding_reference_id, allowed_teams=allowed_teams)
     db.commit()
     await _invalidate_and_broadcast(deleted)
@@ -268,9 +277,7 @@ async def delete_tool_plugin_binding(
         True
     """
     try:
-        is_admin: bool = current_user_ctx.get("is_admin", False)
-        user_teams: list = current_user_ctx.get("teams", []) or []
-        allowed_teams = None if is_admin else set(user_teams)
+        allowed_teams = _allowed_teams_from_ctx(current_user_ctx)
         deleted = _service.delete_binding(db, binding_id, allowed_teams=allowed_teams)
         db.commit()
         await _invalidate_and_broadcast([deleted])

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -27,6 +27,10 @@ class ToolPluginBindingNotFoundError(Exception):
     """Raised when a binding with the given ID does not exist."""
 
 
+class ToolPluginBindingForbiddenError(Exception):
+    """Raised when the caller is not authorised to modify a binding from another team."""
+
+
 def get_bindings_for_tool(
     db: Session,
     team_id: str,
@@ -295,7 +299,7 @@ class ToolPluginBindingService:
     # Delete
     # ------------------------------------------------------------------
 
-    def delete_binding(self, db: Session, binding_id: str) -> ToolPluginBindingResponse:
+    def delete_binding(self, db: Session, binding_id: str, allowed_teams: Optional[set] = None) -> ToolPluginBindingResponse:
         """Delete a binding by its primary key and return its details.
 
         The response is captured before the row is removed so the caller
@@ -304,16 +308,25 @@ class ToolPluginBindingService:
         Args:
             db: SQLAlchemy session.
             binding_id: UUID of the binding to delete.
+            allowed_teams: When non-None, the binding's ``team_id`` must be in
+                this set or ``ToolPluginBindingForbiddenError`` is raised.
+                Pass ``None`` for admin callers (unrestricted).
 
         Returns:
             ToolPluginBindingResponse: Details of the deleted binding.
 
         Raises:
             ToolPluginBindingNotFoundError: If no binding with the given ID exists.
+            ToolPluginBindingForbiddenError: If ``allowed_teams`` is set and the
+                binding belongs to a team the caller is not a member of.
         """
         binding = db.query(ToolPluginBinding).filter(ToolPluginBinding.id == binding_id).first()
         if not binding:
             raise ToolPluginBindingNotFoundError(f"Tool plugin binding '{binding_id}' not found")
+        if allowed_teams is not None and binding.team_id not in allowed_teams:
+            raise ToolPluginBindingForbiddenError(
+                f"Not authorized to delete binding '{binding_id}' for team '{binding.team_id}'"
+            )
         response = self._to_response(binding)
         db.delete(binding)
         db.flush()  # flush so the DELETE is sent before the caller's commit
@@ -324,6 +337,7 @@ class ToolPluginBindingService:
         self,
         db: Session,
         binding_reference_id: str,
+        allowed_teams: Optional[set] = None,
     ) -> List[ToolPluginBindingResponse]:
         """Delete all bindings tagged with a given external reference ID.
 
@@ -334,12 +348,19 @@ class ToolPluginBindingService:
         Args:
             db: SQLAlchemy session.
             binding_reference_id: The external reference ID to match.
+            allowed_teams: When non-None, only bindings whose ``team_id`` is in
+                this set are deleted.  Bindings for other teams are silently
+                skipped (defence-in-depth; the router also enforces this).
+                Pass ``None`` for admin callers (unrestricted).
 
         Returns:
             List[ToolPluginBindingResponse]: All deleted binding records.
                 Returns an empty list (not an error) if no bindings matched.
         """
-        rows = db.query(ToolPluginBinding).filter(ToolPluginBinding.binding_reference_id == binding_reference_id).all()
+        query = db.query(ToolPluginBinding).filter(ToolPluginBinding.binding_reference_id == binding_reference_id)
+        if allowed_teams is not None:
+            query = query.filter(ToolPluginBinding.team_id.in_(allowed_teams))
+        rows = query.all()
         responses = [self._to_response(r) for r in rows]
         for row in rows:
             logger.debug("Deleted tool plugin binding id=%s ref=%s", row.id, binding_reference_id)

--- a/mcpgateway/services/tool_plugin_binding_service.py
+++ b/mcpgateway/services/tool_plugin_binding_service.py
@@ -28,7 +28,7 @@ class ToolPluginBindingNotFoundError(Exception):
 
 
 class ToolPluginBindingForbiddenError(Exception):
-    """Raised when the caller is not authorised to modify a binding from another team."""
+    """Raised when the caller is not authorized to modify a binding from another team."""
 
 
 def get_bindings_for_tool(
@@ -299,7 +299,7 @@ class ToolPluginBindingService:
     # Delete
     # ------------------------------------------------------------------
 
-    def delete_binding(self, db: Session, binding_id: str, allowed_teams: Optional[set] = None) -> ToolPluginBindingResponse:
+    def delete_binding(self, db: Session, binding_id: str, allowed_teams: Optional[set[str]] = None) -> ToolPluginBindingResponse:
         """Delete a binding by its primary key and return its details.
 
         The response is captured before the row is removed so the caller
@@ -337,7 +337,7 @@ class ToolPluginBindingService:
         self,
         db: Session,
         binding_reference_id: str,
-        allowed_teams: Optional[set] = None,
+        allowed_teams: Optional[set[str]] = None,
     ) -> List[ToolPluginBindingResponse]:
         """Delete all bindings tagged with a given external reference ID.
 
@@ -350,7 +350,8 @@ class ToolPluginBindingService:
             binding_reference_id: The external reference ID to match.
             allowed_teams: When non-None, only bindings whose ``team_id`` is in
                 this set are deleted.  Bindings for other teams are silently
-                skipped (defence-in-depth; the router also enforces this).
+                skipped (defence-in-depth; the router derives the constraint and
+                the service enforces it).
                 Pass ``None`` for admin callers (unrestricted).
 
         Returns:

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -14,7 +14,8 @@ Tests cover:
     - POST /  (upsert): success, service exception → 400
     - GET /   (list all): success, empty
     - GET /{team_id}: filtered list, empty
-    - DELETE /{binding_id}: success → 200, not found → 404
+    - DELETE /{binding_id}: success → 200, not found → 404, non-admin foreign team → 403
+    - DELETE /: by reference, non-admin scoped to own teams (cross-team bindings silently skipped)
 """
 
 # Standard
@@ -45,7 +46,7 @@ from mcpgateway.schemas import (
     ToolPluginBindingRequest,
     ToolPluginBindingResponse,
 )
-from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingNotFoundError
+from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingForbiddenError, ToolPluginBindingNotFoundError
 
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
 
@@ -474,6 +475,96 @@ class TestToolPluginBindingsRouter:
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "nonexistent-id" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_delete_non_admin_foreign_team_raises_403(self, user_ctx, db_session):
+        """Non-admin cannot delete a binding that belongs to a team they're not a member of."""
+        # Seed a binding on team-a as admin
+        upsert_result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        binding_id = upsert_result.bindings[0].id
+
+        # Caller is a member of team-b only
+        non_admin_ctx = {
+            "email": "outsider@example.com",
+            "full_name": "Outsider",
+            "is_admin": False,
+            "teams": ["team-b"],
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_tool_plugin_binding(
+                binding_id=binding_id,
+                current_user_ctx=non_admin_ctx,
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        # Binding must still exist
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_non_admin_scoped_to_own_teams(self, user_ctx, db_session):
+        """Non-admin DELETE ?binding_reference_id= only removes bindings for the caller's own teams.
+
+        Bindings belonging to other teams with the same reference ID are silently
+        skipped — not an error, and not deleted.
+        """
+        # Seed bindings on both team-a and team-b with the same reference ID
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id="OutputLengthGuardPlugin",
+                            config=dict(_OLG),
+                            binding_reference_id="shared-ref",
+                        )
+                    ]
+                ),
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_y"],
+                            plugin_id="OutputLengthGuardPlugin",
+                            config=dict(_OLG),
+                            binding_reference_id="shared-ref",
+                        )
+                    ]
+                ),
+            }
+        )
+        await upsert_tool_plugin_bindings(request=r, current_user_ctx=user_ctx, db=db_session)
+
+        # Non-admin member of team-a only
+        non_admin_ctx = {
+            "email": "member@example.com",
+            "full_name": "Team A Member",
+            "is_admin": False,
+            "teams": ["team-a"],
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        deleted = await delete_tool_plugin_bindings_by_reference(
+            binding_reference_id="shared-ref",
+            current_user_ctx=non_admin_ctx,
+            db=db_session,
+        )
+
+        # Only the team-a binding should be deleted
+        assert deleted.total == 1
+        assert deleted.bindings[0].team_id == "team-a"
+
+        # team-b binding must still be present
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 1
+        assert after.bindings[0].team_id == "team-b"
 
     # ------------------------------------------------------------------
     # Structural

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -46,8 +46,6 @@ from mcpgateway.schemas import (
     ToolPluginBindingRequest,
     ToolPluginBindingResponse,
 )
-from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingForbiddenError, ToolPluginBindingNotFoundError
-
 from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
 
 # ---------------------------------------------------------------------------
@@ -80,6 +78,7 @@ def user_ctx(db_session):
         "email": "admin@example.com",
         "full_name": "Admin User",
         "is_admin": True,
+        "token_teams": None,
         "db": db_session,
         "permissions": ["tools.manage_plugins", "tools.read"],
     }
@@ -289,7 +288,7 @@ class TestToolPluginBindingsRouter:
             "email": "member@example.com",
             "full_name": "Team Member",
             "is_admin": False,
-            "teams": ["team-a"],
+            "token_teams": ["team-a"],
             "db": db_session,
             "permissions": ["tools.manage_plugins"],
         }
@@ -308,7 +307,7 @@ class TestToolPluginBindingsRouter:
             "email": "outsider@example.com",
             "full_name": "Outsider",
             "is_admin": False,
-            "teams": ["team-b"],
+            "token_teams": ["team-b"],
             "db": db_session,
             "permissions": ["tools.manage_plugins"],
         }
@@ -492,7 +491,7 @@ class TestToolPluginBindingsRouter:
             "email": "outsider@example.com",
             "full_name": "Outsider",
             "is_admin": False,
-            "teams": ["team-b"],
+            "token_teams": ["team-b"],
             "db": db_session,
             "permissions": ["tools.manage_plugins"],
         }
@@ -547,13 +546,124 @@ class TestToolPluginBindingsRouter:
             "email": "member@example.com",
             "full_name": "Team A Member",
             "is_admin": False,
-            "teams": ["team-a"],
+            "token_teams": ["team-a"],
             "db": db_session,
             "permissions": ["tools.manage_plugins"],
         }
         deleted = await delete_tool_plugin_bindings_by_reference(
             binding_reference_id="shared-ref",
             current_user_ctx=non_admin_ctx,
+            db=db_session,
+        )
+
+        # Only the team-a binding should be deleted
+        assert deleted.total == 1
+        assert deleted.bindings[0].team_id == "team-a"
+
+        # team-b binding must still be present
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 1
+        assert after.bindings[0].team_id == "team-b"
+
+    @pytest.mark.asyncio
+    async def test_delete_admin_narrowed_token_cannot_delete_foreign_team(self, user_ctx, db_session):
+        """Admin with a narrowed token (token_teams=["team-a"]) cannot delete a team-b binding."""
+        upsert_result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        binding_id = upsert_result.bindings[0].id
+
+        narrowed_admin_ctx = {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "token_teams": ["team-b"],  # narrowed — does NOT include team-a
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_tool_plugin_binding(
+                binding_id=binding_id,
+                current_user_ctx=narrowed_admin_ctx,
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        # Binding must still exist
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 1
+
+    @pytest.mark.asyncio
+    async def test_delete_admin_unrestricted_token_can_delete_any_team(self, user_ctx, db_session):
+        """Admin with unrestricted token (token_teams=None) can delete any team's binding."""
+        upsert_result = await upsert_tool_plugin_bindings(
+            request=_simple_request(),
+            current_user_ctx=user_ctx,
+            db=db_session,
+        )
+        binding_id = upsert_result.bindings[0].id
+
+        unrestricted_admin_ctx = {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "token_teams": None,  # unrestricted
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        result = await delete_tool_plugin_binding(
+            binding_id=binding_id,
+            current_user_ctx=unrestricted_admin_ctx,
+            db=db_session,
+        )
+        assert result.id == binding_id
+        after = await list_tool_plugin_bindings(current_user_ctx=user_ctx, db=db_session)
+        assert after.total == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_by_reference_admin_narrowed_token_scoped(self, user_ctx, db_session):
+        """Admin with narrowed token can only delete by-reference bindings in allowed teams."""
+        # Seed bindings on both team-a and team-b with the same reference ID
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_x"],
+                            plugin_id="OutputLengthGuardPlugin",
+                            config=dict(_OLG),
+                            binding_reference_id="shared-ref",
+                        )
+                    ]
+                ),
+                "team-b": TeamPolicies(
+                    policies=[
+                        PluginPolicyItem(
+                            tool_names=["tool_y"],
+                            plugin_id="OutputLengthGuardPlugin",
+                            config=dict(_OLG),
+                            binding_reference_id="shared-ref",
+                        )
+                    ]
+                ),
+            }
+        )
+        await upsert_tool_plugin_bindings(request=r, current_user_ctx=user_ctx, db=db_session)
+
+        # Admin narrowed to team-a only
+        narrowed_admin_ctx = {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "token_teams": ["team-a"],
+            "db": db_session,
+            "permissions": ["tools.manage_plugins"],
+        }
+        deleted = await delete_tool_plugin_bindings_by_reference(
+            binding_reference_id="shared-ref",
+            current_user_ctx=narrowed_admin_ctx,
             db=db_session,
         )
 

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -552,6 +552,20 @@ class TestDeleteBinding:
         assert len(remaining) == 1
         assert remaining[0].team_id == "team-b"
 
+    def test_delete_binding_empty_allowed_teams_blocks_own_team(self, service, db_session):
+        """allowed_teams=set() (public-only / empty token) blocks deletion even for the binding's own team."""
+        r = ToolPluginBindingRequest(
+            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=dict(_RL))])}
+        )
+        inserted = service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+        binding_id = inserted[0].id
+
+        with pytest.raises(ToolPluginBindingForbiddenError, match="team-a"):
+            service.delete_binding(db_session, binding_id, allowed_teams=set())
+
+        # Row must still exist
+        assert db_session.query(ToolPluginBinding).filter_by(id=binding_id).first() is not None
+
 
 # ---------------------------------------------------------------------------
 # Schema validation tests — PluginPolicyItem cross-validation

--- a/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py
@@ -35,6 +35,7 @@ from mcpgateway.schemas import (
     ToolPluginBindingResponse,
 )
 from mcpgateway.services.tool_plugin_binding_service import (
+    ToolPluginBindingForbiddenError,
     ToolPluginBindingNotFoundError,
     ToolPluginBindingService,
     get_bindings_for_tool,
@@ -512,6 +513,44 @@ class TestDeleteBinding:
         """delete_binding raises ToolPluginBindingNotFoundError for an unknown ID."""
         with pytest.raises(ToolPluginBindingNotFoundError, match="not found"):
             service.delete_binding(db_session, "nonexistent-id")
+
+    def test_delete_binding_foreign_team_raises_forbidden(self, service, db_session):
+        """delete_binding raises ToolPluginBindingForbiddenError when allowed_teams
+        is set and the binding's team_id is not in the set."""
+        r = ToolPluginBindingRequest(
+            teams={"team-a": TeamPolicies(policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=dict(_RL))])}
+        )
+        inserted = service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+        binding_id = inserted[0].id
+
+        with pytest.raises(ToolPluginBindingForbiddenError, match="team-a"):
+            service.delete_binding(db_session, binding_id, allowed_teams={"team-b"})
+
+        # Row must still exist
+        assert db_session.query(ToolPluginBinding).filter_by(id=binding_id).first() is not None
+
+    def test_delete_bindings_by_reference_scoped_to_allowed_teams(self, service, db_session):
+        """delete_bindings_by_reference only removes bindings whose team_id is in allowed_teams."""
+        r = ToolPluginBindingRequest(
+            teams={
+                "team-a": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_x"], plugin_id="RateLimiterPlugin", config=dict(_RL), binding_reference_id="ref-123")]
+                ),
+                "team-b": TeamPolicies(
+                    policies=[PluginPolicyItem(tool_names=["tool_y"], plugin_id="RateLimiterPlugin", config=dict(_RL), binding_reference_id="ref-123")]
+                ),
+            }
+        )
+        service.upsert_bindings(db_session, r, caller_email="admin@example.com")
+
+        deleted = service.delete_bindings_by_reference(db_session, "ref-123", allowed_teams={"team-a"})
+
+        assert len(deleted) == 1
+        assert deleted[0].team_id == "team-a"
+        # team-b binding still present
+        remaining = db_session.query(ToolPluginBinding).filter_by(binding_reference_id="ref-123").all()
+        assert len(remaining) == 1
+        assert remaining[0].team_id == "team-b"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Bug-fix PR

## 📌 Summary

`DELETE /v1/tools/plugin_bindings/{id}` and `DELETE /v1/tools/plugin_bindings?binding_reference_id=...` relied solely on the `tools.manage_plugins` RBAC permission and did not verify that the caller's team membership overlapped with the binding's `team_id`. A non-admin holding `tools.manage_plugins` on any team could delete a binding belonging to a different team by guessing or observing its UUID or external reference ID. The paired upsert endpoint already enforced this check; the delete endpoints did not.

## 🔗 Related Issue

Closes: #4311

## 🔁 Reproduction Steps

See [#4311](https://github.com/IBM/mcp-context-forge/issues/4311).

1. Authenticate as a non-admin user who holds `tools.manage_plugins` on **team-A**.
2. Obtain the UUID (or `binding_reference_id`) of a binding that belongs to **team-B**.
3. `DELETE /v1/tools/plugin_bindings/<team-B-binding-uuid>` → binding is deleted despite the caller having no membership in team-B.

## 🐞 Root Cause

The router handlers (`delete_tool_plugin_binding`, `delete_tool_plugin_bindings_by_reference`) forwarded the delete straight to the service layer without extracting the caller's team membership or passing it down. The service methods contained no team filter — they matched only on `id` / `binding_reference_id`, making any binding reachable to anyone with the permission.

Affected code:
- `mcpgateway/routers/tool_plugin_bindings.py` lines 189–286
- `mcpgateway/services/tool_plugin_binding_service.py` `delete_binding` / `delete_bindings_by_reference`

## 💡 Fix Description

Two orthogonal layers of defence, mirroring the existing upsert pattern:

1. **Router-side guard** — each delete handler now extracts `is_admin` and `teams` from `current_user_ctx` and computes `allowed_teams = None` (admin bypass) or `set(user_teams)` (non-admin). This is passed to the service.

2. **Service-side scoping**:
   - `delete_binding` — checks `binding.team_id not in allowed_teams` before deleting; raises `ToolPluginBindingForbiddenError` (mapped to HTTP 403 by the router).
   - `delete_bindings_by_reference` — applies `team_id.in_(allowed_teams)` as a SQL filter so foreign-team rows are never fetched or deleted (silent skip, consistent with bulk-operation semantics).

A new `ToolPluginBindingForbiddenError` exception class carries the denial through the service→router boundary cleanly.

## 🧪 Verification

| Check                             | Command                                                                                                   | Status |
|-----------------------------------|-----------------------------------------------------------------------------------------------------------|--------|
| Lint suite                        | `make lint`                                                                                               |        |
| Unit tests                        | `make test`                                                                                               |        |
| Coverage ≥ 90 %                   | `make coverage`                                                                                           |        |
| Plugin-binding tests (76 pass)    | `.venv/bin/pytest tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py tests/unit/mcpgateway/services/test_tool_plugin_binding_service.py -v` | ✅ 76/76 passed |
| Non-admin foreign team → 403      | `test_delete_non_admin_foreign_team_raises_403`                                                           | ✅     |
| Non-admin bulk scoped to own team | `test_delete_by_reference_non_admin_scoped_to_own_teams`                                                  | ✅     |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed