### PR TITLE
feat: fix OAuth redirect_uri hint for proxied/iframe deployments

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3025,7 +3025,7 @@ app.add_middleware(AdminAuthMiddleware)
 # but not X-Forwarded-Host (upstream issue encode/uvicorn#965).
 # This ensures request.base_url reflects the proxy's public host, fixing the
 # OAuth redirect_uri hint and other URL construction throughout the admin UI.
-# Only registered when proxy headers are trusted (same condition as below).
+# Registered alongside ProxyHeadersMiddleware with the same trust model.
 #
 # Registered BEFORE ProxyHeadersMiddleware so that it is inner (executes after
 # ProxyHeadersMiddleware in the ASGI call chain) and can rely on the scheme

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -70,6 +70,8 @@ from starlette.responses import Response as starletteResponse
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 # First-Party
+from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
+
 # Import the admin routes from the new module
 from mcpgateway import __version__
 from mcpgateway import version as version_module
@@ -3020,6 +3022,13 @@ app.add_middleware(AdminAuthMiddleware)
 
 # Trust all proxies (or lock down with a list of host patterns)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+
+# Rewrite Host header from X-Forwarded-Host when behind a reverse proxy.
+# Uvicorn's ProxyHeadersMiddleware handles X-Forwarded-Proto and X-Forwarded-For
+# but not X-Forwarded-Host (upstream issue encode/uvicorn#965).
+# This ensures request.base_url reflects the proxy's public host, fixing the
+# OAuth redirect_uri hint and other URL construction throughout the admin UI.
+app.add_middleware(ForwardedHostMiddleware, trusted_hosts="*")
 
 # Add correlation ID middleware if enabled
 # Note: Registered AFTER RequestLoggingMiddleware so correlation ID is available when RequestLoggingMiddleware executes

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3021,14 +3021,15 @@ app.add_middleware(DocsAuthMiddleware)
 app.add_middleware(AdminAuthMiddleware)
 
 # Trust all proxies (or lock down with a list of host patterns)
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+_proxy_trusted_hosts = "*"
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_proxy_trusted_hosts)
 
 # Rewrite Host header from X-Forwarded-Host when behind a reverse proxy.
 # Uvicorn's ProxyHeadersMiddleware handles X-Forwarded-Proto and X-Forwarded-For
 # but not X-Forwarded-Host (upstream issue encode/uvicorn#965).
 # This ensures request.base_url reflects the proxy's public host, fixing the
 # OAuth redirect_uri hint and other URL construction throughout the admin UI.
-app.add_middleware(ForwardedHostMiddleware, trusted_hosts="*")
+app.add_middleware(ForwardedHostMiddleware, trusted_hosts=_proxy_trusted_hosts)
 
 # Add correlation ID middleware if enabled
 # Note: Registered AFTER RequestLoggingMiddleware so correlation ID is available when RequestLoggingMiddleware executes

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3029,7 +3029,8 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_proxy_trusted_hosts)
 # but not X-Forwarded-Host (upstream issue encode/uvicorn#965).
 # This ensures request.base_url reflects the proxy's public host, fixing the
 # OAuth redirect_uri hint and other URL construction throughout the admin UI.
-app.add_middleware(ForwardedHostMiddleware, trusted_hosts=_proxy_trusted_hosts)
+# Only registered when proxy headers are trusted (same condition as above).
+app.add_middleware(ForwardedHostMiddleware)
 
 # Add correlation ID middleware if enabled
 # Note: Registered AFTER RequestLoggingMiddleware so correlation ID is available when RequestLoggingMiddleware executes

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3020,17 +3020,20 @@ app.add_middleware(DocsAuthMiddleware)
 # This ensures all /admin/* routes (except login/logout) require admin status
 app.add_middleware(AdminAuthMiddleware)
 
-# Trust all proxies (or lock down with a list of host patterns)
-_proxy_trusted_hosts = "*"
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_proxy_trusted_hosts)
-
 # Rewrite Host header from X-Forwarded-Host when behind a reverse proxy.
 # Uvicorn's ProxyHeadersMiddleware handles X-Forwarded-Proto and X-Forwarded-For
 # but not X-Forwarded-Host (upstream issue encode/uvicorn#965).
 # This ensures request.base_url reflects the proxy's public host, fixing the
 # OAuth redirect_uri hint and other URL construction throughout the admin UI.
-# Only registered when proxy headers are trusted (same condition as above).
+# Only registered when proxy headers are trusted (same condition as below).
+#
+# Registered BEFORE ProxyHeadersMiddleware so that it is inner (executes after
+# ProxyHeadersMiddleware in the ASGI call chain) and can rely on the scheme
+# already being corrected when deriving the default port for scope["server"].
 app.add_middleware(ForwardedHostMiddleware)
+
+# Trust all proxies (or lock down with a list of host patterns)
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 # Add correlation ID middleware if enabled
 # Note: Registered AFTER RequestLoggingMiddleware so correlation ID is available when RequestLoggingMiddleware executes

