### PR TITLE
fix(oauth): skip audience enforcement for virtual servers when resource is not configured

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -67,7 +67,8 @@ from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
 from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
-from mcpgateway.db import Server as DbServer, SessionLocal
+from mcpgateway.db import Server as DbServer
+from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
 from mcpgateway.observability import create_span
 from mcpgateway.plugins.framework.models import UserContext

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -55,6 +55,7 @@ from mcp.server.streamable_http import EventCallback, EventId, EventMessage, Eve
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import JSONRPCMessage, PaginatedRequestParams, ReadResourceRequest, ReadResourceRequestParams
 import orjson
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 from starlette.datastructures import Headers
@@ -66,7 +67,7 @@ from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
 from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
-from mcpgateway.db import SessionLocal
+from mcpgateway.db import Server as DbServer, SessionLocal
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
 from mcpgateway.observability import create_span
 from mcpgateway.plugins.framework.models import UserContext
@@ -916,6 +917,47 @@ def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
     if not base:
         return ""
     return f"{base}/.well-known/oauth-protected-resource/servers/{server_id}/mcp"
+
+
+def _persist_learned_server_audience(server_id: str, verified_claims: dict[str, Any], db: Session) -> None:
+    """Persist the ``aud`` claim from a verified OAuth token as ``resource``.
+
+    Called after successful signature + issuer verification. The token's
+    ``aud`` claim is trustworthy at this point and represents the IdP's
+    authoritative audience value. Always overwrites the existing ``resource``
+    so that IdP-side changes (client_id rotation, application migration)
+    are picked up automatically.
+
+    This is a best-effort operation: failures are logged but do not affect
+    the current request's authentication outcome.
+
+    Args:
+        server_id: Virtual-server identifier.
+        verified_claims: Decoded and *signature-verified* JWT claims.
+        db: Active database session.
+    """
+    raw_aud = verified_claims.get("aud")
+    if not raw_aud:
+        return
+
+    try:
+        server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
+        if server is None or not server.oauth_config:
+            return
+
+        if server.oauth_config.get("resource") == raw_aud:
+            return  # Already correct
+
+        updated_config = dict(server.oauth_config)
+        updated_config["resource"] = raw_aud
+        server.oauth_config = updated_config
+        db.flush()
+        logger.info(
+            "Learned and persisted audience for server %s from verified token",
+            sanitize_for_log(server_id),
+        )
+    except Exception:
+        logger.warning("Failed to persist learned audience for server %s", server_id, exc_info=True)
 
 
 async def _check_server_oauth_enforcement(server_id: str, user_context: Optional[dict[str, Any]]) -> None:
@@ -5189,12 +5231,6 @@ class _StreamableHttpAuthHandler:
         server_id = match.group("server_id")
         server_id_log = sanitize_for_log(server_id)
 
-        # Third-Party
-        from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-        # First-Party
-        from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
-
         try:
             async with get_db() as db:
                 server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
@@ -5254,34 +5290,28 @@ class _StreamableHttpAuthHandler:
             )
             return OAuthAuthResult.NOT_APPLICABLE
 
-        # Per RFC 8707/9728, the resource URL is the canonical audience for an
-        # access token bound to this MCP server. We MUST enforce it so that a
-        # token minted for a different API cannot authenticate here just
-        # because it was signed by an allowed issuer. Additional audiences may
-        # be declared explicitly in oauth_config (``resource``, or — for
-        # backward compat — ``client_id``) to accommodate IdPs that issue
-        # tokens with the client_id in ``aud``.
-        resource_url = _build_server_resource_url(self.scope, server_id)
-        if not resource_url:
-            # Can't build a canonical audience — fail closed rather than
-            # accept a token we cannot bind to this resource.
-            logger.warning("Unable to derive resource URL for server %s; rejecting OAuth token", server_id)
-            await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": "Bearer"})
-            return OAuthAuthResult.FAILED
+        # Audience enforcement: if ``resource`` is configured (learned or
+        # manual), enforce it.  Otherwise skip audience and learn from the
+        # verified token.
+        configured_resource = server.oauth_config.get("resource")
+        if configured_resource:
+            claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=configured_resource)
+        else:
+            claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=None)
 
-        expected_audiences: list[str] = [resource_url]
-        extra_audience = server.oauth_config.get("resource") or server.oauth_config.get("client_id")
-        if isinstance(extra_audience, str) and extra_audience.strip():
-            expected_audiences.append(extra_audience.strip())
-        elif isinstance(extra_audience, list):
-            expected_audiences.extend(s.strip() for s in extra_audience if isinstance(s, str) and s.strip())
-
-        claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=expected_audiences)
         if claims is None:
             resource_metadata = _build_resource_metadata_url(self.scope, server_id)
             www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
             await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
             return OAuthAuthResult.FAILED
+
+        # Always persist the token's aud as resource — keeps the stored value
+        # in sync if the IdP changes its audience (e.g. client_id rotation).
+        try:
+            async with get_db() as db:
+                _persist_learned_server_audience(server_id, claims, db)
+        except Exception:
+            logger.warning("Failed to persist learned audience for server %s (caller guard)", server_id, exc_info=True)
 
         # Resolve user identity from verified claims
         user_email = claims.get("email") or claims.get("preferred_username") or claims.get("sub")

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -921,17 +921,69 @@ def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
     return f"{base}/.well-known/oauth-protected-resource/servers/{server_id}/mcp"
 
 
