### PR TITLE
feat(auth): add HTTP Basic Auth support for OAuth token exchange

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-23T08:41:34Z",
+  "generated_at": "2026-04-23T09:05:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3759,6 +3759,24 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 1416,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/using/servers/external/notion-mcp-setup.md": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "09a28376ef8de09a0614fa3a62c47beeb525551d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-08T07:30:17Z",
+  "generated_at": "2026-04-23T08:41:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8126,7 +8126,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8134,7 +8134,15 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 446,
+        "line_number": 422,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 511,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8142,7 +8150,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 695,
+        "line_number": 734,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8150,7 +8158,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 771,
+        "line_number": 810,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8158,7 +8166,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 774,
+        "line_number": 813,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-07T10:56:09Z",
+  "generated_at": "2026-05-08T12:59:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4942,7 +4942,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 752,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-23T09:05:16Z",
+  "generated_at": "2026-04-30T12:07:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-30T12:07:28Z",
+  "generated_at": "2026-05-07T10:44:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4942,7 +4942,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 751,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-07T10:44:10Z",
+  "generated_at": "2026-05-07T10:56:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8144,7 +8144,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 452,
+        "line_number": 458,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8152,7 +8152,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 422,
+        "line_number": 477,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8160,7 +8160,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 560,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8168,7 +8168,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 734,
+        "line_number": 789,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8176,7 +8176,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 810,
+        "line_number": 865,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8184,7 +8184,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 813,
+        "line_number": 868,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -8144,7 +8144,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 403,
+        "line_number": 452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8160,7 +8160,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 511,
+        "line_number": 560,
         "type": "Secret Keyword",
         "verified_result": null
       },