--- a/mcpgateway/middleware/__init__.py
+++ b/mcpgateway/middleware/__init__.py
@@ -8,6 +8,7 @@ Middleware package for ContextForge.
 Contains various middleware components for request processing.
 """
 
+from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
 from mcpgateway.middleware.token_scoping import TokenScopingMiddleware, token_scoping_middleware
 
-__all__ = ["TokenScopingMiddleware", "token_scoping_middleware"]
+__all__ = ["ForwardedHostMiddleware", "TokenScopingMiddleware", "token_scoping_middleware"]

--- a/mcpgateway/middleware/forwarded_host.py
+++ b/mcpgateway/middleware/forwarded_host.py
@@ -45,6 +45,83 @@ from typing import Any, Awaitable, Callable, MutableMapping
 logger = logging.getLogger(__name__)
 
 
+def _parse_forwarded_host(value: str, scheme: str) -> tuple[str, int, str] | None:
+    """Parse an X-Forwarded-Host value into (server_host, port, host_header_value).
+
+    Returns *None* if the value is malformed or the port is out of range.
+
+    * ``server_host`` is the unbracketed host literal for ``scope["server"]``.
+    * ``host_header_value`` is the full host (with port if present) for the
+      rewritten HTTP ``Host`` header.
+
+    Handles:
+    * Plain hostnames: ``proxy.example.com``
+    * Host:port: ``proxy.example.com:8443``
+    * Bracketed IPv6: ``[2001:db8::1]``
+    * Bracketed IPv6 with port: ``[2001:db8::1]:8080``
+    * Unbracketed IPv6 without port: ``2001:db8::1``
+    * Comma-separated list (only the first value is used)
+    """
+    # Take only the first value if comma-separated (leftmost = client-facing hop).
+    host_value = value.split(",", 1)[0].strip()
+    if not host_value:
+        return None
+
+    # Reject obviously invalid characters in the host portion.
+    if " " in host_value or "\t" in host_value or "\n" in host_value or "\r" in host_value:
+        logger.debug("Ignoring X-Forwarded-Host with whitespace characters: %r", host_value)
+        return None
+
+    default_port = 443 if scheme in ("https", "wss") else 80
+
+    # Bracketed IPv6 – may include a trailing port.
+    if host_value.startswith("["):
+        if "]:" in host_value:
+            bracketed, _colon, port_str = host_value.rpartition(":")
+            if not bracketed.endswith("]"):
+                # e.g. "[::1]junk:8080" – malformed
+                logger.debug("Ignoring malformed bracketed IPv6: %r", host_value)
+                return None
+            if not port_str.isdigit():
+                logger.debug("Ignoring X-Forwarded-Host with invalid port: %r", host_value)
+                return None
+            port = int(port_str)
+            server_host = bracketed[1:-1]  # strip brackets
+        else:
+            if not host_value.endswith("]"):
+                logger.debug("Ignoring malformed bracketed IPv6: %r", host_value)
+                return None
+            server_host = host_value[1:-1]  # strip brackets
+            port = default_port
+    elif ":" in host_value:
+        # Could be host:port or unbracketed IPv6.
+        # Unbracketed IPv6 has more than one colon and no port suffix.
+        if host_value.count(":") > 1:
+            server_host = host_value
+            port = default_port
+        else:
+            server_host, port_str = host_value.rsplit(":", 1)
+            if not port_str.isdigit():
+                logger.debug("Ignoring X-Forwarded-Host with invalid port: %r", host_value)
+                return None
+            port = int(port_str)
+    else:
+        server_host = host_value
+        port = default_port
+
+    # Validate port range.
+    if not 1 <= port <= 65535:
+        logger.debug("Ignoring X-Forwarded-Host with out-of-range port: %r", host_value)
+        return None
+
+    # Reject paths or other invalid host syntax, and empty hosts.
+    if not server_host or "/" in server_host:
+        logger.debug("Ignoring X-Forwarded-Host with empty or invalid host: %r", host_value)
+        return None
+
+    return server_host, port, host_value
+
+
 class ForwardedHostMiddleware:
     """Rewrite the ASGI ``host`` header from ``X-Forwarded-Host``.
 
@@ -73,36 +150,24 @@ class ForwardedHostMiddleware:
     ) -> None:
         """Rewrite host header from X-Forwarded-Host if present."""
         if scope["type"] in ("http", "websocket"):
-            headers = dict(scope["headers"])  # type: ignore[arg-type]
+            # Use the first occurrence of X-Forwarded-Host (leftmost = client-facing hop).
+            raw = next(
+                (v.decode("latin1") for k, v in scope["headers"] if k == b"x-forwarded-host"),
+                None,
+            )
 
-            if b"x-forwarded-host" in headers:
-                raw = headers[b"x-forwarded-host"].decode("latin1")
-                # Take only the first value if comma-separated (leftmost =
-                # client-facing hop).
-                x_forwarded_host = raw.split(",")[0].strip()
+            if raw is not None:
+                parsed = _parse_forwarded_host(raw, scope.get("scheme", "http"))
+                if parsed is not None:
+                    server_host, port, host_header_value = parsed
 
-                if x_forwarded_host:
-                    # Default port for scope["server"] when the header omits one.
-                    default_port = 443 if scope.get("scheme") in ("https", "wss") else 80
-
-                    # Parse host and optional port.
-                    # IPv6 addresses are bracketed, e.g. [::1]:8080.  A trailing
-                    # "]" means IPv6 *without* a port suffix.
-                    if ":" in x_forwarded_host and not x_forwarded_host.endswith("]"):
-                        host_part, port_str = x_forwarded_host.rsplit(":", 1)
-                        try:
-                            port = int(port_str)
-                        except ValueError:
-                            port = default_port
-                    else:
-                        host_part = x_forwarded_host
-                        port = default_port
-
-                    scope["server"] = (host_part, port)
+                    scope["server"] = (server_host, port)
 
                     # Replace the ``host`` header so Starlette sees the proxy host.
-                    new_headers: list[tuple[bytes, bytes]] = [(name, value) for name, value in scope["headers"] if name != b"host"]  # type: ignore[union-attr]
-                    new_headers.append((b"host", x_forwarded_host.encode("latin1")))
-                    scope["headers"] = new_headers  # type: ignore[typeddict-item]
+                    new_headers: list[tuple[bytes, bytes]] = [
+                        (name, value) for name, value in scope["headers"] if name != b"host"
+                    ]
+                    new_headers.append((b"host", host_header_value.encode("latin1")))
+                    scope["headers"] = new_headers
 
         return await self.app(scope, receive, send)