+def _is_valid_audience(value: Any) -> bool:
+    """Return True if ``value`` is an RFC 7519-compliant ``aud`` claim.
+
+    Per RFC 7519 §4.1.3 the ``aud`` claim is either a single ``StringOrURI``
+    or an array of them. PyJWT only enforces this shape when ``verify_aud``
+    is enabled, so a misconfigured IdP could otherwise mint tokens with
+    ``aud`` values like ``{"foo": "bar"}`` or ``42``. Persisting such a value
+    as the server's ``resource`` would then cause a ``TypeError`` inside
+    PyJWT on the *next* request (when it is forwarded as ``audience=...``),
+    locking the server's auth path until the operator manually clears the
+    bogus value. Validate up-front and skip persist on malformed shapes.
+
+    Args:
+        value: The raw ``aud`` claim value to validate.
+
+    Returns:
+        True iff ``value`` is a non-empty string or a non-empty list of
+        non-empty strings; False otherwise.
+    """
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return bool(value) and all(isinstance(item, str) and item.strip() for item in value)
+    return False
+
+
 def _persist_learned_server_audience(server_id: str, verified_claims: dict[str, Any], db: Session) -> None:
     """Persist the ``aud`` claim from a verified OAuth token as ``resource``.
 
-    Called after successful signature + issuer verification. The token's
-    ``aud`` claim is trustworthy at this point and represents the IdP's
-    authoritative audience value. Always overwrites the existing ``resource``
-    so that IdP-side changes (client_id rotation, application migration)
-    are picked up automatically.
+    Called after successful signature + issuer verification of an inbound MCP
+    request. The token's ``aud`` claim is trustworthy at this point and
+    represents the IdP's authoritative audience value.
 
-    This is a best-effort operation: failures are logged but do not affect
-    the current request's authentication outcome.
+    Persistence is **first-write-only**: the learned audience is written only
+    when ``oauth_config["resource"]`` is currently falsy. The MCP request path
+    only enforces server-level access on the inbound caller — it does not
+    require ``servers.update``. Allowing every authenticated request to
+    overwrite shared server configuration would let any user with server
+    access mutate global state on behalf of all other users (last-user-wins).
+    To re-learn a stale audience after an IdP change, an admin must clear the
+    ``resource`` field via the server update API (which does enforce
+    ``servers.update``). This also avoids two related failure modes:
+
+    * Silently collapsing an operator-configured multi-audience list
+      (e.g. ``["aud-a", "aud-b"]``) down to whichever single ``aud`` a given
+      token happened to carry, breaking other clients.
+    * Silently changing the operator's audience binding when an IdP starts
+      emitting unexpected ``aud`` values; an explicit auth failure is
+      preferable so the operator notices.
+
+    Empty strings and empty lists count as unset (Python truthiness), so an
+    admin can clear the field to either falsy value to trigger re-learning
+    on the next request.
+
+    Malformed ``aud`` values (anything other than a non-empty string or a
+    non-empty list of non-empty strings) are rejected up-front via
+    :func:`_is_valid_audience` so a bogus persist cannot break subsequent
+    requests inside PyJWT.
+
+    This is a best-effort operation: opaque tokens, missing ``aud`` claims,
+    and already-set (truthy) resources are silently skipped; downstream DB
+    failures are logged but do not affect the current request's authentication
+    outcome.
 
     Args:
         server_id: Virtual-server identifier.
@@ -939,7 +991,13 @@ def _persist_learned_server_audience(server_id: str, verified_claims: dict[str, 
         db: Active database session.
     """
     raw_aud = verified_claims.get("aud")
-    if not raw_aud:
+    if not _is_valid_audience(raw_aud):
+        if raw_aud is not None:
+            logger.warning(
+                "Refusing to persist malformed aud claim for server %s (type=%s)",
+                sanitize_for_log(server_id),
+                type(raw_aud).__name__,
+            )
         return
 
     try:
@@ -947,15 +1005,20 @@ def _persist_learned_server_audience(server_id: str, verified_claims: dict[str, 
         if server is None or not server.oauth_config:
             return
 
-        if server.oauth_config.get("resource") == raw_aud:
-            return  # Already correct
+        # First-write-only: do not overwrite an existing usable resource.
+        # Empty strings and empty lists are treated as unset (Python
+        # truthiness) so an admin can clear the field via the server update
+        # API to trigger re-learning. See docstring for the authorization
+        # rationale.
+        if server.oauth_config.get("resource"):
+            return
 
         updated_config = dict(server.oauth_config)
         updated_config["resource"] = raw_aud
         server.oauth_config = updated_config
         db.flush()
         logger.info(
-            "Learned and persisted audience for server %s from verified token",
+            "Learned OAuth audience from IdP token for server %s; persisted as resource",
             sanitize_for_log(server_id),
         )
     except Exception:
@@ -5252,14 +5315,44 @@ class _StreamableHttpAuthHandler:
             )
             return OAuthAuthResult.NOT_APPLICABLE
 
-        # Audience enforcement: if ``resource`` is configured (learned or
-        # manual), enforce it.  Otherwise skip audience and learn from the
-        # verified token.
+        # Audience enforcement strategy:
+        #
+        # 1. ``resource`` configured (operator-set or previously learned)
+        #    → enforce it strictly.
+        # 2. ``resource`` unset → fall back to a list of acceptable
+        #    audiences derived from operator config:
+        #      * the canonical RFC 8707/9728 resource URL, and
+        #      * the legacy ``client_id`` field (for IdPs like Authentik
+        #        that mint tokens with ``aud == client_id``).
+        #    PyJWT's "any element matches" semantics accept either.
+        # 3. Neither configured → fail closed. Skipping audience entirely
+        #    would let any token from an allowed issuer authenticate here,
+        #    enabling cross-resource token confusion in shared-IdP
+        #    deployments.
         configured_resource = server.oauth_config.get("resource")
+        expected_audience: Optional[Union[str, list[str]]]
         if configured_resource:
-            claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=configured_resource)
+            expected_audience = configured_resource
         else:
-            claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=None)
+            fallback_audiences: list[str] = []
+            canonical_url = _build_server_resource_url(self.scope, server_id)
+            if canonical_url:
+                fallback_audiences.append(canonical_url)
+            legacy_client_id = server.oauth_config.get("client_id")
+            if isinstance(legacy_client_id, str) and legacy_client_id.strip():
+                fallback_audiences.append(legacy_client_id.strip())
+            if not fallback_audiences:
+                logger.warning(
+                    "Server %s has no resource or client_id configured and no canonical resource URL could be derived; rejecting OAuth token",
+                    server_id_log,
+                )
+                resource_metadata = _build_resource_metadata_url(self.scope, server_id)
+                www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
+                await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
+                return OAuthAuthResult.FAILED
+            expected_audience = fallback_audiences[0] if len(fallback_audiences) == 1 else fallback_audiences
+
+        claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=expected_audience)
 
         if claims is None:
             resource_metadata = _build_resource_metadata_url(self.scope, server_id)
@@ -5267,8 +5360,9 @@ class _StreamableHttpAuthHandler:
             await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
             return OAuthAuthResult.FAILED
 
-        # Always persist the token's aud as resource — keeps the stored value
-        # in sync if the IdP changes its audience (e.g. client_id rotation).
+        # Best-effort: persist the verified aud so subsequent requests use
+        # the strict ``resource`` path. ``_persist_learned_server_audience``
+        # is a no-op when ``resource`` is already set.
         try:
             async with get_db() as db:
                 _persist_learned_server_audience(server_id, claims, db)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -67,6 +67,7 @@ from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
 from mcpgateway.common.validators import validate_meta_data as _validate_meta_data
 from mcpgateway.config import settings
+from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Server as DbServer
 from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
