### PR TITLE
feat(ui-rewrite): create a modal with the form for adding MCP servers

### DIFF
--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -34,11 +34,8 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Playwright smoke + auth
     runs-on: ubuntu-latest
+    container: node:22-bookworm-slim
     timeout-minutes: 20
-
-    defaults:
-      run:
-        working-directory: ./client
 
     env:
       CI: "true"
@@ -51,14 +48,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: 🟢 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: client/package-lock.json
-
       - name: 📥 Install client dependencies
+        working-directory: ./client
         run: npm ci
 
       - name: 🎭 Cache Playwright browsers
@@ -79,6 +70,7 @@ jobs:
         run: npx playwright install-deps chromium
 
       - name: 🧪 Run Playwright tests
+        working-directory: ./client
         run: npm run e2e
 
       - name: 📦 Upload Playwright HTML report

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
+        "@radix-ui/react-dialog": "^1.1.15",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.8.0",

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
+    "@radix-ui/react-dialog": "^1.1.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/client/src/components/mcpServers/NewMCPServerModal.tsx
+++ b/client/src/components/mcpServers/NewMCPServerModal.tsx
@@ -80,10 +80,10 @@ export function NewMCPServerModal({
                 Connect MCP server
               </h2>
             </div>
-            
+
             <p className="text-sm leading-6 text-neutral-600">
-              Context Forge will discover the server's tools, resources, and prompts.
-              The MCP server should be running and reachable. Or, choose a server from the{" "}
+              Context Forge will discover the server's tools, resources, and prompts. The MCP server
+              should be running and reachable. Or, choose a server from the{" "}
               <button
                 type="button"
                 onClick={() => {
@@ -132,7 +132,10 @@ export function NewMCPServerModal({
             </div>
 
             <div className="space-y-1">
-              <label htmlFor="server-name" className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900">
+              <label
+                htmlFor="server-name"
+                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900"
+              >
                 Name<span className="text-red-500">*</span>
               </label>
               <Input
@@ -181,9 +184,7 @@ export function NewMCPServerModal({
                 className="inline-flex w-fit items-center gap-2 text-sm font-medium text-neutral-700 transition hover:text-neutral-950"
                 aria-expanded={advancedOpen}
               >
-                <ChevronDown
-                  className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`}
-                />
+                <ChevronDown className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`} />
                 Advanced options
               </button>
 

--- a/client/src/components/mcpServers/NewMCPServerModal.tsx
+++ b/client/src/components/mcpServers/NewMCPServerModal.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, CircleAlert, Plus } from "lucide-react";
 import { useState, type FormEvent } from "react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Dialog,
@@ -12,12 +12,13 @@ import {
 } from "@/components/ui/dialog";
 import { MCPIcon } from "@/components/icons/MCPIcon";
 import { useRouter } from "@/router";
+import { type VariantProps } from "class-variance-authority";
 
 type TransportType = "sse" | "streamable-http";
 
 interface NewMCPServerModalProps {
   triggerLabel?: string;
-  triggerVariant?: "default" | "outline" | "secondary" | "ghost" | "destructive" | "link";
+  triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   showTriggerIcon?: boolean;
 }
 
@@ -44,22 +45,20 @@ export function NewMCPServerModal({
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
-    if (!nextOpen) {
-      resetForm();
-    }
   };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // Handle form submission
     setOpen(false);
+    resetForm();
   };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant={triggerVariant} className="h-10 w-fit rounded-lg px-4">
-          {showTriggerIcon ? <Plus className="h-4 w-4" /> : null}
+          {showTriggerIcon && <Plus className="h-4 w-4" />}
           {triggerLabel}
         </Button>
       </DialogTrigger>
@@ -100,34 +99,42 @@ export function NewMCPServerModal({
 
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="space-y-1">
-              <label className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100">
-                Server transport type
-              </label>
-              <div className="grid grid-cols-2 gap-2 rounded-md bg-neutral-100 p-1 dark:bg-neutral-800">
-                <button
-                  type="button"
-                  onClick={() => setTransport("sse")}
-                  className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
-                    transport === "sse"
-                      ? "bg-white text-neutral-950 shadow-sm dark:bg-neutral-900 dark:text-neutral-50"
-                      : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
-                  }`}
-                  aria-pressed={transport === "sse"}
+              <div
+                role="radiogroup"
+                aria-label="Server transport type"
+                className="grid grid-cols-2 gap-2 rounded-md bg-neutral-100 p-1 dark:bg-neutral-800"
+              >
+                <input
+                  type="radio"
+                  id="transport-sse"
+                  name="transport"
+                  value="sse"
+                  checked={transport === "sse"}
+                  onChange={(e) => setTransport(e.target.value as TransportType)}
+                  className="sr-only peer/sse"
+                />
+                <label
+                  htmlFor="transport-sse"
+                  className="cursor-pointer rounded-md px-4 py-2.5 text-sm font-medium transition peer-checked/sse:bg-white peer-checked/sse:text-neutral-950 peer-checked/sse:shadow-sm peer-focus-visible/sse:ring-2 peer-focus-visible/sse:ring-ring peer-focus-visible/sse:ring-offset-2 dark:peer-checked/sse:bg-neutral-900 dark:peer-checked/sse:text-neutral-50 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
                 >
                   SSE
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setTransport("streamable-http")}
-                  className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
-                    transport === "streamable-http"
-                      ? "bg-white text-neutral-950 shadow-sm dark:bg-neutral-900 dark:text-neutral-50"
-                      : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
-                  }`}
-                  aria-pressed={transport === "streamable-http"}
+                </label>
+
+                <input
+                  type="radio"
+                  id="transport-http"
+                  name="transport"
+                  value="streamable-http"
+                  checked={transport === "streamable-http"}
+                  onChange={(e) => setTransport(e.target.value as TransportType)}
+                  className="sr-only peer/http"
+                />
+                <label
+                  htmlFor="transport-http"
+                  className="cursor-pointer rounded-md px-4 py-2.5 text-sm font-medium transition peer-checked/http:bg-white peer-checked/http:text-neutral-950 peer-checked/http:shadow-sm peer-focus-visible/http:ring-2 peer-focus-visible/http:ring-ring peer-focus-visible/http:ring-offset-2 dark:peer-checked/http:bg-neutral-900 dark:peer-checked/http:text-neutral-50 text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
                 >
                   Streamable HTTP
-                </button>
+                </label>
               </div>
             </div>
 
@@ -137,6 +144,7 @@ export function NewMCPServerModal({
                 className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
               >
                 Name<span className="text-red-500">*</span>
+                <span className="sr-only">(required)</span>
               </label>
               <Input
                 id="server-name"
@@ -153,6 +161,7 @@ export function NewMCPServerModal({
                 className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
               >
                 URL<span className="text-red-500">*</span>
+                <span className="sr-only">(required)</span>
                 <CircleAlert className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
               </label>
               <Input
@@ -188,11 +197,11 @@ export function NewMCPServerModal({
                 Advanced options
               </button>
 
-              {advancedOpen ? (
+              {advancedOpen && (
                 <div className="rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-4 py-3 text-sm text-neutral-600 dark:border-neutral-700 dark:bg-neutral-800/50 dark:text-neutral-400">
                   Additional gateway configuration options can be added here.
                 </div>
-              ) : null}
+              )}
 
               <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
                 <Button

--- a/client/src/components/mcpServers/NewMCPServerModal.tsx
+++ b/client/src/components/mcpServers/NewMCPServerModal.tsx
@@ -64,7 +64,7 @@ export function NewMCPServerModal({
         </Button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-3xl rounded-[24px] border border-neutral-200 bg-white p-0 shadow-[0_12px_40px_rgba(15,23,42,0.12)]">
+      <DialogContent className="max-w-3xl rounded-[24px] border border-neutral-200 bg-white p-0 shadow-[0_12px_40px_rgba(15,23,42,0.12)] dark:border-neutral-800 dark:bg-neutral-900">
         <DialogHeader className="sr-only">
           <DialogTitle>Connect MCP server</DialogTitle>
           <DialogDescription>Create a new MCP server connection.</DialogDescription>
@@ -76,21 +76,21 @@ export function NewMCPServerModal({
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-orange-500 text-white shadow-sm">
                 <MCPIcon className="h-5 w-5 [&_path]:fill-white" />
               </div>
-              <h2 className="text-2xl font-semibold tracking-tight text-neutral-950">
+              <h2 className="text-2xl font-semibold tracking-tight text-neutral-950 dark:text-neutral-50">
                 Connect MCP server
               </h2>
             </div>
 
-            <p className="text-sm leading-6 text-neutral-600">
-              Context Forge will discover the server's tools, resources, and prompts. The MCP server
-              should be running and reachable. Or, choose a server from the{" "}
+            <p className="text-sm leading-6 text-neutral-600 dark:text-neutral-400">
+              Context Forge will discover the server&#39;s tools, resources, and prompts. The MCP
+              server should be running and reachable. Or, choose a server from the{" "}
               <button
                 type="button"
                 onClick={() => {
                   handleOpenChange(false);
                   navigate("/app/server-catalog");
                 }}
-                className="font-medium text-cyan-700 underline decoration-cyan-300 underline-offset-4 transition hover:text-cyan-800"
+                className="font-medium text-cyan-700 underline decoration-cyan-300 underline-offset-4 transition hover:text-cyan-800 dark:text-cyan-400 dark:decoration-cyan-700 dark:hover:text-cyan-300"
               >
                 mcp server catalog
               </button>
@@ -100,17 +100,17 @@ export function NewMCPServerModal({
 
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="space-y-1">
-              <label className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900">
+              <label className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100">
                 Server transport type
               </label>
-              <div className="grid grid-cols-2 gap-2 rounded-md bg-neutral-100 p-1">
+              <div className="grid grid-cols-2 gap-2 rounded-md bg-neutral-100 p-1 dark:bg-neutral-800">
                 <button
                   type="button"
                   onClick={() => setTransport("sse")}
                   className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
                     transport === "sse"
-                      ? "bg-white text-neutral-950 shadow-sm"
-                      : "text-neutral-500 hover:text-neutral-800"
+                      ? "bg-white text-neutral-950 shadow-sm dark:bg-neutral-900 dark:text-neutral-50"
+                      : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
                   }`}
                   aria-pressed={transport === "sse"}
                 >
@@ -121,8 +121,8 @@ export function NewMCPServerModal({
                   onClick={() => setTransport("streamable-http")}
                   className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
                     transport === "streamable-http"
-                      ? "bg-white text-neutral-950 shadow-sm"
-                      : "text-neutral-500 hover:text-neutral-800"
+                      ? "bg-white text-neutral-950 shadow-sm dark:bg-neutral-900 dark:text-neutral-50"
+                      : "text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200"
                   }`}
                   aria-pressed={transport === "streamable-http"}
                 >
@@ -134,7 +134,7 @@ export function NewMCPServerModal({
             <div className="space-y-1">
               <label
                 htmlFor="server-name"
-                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900"
+                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
               >
                 Name<span className="text-red-500">*</span>
               </label>
@@ -143,24 +143,24 @@ export function NewMCPServerModal({
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 placeholder="Add MCP server name..."
-                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400"
+                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500"
               />
             </div>
 
             <div className="space-y-1">
               <label
                 htmlFor="server-url"
-                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900"
+                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100"
               >
                 URL<span className="text-red-500">*</span>
-                <CircleAlert className="h-4 w-4 text-neutral-400" />
+                <CircleAlert className="h-4 w-4 text-neutral-400 dark:text-neutral-500" />
               </label>
               <Input
                 id="server-url"
                 value={url}
                 onChange={(event) => setUrl(event.target.value)}
                 placeholder="Add URL for a running MCP server..."
-                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400"
+                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500"
               />
             </div>
 
@@ -173,7 +173,7 @@ export function NewMCPServerModal({
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
                 placeholder="Add an optional description..."
-                className="min-h-28 w-full rounded-md border border-neutral-300 bg-white px-4 py-3 text-sm text-neutral-900 shadow-none outline-none transition placeholder:text-neutral-400 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                className="min-h-28 w-full rounded-md border border-neutral-300 bg-white px-4 py-3 text-sm text-neutral-900 shadow-none outline-none transition placeholder:text-neutral-400 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500"
               />
             </div>
 
@@ -181,7 +181,7 @@ export function NewMCPServerModal({
               <button
                 type="button"
                 onClick={() => setAdvancedOpen((current) => !current)}
-                className="inline-flex w-fit items-center gap-2 text-sm font-medium text-neutral-700 transition hover:text-neutral-950"
+                className="inline-flex w-fit items-center gap-2 text-sm font-medium text-neutral-700 transition hover:text-neutral-950 dark:text-neutral-300 dark:hover:text-neutral-100"
                 aria-expanded={advancedOpen}
               >
                 <ChevronDown className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`} />
@@ -189,23 +189,23 @@ export function NewMCPServerModal({
               </button>
 
               {advancedOpen ? (
-                <div className="rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-4 py-3 text-sm text-neutral-600">
+                <div className="rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-4 py-3 text-sm text-neutral-600 dark:border-neutral-700 dark:bg-neutral-800/50 dark:text-neutral-400">
                   Additional gateway configuration options can be added here.
                 </div>
               ) : null}
 
-              <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-6">
+              <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-6 dark:border-neutral-800">
                 <Button
                   type="button"
                   variant="ghost"
                   onClick={() => handleOpenChange(false)}
-                  className="h-10 rounded-md px-3 text-sm font-medium text-neutral-700 hover:bg-neutral-100 hover:text-neutral-950"
+                  className="h-10 rounded-md px-3 text-sm font-medium text-neutral-700 hover:bg-neutral-100 hover:text-neutral-950 dark:text-neutral-300 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
                 >
                   Cancel
                 </Button>
                 <Button
                   type="submit"
-                  className="h-10 rounded-md bg-neutral-950 px-4 text-sm font-medium text-white hover:bg-neutral-800"
+                  className="h-10 rounded-md bg-neutral-950 px-4 text-sm font-medium text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-950 dark:hover:bg-neutral-200"
                 >
                   Connect server
                 </Button>

--- a/client/src/components/mcpServers/NewMCPServerModal.tsx
+++ b/client/src/components/mcpServers/NewMCPServerModal.tsx
@@ -1,0 +1,218 @@
+import { ChevronDown, CircleAlert, Plus } from "lucide-react";
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { MCPIcon } from "@/components/icons/MCPIcon";
+import { useRouter } from "@/router";
+
+type TransportType = "sse" | "streamable-http";
+
+interface NewMCPServerModalProps {
+  triggerLabel?: string;
+  triggerVariant?: "default" | "outline" | "secondary" | "ghost" | "destructive" | "link";
+  showTriggerIcon?: boolean;
+}
+
+export function NewMCPServerModal({
+  triggerLabel = "Connect",
+  triggerVariant = "default",
+  showTriggerIcon = true,
+}: NewMCPServerModalProps) {
+  const { navigate } = useRouter();
+  const [open, setOpen] = useState(false);
+  const [transport, setTransport] = useState<TransportType>("sse");
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  const resetForm = () => {
+    setTransport("sse");
+    setName("");
+    setUrl("");
+    setDescription("");
+    setAdvancedOpen(false);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      resetForm();
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Handle form submission
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant={triggerVariant} className="h-10 w-fit rounded-lg px-4">
+          {showTriggerIcon ? <Plus className="h-4 w-4" /> : null}
+          {triggerLabel}
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-3xl rounded-[24px] border border-neutral-200 bg-white p-0 shadow-[0_12px_40px_rgba(15,23,42,0.12)]">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Connect MCP server</DialogTitle>
+          <DialogDescription>Create a new MCP server connection.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-8 p-6 sm:p-8">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-orange-500 text-white shadow-sm">
+                <MCPIcon className="h-5 w-5 [&_path]:fill-white" />
+              </div>
+              <h2 className="text-2xl font-semibold tracking-tight text-neutral-950">
+                Connect MCP server
+              </h2>
+            </div>
+            
+            <p className="text-sm leading-6 text-neutral-600">
+              Context Forge will discover the server's tools, resources, and prompts.
+              The MCP server should be running and reachable. Or, choose a server from the{" "}
+              <button
+                type="button"
+                onClick={() => {
+                  handleOpenChange(false);
+                  navigate("/app/server-catalog");
+                }}
+                className="font-medium text-cyan-700 underline decoration-cyan-300 underline-offset-4 transition hover:text-cyan-800"
+              >
+                mcp server catalog
+              </button>
+              .
+            </p>
+          </div>
+
+          <form className="space-y-6" onSubmit={handleSubmit}>
+            <div className="space-y-1">
+              <label className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900">
+                Server transport type
+              </label>
+              <div className="grid grid-cols-2 gap-2 rounded-md bg-neutral-100 p-1">
+                <button
+                  type="button"
+                  onClick={() => setTransport("sse")}
+                  className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
+                    transport === "sse"
+                      ? "bg-white text-neutral-950 shadow-sm"
+                      : "text-neutral-500 hover:text-neutral-800"
+                  }`}
+                  aria-pressed={transport === "sse"}
+                >
+                  SSE
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setTransport("streamable-http")}
+                  className={`rounded-md px-4 py-2.5 text-sm font-medium transition ${
+                    transport === "streamable-http"
+                      ? "bg-white text-neutral-950 shadow-sm"
+                      : "text-neutral-500 hover:text-neutral-800"
+                  }`}
+                  aria-pressed={transport === "streamable-http"}
+                >
+                  Streamable HTTP
+                </button>
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="server-name" className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900">
+                Name<span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="server-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="Add MCP server name..."
+                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label
+                htmlFor="server-url"
+                className="inline-flex items-center gap-0.5 text-sm font-medium text-neutral-900"
+              >
+                URL<span className="text-red-500">*</span>
+                <CircleAlert className="h-4 w-4 text-neutral-400" />
+              </label>
+              <Input
+                id="server-url"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder="Add URL for a running MCP server..."
+                className="h-11 rounded-md border-neutral-300 bg-white px-4 text-sm text-neutral-900 shadow-none placeholder:text-neutral-400"
+              />
+            </div>
+
+            <div className="space-y-1">
+              <label htmlFor="server-description" className="sr-only">
+                Description
+              </label>
+              <textarea
+                id="server-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Add an optional description..."
+                className="min-h-28 w-full rounded-md border border-neutral-300 bg-white px-4 py-3 text-sm text-neutral-900 shadow-none outline-none transition placeholder:text-neutral-400 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+              />
+            </div>
+
+            <div className="flex flex-col gap-5 pt-2">
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen((current) => !current)}
+                className="inline-flex w-fit items-center gap-2 text-sm font-medium text-neutral-700 transition hover:text-neutral-950"
+                aria-expanded={advancedOpen}
+              >
+                <ChevronDown
+                  className={`h-4 w-4 transition ${advancedOpen ? "rotate-180" : ""}`}
+                />
+                Advanced options
+              </button>
+
+              {advancedOpen ? (
+                <div className="rounded-md border border-dashed border-neutral-300 bg-neutral-50 px-4 py-3 text-sm text-neutral-600">
+                  Additional gateway configuration options can be added here.
+                </div>
+              ) : null}
+
+              <div className="flex items-center justify-end gap-3 border-t border-neutral-200 pt-6">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => handleOpenChange(false)}
+                  className="h-10 rounded-md px-3 text-sm font-medium text-neutral-700 hover:bg-neutral-100 hover:text-neutral-950"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  className="h-10 rounded-md bg-neutral-950 px-4 text-sm font-medium text-white hover:bg-neutral-800"
+                >
+                  Connect server
+                </Button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -13,7 +13,9 @@ export function Servers() {
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-orange-500 text-white shadow-sm">
               <MCPIcon className="h-5 w-5 [&_path]:fill-white" />
             </div>
-            <h2 className="text-xl font-semibold text-neutral-950 dark:text-neutral-50">Connect MCP server</h2>
+            <h2 className="text-xl font-semibold text-neutral-950 dark:text-neutral-50">
+              Connect MCP server
+            </h2>
           </div>
 
           <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
@@ -28,7 +30,11 @@ export function Servers() {
             .
           </p>
 
-          <NewMCPServerModal triggerLabel="Connect" triggerVariant="default" showTriggerIcon={true} />
+          <NewMCPServerModal
+            triggerLabel="Connect"
+            triggerVariant="default"
+            showTriggerIcon={true}
+          />
         </div>
       </div>
     </div>

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -1,3 +1,36 @@
+import { MCPIcon } from "@/components/icons/MCPIcon";
+import { NewMCPServerModal } from "@/components/mcpServers/NewMCPServerModal";
+import { useRouter } from "@/router";
+
 export function Servers() {
-  return <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">Servers</h1>;
+  const { navigate } = useRouter();
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-neutral-200 bg-white p-8 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-sm bg-orange-500 text-white shadow-sm">
+              <MCPIcon className="h-5 w-5 [&_path]:fill-white" />
+            </div>
+            <h2 className="text-xl font-semibold text-neutral-950 dark:text-neutral-50">Connect MCP server</h2>
+          </div>
+
+          <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+            Register an MCP server to federate its tools, resources, and prompts. Or,{" "}
+            <button
+              type="button"
+              onClick={() => navigate("/app/server-catalog")}
+              className="font-medium text-cyan-700 underline decoration-cyan-300 underline-offset-4 transition hover:text-cyan-800 dark:text-cyan-400 dark:decoration-cyan-700 dark:hover:text-cyan-300"
+            >
+              select from available servers
+            </button>
+            .
+          </p>
+
+          <NewMCPServerModal triggerLabel="Connect" triggerVariant="default" showTriggerIcon={true} />
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

Related #4175

---

## 🚀 Summary (1-2 sentences)

Now I add a modal with the basic form to add a new MCP Server

#### Light mode:
<img width="1675" height="877" alt="Screenshot 2026-04-23 at 14 03 49" src="https://github.com/user-attachments/assets/0f5ffd73-d7a3-4ba9-b636-9534e690043c" />

<img width="1673" height="889" alt="Screenshot 2026-04-23 at 14 03 59" src="https://github.com/user-attachments/assets/30b26aaa-347e-4744-a7ef-e7bc8766e22d" />

#### Dark mode:
<img width="1456" height="926" alt="Screenshot 2026-04-23 at 15 46 01" src="https://github.com/user-attachments/assets/85e2d2ad-0cb5-44b6-bc9a-0bf17e8a876b" />

<img width="1486" height="930" alt="Screenshot 2026-04-23 at 15 45 48" src="https://github.com/user-attachments/assets/575ae9de-5179-49b8-b5ca-a4be40ee8037" />


---

## 🧪 Checks

- [x] `npm run format` passes
- [x] `npm run test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)
The next step is link the form with the API