--- a/mcpgateway/middleware/forwarded_host.py
+++ b/mcpgateway/middleware/forwarded_host.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/middleware/forwarded_host.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: ContextForge Contributors
+
+Forwarded Host Middleware.
+
+Rewrites the ASGI ``host`` header and ``scope["server"]`` tuple from the
+``X-Forwarded-Host`` header when the request originates from a trusted proxy.
+
+Uvicorn's ``ProxyHeadersMiddleware`` handles ``X-Forwarded-Proto`` (scheme)
+and ``X-Forwarded-For`` (client IP) but does **not** handle
+``X-Forwarded-Host`` (upstream issue encode/uvicorn#965, open PR #2811).
+
+This middleware fills that gap so that ``request.base_url`` (used in admin UI
+hints, OAuth redirect_uri display, well-known URLs, etc.) reflects the
+proxy's public host rather than the gateway's internal address.
+
+Register this middleware **after** ``ProxyHeadersMiddleware`` in the
+``add_middleware`` stack (which means it executes **before** it in the ASGI
+call chain, ensuring the scheme is already corrected when we derive the
+default port).
+
+When Uvicorn merges upstream support, this middleware can be removed.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+
+# Third-Party
+from uvicorn._types import (
+    ASGI3Application,
+    ASGIReceiveCallable,
+    ASGISendCallable,
+    Scope,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ForwardedHostMiddleware:
+    """Rewrite the ASGI ``host`` header from ``X-Forwarded-Host``.
+
+    Mirrors the approach in Uvicorn PR #2811:
+    * Parses host and optional port from the header value.
+    * Updates ``scope["server"]`` with ``(host, port)``.
+    * Replaces the ``host`` entry in ``scope["headers"]`` so that
+      Starlette's ``request.base_url`` returns the proxy origin.
+
+    Only acts when the connecting client is in *trusted_hosts* (same
+    trust model as ``ProxyHeadersMiddleware``).  The gateway registers
+    both middlewares with ``trusted_hosts="*"``; deployments that
+    restrict trusted hosts should pass the same value here.
+    """
+
+    def __init__(
+        self,
+        app: ASGI3Application,
+        trusted_hosts: list[str] | str = "127.0.0.1",
+    ) -> None:
+        """Initialise middleware with the inner ASGI app and trusted hosts."""
+        self.app = app
+        if isinstance(trusted_hosts, str):
+            self.always_trust = trusted_hosts == "*"
+        else:
+            self.always_trust = trusted_hosts == ["*"]
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: ASGIReceiveCallable,
+        send: ASGISendCallable,
+    ) -> None:
+        """Rewrite host header from X-Forwarded-Host if present and trusted."""
+        if scope["type"] in ("http", "websocket") and self.always_trust:
+            headers = dict(scope["headers"])  # type: ignore[arg-type]
+
+            if b"x-forwarded-host" in headers:
+                raw = headers[b"x-forwarded-host"].decode("latin1")
+                # Take only the first value if comma-separated (leftmost =
+                # client-facing hop).
+                x_forwarded_host = raw.split(",")[0].strip()
+
+                if x_forwarded_host:
+                    # Determine default port from the (already-corrected) scheme.
+                    default_port = 443 if scope.get("scheme") in ("https", "wss") else 80
+
+                    # Parse host and optional port.
+                    # IPv6 addresses are bracketed, e.g. [::1]:8080.  A trailing
+                    # "]" means IPv6 *without* a port suffix.
+                    if ":" in x_forwarded_host and not x_forwarded_host.endswith("]"):
+                        host_part, port_str = x_forwarded_host.rsplit(":", 1)
+                        try:
+                            port = int(port_str)
+                        except ValueError:
+                            port = default_port
+                    else:
+                        host_part = x_forwarded_host
+                        port = default_port
+
+                    scope["server"] = (host_part, port)
+
+                    # Replace the ``host`` header so Starlette sees the proxy host.
+                    new_headers: list[tuple[bytes, bytes]] = [(name, value) for name, value in scope["headers"] if name != b"host"]  # type: ignore[union-attr]
+                    new_headers.append((b"host", x_forwarded_host.encode("latin1")))
+                    scope["headers"] = new_headers  # type: ignore[typeddict-item]
+
+        return await self.app(scope, receive, send)

--- a/mcpgateway/middleware/forwarded_host.py
+++ b/mcpgateway/middleware/forwarded_host.py
@@ -21,10 +21,10 @@ Starlette builds ``request.base_url`` from the ``host`` header, not from
 ``scope["server"]``.  The host header rewrite is therefore the critical
 change; ``scope["server"]`` is updated as well for other ASGI consumers.
 
-Register this middleware **after** ``ProxyHeadersMiddleware`` in the
-``add_middleware`` stack (which means it executes **before** it in the ASGI
-call chain, ensuring the scheme is already corrected when we derive the
-default port for ``scope["server"]``).
+Register this middleware **before** ``ProxyHeadersMiddleware`` in the
+``add_middleware`` stack (which means it is inner / executes **after**
+``ProxyHeadersMiddleware`` in the ASGI call chain, ensuring the scheme is
+already corrected when we derive the default port for ``scope["server"]``).
 
 Trust decisions (which upstream IPs may set forwarded headers) are the
 responsibility of the caller — this middleware always acts when
@@ -40,14 +40,7 @@ from __future__ import annotations
 
 # Standard
 import logging
-
-# Third-Party
-from uvicorn._types import (
-    ASGI3Application,
-    ASGIReceiveCallable,
-    ASGISendCallable,
-    Scope,
-)
+from typing import Any, Awaitable, Callable, MutableMapping
 
 logger = logging.getLogger(__name__)
 
@@ -68,15 +61,15 @@ class ForwardedHostMiddleware:
     default for the scheme (80 for http/ws, 443 for https/wss).
     """
 
-    def __init__(self, app: ASGI3Application) -> None:
+    def __init__(self, app: Callable[..., Awaitable[None]]) -> None:
         """Initialise middleware with the inner ASGI app."""
         self.app = app
 
     async def __call__(
         self,
-        scope: Scope,
-        receive: ASGIReceiveCallable,
-        send: ASGISendCallable,
+        scope: MutableMapping[str, Any],
+        receive: Callable[[], Awaitable[MutableMapping[str, Any]]],
+        send: Callable[[MutableMapping[str, Any]], Awaitable[None]],
     ) -> None:
         """Rewrite host header from X-Forwarded-Host if present."""
         if scope["type"] in ("http", "websocket"):

--- a/mcpgateway/middleware/forwarded_host.py
+++ b/mcpgateway/middleware/forwarded_host.py
@@ -7,7 +7,7 @@ Authors: ContextForge Contributors
 Forwarded Host Middleware.
 
 Rewrites the ASGI ``host`` header and ``scope["server"]`` tuple from the
-``X-Forwarded-Host`` header when the request originates from a trusted proxy.
+``X-Forwarded-Host`` header set by a reverse proxy.
 
 Uvicorn's ``ProxyHeadersMiddleware`` handles ``X-Forwarded-Proto`` (scheme)
 and ``X-Forwarded-For`` (client IP) but does **not** handle
@@ -17,10 +17,20 @@ This middleware fills that gap so that ``request.base_url`` (used in admin UI
 hints, OAuth redirect_uri display, well-known URLs, etc.) reflects the
 proxy's public host rather than the gateway's internal address.
 
+Starlette builds ``request.base_url`` from the ``host`` header, not from
+``scope["server"]``.  The host header rewrite is therefore the critical
+change; ``scope["server"]`` is updated as well for other ASGI consumers.
+
 Register this middleware **after** ``ProxyHeadersMiddleware`` in the
 ``add_middleware`` stack (which means it executes **before** it in the ASGI
 call chain, ensuring the scheme is already corrected when we derive the
-default port).
+default port for ``scope["server"]``).
+
+Trust decisions (which upstream IPs may set forwarded headers) are the
+responsibility of the caller — this middleware always acts when
+``X-Forwarded-Host`` is present.  The gateway should only register it
+when proxy headers are trusted (the same condition under which
+``ProxyHeadersMiddleware`` is registered).
 
 When Uvicorn merges upstream support, this middleware can be removed.
 """
@@ -51,28 +61,16 @@ class ForwardedHostMiddleware:
     * Replaces the ``host`` entry in ``scope["headers"]`` so that
       Starlette's ``request.base_url`` returns the proxy origin.
 
-    Only acts when ``trusted_hosts="*"`` (trust all proxies).  Per-IP trust
-    checking is not implemented — for non-wildcard values the middleware is a
-    no-op.  This is intentional: the gateway registers both this and
-    ``ProxyHeadersMiddleware`` with ``trusted_hosts="*"`` via a shared variable,
-    and this middleware is temporary until Uvicorn merges upstream support.
-
-    Default port values (80 for http/ws, 443 for https/wss) follow RFC 2616
-    and match the convention in Uvicorn PR #2811.  They populate
-    ``scope["server"]`` only when the ``X-Forwarded-Host`` header omits a port.
+    Proxies typically send just the hostname for standard ports
+    (``X-Forwarded-Host: example.com``) and include the port only for
+    non-standard ones (``X-Forwarded-Host: example.com:8443``).  When
+    no port is present, ``scope["server"]`` is filled with the standard
+    default for the scheme (80 for http/ws, 443 for https/wss).
     """
 
-    def __init__(
-        self,
-        app: ASGI3Application,
-        trusted_hosts: list[str] | str = "127.0.0.1",
-    ) -> None:
-        """Initialise middleware with the inner ASGI app and trusted hosts."""
+    def __init__(self, app: ASGI3Application) -> None:
+        """Initialise middleware with the inner ASGI app."""
         self.app = app
-        if isinstance(trusted_hosts, str):
-            self.always_trust = trusted_hosts == "*"
-        else:
-            self.always_trust = trusted_hosts == ["*"]
 
     async def __call__(
         self,
@@ -80,8 +78,8 @@ class ForwardedHostMiddleware:
         receive: ASGIReceiveCallable,
         send: ASGISendCallable,
     ) -> None:
-        """Rewrite host header from X-Forwarded-Host if present and trusted."""
-        if scope["type"] in ("http", "websocket") and self.always_trust:
+        """Rewrite host header from X-Forwarded-Host if present."""
+        if scope["type"] in ("http", "websocket"):
             headers = dict(scope["headers"])  # type: ignore[arg-type]
 
             if b"x-forwarded-host" in headers:
@@ -91,7 +89,7 @@ class ForwardedHostMiddleware:
                 x_forwarded_host = raw.split(",")[0].strip()
 
                 if x_forwarded_host:
-                    # Determine default port from the (already-corrected) scheme.
+                    # Default port for scope["server"] when the header omits one.
                     default_port = 443 if scope.get("scheme") in ("https", "wss") else 80
 
                     # Parse host and optional port.

--- a/mcpgateway/middleware/forwarded_host.py
+++ b/mcpgateway/middleware/forwarded_host.py
@@ -51,10 +51,15 @@ class ForwardedHostMiddleware:
     * Replaces the ``host`` entry in ``scope["headers"]`` so that
       Starlette's ``request.base_url`` returns the proxy origin.
 
-    Only acts when the connecting client is in *trusted_hosts* (same
-    trust model as ``ProxyHeadersMiddleware``).  The gateway registers
-    both middlewares with ``trusted_hosts="*"``; deployments that
-    restrict trusted hosts should pass the same value here.
+    Only acts when ``trusted_hosts="*"`` (trust all proxies).  Per-IP trust
+    checking is not implemented — for non-wildcard values the middleware is a
+    no-op.  This is intentional: the gateway registers both this and
+    ``ProxyHeadersMiddleware`` with ``trusted_hosts="*"`` via a shared variable,
+    and this middleware is temporary until Uvicorn merges upstream support.
+
+    Default port values (80 for http/ws, 443 for https/wss) follow RFC 2616
+    and match the convention in Uvicorn PR #2811.  They populate
+    ``scope["server"]`` only when the ``X-Forwarded-Host`` header omits a port.
     """
 
     def __init__(

--- a/tests/playwright/test_forwarded_host_redirect_hint.py
+++ b/tests/playwright/test_forwarded_host_redirect_hint.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/playwright/test_forwarded_host_redirect_hint.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: ContextForge Contributors
+
+Playwright tests verifying that the OAuth redirect_uri hint in the admin UI
+reflects the ``X-Forwarded-Host`` header when the gateway is behind a proxy.
+
+Covers issue #4354: the admin UI's "Use: ..." hint for the OAuth redirect_uri
+should show the proxy's public host, not the gateway's internal address.
+"""
+
+# Standard
+import re
+
+# Third-Party
+from playwright.sync_api import expect, Page
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+import pytest
+
+# Local
+from .conftest import _ensure_admin_logged_in
+
+_FORWARDED_HOST = "frontend-proxy.example.com"
+_FORWARDED_PROTO = "https"
+
+# CSS selector for the OAuth redirect_uri hint <code> element in the
+# add-gateway form.  The hint lives inside #oauth-auth-code-fields-gw.
+_HINT_CODE_SELECTOR_GW = "#oauth-auth-code-fields-gw p.text-blue-600 code.bg-blue-100"
+
+
+def _wait_for_admin_content(page: Page) -> None:
+    """Wait for admin app to settle after navigation."""
+    try:
+        page.wait_for_load_state("domcontentloaded", timeout=10000)
+    except PlaywrightTimeoutError:
+        pass
+    page.wait_for_timeout(1500)
+
+
+@pytest.mark.ui
+class TestForwardedHostRedirectHint:
+    """Verify the OAuth redirect_uri hint reflects X-Forwarded-Host.
+
+    Uses ``page.route()`` to intercept requests to the admin panel and
+    re-fetch them with ``X-Forwarded-Host`` / ``X-Forwarded-Proto`` headers
+    injected, simulating a reverse-proxy deployment.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_forwarded_headers(self, page: Page, base_url: str):
+        """Intercept admin requests and inject X-Forwarded-Host/Proto headers."""
+        page.set_default_timeout(10000)
+
+        def _handle_route(route):
+            # Skip SSE event-stream requests -- they are long-lived and will
+            # cause TargetClosedError on teardown.
+            if "/events" in route.request.url:
+                route.continue_()
+                return
+            response = route.fetch(
+                headers={
+                    **route.request.headers,
+                    "x-forwarded-host": _FORWARDED_HOST,
+                    "x-forwarded-proto": _FORWARDED_PROTO,
+                },
+            )
+            route.fulfill(response=response)
+
+        pattern = re.compile(re.escape(base_url.rstrip("/")) + r"/.*")
+        page.route(pattern, _handle_route)
+        yield
+        page.unroute_all(behavior="ignoreErrors")
+
+    def test_gateway_add_form_redirect_hint_uses_forwarded_host(self, page: Page, base_url: str):
+        """The redirect_uri hint in the Add Gateway form shows the proxy host."""
+        _ensure_admin_logged_in(page, base_url)
+
+        page.goto(f"{base_url.rstrip('/')}/admin/#gateways")
+        _wait_for_admin_content(page)
+
+        # Reveal OAuth fields: select auth type "oauth".
+        auth_type_select = page.locator("#auth-type-gw")
+        auth_type_select.select_option("oauth")
+        page.wait_for_selector("#auth-oauth-fields-gw", state="visible", timeout=5000)
+
+        # authorization_code is the default grant type, so
+        # #oauth-auth-code-fields-gw should already be visible.
+        page.wait_for_selector("#oauth-auth-code-fields-gw", state="visible", timeout=5000)
+
+        # Assert the hint <code> element contains the forwarded host.
+        hint_code = page.locator(_HINT_CODE_SELECTOR_GW)
+        expect(hint_code).to_be_visible()
+
+        hint_text = hint_code.text_content()
+        assert hint_text is not None, "Hint <code> element has no text content"
+
+        expected_prefix = f"{_FORWARDED_PROTO}://{_FORWARDED_HOST}"
+        assert hint_text.startswith(expected_prefix), f"Expected redirect_uri hint to start with '{expected_prefix}', but got: '{hint_text}'"
+        assert hint_text.endswith("oauth/callback"), f"Expected redirect_uri hint to end with 'oauth/callback', but got: '{hint_text}'"
+
+    def test_gateway_add_form_redirect_hint_without_forwarded_host(self, page: Page, base_url: str):
+        """Without X-Forwarded-Host, the hint shows the direct server address."""
+        # Remove the autouse routes so no forwarded headers are injected.
+        page.unroute_all(behavior="ignoreErrors")
+
+        _ensure_admin_logged_in(page, base_url)
+        page.goto(f"{base_url.rstrip('/')}/admin/#gateways")
+        _wait_for_admin_content(page)
+
+        auth_type_select = page.locator("#auth-type-gw")
+        auth_type_select.select_option("oauth")
+        page.wait_for_selector("#auth-oauth-fields-gw", state="visible", timeout=5000)
+        page.wait_for_selector("#oauth-auth-code-fields-gw", state="visible", timeout=5000)
+
+        hint_code = page.locator(_HINT_CODE_SELECTOR_GW)
+        expect(hint_code).to_be_visible()
+
+        hint_text = hint_code.text_content()
+        assert hint_text is not None, "Hint <code> element has no text content"
+
+        # Without forwarded headers, should NOT show the proxy host.
+        assert _FORWARDED_HOST not in hint_text, f"Hint should not contain forwarded host '{_FORWARDED_HOST}' without forwarding headers, but got: '{hint_text}'"
+        assert hint_text.endswith("oauth/callback"), f"Expected redirect_uri hint to end with 'oauth/callback', but got: '{hint_text}'"

--- a/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
@@ -54,7 +54,7 @@ class TestForwardedHostMiddleware:
         original_server = scope["server"]
         original_headers = list(scope["headers"])
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == original_server
@@ -67,7 +67,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "proxy.example.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 443)
@@ -80,7 +80,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "proxy.example.com:8443")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 8443)
@@ -89,44 +89,44 @@ class TestForwardedHostMiddleware:
 
     @pytest.mark.asyncio
     async def test_http_default_port(self):