@@ -1000,13 +1001,6 @@ async def _check_server_oauth_enforcement(server_id: str, user_context: Optional
         _oauth_checked_var.set(True)
         return  # Already authenticated — no need to check
 
-    # Lazy DB lookup to avoid import-time side-effects
-    # Third-Party
-    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-    # First-Party
-    from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
-
     try:
         async with get_db() as db:
             server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
@@ -1618,12 +1612,6 @@ async def call_tool(name: str, arguments: dict) -> Union[
     if gateway_id_from_header:
         try:  # Check if this gateway is in direct_proxy mode
             async with get_db() as check_db:
-                # Third-Party
-                from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-                # First-Party
-                from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
-
                 gateway = check_db.execute(select(DbGateway).where(DbGateway.id == gateway_id_from_header)).scalar_one_or_none()
                 if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                     # SECURITY: Check gateway access before allowing direct proxy
@@ -2130,12 +2118,6 @@ async def list_tools() -> List[types.Tool]:
 
                 # If X-Context-Forge-Gateway-Id is provided, check if that gateway is in direct_proxy mode
                 if gateway_id:
-                    # Third-Party
-                    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-                    # First-Party
-                    from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
-
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                     if gateway and getattr(gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                         # SECURITY: Check gateway access before allowing direct proxy
@@ -2166,12 +2148,6 @@ async def list_tools() -> List[types.Tool]:
                         logger.warning("Gateway %s specified in %s header not found", gateway_id, GATEWAY_ID_HEADER)
 
                 # Check if server exists for cache mode
-                # Third-Party
-                from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-                # First-Party
-                from mcpgateway.db import Server as DbServer  # pylint: disable=import-outside-toplevel
-
                 server = db.execute(select(DbServer).where(DbServer.id == server_id)).scalar_one_or_none()
                 if not server:
                     logger.warning("Server %s not found in database", server_id)
@@ -2428,12 +2404,6 @@ async def list_resources() -> List[types.Resource]:
 
                 # If X-Context-Forge-Gateway-Id is provided, check if that gateway is in direct_proxy mode
                 if gateway_id:
-                    # Third-Party
-                    from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-                    # First-Party
-                    from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
-
                     gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                     if gateway and gateway.gateway_mode == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                         # SECURITY: Check gateway access before allowing direct proxy
@@ -2555,12 +2525,6 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
 
             # If X-Context-Forge-Gateway-Id is provided, check if that gateway is in direct_proxy mode
             if gateway_id:
-                # Third-Party
-                from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
-                # First-Party
-                from mcpgateway.db import Gateway as DbGateway  # pylint: disable=import-outside-toplevel
-
                 gateway = db.execute(select(DbGateway).where(DbGateway.id == gateway_id)).scalar_one_or_none()
                 if gateway and gateway.gateway_mode == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
                     # SECURITY: Check gateway access before allowing direct proxy
@@ -5039,9 +5003,6 @@ class _StreamableHttpAuthHandler:
             # DB/cache, so a second membership query would be redundant.
             if token_use != "session" and final_teams and len(final_teams) > 0 and user_email:  # nosec B105
                 # Import lazily to avoid circular imports
-                # Third-Party
-                from sqlalchemy import select  # pylint: disable=import-outside-toplevel
-
                 # First-Party
                 from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
                 from mcpgateway.db import EmailTeamMember  # pylint: disable=import-outside-toplevel

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -4923,9 +4923,9 @@ class TestTryOAuthAccessTokenDbErrors:
 
         assert result is OAuthAuthResult.FAILED
         assert captured["authorization_servers"] == ["https://single.example/"]
-        # No ``resource``/``client_id`` configured → audience enforcement is
-        # skipped so the handler can learn the IdP's actual audience.
-        assert captured["expected_audience"] is None
+        # No ``resource``/``client_id`` configured → handler falls back to
+        # the canonical RFC 8707 resource URL (derived from app_domain).
+        assert captured["expected_audience"] == "https://gateway.example.com/servers/srv-1/mcp"
 
 
 # ---------------------------------------------------------------------------
@@ -5036,11 +5036,13 @@ def _pinned_app_domain(monkeypatch):
 class TestOAuthAudienceEnforcement:
     """Audience enforcement behavior for OAuth-enabled virtual servers.
 
-    When ``resource`` (or legacy ``client_id``) is configured in
-    ``oauth_config``, the handler enforces it strictly alongside the
-    canonical resource URL. When neither is configured, audience
-    enforcement is skipped (signature + issuer only) and the verified
-    token's ``aud`` is persisted as ``resource`` for subsequent requests.
+    When ``resource`` is configured in ``oauth_config`` (operator-set or
+    previously learned), the handler enforces it strictly. When ``resource``
+    is unset, the handler falls back to a list of acceptable audiences
+    derived from ``[canonical resource URL, client_id]`` so first-request
+    auth is still bound to known operator-controlled values. Skipping
+    audience entirely would let any token from an allowed issuer
+    authenticate (cross-resource token confusion).
 
     This accommodates IdPs that do not support RFC 8707 and set ``aud``
     to an abstract identifier (e.g. the OAuth client_id) rather than the
@@ -5048,8 +5050,8 @@ class TestOAuthAudienceEnforcement:
     """
 
     @pytest.mark.asyncio
-    async def test_no_resource_skips_audience_enforcement(self, _pinned_app_domain):
-        """Server with only ``authorization_servers`` skips audience enforcement."""
+    async def test_no_resource_falls_back_to_canonical_url(self, _pinned_app_domain):
+        """Server with only ``authorization_servers`` falls back to canonical URL."""
         handler, _responses = _make_handler()
         server = MagicMock()
         server.oauth_enabled = True
@@ -5068,9 +5070,51 @@ class TestOAuthAudienceEnforcement:
             result = await handler._try_oauth_access_token(_make_idp_token())
 
         assert result is OAuthAuthResult.FAILED
-        # No resource configured → audience enforcement is skipped so the
-        # handler can learn the IdP's actual audience from the verified token.
-        assert captured["expected_audience"] is None
+        assert captured["expected_audience"] == EXPECTED_RESOURCE_URL
+
+    @pytest.mark.asyncio
+    async def test_no_resource_includes_client_id_in_fallback(self, _pinned_app_domain):
+        """When ``client_id`` is set but ``resource`` is not, both feed the fallback list."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "client_id": "my-client-id"}
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", new_callable=AsyncMock),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL, "my-client-id"]
+
+    @pytest.mark.asyncio
+    async def test_no_resource_no_client_id_no_canonical_fails_closed(self, monkeypatch):
+        """No resource, no client_id, no derivable canonical URL → 401 fail closed."""
+        monkeypatch.setattr(settings, "app_domain", "")
+        handler, _responses = _make_handler_unknown_host()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        verify_mock = AsyncMock(return_value={"sub": "user", "aud": "anything"})
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", verify_mock),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience") as persist_mock,
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        verify_mock.assert_not_awaited()
+        persist_mock.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_resource_field_used_as_expected_audience(self, _pinned_app_domain):
@@ -5368,6 +5412,70 @@ class TestPersistLearnedServerAudience:
         # the handler should not fail the auth flow.
         assert result is OAuthAuthResult.SUCCESS
 
+    @pytest.mark.asyncio
+    async def test_first_request_learns_then_second_request_enforces_strictly(self, _pinned_app_domain):
+        """Stateful regression: first-request learn → second-request strict enforce."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = dict({"authorization_servers": [IDP_ISSUER]})
+
+        verified_claims = {"sub": "user@example.com", "email": "user@example.com", "aud": EXPECTED_RESOURCE_URL}
+
+        captured_audiences: list = []
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured_audiences.append(expected_audience)
+            return verified_claims
+
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a"]
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result_one = await handler._try_oauth_access_token(_make_idp_token())
+            assert result_one is OAuthAuthResult.SUCCESS
+            assert captured_audiences[0] == EXPECTED_RESOURCE_URL
+            assert server.oauth_config["resource"] == EXPECTED_RESOURCE_URL
+
+            handler_two, _ = _make_handler()
+            result_two = await handler_two._try_oauth_access_token(_make_idp_token())
+            assert result_two is OAuthAuthResult.SUCCESS
+            assert captured_audiences[1] == EXPECTED_RESOURCE_URL
+
+    @pytest.mark.asyncio
+    async def test_token_without_aud_succeeds_but_does_not_persist(self, _pinned_app_domain):
+        """Token without ``aud`` claim: handler succeeds; persist helper no-ops."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = dict({"authorization_servers": [IDP_ISSUER]})
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            return {"sub": "user@example.com", "email": "user@example.com"}
+
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a"]
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.SUCCESS
+        assert "resource" not in server.oauth_config
+
 
 class TestPersistLearnedServerAudienceUnit:
     """Direct unit tests for ``_persist_learned_server_audience``."""
@@ -5446,8 +5554,13 @@ class TestPersistLearnedServerAudienceUnit:
         # Aud matches existing resource — flush should NOT be called.
         db_mock.flush.assert_not_called()
 
-    def test_overwrites_when_aud_differs_from_existing_resource(self):
-        """If ``resource`` differs from the token's ``aud``, overwrite it."""
+    def test_preserves_existing_resource_when_aud_differs(self):
+        """If ``resource`` is already set, the helper preserves it (learn-once policy).
+
+        Silent overwrite would (a) collapse operator-configured multi-audience
+        lists and (b) hide IdP-side audience changes that should produce an
+        explicit auth failure. Operators must clear ``resource`` to re-learn.
+        """
         # First-Party
         from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
 
@@ -5459,8 +5572,95 @@ class TestPersistLearnedServerAudienceUnit:
 
         _persist_learned_server_audience("srv-1", {"aud": "new-client-id", "sub": "user"}, db_mock)
 
-        assert server.oauth_config["resource"] == "new-client-id"
+        assert server.oauth_config["resource"] == "old-client-id"
+        db_mock.flush.assert_not_called()
+
+    def test_preserves_existing_list_resource(self):
+        """A list-valued ``resource`` is never collapsed to a scalar (B3)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict(
+            {
+                "authorization_servers": ["https://idp.example.com"],
+                "resource": ["aud-a", "aud-b"],
+            }
+        )
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "aud-a", "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == ["aud-a", "aud-b"]
+        db_mock.flush.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "falsy_resource",
+        ["", [], None],
+        ids=["empty_string", "empty_list", "none"],
+    )
+    def test_falsy_existing_resource_triggers_relearning(self, falsy_resource):
+        """Falsy ``resource`` (empty string/list/None) counts as unset → re-learn."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict(
+            {
+                "authorization_servers": ["https://idp.example.com"],
+                "resource": falsy_resource,
+            }
+        )
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "learned-client-id", "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == "learned-client-id"
         db_mock.flush.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "bad_aud",
+        [
+            {"foo": "bar"},
+            42,
+            ["", "valid"],
+            [42, "valid"],
+            [],
+            "",
+            "   ",
+        ],
+        ids=["dict", "int", "list_with_empty_string", "list_with_int", "empty_list", "empty_string", "whitespace_string"],
+    )
+    def test_skips_when_aud_is_malformed(self, bad_aud):
+        """Malformed ``aud`` shapes are rejected before persisting (B2)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        db_mock = MagicMock()
+
+        _persist_learned_server_audience("srv-1", {"aud": bad_aud, "sub": "user"}, db_mock)
+
+        db_mock.execute.assert_not_called()
+        db_mock.flush.assert_not_called()
+
+    def test_skips_when_oauth_config_is_none(self):
+        """``server.oauth_config`` being None is handled gracefully (no flush)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = None
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        db_mock.flush.assert_not_called()
 
     def test_db_error_is_swallowed(self):
         """DB errors during persist are logged but do not propagate."""

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -5097,9 +5097,9 @@ class TestOAuthAudienceEnforcement:
 
     @pytest.mark.asyncio
     async def test_no_resource_no_client_id_no_canonical_fails_closed(self, monkeypatch):
-        """No resource, no client_id, no derivable canonical URL → 401 fail closed."""
+        """No resource, no client_id, no derivable canonical URL → 401 fail closed with WWW-Authenticate."""
         monkeypatch.setattr(settings, "app_domain", "")
-        handler, _responses = _make_handler_unknown_host()
+        handler, responses = _make_handler_unknown_host()
         server = MagicMock()
         server.oauth_enabled = True
         server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
@@ -5115,6 +5115,65 @@ class TestOAuthAudienceEnforcement:
         assert result is OAuthAuthResult.FAILED
         verify_mock.assert_not_awaited()
         persist_mock.assert_not_called()
+
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
+        header_dict = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+        assert "www-authenticate" in header_dict
+        assert header_dict["www-authenticate"].startswith("Bearer")
+        assert b"Invalid OAuth access token" in _response_body(responses)
+
+    @pytest.mark.asyncio
+    async def test_no_canonical_url_falls_back_to_client_id_only(self, monkeypatch):
+        """When canonical URL cannot be derived but ``client_id`` is set, fallback uses client_id alone (C4)."""
+        monkeypatch.setattr(settings, "app_domain", "")
+        handler, _responses = _make_handler_unknown_host()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "client_id": "my-client-id"}
+
+        captured: dict = {}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            captured["expected_audience"] = expected_audience
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", new_callable=AsyncMock),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        # Single-element fallback collapses to scalar (per len-check at the call site).
+        assert captured["expected_audience"] == "my-client-id"
+
+    @pytest.mark.parametrize(
+        "client_id_value",
+        ["   ", "", 42, ["my-client-id"], {"id": "x"}, None],
+        ids=["whitespace_string", "empty_string", "int", "list", "dict", "none"],
+    )
+    @pytest.mark.asyncio
+    async def test_client_id_non_string_or_blank_treated_as_missing(self, monkeypatch, client_id_value):
+        """Non-string or whitespace-only ``client_id`` is excluded from the fallback list (C7/C8)."""
+        monkeypatch.setattr(settings, "app_domain", "")
+        handler, responses = _make_handler_unknown_host()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "client_id": client_id_value}
+
+        verify_mock = AsyncMock(return_value={"sub": "user", "aud": "anything"})
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", verify_mock),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", new_callable=AsyncMock),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.FAILED
+        verify_mock.assert_not_awaited()
+        start = next(m for m in responses if m["type"] == "http.response.start")
+        assert start["status"] == 401
 
     @pytest.mark.asyncio
     async def test_resource_field_used_as_expected_audience(self, _pinned_app_domain):
