### PR TITLE
fix: Resolve Rust Cargo Dependency - Update rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,9 +2878,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -7,6 +7,12 @@ criteria = "safe-to-deploy"
 delta = "0.103.11 -> 0.103.12"
 notes = "Security patch update for RUSTSEC-2026-0098; reviewed upstream diff for URI name-constraint handling change."
 
+[[audits.rustls-webpki]]
+who = "prakhar-singh1928 <prakhar.singh1928@ibm.com>"
+criteria = "safe-to-deploy"
+delta = "0.103.12 -> 0.103.13"
+notes = "Security patch update for RUSTSEC-2026-0104; fixes reachable panic in CRL parsing for empty BIT STRING in IssuingDistributionPoint extension. Reviewed upstream diff - minimal change, only affects CRL parsing logic."
+
 [[trusted.aho-corasick]]
 criteria = "safe-to-deploy"
 user-id = 189 # Andrew Gallant (BurntSushi)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -78,6 +78,13 @@ user-id = 267
 user-login = "tarcieri"
 user-name = "Tony Arcieri"
 
+[[publisher.block-buffer]]
+version = "0.10.4"
+when = "2023-03-09"
+user-id = 5059
+user-login = "newpavlov"
+user-name = "Artyom Pavlov"
+
 [[publisher.bumpalo]]
 version = "3.20.2"
 when = "2026-02-19"
@@ -181,6 +188,13 @@ user-id = 11235
 user-login = "baloo"
 user-name = "Arthur Gautier"
 
+[[publisher.digest]]
+version = "0.10.7"
+when = "2023-05-19"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
 [[publisher.fallible-iterator]]
 version = "0.2.0"
 when = "2019-03-10"
@@ -255,13 +269,6 @@ when = "2026-04-12"
 user-id = 4556
 user-login = "djc"
 user-name = "Dirkjan Ochtman"
-
-[[publisher.hyper-tls]]
-version = "0.6.0"
-when = "2023-11-27"
-user-id = 359
-user-login = "seanmonstar"
-user-name = "Sean McArthur"
 
 [[publisher.hyper-util]]
 version = "0.1.20"
@@ -338,6 +345,13 @@ user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
+[[publisher.md-5]]
+version = "0.10.6"
+when = "2023-09-22"
+user-id = 5059
+user-login = "newpavlov"
+user-name = "Artyom Pavlov"
+
 [[publisher.memchr]]
 version = "2.8.0"
 when = "2026-02-06"
@@ -358,13 +372,6 @@ when = "2026-03-27"
 user-id = 6025
 user-login = "Thomasdezeeuw"
 user-name = "Thomas de Zeeuw"
-
-[[publisher.native-tls]]
-version = "0.2.18"
-when = "2026-02-18"
-user-id = 988
-user-login = "kornelski"
-user-name = "Kornel"
 
 [[publisher.num-bigint]]
 version = "0.4.6"
@@ -472,8 +479,8 @@ user-login = "JohnTitor"
 user-name = "Yuki Okushi"
 
 [[publisher.postgres-protocol]]
-version = "0.6.11"
-when = "2026-03-30"
+version = "0.6.10"
+when = "2026-01-14"
 user-id = 55015
 user-login = "paolobarbolini"
 user-name = "Paolo Barbolini"
@@ -729,6 +736,13 @@ when = "2026-03-31"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
+
+[[publisher.sha2]]
+version = "0.10.9"
+when = "2025-04-30"
+user-id = 5059
+user-login = "newpavlov"
+user-name = "Artyom Pavlov"
 
 [[publisher.slab]]
 version = "0.4.12"
@@ -2596,6 +2610,11 @@ delta = "0.2.17 -> 0.3.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.3 -> 0.3.4"
+
+[[audits.isrg.audits.hmac]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.12.1"
 
 [[audits.isrg.audits.once_cell]]
 who = "Brandon Pitman <bran@bran.land>"


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #

---

## 📝 Summary
Fixes security vulnerability RUSTSEC-2026-0104 in rustls-webpki by updating from version 0.103.12 to 0.103.13.

Security Issue: Reachable panic in certificate revocation list (CRL) parsing when handling syntactically valid empty BIT STRING in IssuingDistributionPoint extension. The panic was reachable before CRL signature verification.

Changes:

Updated rustls-webpki: 0.103.12 → 0.103.13

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [X] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    ✅    |
| Unit tests                | `make test`     |    ✅    |
| Coverage ≥ 80%            | `make coverage` |    ✅    |

---

## ✅ Checklist
- [X] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