-        """HTTP scheme defaults to port 80."""
+        """HTTP scheme defaults to port 80 in scope['server']."""
         scope = _make_scope(scheme="http")
         _add_header(scope, "x-forwarded-host", "proxy.example.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 80)
 
     @pytest.mark.asyncio
     async def test_https_default_port(self):
-        """HTTPS scheme defaults to port 443."""
+        """HTTPS scheme defaults to port 443 in scope['server']."""
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "proxy.example.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 443)
 
     @pytest.mark.asyncio
     async def test_wss_default_port(self):
-        """WSS scheme defaults to port 443."""
+        """WSS scheme defaults to port 443 in scope['server']."""
         scope = _make_scope(scheme="wss", scope_type="websocket")
         _add_header(scope, "x-forwarded-host", "proxy.example.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 443)
 
     @pytest.mark.asyncio
     async def test_ws_default_port(self):
-        """WS scheme defaults to port 80."""
+        """WS scheme defaults to port 80 in scope['server']."""
         scope = _make_scope(scheme="ws", scope_type="websocket")
         _add_header(scope, "x-forwarded-host", "proxy.example.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 80)
@@ -137,7 +137,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "[2001:db8::1]")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("[2001:db8::1]", 443)
@@ -150,7 +150,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "[2001:db8::1]:8080")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("[2001:db8::1]", 8080)
@@ -164,7 +164,7 @@ class TestForwardedHostMiddleware:
         original_server = scope["server"]
         _add_header(scope, "x-forwarded-host", "")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == original_server
@@ -176,7 +176,7 @@ class TestForwardedHostMiddleware:
         original_server = scope["server"]
         _add_header(scope, "x-forwarded-host", "   ")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == original_server
@@ -187,7 +187,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "first-proxy.com, second-proxy.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("first-proxy.com", 443)
@@ -195,24 +195,11 @@ class TestForwardedHostMiddleware:
         assert host_values == ["first-proxy.com"]
 
     @pytest.mark.asyncio
-    async def test_untrusted_host_passthrough(self):
-        """When trusted_hosts is restrictive, untrusted requests pass through."""
-        scope = _make_scope()
-        original_server = scope["server"]
-        _add_header(scope, "x-forwarded-host", "evil.com")
-
-        # Not trusted (trusted_hosts is not "*")
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="192.168.0.1")
-        await mw(scope, None, None)
-
-        assert scope["server"] == original_server
-
-    @pytest.mark.asyncio
     async def test_lifespan_scope_passthrough(self):
         """Lifespan events are passed through without modification."""
         scope = {"type": "lifespan"}
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert "server" not in scope
@@ -223,7 +210,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(host="internal:4444", scheme="https")
         _add_header(scope, "x-forwarded-host", "external.com")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         host_entries = [(k, v) for k, v in scope["headers"] if k == b"host"]