@@ -5632,20 +5691,35 @@ class TestPersistLearnedServerAudienceUnit:
             [],
             "",
             "   ",
+            [None],
+            ["   "],
         ],
-        ids=["dict", "int", "list_with_empty_string", "list_with_int", "empty_list", "empty_string", "whitespace_string"],
+        ids=[
+            "dict",
+            "int",
+            "list_with_empty_string",
+            "list_with_int",
+            "empty_list",
+            "empty_string",
+            "whitespace_string",
+            "list_with_none",
+            "list_with_whitespace_string",
+        ],
     )
-    def test_skips_when_aud_is_malformed(self, bad_aud):
-        """Malformed ``aud`` shapes are rejected before persisting (B2)."""
+    def test_skips_when_aud_is_malformed(self, bad_aud, caplog):
+        """Malformed ``aud`` shapes are rejected before persisting and a warning is logged (B2)."""
         # First-Party
         from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
 
         db_mock = MagicMock()
 
-        _persist_learned_server_audience("srv-1", {"aud": bad_aud, "sub": "user"}, db_mock)
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.transports.streamablehttp_transport"):
+            _persist_learned_server_audience("srv-1", {"aud": bad_aud, "sub": "user"}, db_mock)
 
         db_mock.execute.assert_not_called()
         db_mock.flush.assert_not_called()
