### PR TITLE
ci: route lightweight workflow jobs to ubuntu-slim runners

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -61,7 +61,7 @@ permissions:
 jobs:
   dependency-review:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -51,7 +51,7 @@ jobs:
   lint:
     name: Lint chart
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     permissions:
@@ -78,7 +78,7 @@ jobs:
   publish:
     name: Package and publish to GHCR
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     if: |
       (

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   license-check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   license-check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,21 +58,26 @@ jobs:
         target: [mcpgateway, plugins]
         tool:
           - id: ruff
+            runner: ubuntu-slim
             cmd: "uv tool run ruff==$RUFF_VERSION check $TARGET"
           - id: vulture
+            runner: ubuntu-slim
             cmd: 'uv tool run vulture==$VULTURE_VERSION $TARGET --min-confidence 80 --exclude "*_pb2.py,*_pb2_grpc.py"'
           - id: pylint
+            runner: ubuntu-latest
             cmd: >-
               uv tool run --with-editable . --with pylint-pydantic==$PYLINT_PYDANTIC_VERSION
               pylint==$PYLINT_VERSION $TARGET
               --rcfile=.pylintrc.$TARGET --fail-on E --fail-under=10 --jobs=0
           - id: interrogate
+            runner: ubuntu-slim
             cmd: "uv tool run interrogate==$INTERROGATE_VERSION -vv $TARGET --fail-under 100"
           - id: radon
+            runner: ubuntu-slim
             cmd: "uv tool run radon==$RADON_VERSION cc $TARGET --min C --show-complexity && uv tool run radon==$RADON_VERSION mi $TARGET --min B"
 
     name: "${{ matrix.tool.id }} (${{ matrix.target }})"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.tool.runner }}
     timeout-minutes: 20
 
     steps:
@@ -126,7 +131,7 @@ jobs:
                 xargs -0 -I{} uv tool run tomlcheck==$TOMLCHECK_VERSION "{}"
 
     name: ${{ matrix.id }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/linting-full.yml
+++ b/.github/workflows/linting-full.yml
@@ -21,7 +21,7 @@ jobs:
   linting-full:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: linting-full
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   build-package:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 20
 
     # Build the package under multiple Python versions to catch ABI issues early

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -39,7 +39,7 @@ jobs:
   vitest:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: vitest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -601,7 +601,7 @@ repos:
       - id: check-ci-workflows
         name: 🔐 Check CI Workflows
         description: Verifies CI workflow YAML structure and SHA pinning.
-        entry: uv run python3 scripts/pre-commit/check_ci_workflows.py
+        entry: uv run --no-project --with pyyaml python3 scripts/pre-commit/check_ci_workflows.py
         language: system
         pass_filenames: false
         files: ^\.github/workflows/|^Makefile$


### PR DESCRIPTION
## 📝 Summary

Move CI jobs that don't need cores or RAM from `ubuntu-latest` (4 CPU, 16 GB) to `ubuntu-slim` (1 CPU, 5 GB). The intent is to free up the larger runners for jobs that actually use them (pylint, pytest, cargo, docker buildx, playwright) without slowing the lightweight ones meaningfully.

**Workflow changes**

- **`lint.yml`** — added a per-tool `runner` field in the matrix. `ruff`, `vulture`, `interrogate`, `radon`, and the `syntax-check` matrix (yamllint/jsonlint/tomllint) now run on `ubuntu-slim`. `pylint` stays on `ubuntu-latest` because it imports the project and fans out with `--jobs=0`.
- **`linting-full.yml`** — whole job moves to `ubuntu-slim`. `make linting-full` runs `actionlint`, `reviewdog`, `commitlint`, `helm lint/chart-testing/unittest`, `gosec`, `govulncheck` — none of which need the larger runner.
- **`dependency-review.yml`**, **`helm-publish.yml`** (lint + publish), **`license-check.yml`**, **`vitest.yml`**, **`python-package.yml`** — single-purpose jobs with no compilation or parallel test workload, flipped outright.

**Pre-commit fix (separate commit)**

The `check-ci-workflows` hook imported `pyyaml` but ran under bare `python3`, which fails when the system Python lacks pyyaml. Switched its `entry` to `uv run --no-project --with pyyaml python3 …` so it self-bootstraps without polluting the system Python or rebuilding the project venv.

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)

## 📓 Notes

Workflows left on `ubuntu-latest` deliberately: `pytest`, `pytest-rust`, `rust.*`, `docker-multiplatform`, `docker-scan`, `docker-release`, `playwright`, `alembic-upgrade-validation`, `sql-sanitizer`, `wrapper`, `pre-commit`, `lint-web`. These either compile, run parallel test suites, build container images, or were judged borderline and left for a follow-up after observing slim behavior in practice.

`ubuntu-slim` is a relatively new GitHub-hosted runner tier; if any of the migrated jobs misbehave under 1 CPU / 5 GB, the fix is a one-line revert per workflow.