@@ -236,18 +223,7 @@ class TestForwardedHostMiddleware:
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "proxy.example.com:notaport")
 
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
-        await mw(scope, None, None)
-
-        assert scope["server"] == ("proxy.example.com", 443)
-
-    @pytest.mark.asyncio
-    async def test_list_trusted_hosts_wildcard(self):
-        """trusted_hosts as list ['*'] is also trusted."""
-        scope = _make_scope(scheme="https")
-        _add_header(scope, "x-forwarded-host", "proxy.example.com")
-
-        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts=["*"])
+        mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
         assert scope["server"] == ("proxy.example.com", 443)

--- a/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: ContextForge Contributors
+
+Unit tests for ForwardedHostMiddleware.
+"""
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
+
+
+def _make_scope(
+    *,
+    host: str = "internal-gw:4444",
+    server: tuple = ("internal-gw", 4444),
+    scheme: str = "http",
+    scope_type: str = "http",
+) -> dict:
+    """Build a minimal ASGI scope for testing."""
+    headers = [(b"host", host.encode("latin1"))]
+    return {
+        "type": scope_type,
+        "scheme": scheme,
+        "server": server,
+        "headers": headers,
+        "path": "/admin",
+        "query_string": b"",
+    }
+
+
+def _add_header(scope: dict, name: str, value: str) -> dict:
+    """Add a header to an ASGI scope."""
+    scope["headers"].append((name.lower().encode("latin1"), value.encode("latin1")))
+    return scope
+
+
+async def _capture_app(scope, receive, send):
+    """A no-op ASGI app that records the scope it received."""
+    scope["_captured"] = True
+
+
+class TestForwardedHostMiddleware:
+    """Tests for X-Forwarded-Host header rewriting."""
+
+    @pytest.mark.asyncio
+    async def test_no_forwarded_host_passthrough(self):
+        """Without X-Forwarded-Host, scope is unchanged."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        original_headers = list(scope["headers"])
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+        host_values = [v for k, v in scope["headers"] if k == b"host"]
+        assert host_values == [h for _, h in original_headers if _ == b"host"]
+
+    @pytest.mark.asyncio
+    async def test_simple_hostname(self):
+        """X-Forwarded-Host with a plain hostname rewrites host and server."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["proxy.example.com"]
+
+    @pytest.mark.asyncio
+    async def test_hostname_with_port(self):
+        """X-Forwarded-Host with host:port rewrites both."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com:8443")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 8443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["proxy.example.com:8443"]
+
+    @pytest.mark.asyncio
+    async def test_http_default_port(self):
+        """HTTP scheme defaults to port 80."""
+        scope = _make_scope(scheme="http")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 80)
+
+    @pytest.mark.asyncio
+    async def test_https_default_port(self):
+        """HTTPS scheme defaults to port 443."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 443)
+
+    @pytest.mark.asyncio
+    async def test_wss_default_port(self):
+        """WSS scheme defaults to port 443."""
+        scope = _make_scope(scheme="wss", scope_type="websocket")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 443)
+
+    @pytest.mark.asyncio
+    async def test_ws_default_port(self):
+        """WS scheme defaults to port 80."""
+        scope = _make_scope(scheme="ws", scope_type="websocket")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 80)
+
+    @pytest.mark.asyncio
+    async def test_ipv6_without_port(self):
+        """IPv6 address in brackets without port."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "[2001:db8::1]")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("[2001:db8::1]", 443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["[2001:db8::1]"]
+
+    @pytest.mark.asyncio
+    async def test_ipv6_with_port(self):
+        """IPv6 address in brackets with port."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "[2001:db8::1]:8080")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("[2001:db8::1]", 8080)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["[2001:db8::1]:8080"]
+
+    @pytest.mark.asyncio
+    async def test_empty_forwarded_host_ignored(self):
+        """Empty X-Forwarded-Host is ignored."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_forwarded_host_ignored(self):
+        """Whitespace-only X-Forwarded-Host is ignored."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "   ")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_comma_separated_takes_first(self):
+        """Comma-separated X-Forwarded-Host takes the first (leftmost) value."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "first-proxy.com, second-proxy.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("first-proxy.com", 443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["first-proxy.com"]
+
+    @pytest.mark.asyncio
+    async def test_untrusted_host_passthrough(self):
+        """When trusted_hosts is restrictive, untrusted requests pass through."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "evil.com")
+
+        # Not trusted (trusted_hosts is not "*")
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="192.168.0.1")
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_lifespan_scope_passthrough(self):
+        """Lifespan events are passed through without modification."""
+        scope = {"type": "lifespan"}
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert "server" not in scope
+
+    @pytest.mark.asyncio
+    async def test_replaces_existing_host_header(self):
+        """Ensures the original host header is replaced, not duplicated."""
+        scope = _make_scope(host="internal:4444", scheme="https")
+        _add_header(scope, "x-forwarded-host", "external.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        host_entries = [(k, v) for k, v in scope["headers"] if k == b"host"]
+        assert len(host_entries) == 1
+        assert host_entries[0][1] == b"external.com"
+
+    @pytest.mark.asyncio
+    async def test_invalid_port_uses_default(self):
+        """Non-numeric port falls back to default port for the scheme."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com:notaport")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts="*")
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 443)
+
+    @pytest.mark.asyncio
+    async def test_list_trusted_hosts_wildcard(self):
+        """trusted_hosts as list ['*'] is also trusted."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "proxy.example.com")
+
+        mw = ForwardedHostMiddleware(_capture_app, trusted_hosts=["*"])
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("proxy.example.com", 443)

--- a/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py
@@ -133,29 +133,42 @@ class TestForwardedHostMiddleware:
 
     @pytest.mark.asyncio
     async def test_ipv6_without_port(self):
-        """IPv6 address in brackets without port."""
+        """Bracketed IPv6 address without port; server is unbracketed."""
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "[2001:db8::1]")
 
         mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
-        assert scope["server"] == ("[2001:db8::1]", 443)
+        assert scope["server"] == ("2001:db8::1", 443)
         host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
         assert host_values == ["[2001:db8::1]"]
 
     @pytest.mark.asyncio
     async def test_ipv6_with_port(self):
-        """IPv6 address in brackets with port."""
+        """Bracketed IPv6 address with port; server is unbracketed."""
         scope = _make_scope(scheme="https")
         _add_header(scope, "x-forwarded-host", "[2001:db8::1]:8080")
 
         mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
-        assert scope["server"] == ("[2001:db8::1]", 8080)
+        assert scope["server"] == ("2001:db8::1", 8080)
         host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
         assert host_values == ["[2001:db8::1]:8080"]
+
+    @pytest.mark.asyncio
+    async def test_ipv6_unbracketed_without_port(self):
+        """Unbracketed IPv6 without port is treated as a literal host."""
+        scope = _make_scope(scheme="https")
+        _add_header(scope, "x-forwarded-host", "2001:db8::1")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("2001:db8::1", 443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["2001:db8::1"]
 
     @pytest.mark.asyncio
     async def test_empty_forwarded_host_ignored(self):
@@ -218,12 +231,138 @@ class TestForwardedHostMiddleware:
         assert host_entries[0][1] == b"external.com"
 
     @pytest.mark.asyncio
-    async def test_invalid_port_uses_default(self):
-        """Non-numeric port falls back to default port for the scheme."""
+    async def test_invalid_port_ignored(self):
+        """Non-numeric port causes the header to be ignored entirely."""
         scope = _make_scope(scheme="https")
+        original_server = scope["server"]
         _add_header(scope, "x-forwarded-host", "proxy.example.com:notaport")
 
         mw = ForwardedHostMiddleware(_capture_app)
         await mw(scope, None, None)
 
-        assert scope["server"] == ("proxy.example.com", 443)
+        assert scope["server"] == original_server
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["internal-gw:4444"]
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_port_ignored(self):
+        """Port outside 1-65535 causes the header to be ignored entirely."""
+        scope = _make_scope(scheme="https")
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "proxy.example.com:99999")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_path_in_host_ignored(self):
+        """Host value containing '/' is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "evil.com/path")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_duplicate_headers_first_wins(self):
+        """When multiple X-Forwarded-Host headers are present, the first wins."""
+        scope = _make_scope(scheme="https")
+        # Add two headers; the first (client-facing) should win.
+        _add_header(scope, "x-forwarded-host", "first-proxy.com")
+        _add_header(scope, "x-forwarded-host", "last-proxy.com")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == ("first-proxy.com", 443)
+        host_values = [v.decode() for k, v in scope["headers"] if k == b"host"]
+        assert host_values == ["first-proxy.com"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_bracketed_ipv6_ignored(self):
+        """Bracketed IPv6 missing closing ']' is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "[2001:db8::1")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_empty_bracketed_host_ignored(self):
+        """Empty brackets '[]' result in empty host and are rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "[]")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_empty_host_with_port_ignored(self):
+        """Host value ':443' with empty host is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", ":443")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_plus_sign_in_port_ignored(self):
+        """Port with leading '+' is rejected as invalid."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "example.com:+443")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_whitespace_in_forwarded_host_ignored(self):
+        """X-Forwarded-Host containing an embedded space is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "evil.com/path with space")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_bracketed_ipv6_with_trailing_junk_ignored(self):
+        """Bracketed IPv6 with extra colons (last not after ]) is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "[::1]:8080:extra")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server
+
+    @pytest.mark.asyncio
+    async def test_bracketed_ipv6_with_non_digit_port_ignored(self):
+        """Bracketed IPv6 with an alphabetic port is rejected."""
+        scope = _make_scope()
+        original_server = scope["server"]
+        _add_header(scope, "x-forwarded-host", "[::1]:abc")
+
+        mw = ForwardedHostMiddleware(_capture_app)
+        await mw(scope, None, None)
+
+        assert scope["server"] == original_server


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #4354