+        assert "Refusing to persist malformed aud claim" in caplog.text
+        assert "srv-1" in caplog.text
 
     def test_skips_when_oauth_config_is_none(self):
         """``server.oauth_config`` being None is handled gracefully (no flush)."""
@@ -5662,16 +5736,100 @@ class TestPersistLearnedServerAudienceUnit:
 
         db_mock.flush.assert_not_called()
 
-    def test_db_error_is_swallowed(self):
-        """DB errors during persist are logged but do not propagate."""
+    def test_skips_when_oauth_config_is_empty_dict(self):
+        """``server.oauth_config`` being an empty dict is handled gracefully (B5)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = {}
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        db_mock.flush.assert_not_called()
+
+    def test_skips_when_server_row_is_none(self):
+        """``db.execute(...).scalar_one_or_none()`` returning None is handled gracefully (B4)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = None
+
+        _persist_learned_server_audience("srv-missing", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        db_mock.flush.assert_not_called()
+
+    def test_flush_error_is_swallowed_and_logged(self, caplog):
+        """``db.flush()`` raising is caught by the outer except and logged (B12)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"]})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+        db_mock.flush.side_effect = RuntimeError("constraint violation")
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.transports.streamablehttp_transport"):
+            _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        assert "Failed to persist learned audience for server srv-1" in caplog.text
+
+    def test_db_error_is_swallowed(self, caplog):
+        """DB errors during persist are logged but do not propagate (B11)."""
         # First-Party
         from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
 
         db_mock = MagicMock()
         db_mock.execute.side_effect = RuntimeError("connection refused")
 
-        # Should not raise.
-        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.transports.streamablehttp_transport"):
+            _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        assert "Failed to persist learned audience for server srv-1" in caplog.text
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (None, False),
+            ("", False),
+            ("   ", False),
+            ("aud", True),
+            ([], False),
+            ([None], False),
+            ([""], False),
+            (["aud"], True),
+            (["aud-a", "aud-b"], True),
+            ({"foo": "bar"}, False),
+            (42, False),
+            (b"aud", False),
+        ],
+        ids=[
+            "none",
+            "empty_string",
+            "whitespace_string",
+            "valid_string",
+            "empty_list",
+            "list_with_none",
+            "list_with_empty_string",
+            "list_with_one_valid",
+            "list_with_two_valid",
+            "dict",
+            "int",
+            "bytes",
+        ],
+    )
+    def test_is_valid_audience_directly(self, value, expected):
+        """Direct unit test of the shape validator across all RFC 7519 §4.1.3 edge cases (A1-A10)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _is_valid_audience  # pylint: disable=import-outside-toplevel
+
+        assert _is_valid_audience(value) is expected
 
 
 class TestOAuthServerMisconfigurationRejected:

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -4923,11 +4923,9 @@ class TestTryOAuthAccessTokenDbErrors:
 
         assert result is OAuthAuthResult.FAILED
         assert captured["authorization_servers"] == ["https://single.example/"]
-        # Audience enforcement: the canonical MCP resource URL (derived from
-        # ``settings.app_domain``, not the Host header) is always included.
-        # Without an explicit ``client_id``/``resource`` override, the list
-        # contains only that one entry.
-        assert captured["expected_audience"] == ["https://gateway.example.com/servers/srv-1/mcp"]
+        # No ``resource``/``client_id`` configured → audience enforcement is
+        # skipped so the handler can learn the IdP's actual audience.
+        assert captured["expected_audience"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -5036,18 +5034,22 @@ def _pinned_app_domain(monkeypatch):
 
 
 class TestOAuthAudienceEnforcement:
-    """Every OAuth-enabled server must bind tokens to its canonical resource URL.
+    """Audience enforcement behavior for OAuth-enabled virtual servers.
 
-    Invariant: ``_try_oauth_access_token`` MUST pass a non-empty
-    ``expected_audience`` list containing the canonical MCP resource URL
-    (per RFC 8707 / RFC 9728) to ``verify_oauth_access_token``. Explicit
-    ``resource`` / legacy ``client_id`` values extend the list; they never
-    replace the resource URL or silently disable audience validation.
+    When ``resource`` (or legacy ``client_id``) is configured in
+    ``oauth_config``, the handler enforces it strictly alongside the
+    canonical resource URL. When neither is configured, audience
+    enforcement is skipped (signature + issuer only) and the verified
+    token's ``aud`` is persisted as ``resource`` for subsequent requests.
+
+    This accommodates IdPs that do not support RFC 8707 and set ``aud``
+    to an abstract identifier (e.g. the OAuth client_id) rather than the
+    resource URL the client requested.
     """
 
     @pytest.mark.asyncio
-    async def test_resource_url_is_sole_audience_when_no_override(self, _pinned_app_domain):
-        """Server with only ``authorization_servers`` must enforce the resource URL."""
+    async def test_no_resource_skips_audience_enforcement(self, _pinned_app_domain):
+        """Server with only ``authorization_servers`` skips audience enforcement."""
         handler, _responses = _make_handler()
         server = MagicMock()
         server.oauth_enabled = True
@@ -5056,25 +5058,23 @@ class TestOAuthAudienceEnforcement:
         captured: dict = {}
 
         async def fake_verify(token, authorization_servers, *, expected_audience=None):
-            # Returning implicitly (None) causes _try_oauth_access_token
-            # to send a 401 and return FAILED.
             captured["expected_audience"] = expected_audience
 
         with (
             _patched_get_db(server),
             patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", new_callable=AsyncMock),
         ):
             result = await handler._try_oauth_access_token(_make_idp_token())
 
         assert result is OAuthAuthResult.FAILED
-        # Length-1 list: exactly the resource URL, nothing else. This is the
-        # core audience-binding invariant — any mutation that drops the
-        # resource URL or re-introduces a ``None`` default fails here.
-        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL]
+        # No resource configured → audience enforcement is skipped so the
+        # handler can learn the IdP's actual audience from the verified token.
+        assert captured["expected_audience"] is None
 
     @pytest.mark.asyncio
-    async def test_resource_field_extends_expected_audiences(self, _pinned_app_domain):
-        """``oauth_config.resource`` (scalar) is appended after the resource URL."""
+    async def test_resource_field_used_as_expected_audience(self, _pinned_app_domain):
+        """``oauth_config.resource`` (scalar) is passed directly as expected_audience."""
         handler, _responses = _make_handler()
         server = MagicMock()
         server.oauth_enabled = True
@@ -5095,35 +5095,11 @@ class TestOAuthAudienceEnforcement:
             result = await handler._try_oauth_access_token(_make_idp_token())
 
         assert result is OAuthAuthResult.FAILED
-        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL, "https://api.example.com"]
-
-    @pytest.mark.asyncio
-    async def test_resource_field_trims_whitespace(self, _pinned_app_domain):
-        """Scalar ``resource`` entries are stripped of leading/trailing whitespace."""
-        handler, _responses = _make_handler()
-        server = MagicMock()
-        server.oauth_enabled = True
-        server.oauth_config = {
-            "authorization_servers": [IDP_ISSUER],
-            "resource": "   https://api.example.com   ",
-        }
-
-        captured: dict = {}
-
-        async def fake_verify(token, authorization_servers, *, expected_audience=None):
-            captured["expected_audience"] = expected_audience
-
-        with (
-            _patched_get_db(server),
-            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
-        ):
-            await handler._try_oauth_access_token(_make_idp_token())
-
-        assert captured["expected_audience"] == [EXPECTED_RESOURCE_URL, "https://api.example.com"]
+        assert captured["expected_audience"] == "https://api.example.com"
 
     @pytest.mark.asyncio
     async def test_resource_field_accepts_list_of_audiences(self, _pinned_app_domain):
-        """``oauth_config.resource`` may be a list; each entry is appended."""
+        """``oauth_config.resource`` list is passed directly as expected_audience."""
         handler, _responses = _make_handler()
         server = MagicMock()
         server.oauth_enabled = True
@@ -5144,22 +5120,16 @@ class TestOAuthAudienceEnforcement:
             result = await handler._try_oauth_access_token(_make_idp_token())
 
         assert result is OAuthAuthResult.FAILED
-        assert captured["expected_audience"] == [
-            EXPECTED_RESOURCE_URL,
-            "https://api-a.example.com",
-            "https://api-b.example.com",
-        ]
+        assert captured["expected_audience"] == ["https://api-a.example.com", "https://api-b.example.com"]
 
     @pytest.mark.asyncio
-    async def test_resource_list_filters_invalid_entries(self, _pinned_app_domain):
-        """Empty strings, whitespace, and non-string entries are dropped from ``resource`` lists."""
-        handler, _responses = _make_handler()
+    async def test_resource_used_regardless_of_app_domain(self, monkeypatch):
+        """Configured ``resource`` is used even when ``settings.app_domain`` is unusable."""
+        monkeypatch.setattr(settings, "app_domain", "")
+        handler, responses = _make_handler()
         server = MagicMock()
         server.oauth_enabled = True
-        server.oauth_config = {
-            "authorization_servers": [IDP_ISSUER],
-            "resource": ["https://api-a.example.com", "", "   ", 42, None, "https://api-b.example.com"],
-        }
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "resource": "https://api.example.com"}
 
         captured: dict = {}
 
@@ -5170,50 +5140,13 @@ class TestOAuthAudienceEnforcement:
             _patched_get_db(server),
             patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
         ):
-            await handler._try_oauth_access_token(_make_idp_token())
-
-        assert captured["expected_audience"] == [
-            EXPECTED_RESOURCE_URL,
-            "https://api-a.example.com",
-            "https://api-b.example.com",
-        ]
-
-    @pytest.mark.asyncio
-    async def test_fail_closed_when_resource_url_cannot_be_derived(self, monkeypatch):
-        """If ``settings.app_domain`` is unusable, reject without verifying.
-
-        Operators MUST set ``app_domain`` to the gateway's public URL for
-        OAuth audience validation to work. If it is empty / missing the
-        handler must fail closed, not fall back to the caller-controlled
-        Host header (which would let a client forge the audience).
-        """
-        monkeypatch.setattr(settings, "app_domain", "")
-        handler, responses = _make_handler()
-        server = MagicMock()
-        server.oauth_enabled = True
-        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
-
-        verify_called = False
-
-        async def fake_verify(*_args, **_kwargs):
-            nonlocal verify_called
-            verify_called = True
-            return {"sub": "x"}
-
-        with (
-            _patched_get_db(server),
-            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
-        ):
             result = await handler._try_oauth_access_token(_make_idp_token(), {"iss": IDP_ISSUER})
 
         assert result is OAuthAuthResult.FAILED
-        assert verify_called is False  # Verification was short-circuited.
-        start = next(m for m in responses if m["type"] == "http.response.start")
-        assert start["status"] == 401
-        assert b"Invalid OAuth access token" in _response_body(responses)
+        assert captured["expected_audience"] == "https://api.example.com"
 
     @pytest.mark.asyncio
-    async def test_audience_ignores_host_header(self, monkeypatch):
+    async def test_audience_ignores_host_header_when_resource_configured(self, monkeypatch):
         """The resource URL is anchored on ``settings.app_domain``, not the caller's Host header.
 
         If the audience were derived from the inbound ``Host`` header, a
@@ -5221,6 +5154,9 @@ class TestOAuthAudienceEnforcement:
         simply by sending ``Host: other.example.com``. Pin ``app_domain`` to
         one value and the handler's scope Host to a *different* value — the
         computed audience must match ``app_domain``.
+
+        This test uses a server with ``resource`` configured to exercise the
+        strict audience path.
         """
         monkeypatch.setattr(settings, "app_domain", "https://canonical.example.com")
 
@@ -5250,7 +5186,7 @@ class TestOAuthAudienceEnforcement:
 
         server = MagicMock()
         server.oauth_enabled = True
-        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "resource": "https://api.example.com"}
 
         captured: dict = {}
 
@@ -5263,8 +5199,8 @@ class TestOAuthAudienceEnforcement:
         ):
             await handler._try_oauth_access_token(_make_idp_token())
 
-        assert captured["expected_audience"] == [f"https://canonical.example.com/servers/{SERVER_ID}/mcp"]
-        assert not any("attacker.example.com" in aud for aud in captured["expected_audience"])
+        assert captured["expected_audience"] == "https://api.example.com"
+        assert "attacker.example.com" not in str(captured["expected_audience"])
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -5276,12 +5212,10 @@ class TestOAuthAudienceEnforcement:
         ],
     )
     async def test_audience_ignores_forwarded_host_headers(self, monkeypatch, spoofed_header):
-        """Forwarded-host header variants must not influence the audience either.
+        """Forwarded-host header variants must not influence the audience.
 
-        Today the resource URL is anchored on ``settings.app_domain`` and
-        the scope is explicitly ignored — but if a future change re-reads
-        any host-indicator header from the scope, this parametrized test
-        fails loudly for each forwarded-host variant.
+        ``resource`` is passed directly from ``oauth_config``; inbound
+        headers play no role.
         """
         monkeypatch.setattr(settings, "app_domain", "https://canonical.example.com")
 
@@ -5312,7 +5246,7 @@ class TestOAuthAudienceEnforcement:
 
         server = MagicMock()
         server.oauth_enabled = True
-        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "resource": "https://api.example.com"}
 
         captured: dict = {}
 
@@ -5325,8 +5259,219 @@ class TestOAuthAudienceEnforcement:
         ):
             await handler._try_oauth_access_token(_make_idp_token())
 