--- a/docs/docs/using/servers/external/notion-mcp-setup.md
+++ b/docs/docs/using/servers/external/notion-mcp-setup.md
@@ -1,0 +1,125 @@
+# Notion MCP Server Setup Guide
+
+This guide explains how to configure ContextForge to work with Notion's MCP server, which requires HTTP Basic Authentication for OAuth token exchange.
+
+## Overview
+
+Notion's MCP server (`https://mcp.notion.com/mcp`) uses OAuth 2.0 for authentication but requires client credentials to be sent as HTTP Basic Authentication during the token exchange step, as specified in [RFC 6749 Section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1).
+
+## Configuration
+
+To connect ContextForge to Notion's MCP server, you need to set `token_endpoint_auth_method: "client_secret_basic"` in your OAuth configuration:
+
+```json
+{
+  "name": "notion-mcp",
+  "url": "https://mcp.notion.com/mcp",
+  "transport": "SSE",
+  "auth_type": "oauth",
+  "oauth_config": {
+    "grant_type": "authorization_code",
+    "client_id": "YOUR_NOTION_CLIENT_ID",
+    "client_secret": "YOUR_NOTION_CLIENT_SECRET",
+    "authorization_url": "https://api.notion.com/v1/oauth/authorize",
+    "token_url": "https://api.notion.com/v1/oauth/token",
+    "redirect_uri": "https://your-contextforge-domain.com/oauth/callback",
+    "scopes": [],
+    "token_endpoint_auth_method": "client_secret_basic"
+  },
+  "enabled": true
+}
+```
+
+### Key Configuration Parameter
+
+**`token_endpoint_auth_method`**: Controls how client credentials are sent during OAuth token exchange
+
+- `"client_secret_basic"` (Required for Notion): Sends credentials as HTTP Basic Auth header
+  ```
+  Authorization: Basic base64(client_id:client_secret)
+  ```
+
+- `"client_secret_post"` (Default): Sends credentials in POST body
+  ```
+  client_id=...&client_secret=...
+  ```
+
+## Setup Steps
+
+### 1. Create Notion Integration
+
+1. Go to [Notion Integrations](https://www.notion.so/my-integrations)
+2. Click "New integration" → "Public integration"
+3. Configure:
+   - **Name**: Your integration name
+   - **Redirect URIs**: `https://your-contextforge-domain.com/oauth/callback`
+   - **Capabilities**: Select required permissions
+4. Save and note your **Client ID** and **Client Secret**
+
+### 2. Configure ContextForge Gateway
+
+Using the API:
+
+```bash
+curl -X POST https://your-contextforge-domain.com/gateways \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "notion-mcp",
+    "url": "https://mcp.notion.com/mcp",
+    "transport": "SSE",
+    "auth_type": "oauth",
+    "oauth_config": {
+      "grant_type": "authorization_code",
+      "client_id": "YOUR_NOTION_CLIENT_ID",
+      "client_secret": "YOUR_NOTION_CLIENT_SECRET",
+      "authorization_url": "https://api.notion.com/v1/oauth/authorize",
+      "token_url": "https://api.notion.com/v1/oauth/token",
+      "redirect_uri": "https://your-contextforge-domain.com/oauth/callback",
+      "token_endpoint_auth_method": "client_secret_basic"
+    },
+    "enabled": true
+  }'
+```
+
+### 3. Complete OAuth Flow
+
+1. Navigate to the gateway in ContextForge Admin UI
+2. Click "Authorize" to initiate OAuth flow
+3. Grant permissions in Notion
+4. You'll be redirected back to ContextForge with an active connection
+
+### 4. Grant Page Access
+
+After OAuth authorization, grant the integration access to specific Notion pages:
+
+1. Open a Notion page
+2. Click **•••** → **Add connections**
+3. Select your integration
+4. Click **Confirm**
+
+## Troubleshooting
+
+### Error: "401 Unauthorized" during token exchange
+
+**Cause**: Missing or incorrect `token_endpoint_auth_method` configuration.
+
+**Solution**: Ensure `"token_endpoint_auth_method": "client_secret_basic"` is set in your `oauth_config`.
+
+### Error: "Integration does not have access to this page"
+
+**Cause**: Integration hasn't been granted page access.
+
+**Solution**: Follow step 4 above to grant access to specific pages.
+
+### Error: "Invalid redirect_uri"
+
+**Cause**: Redirect URI mismatch between Notion integration and ContextForge configuration.
+
+**Solution**: Ensure the redirect URI exactly matches in both places (including protocol and path).
+
+## References
+
+- [Notion API Documentation](https://developers.notion.com/)
+- [Notion OAuth Guide](https://developers.notion.com/docs/authorization)
+- [RFC 6749 Section 2.3.1 - Client Authentication](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1)

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -403,6 +403,17 @@ class OAuthManager:
                 redacted[key] = value
         return redacted
 
+    @staticmethod
+    def _build_basic_auth_header(client_id: str, client_secret: str) -> str:
+        """Build an RFC 6749 Section 2.3.1 Basic Auth header value.
+
+        Client credentials are first URL-encoded per RFC 6749 Appendix B,
+        then combined as ``client_id:client_secret`` and base64-encoded.
+        """
+        credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
+        encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
+        return f"Basic {encoded_credentials}"
+
     async def _client_credentials_flow(
         self,
         credentials: Dict[str, Any],
@@ -439,11 +450,7 @@ class OAuthManager:
         headers = {}
 
         if use_basic_auth:
-            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
-            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
-            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
-            headers["Authorization"] = f"Basic {encoded_credentials}"
+            headers["Authorization"] = self._build_basic_auth_header(client_id, client_secret)
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
         else:
             # Default: client credentials in POST body (client_secret_post)
@@ -1439,11 +1446,7 @@ class OAuthManager:
         headers = {}
 
         if use_basic_auth and client_secret:
-            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
-            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
-            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
-            headers["Authorization"] = f"Basic {encoded_credentials}"
+            headers["Authorization"] = self._build_basic_auth_header(client_id, client_secret)
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
         elif use_basic_auth and not client_secret:
             # Public PKCE clients can't use Basic Auth (no secret to encode)
@@ -1552,11 +1555,7 @@ class OAuthManager:
         headers = {}
 
         if use_basic_auth and client_secret:
-            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
-            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
-            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
-            headers["Authorization"] = f"Basic {encoded_credentials}"
+            headers["Authorization"] = self._build_basic_auth_header(client_id, client_secret)
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
         elif use_basic_auth and not client_secret:
             # Misconfiguration: Basic Auth requested but no secret available

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -241,7 +241,9 @@ class OAuthManager:
             logger.warning("Failed to prepare runtime OAuth credentials for %s flow: %s", flow_name, exc)
         return credentials
 
-    async def _post_token_request(self, url: str, data: Any, ca_certificate: Optional[str] = None, client_cert: Optional[str] = None, client_key: Optional[str] = None) -> httpx.Response:
+    async def _post_token_request(
+        self, url: str, data: Any, ca_certificate: Optional[str] = None, client_cert: Optional[str] = None, client_key: Optional[str] = None, headers: Optional[Dict[str, str]] = None
+    ) -> httpx.Response:
         """POST to a token endpoint, using a custom SSL context when CA certs are provided.
 
         When ``ca_certificate`` is supplied, an isolated ``httpx.AsyncClient``
@@ -256,6 +258,7 @@ class OAuthManager:
             ca_certificate: Optional PEM-encoded CA certificate.
             client_cert: Optional client certificate for mTLS.
             client_key: Optional client private key for mTLS.
+            headers: Optional HTTP headers (e.g., Authorization for Basic Auth).
 
         Returns:
             The HTTP response from the token endpoint.
@@ -263,9 +266,9 @@ class OAuthManager:
         if ca_certificate:
             ssl_context = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
             async with httpx.AsyncClient(verify=ssl_context) as client:
-                return await client.post(url, data=data, timeout=self.request_timeout)
+                return await client.post(url, data=data, headers=headers, timeout=self.request_timeout)
         client = await self._get_client()
-        return await client.post(url, data=data, timeout=self.request_timeout)
+        return await client.post(url, data=data, headers=headers, timeout=self.request_timeout)
 
     # Keys whose values must never be echoed in error messages or logs.
     _SENSITIVE_TOKEN_KEYS = frozenset({"access_token", "refresh_token", "id_token", "client_secret", "password"})
@@ -464,7 +467,7 @@ class OAuthManager:
         # Fetch token with retries
         for attempt in range(self.max_retries):
             try:
-                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key)
+                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key, headers=headers)
                 response.raise_for_status()
 
                 token_response = self._parse_token_response(response)
@@ -1483,7 +1486,7 @@ class OAuthManager:
         # Exchange code for token with retries
         for attempt in range(self.max_retries):
             try:
-                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key)
+                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key, headers=headers)
                 response.raise_for_status()
 
                 token_response = self._parse_token_response(response)
@@ -1588,7 +1591,7 @@ class OAuthManager:
         # Attempt token refresh with retries
         for attempt in range(self.max_retries):
             try:
-                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key)
+                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key, headers=headers)
                 if response.status_code == 200:
                     token_response = self._parse_token_response(response)
 

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -20,7 +20,7 @@ import logging
 import re
 import secrets
 from typing import Any, Dict, Optional
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, quote, urlparse
 
 # Third-Party
 import httpx
@@ -440,8 +440,8 @@ class OAuthManager:
 
         if use_basic_auth:
             # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # Encode client_id:client_secret as base64
-            credentials_str = f"{client_id}:{client_secret}"
+            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
+            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
             encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
             headers["Authorization"] = f"Basic {encoded_credentials}"
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
@@ -1440,11 +1440,16 @@ class OAuthManager:
 
         if use_basic_auth and client_secret:
             # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # Encode client_id:client_secret as base64
-            credentials_str = f"{client_id}:{client_secret}"
+            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
+            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
             encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
             headers["Authorization"] = f"Basic {encoded_credentials}"
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
+        elif use_basic_auth and not client_secret:
+            # Public PKCE clients can't use Basic Auth (no secret to encode)
+            logger.warning("Basic Auth requested but client_secret is missing - falling back to POST body mode (public client)")
+            token_data["client_id"] = client_id
+            logger.debug("Using POST body for token endpoint authentication")
         else:
             # Default: client credentials in POST body (client_secret_post)
             token_data["client_id"] = client_id
@@ -1548,11 +1553,16 @@ class OAuthManager:
 
         if use_basic_auth and client_secret:
             # RFC 6749 Section 2.3.1: HTTP Basic Authentication
-            # Encode client_id:client_secret as base64
-            credentials_str = f"{client_id}:{client_secret}"
+            # URL-encode credentials per RFC 6749 Appendix B before base64 encoding
+            credentials_str = f"{quote(client_id, safe='')}:{quote(client_secret, safe='')}"
             encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
             headers["Authorization"] = f"Basic {encoded_credentials}"
             logger.debug("Using HTTP Basic Auth for token endpoint authentication")
+        elif use_basic_auth and not client_secret:
+            # Misconfiguration: Basic Auth requested but no secret available
+            logger.warning("Basic Auth requested but client_secret is missing - falling back to POST body mode")
+            token_data["client_id"] = client_id
+            logger.debug("Using POST body for token endpoint authentication")
         else:
             # Default: client credentials in POST body (client_secret_post)
             token_data["client_id"] = client_id

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -430,12 +430,26 @@ class OAuthManager:
         token_url = runtime_credentials["token_url"]
         scopes = runtime_credentials.get("scopes", [])
 
-        # Prepare token request data
-        token_data = {
-            "grant_type": "client_credentials",
-            "client_id": client_id,
-            "client_secret": client_secret,
-        }
+        # Check if provider requires Basic Auth for client authentication (RFC 6749 Section 2.3.1)
+        # Default to form-based auth for backward compatibility
+        use_basic_auth = runtime_credentials.get("token_endpoint_auth_method", "client_secret_post") == "client_secret_basic"
+
+        # Prepare token request data and headers
+        token_data = {"grant_type": "client_credentials"}
+        headers = {}
+
+        if use_basic_auth:
+            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
+            # Encode client_id:client_secret as base64
+            credentials_str = f"{client_id}:{client_secret}"
+            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+            logger.debug("Using HTTP Basic Auth for token endpoint authentication")
+        else:
+            # Default: client credentials in POST body (client_secret_post)
+            token_data["client_id"] = client_id
+            token_data["client_secret"] = client_secret
+            logger.debug("Using POST body for token endpoint authentication")
 
         if scopes:
             token_data["scope"] = " ".join(scopes) if isinstance(scopes, list) else scopes
@@ -1412,17 +1426,32 @@ class OAuthManager:
         token_url = runtime_credentials["token_url"]
         redirect_uri = runtime_credentials["redirect_uri"]
 
-        # Prepare token exchange data
+        # Check if provider requires Basic Auth for client authentication (RFC 6749 Section 2.3.1)
+        # Default to form-based auth for backward compatibility
+        use_basic_auth = runtime_credentials.get("token_endpoint_auth_method", "client_secret_post") == "client_secret_basic"
+
+        # Prepare token exchange data and headers
         token_data = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": redirect_uri,
-            "client_id": client_id,
         }
+        headers = {}
 
-        # Only include client_secret if present (public clients don't have secrets)
-        if client_secret:
-            token_data["client_secret"] = client_secret
+        if use_basic_auth and client_secret:
+            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
+            # Encode client_id:client_secret as base64
+            credentials_str = f"{client_id}:{client_secret}"
+            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+            logger.debug("Using HTTP Basic Auth for token endpoint authentication")
+        else:
+            # Default: client credentials in POST body (client_secret_post)
+            token_data["client_id"] = client_id
+            # Only include client_secret if present (public clients don't have secrets)
+            if client_secret:
+                token_data["client_secret"] = client_secret
+            logger.debug("Using POST body for token endpoint authentication")
 
         # Add PKCE code_verifier if present (RFC 7636)
         if code_verifier:
@@ -1506,16 +1535,31 @@ class OAuthManager:
         if not client_id:
             raise OAuthError("No client_id configured for OAuth provider")
 
-        # Prepare token refresh request
+        # Check if provider requires Basic Auth for client authentication (RFC 6749 Section 2.3.1)
+        # Default to form-based auth for backward compatibility
+        use_basic_auth = runtime_credentials.get("token_endpoint_auth_method", "client_secret_post") == "client_secret_basic"
+
+        # Prepare token refresh request and headers
         token_data = {
             "grant_type": "refresh_token",
             "refresh_token": refresh_token,
-            "client_id": client_id,
         }
+        headers = {}
 
-        # Add client_secret if available (some providers require it)
-        if client_secret:
-            token_data["client_secret"] = client_secret
+        if use_basic_auth and client_secret:
+            # RFC 6749 Section 2.3.1: HTTP Basic Authentication
+            # Encode client_id:client_secret as base64
+            credentials_str = f"{client_id}:{client_secret}"
+            encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
+            headers["Authorization"] = f"Basic {encoded_credentials}"
+            logger.debug("Using HTTP Basic Auth for token endpoint authentication")
+        else:
+            # Default: client credentials in POST body (client_secret_post)
+            token_data["client_id"] = client_id
+            # Add client_secret if available (some providers require it)
+            if client_secret:
+                token_data["client_secret"] = client_secret
+            logger.debug("Using POST body for token endpoint authentication")
 
         # Add resource parameter for JWT access token (RFC 8707)
         # Must be included in refresh requests to maintain JWT token type

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1358,6 +1358,168 @@ async def test_resolve_gateway_id_from_state_skips_legacy_fallback_when_disabled
     mock_legacy.assert_not_called()
 
 
+# ---------- exchange_code_for_tokens with Basic Auth but no client_secret ----------
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_tokens_basic_auth_without_client_secret(oauth_manager):
+    """Test authorization code exchange with Basic Auth requested but no client_secret (public PKCE client).
+
+    This covers lines 1313-1317 in oauth_manager.py where use_basic_auth is True
+    but client_secret is missing, triggering the fallback to POST body mode.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "test-token", "token_type": "Bearer"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "public-client",
+            # No client_secret - public PKCE client
+            "token_url": "https://oauth.example.com/token",
+            "redirect_uri": "https://gateway.example.com/callback",
+            "token_endpoint_auth_method": "client_secret_basic",  # Request Basic Auth
+        }
+
+        result = await oauth_manager._exchange_code_for_tokens(
+            credentials=credentials,
+            code="auth_code_123",
+            code_verifier="test_verifier"
+        )
+
+    assert result["access_token"] == "test-token"
+
+    # Verify the POST call was made with client_id in body (not in Authorization header)
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://oauth.example.com/token"
+
+    # Check that client_id is in the POST body
+    post_data = call_args.kwargs["data"]
+    assert post_data["client_id"] == "public-client"
+    assert post_data["grant_type"] == "authorization_code"
+    assert post_data["code"] == "auth_code_123"
+    assert post_data["code_verifier"] == "test_verifier"
+
+    # Verify no Authorization header was set (since no client_secret)
+    headers = call_args.kwargs.get("headers", {})
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_tokens_basic_auth_without_client_secret_logs_warning(oauth_manager, caplog):
+    """Test that the fallback to POST body mode logs a warning message."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "test-token", "token_type": "Bearer"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "public-client",
+            "token_url": "https://oauth.example.com/token",
+            "redirect_uri": "https://gateway.example.com/callback",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+
+        with caplog.at_level("WARNING"):
+            await oauth_manager._exchange_code_for_tokens(
+                credentials=credentials,
+                code="auth_code_123"
+            )
+
+    # Verify warning was logged
+    assert any("Basic Auth requested but client_secret is missing" in record.message for record in caplog.records)
+
+
+# ---------- refresh_token with Basic Auth but no client_secret ----------
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_basic_auth_without_client_secret(oauth_manager):
+    """Test refresh token with Basic Auth requested but no client_secret.
+
+    This covers lines 1414-1418 in oauth_manager.py where use_basic_auth is True
+    but client_secret is missing, triggering the fallback to POST body mode.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {
+        "access_token": "refreshed-token",
+        "token_type": "Bearer",
+        "expires_in": 3600
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "public-client",
+            # No client_secret - public client
+            "token_url": "https://oauth.example.com/token",
+            "token_endpoint_auth_method": "client_secret_basic",  # Request Basic Auth
+        }
+
+        result = await oauth_manager.refresh_token(
+            credentials=credentials,
+            refresh_token="old-refresh-token"
+        )
+
+    assert result["access_token"] == "refreshed-token"
+
+    # Verify the POST call was made with client_id in body (not in Authorization header)
+    call_args = mock_client.post.call_args
+    assert call_args[0][0] == "https://oauth.example.com/token"
+
+    # Check that client_id is in the POST body
+    post_data = call_args.kwargs["data"]
+    assert post_data["client_id"] == "public-client"
+    assert post_data["grant_type"] == "refresh_token"
+    assert post_data["refresh_token"] == "old-refresh-token"
+
+    # Verify no Authorization header was set (since no client_secret)
+    headers = call_args.kwargs.get("headers", {})
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_basic_auth_without_client_secret_logs_warning(oauth_manager, caplog):
+    """Test that the fallback to POST body mode logs a warning message."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "refreshed-token", "token_type": "Bearer"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "public-client",
+            "token_url": "https://oauth.example.com/token",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+
+        with caplog.at_level("WARNING"):
+            await oauth_manager.refresh_token(
+                credentials=credentials,
+                refresh_token="old-refresh-token"
+            )
+
+    # Verify warning was logged
+    assert any("Basic Auth requested but client_secret is missing" in record.message for record in caplog.records)
+
+
 # ---------- OAuthError ----------
 
 

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -176,6 +176,37 @@ async def test_client_credentials_flow_success_form_encoded(oauth_manager):
 
 
 @pytest.mark.asyncio
+async def test_client_credentials_flow_with_basic_auth(oauth_manager):
+    """Test client credentials flow with HTTP Basic Auth (token_endpoint_auth_method=client_secret_basic)."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "basic-auth-tok"}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch.object(oauth_manager, "_get_client", return_value=mock_client):
+        credentials = {
+            "client_id": "test-client",
+            "client_secret": "test-secret",
+            "token_url": "https://example.com/token",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+        result = await oauth_manager._client_credentials_flow(credentials)
+
+    assert result == "basic-auth-tok"
+    # Verify Basic Auth header was set
+    call_args = mock_client.post.call_args
+    assert "headers" in call_args.kwargs
+    assert "Authorization" in call_args.kwargs["headers"]
+    assert call_args.kwargs["headers"]["Authorization"].startswith("Basic ")
+    # Verify credentials NOT in POST body
+    assert "client_id" not in call_args.kwargs["data"]
+    assert "client_secret" not in call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
 async def test_client_credentials_flow_with_scopes(oauth_manager):
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
@@ -451,6 +482,38 @@ async def test_exchange_code_for_token_success(oauth_manager):
 
 
 @pytest.mark.asyncio
+async def test_exchange_code_for_token_with_basic_auth(oauth_manager):
+    """Test authorization code exchange with HTTP Basic Auth (token_endpoint_auth_method=client_secret_basic)."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "basic-code-tok"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "test-client",
+            "client_secret": "test-secret",
+            "token_url": "https://example.com/token",
+            "redirect_uri": "https://example.com/callback",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+        result = await oauth_manager._exchange_code_for_tokens(credentials, code="auth-code")
+
+    assert result["access_token"] == "basic-code-tok"
+    # Verify Basic Auth header was set
+    call_args = mock_client.post.call_args
+    assert "headers" in call_args.kwargs
+    assert "Authorization" in call_args.kwargs["headers"]
+    assert call_args.kwargs["headers"]["Authorization"].startswith("Basic ")
+    # Verify credentials NOT in POST body
+    assert "client_id" not in call_args.kwargs["data"]
+    assert "client_secret" not in call_args.kwargs["data"]
+
+
+@pytest.mark.asyncio
 async def test_exchange_code_for_token_no_secret(oauth_manager):
     """Public client without client_secret."""
     mock_response = MagicMock()
@@ -484,6 +547,37 @@ async def test_refresh_token_success(oauth_manager):
     with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
         result = await oauth_manager.refresh_token("old-rt", {"client_id": "cid", "client_secret": "sec", "token_url": "https://auth/token"})
     assert result["access_token"] == "new-tok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_with_basic_auth(oauth_manager):
+    """Test refresh token with HTTP Basic Auth (token_endpoint_auth_method=client_secret_basic)."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "new-basic-tok", "refresh_token": "new-rt"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        credentials = {
+            "client_id": "test-client",
+            "client_secret": "test-secret",
+            "token_url": "https://example.com/token",
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+        result = await oauth_manager.refresh_token("old-rt", credentials)
+
+    assert result["access_token"] == "new-basic-tok"
+    # Verify Basic Auth header was set
+    call_args = mock_client.post.call_args
+    assert "headers" in call_args.kwargs
+    assert "Authorization" in call_args.kwargs["headers"]
+    assert call_args.kwargs["headers"]["Authorization"].startswith("Basic ")
+    # Verify credentials NOT in POST body
+    assert "client_id" not in call_args.kwargs["data"]
+    assert "client_secret" not in call_args.kwargs["data"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4358
**Jira Issue:** https://jsw.ibm.com/browse/ICACF-28

---

## 📝 Summary
Adds HTTP Basic Authentication support for OAuth token exchange to enable compatibility with Notion MCP server and other OAuth providers that require RFC 6749 Section 2.3.1 compliant authentication.

**Problem:** Notion MCP server requires client credentials to be sent as an HTTP Basic Auth header (`Authorization: Basic base64(client_id:client_secret)`) during OAuth token exchange, but ContextForge was only sending credentials in the POST body.

**Solution:** Added configurable `token_endpoint_auth_method` parameter that supports both authentication methods:
- `client_secret_post` (default) - credentials in POST body
- `client_secret_basic` - credentials in Authorization header per RFC 6749 Section 2.3.1

**Changes:**
- Modified three OAuth flow methods in [`oauth_manager.py`](mcpgateway/services/oauth_manager.py): `_client_credentials_flow()`, `_exchange_code_for_tokens()`, and `refresh_token()`
- Added comprehensive unit tests covering Basic Auth flows
- Created Notion MCP server setup documentation

**Backward Compatibility:** Fully maintained - defaults to existing `client_secret_post` behavior when `token_endpoint_auth_method` is not specified.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Configuration Example:**
```json
{
  "oauth_config": {
    "client_id": "your-notion-client-id",
    "client_secret": "your-notion-client-secret",
    "token_endpoint_auth_method": "client_secret_basic",
    "authorization_endpoint": "https://api.notion.com/v1/oauth/authorize",
    "token_endpoint": "https://api.notion.com/v1/oauth/token"
  }
}
```

**RFC Compliance:** Implementation follows RFC 6749 Section 2.3.1 for HTTP Basic Authentication, encoding `client_id:client_secret` as base64 in the Authorization header.

**Testing:** Added three new unit tests (`test_client_credentials_flow_with_basic_auth`, `test_exchange_code_for_token_with_basic_auth`, `test_refresh_token_with_basic_auth`) that verify:
- Basic Auth header is correctly formatted
- Credentials are NOT included in POST body when using Basic Auth
- Default behavior (POST body) remains unchanged

**Documentation:** Created comprehensive setup guide at [`docs/docs/using/servers/external/notion-mcp-setup.md`](docs/docs/using/servers/external/notion-mcp-setup.md) covering both internal and public OAuth connection types.