---

## 🚀 Summary (1-2 sentences)

Add `ForwardedHostMiddleware` that rewrites the ASGI `host` header from `X-Forwarded-Host`, so that `request.base_url` reflects the proxy's public address when the gateway is behind a reverse proxy. This fixes the OAuth `redirect_uri` hint in the admin UI showing the gateway's internal address instead of the proxy URL.

---

## 🧪 Checks

- [x] `make lint` passes
- [x] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes

### Problem

The admin UI shows an OAuth redirect_uri hint (`💡 Use: {base_url}oauth/callback`) on gateway and A2A agent add/edit forms. When the gateway is behind a reverse proxy, this hint shows the internal gateway address because Uvicorn's `ProxyHeadersMiddleware` handles `X-Forwarded-Proto` (scheme) and `X-Forwarded-For` (client IP) but not `X-Forwarded-Host` (host). This is a known upstream gap: [encode/uvicorn#965](https://github.com/encode/uvicorn/issues/965), with an unmerged PR [#2811](https://github.com/Kludex/uvicorn/pull/2811).

### Solution

A small ASGI middleware (`ForwardedHostMiddleware`) registered alongside `ProxyHeadersMiddleware` that:
- Reads `X-Forwarded-Host`, takes the first comma-separated value
- Parses optional port (including IPv6 bracket notation)
- Rewrites the `host` header in `scope["headers"]` and the `scope["server"]` tuple
- No template changes needed — all 4 hint locations are fixed automatically

### Security review

- **OAuth audience binding** (`_build_server_resource_url`): uses `settings.app_domain`, immune to host rewriting
- **SSO redirect validation**: uses `settings.app_domain` + allowlist, immune
- **CSRF origin check**: already reads `X-Forwarded-Host` directly (pre-existing), no regression
- **`trusted_hosts="*"`**: pre-existing decision on `ProxyHeadersMiddleware`, not introduced by this change

### Files changed

| File | Change |
|------|--------|
| `mcpgateway/middleware/forwarded_host.py` | New middleware |
| `mcpgateway/main.py` | Import + register middleware |
| `tests/unit/mcpgateway/middleware/test_forwarded_host_middleware.py` | 15 unit tests |
| `tests/playwright/test_forwarded_host_redirect_hint.py` | 2 Playwright E2E tests |

Can be removed when Uvicorn merges upstream `X-Forwarded-Host` support.