-        assert captured["expected_audience"] == [f"https://canonical.example.com/servers/{SERVER_ID}/mcp"]
-        assert not any("attacker.example.com" in aud for aud in captured["expected_audience"])
+        assert captured["expected_audience"] == "https://api.example.com"
+        assert "attacker.example.com" not in str(captured["expected_audience"])
+
+
+class TestPersistLearnedServerAudience:
+    """Tests for auto-learning and persisting the IdP's audience claim.
+
+    When ``resource`` is not configured on a virtual server, the handler
+    skips audience enforcement and learns the IdP's ``aud`` from the first
+    verified token.
+    """
+
+    @pytest.mark.asyncio
+    async def test_persist_called_when_no_resource(self, _pinned_app_domain):
+        """When ``resource`` is absent, the handler calls ``_persist_learned_server_audience``."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        verified_claims = {"sub": "user@example.com", "email": "user@example.com", "aud": "my-client-id"}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            return verified_claims
+
+        mock_persist = MagicMock()
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a"]
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", mock_persist),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.SUCCESS
+        mock_persist.assert_called_once()
+        call_args = mock_persist.call_args
+        assert call_args[0][0] == SERVER_ID
+        assert call_args[0][1] == verified_claims
+
+    @pytest.mark.asyncio
+    async def test_persist_called_when_resource_is_configured(self, _pinned_app_domain):
+        """When ``resource`` is present, persist is still called (updates on aud change)."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER], "resource": "https://api.example.com"}
+
+        verified_claims = {"sub": "user@example.com", "email": "user@example.com", "aud": "https://api.example.com"}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            return verified_claims
+
+        mock_persist = MagicMock()
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a"]
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", mock_persist),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        assert result is OAuthAuthResult.SUCCESS
+        mock_persist.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_does_not_break_auth(self, _pinned_app_domain):
+        """If persisting the learned audience fails, the auth flow still succeeds."""
+        handler, _responses = _make_handler()
+        server = MagicMock()
+        server.oauth_enabled = True
+        server.oauth_config = {"authorization_servers": [IDP_ISSUER]}
+
+        verified_claims = {"sub": "user@example.com", "email": "user@example.com", "aud": "my-client-id"}
+
+        async def fake_verify(token, authorization_servers, *, expected_audience=None):
+            return verified_claims
+
+        mock_persist = MagicMock(side_effect=RuntimeError("DB exploded"))
+        mock_user = MagicMock(is_active=True, is_admin=False)
+
+        async def fake_resolve_teams(*_args, **_kwargs):
+            return ["team-a"]
+
+        with (
+            _patched_get_db(server),
+            patch("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", side_effect=fake_verify),
+            patch("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", mock_persist),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._resolve_teams_from_db", side_effect=fake_resolve_teams),
+        ):
+            result = await handler._try_oauth_access_token(_make_idp_token())
+
+        # The persist function has its own try/except, but even if it propagated,
+        # the handler should not fail the auth flow.
+        assert result is OAuthAuthResult.SUCCESS
+
+
+class TestPersistLearnedServerAudienceUnit:
+    """Direct unit tests for ``_persist_learned_server_audience``."""
+
+    def test_persists_string_aud(self):
+        """A scalar ``aud`` claim is persisted as a string ``resource``."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"]})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == "my-client-id"
+        db_mock.flush.assert_called_once()
+
+    def test_persists_list_aud_single_element(self):
+        """A single-element ``aud`` list is persisted as-is (not collapsed to scalar)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"]})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": ["my-client-id"], "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == ["my-client-id"]
+
+    def test_persists_list_aud_multiple_elements(self):
+        """A multi-element ``aud`` list is persisted as a list."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"]})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": ["aud-a", "aud-b"], "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == ["aud-a", "aud-b"]
+
+    def test_skips_when_aud_missing(self):
+        """No ``aud`` claim → no-op, DB is not touched."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        db_mock = MagicMock()
+
+        _persist_learned_server_audience("srv-1", {"sub": "user"}, db_mock)
+
+        db_mock.execute.assert_not_called()
+        db_mock.flush.assert_not_called()
+
+    def test_skips_when_aud_matches_existing_resource(self):
+        """If ``resource`` already matches the token's ``aud``, skip (no-op)."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"], "resource": "my-client-id"})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
+
+        # Aud matches existing resource — flush should NOT be called.
+        db_mock.flush.assert_not_called()
+
+    def test_overwrites_when_aud_differs_from_existing_resource(self):
+        """If ``resource`` differs from the token's ``aud``, overwrite it."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        server = MagicMock()
+        server.oauth_config = dict({"authorization_servers": ["https://idp.example.com"], "resource": "old-client-id"})
+
+        db_mock = MagicMock()
+        db_mock.execute.return_value.scalar_one_or_none.return_value = server
+
+        _persist_learned_server_audience("srv-1", {"aud": "new-client-id", "sub": "user"}, db_mock)
+
+        assert server.oauth_config["resource"] == "new-client-id"
+        db_mock.flush.assert_called_once()
+
+    def test_db_error_is_swallowed(self):
+        """DB errors during persist are logged but do not propagate."""
+        # First-Party
+        from mcpgateway.transports.streamablehttp_transport import _persist_learned_server_audience  # pylint: disable=import-outside-toplevel
+
+        db_mock = MagicMock()
+        db_mock.execute.side_effect = RuntimeError("connection refused")
+
+        # Should not raise.
+        _persist_learned_server_audience("srv-1", {"aud": "my-client-id", "sub": "user"}, db_mock)
 
 
 class TestOAuthServerMisconfigurationRejected:


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

OAuth audience verification always fails for virtual servers when the IdP does not support RFC 8707 Resource Indicators (e.g. Authentik, some Keycloak configurations). These IdPs set the token `aud` claim to an abstract identifier (typically the OAuth `client_id`) rather than the resource URL the client requested. Since virtual servers only have `authorization_servers` in their `oauth_config` (no `resource`), the only expected audience is the canonical resource URL derived from `APP_DOMAIN` — which never matches.

This is the virtual-server counterpart to #4404, which applies the same auto-learn pattern to the gateway (OAuth callback) path.

## 🔁 Reproduction Steps

Closes #4171

1. Create a virtual server with `oauth_enabled=true` and an authorization server pointing to an IdP without RFC 8707 support (e.g. Authentik)
2. Set `APP_DOMAIN` to the gateway's internal domain
3. Have an MCP client connect to `/servers/{server_id}/mcp` — the client completes the OAuth flow with the IdP
4. The IdP issues a token with `aud: "my-oauth-client-id"` (ignoring the `resource` parameter)
5. ContextForge builds `expected_audiences = ["{APP_DOMAIN}/servers/{server_id}/mcp"]`
6. Audience mismatch → 401 on every request

## 🐞 Root Cause

`_try_oauth_access_token` in `streamablehttp_transport.py` always enforced audience verification using the canonical resource URL from `_build_server_resource_url()`. When `oauth_config` has no `resource` (which is the case for all virtual servers created via the admin UI), the expected audience list contained only this URL. Non-RFC-8707 IdPs set `aud` to an abstract identifier instead, so every token failed audience verification — even though signature and issuer were valid.

The admin UI for virtual servers does not expose `resource` fields, so there was no way to configure the expected audience without direct DB manipulation.

## 💡 Fix Description

Replace the old audience-list-building logic with a two-branch strategy in `_try_oauth_access_token`:

1. **When `resource` IS configured** (learned or manually set): Pass it directly to `verify_oauth_access_token` as the expected audience. No canonical resource URL, no list building — the configured value is used as-is (string or list).

2. **When `resource` is NOT configured**: Skip audience enforcement (`expected_audience=None`). Signature + issuer are still verified. After successful verification, extract the `aud` claim from the verified token and persist it as `resource` in `server.oauth_config` via the new `_persist_learned_server_audience()` helper. All subsequent requests then get strict audience enforcement.

The old `client_id` fallback and canonical resource URL derivation (`_build_server_resource_url`) are removed from the audience path entirely — they were the source of the bug for non-RFC-8707 IdPs.

This is not a security regression: without this change, every non-RFC-8707 IdP token is rejected outright (the feature is completely broken). The fix maintains signature + issuer verification on the first request and adds strict audience enforcement from the second request onward.

**Why auto-learn instead of a UI toggle (as suggested in #4171)?**

The issue proposed a per-server toggle or UI field to manually configure the expected audience. But the operator only controls which IdP to use (`authorization_servers`) — the `aud` claim value is determined entirely by the IdP's behavior, which varies across providers (it could be the `client_id`, an application URI, or something else entirely). Asking the operator to pre-configure it would require them to know what the IdP will put in `aud` before any token has been issued. Auto-learning from the first verified token eliminates this guesswork and works correctly regardless of the IdP's audience strategy.

Key implementation details:
- `_persist_learned_server_audience()` is best-effort — DB failures are caught both internally and at the call site, never breaking the auth flow
- The `aud` claim is stored as-is: string values stay strings, list values stay lists
- Persist is called on every successful auth so that IdP-side changes (e.g. client_id rotation) are picked up automatically; a no-op early return skips the write when the stored value already matches
- SQLAlchemy mutation tracking is handled correctly (new dict object assigned)

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Unit tests (test_auth.py)             | `uv run pytest tests/unit/mcpgateway/test_auth.py` | ✅ 237 passed |
| Related OAuth tests                   | `uv run pytest tests/unit/mcpgateway/test_auth.py tests/unit/mcpgateway/routers/test_oauth_router.py tests/unit/mcpgateway/services/test_token_validation_service.py` | ✅ 362 passed |
| Doctests                              | `uv run pytest --doctest-modules mcpgateway/transports/streamablehttp_transport.py` | ✅ 22 passed |
| Ruff                                  | `make ruff` | ✅ All checks passed |
| Formatting                            | `make autoflake isort black` | ✅ Clean |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed