### PR TITLE
fix(oauth): preserve mTLS for token requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-24T08:41:31Z",
+  "generated_at": "2026-05-10T07:22:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 547,
+        "line_number": 624,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 742,
+        "line_number": 819,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1011,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1037,
+        "line_number": 1118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1045,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1130,
+        "line_number": 1210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1135,
+        "line_number": 1215,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1141,
+        "line_number": 1221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1153,
+        "line_number": 1233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1171,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1232,
+        "line_number": 1312,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -216,7 +216,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -224,7 +224,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 200,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 262,
+        "line_number": 272,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 273,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -250,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 765,
+        "line_number": 1077,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 853,
+        "line_number": 1165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1203,
+        "line_number": 1515,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2569,
+        "line_number": 2881,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2660,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2703,
+        "line_number": 3015,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2708,
+        "line_number": 3020,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2713,
+        "line_number": 3025,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -326,7 +326,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -334,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 951,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 953,
+        "line_number": 993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1857,
+        "line_number": 1858,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6263,
+        "line_number": 6296,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6760,
+        "line_number": 6793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6772,
+        "line_number": 6805,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6844,
+        "line_number": 6877,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7923,
+        "line_number": 7958,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -546,7 +546,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 994,
+        "line_number": 1066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -554,7 +554,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1301,
+        "line_number": 1373,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -618,7 +618,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 969,
+        "line_number": 968,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +626,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1072,
+        "line_number": 1071,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1075,
+        "line_number": 1074,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1241,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1329,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1795,
+        "line_number": 1794,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -684,7 +684,7 @@
         "hashed_secret": "5b204323030835cdda5d258742d1452e812988de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1642,
+        "line_number": 1647,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -694,7 +694,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 123,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -702,7 +702,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 546,
+        "line_number": 555,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,7 +710,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 643,
+        "line_number": 655,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -718,7 +718,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 704,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -726,7 +726,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 739,
+        "line_number": 754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -734,7 +734,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 963,
+        "line_number": 978,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -742,7 +742,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1233,
+        "line_number": 1247,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -752,7 +752,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 88,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -762,7 +762,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -770,7 +770,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -778,7 +778,7 @@
         "hashed_secret": "4d4acd9b084d13f5fdb23807d857e1c48a1cfd0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 610,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -786,7 +786,7 @@
         "hashed_secret": "db7e2c9fdd884e4d09b55011ee3e1ff27741a1eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 693,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -794,7 +794,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 767,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -802,7 +802,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 813,
+        "line_number": 831,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -810,7 +810,7 @@
         "hashed_secret": "b58991b134e990b6ce9844e054544e2151e48f2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 849,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -818,7 +818,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 866,
+        "line_number": 884,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -826,7 +826,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1110,
+        "line_number": 1128,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -834,7 +834,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1380,
+        "line_number": 1397,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -844,7 +844,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 156,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 227,
+        "line_number": 230,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 236,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 234,
+        "line_number": 237,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 675,
+        "line_number": 684,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 772,
+        "line_number": 784,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 833,
+        "line_number": 848,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 868,
+        "line_number": 883,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1092,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -916,7 +916,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1364,
+        "line_number": 1379,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -926,7 +926,7 @@
         "hashed_secret": "65724217e73023f759367bcb3375ea4c0a618418",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 29,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -936,7 +936,7 @@
         "hashed_secret": "cb58df830a45cc33df1a313e616ecad78cd796c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -944,7 +944,7 @@
         "hashed_secret": "2e0c522bfe4e7885492862df2e0b987c0ca02623",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -952,7 +952,7 @@
         "hashed_secret": "d9d007c8de197b3f36a3a0ba4f13c0f7df175d5a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 312,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -962,7 +962,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 265,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -970,7 +970,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 349,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -978,7 +978,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 359,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -986,7 +986,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 401,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +994,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 409,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 457,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1059,
+        "line_number": 1072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1120,
+        "line_number": 1136,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1694,
+        "line_number": 1710,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1771,
+        "line_number": 1787,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2083,
+        "line_number": 2102,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2540,
+        "line_number": 2559,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2540,
+        "line_number": 2559,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2553,
+        "line_number": 2572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2698,
+        "line_number": 2720,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2719,
+        "line_number": 2741,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2727,
+        "line_number": 2749,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2732,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1282,7 +1282,7 @@
         "hashed_secret": "e204d28a2874f6123747650d3e4003d4357d75eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 851,
+        "line_number": 852,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1290,7 +1290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1146,
+        "line_number": 1147,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1300,7 +1300,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1308,7 +1308,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1770,7 +1770,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2145,16 +2145,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/development/release-management.md": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 902,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2184,7 +2174,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 319,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2192,7 +2182,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2260,7 +2250,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 584,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2343,12 +2333,38 @@
         "verified_result": null
       }
     ],
+    "docs/docs/manage/configurable-auth-header.md": [
+      {
+        "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 164,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 255,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/docs/manage/configuration.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2356,7 +2372,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 477,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2364,7 +2380,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 843,
+        "line_number": 793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2372,7 +2388,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1260,
+        "line_number": 1210,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2380,7 +2396,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1264,
+        "line_number": 1214,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2594,7 +2610,7 @@
         "hashed_secret": "29b8dca3de5ff27bcf8bd3b622adf9970f29381c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2602,7 +2618,7 @@
         "hashed_secret": "d62bd0a3fef6be1bb3bb9078b323d87ac9f37f75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 570,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2612,7 +2628,7 @@
         "hashed_secret": "e42972502db194ed2d6521cd5acf594dc1e1c503",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2620,7 +2636,7 @@
         "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
+        "line_number": 103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2628,7 +2644,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 134,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2636,7 +2652,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2744,7 +2760,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 595,
+        "line_number": 598,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3062,7 +3078,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3070,7 +3086,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3078,7 +3094,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3086,7 +3102,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3094,7 +3110,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 414,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3102,7 +3118,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3110,7 +3126,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 633,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3118,7 +3134,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 844,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3146,7 +3162,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 149,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -3747,6 +3763,24 @@
         "verified_result": null
       }
     ],
+    "docs/docs/using/servers/external/notion-mcp-setup.md": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "09a28376ef8de09a0614fa3a62c47beeb525551d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/docs/using/servers/python/csv-pandas-chat-server.md": [
       {
         "hashed_secret": "1d3b1295c282649864a65fe3bd1631bcf7499ef5",
@@ -3813,6 +3847,108 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/security/password-policy-pentesting-response.md": [
+      {
+        "hashed_secret": "367ad0449ccb6236d757759bfa2b2e1b17fbe197",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5e79cffd9cec958879476a76bbdb55e13f1ffb56",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 175,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "66bf29d0724bceb3e121126ffda523374a9b209a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae4b759ed39e6c14f09775a5a2d442178ac57f7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/security/uaid-cross-gateway-auth.md": [
+      {
+        "hashed_secret": "6567ef5b01d3ef05dbabf70de37d042c658e2008",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "29c32f233d04598b3181c0e27ea0ec7a5c949297",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "51a13bb774ef66e75e0c638fe91ea5bb8341acd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 223,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 226,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 228,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/testing/manual-test-uaid-cross-gateway-auth.md": [
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "366307712bf20a9c0759b6d68f68ae14e0e95cb7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4188,7 +4324,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4187,
+        "line_number": 4201,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4196,7 +4332,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4788,
+        "line_number": 4841,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4204,7 +4340,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4790,
+        "line_number": 4843,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4212,7 +4348,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15118,
+        "line_number": 15339,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4232,7 +4368,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4242,7 +4378,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4252,7 +4388,7 @@
         "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4262,7 +4398,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4270,7 +4406,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4300,7 +4436,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4308,7 +4444,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4328,7 +4464,7 @@
         "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4338,7 +4474,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4348,7 +4484,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4358,7 +4494,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4368,7 +4504,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4378,7 +4514,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4386,7 +4522,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4406,7 +4542,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4416,7 +4552,7 @@
         "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4426,7 +4562,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4436,7 +4572,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4446,7 +4582,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4456,7 +4592,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4466,7 +4602,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 36,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4474,7 +4610,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 37,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4484,7 +4620,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4492,7 +4628,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4502,7 +4638,7 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4510,7 +4646,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4520,7 +4656,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4530,7 +4666,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 37,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4550,7 +4686,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4558,7 +4694,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4568,17 +4704,7 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
-      {
-        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 39,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4588,7 +4714,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 34,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4598,7 +4724,7 @@
         "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 33,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4606,7 +4732,7 @@
         "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 34,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4626,7 +4752,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 35,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4634,7 +4760,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 36,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4662,7 +4788,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4670,7 +4796,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4680,7 +4806,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4688,7 +4814,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4716,7 +4842,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4726,7 +4852,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4736,7 +4862,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4744,7 +4870,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4764,7 +4890,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4784,7 +4910,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4794,7 +4920,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4804,7 +4930,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4814,7 +4940,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4824,7 +4950,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4834,7 +4960,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 153,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4844,16 +4970,8 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 699,
+        "line_number": 752,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1101,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -4862,7 +4980,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 222,
+        "line_number": 248,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4870,7 +4988,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2327,
+        "line_number": 2891,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4916,7 +5034,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4924,7 +5042,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4932,38 +5050,8 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 270,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/hooks/policies.py": [
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -4972,7 +5060,7 @@
         "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 202,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4982,7 +5070,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4990,7 +5078,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4998,7 +5086,7 @@
         "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 680,
+        "line_number": 710,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5008,7 +5096,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 617,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5018,7 +5106,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4229,
+        "line_number": 4224,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5026,7 +5114,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5361,
+        "line_number": 5358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5034,7 +5122,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5710,
+        "line_number": 5707,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5042,7 +5130,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5767,
+        "line_number": 5764,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5050,7 +5138,7 @@
         "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5805,
+        "line_number": 5802,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5058,7 +5146,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5806,
+        "line_number": 5803,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5088,7 +5176,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 669,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5184,7 +5272,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 366,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5192,7 +5280,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3438,
+        "line_number": 3526,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5324,7 +5412,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5332,7 +5420,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 262,
+        "line_number": 261,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5340,7 +5428,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5464,7 +5552,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 810,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5474,7 +5562,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 851,
+        "line_number": 850,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5482,18 +5570,8 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 913,
+        "line_number": 912,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 118,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5786,7 +5864,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5794,7 +5872,7 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 455,
+        "line_number": 646,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5936,7 +6014,7 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 154,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -5944,7 +6022,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 202,
+        "line_number": 203,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5954,7 +6032,7 @@
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 60,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5972,17 +6050,7 @@
         "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 763,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_mcp_rbac_transport.py": [
-      {
-        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 837,
+        "line_number": 766,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5992,41 +6060,7 @@
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_translate_dynamic_env_e2e.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 201,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 290,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 554,
+        "line_number": 59,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6046,7 +6080,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 149,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6066,7 +6100,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 210,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6112,7 +6146,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3783,
+        "line_number": 3780,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6120,7 +6154,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6626,
+        "line_number": 6623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6128,7 +6162,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6982,
+        "line_number": 6979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6136,7 +6170,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7006,
+        "line_number": 7003,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6146,7 +6180,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 87,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6156,7 +6190,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 100,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6362,7 +6396,7 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6370,7 +6404,7 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 34,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6436,7 +6470,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 63,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6446,7 +6480,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 74,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6456,7 +6490,7 @@
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6464,7 +6498,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6472,7 +6506,7 @@
         "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 150,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6482,7 +6516,7 @@
         "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 520,
+        "line_number": 528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6490,7 +6524,7 @@
         "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 593,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6498,7 +6532,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 629,
+        "line_number": 637,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6508,7 +6542,7 @@
         "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6528,7 +6562,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6538,7 +6572,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 30,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6548,7 +6582,7 @@
         "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 243,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6558,7 +6592,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6566,7 +6600,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 587,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6576,7 +6610,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6586,7 +6620,7 @@
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 283,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6596,7 +6630,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 32,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6606,7 +6640,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 46,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6636,7 +6670,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6646,7 +6680,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 20,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6656,7 +6690,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6684,7 +6718,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6692,7 +6726,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6712,7 +6746,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6740,7 +6774,7 @@
         "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6816,7 +6850,7 @@
         "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6824,7 +6858,7 @@
         "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 472,
+        "line_number": 464,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6832,7 +6866,7 @@
         "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 512,
+        "line_number": 502,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6840,7 +6874,7 @@
         "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 674,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6850,7 +6884,7 @@
         "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1387,
+        "line_number": 1396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6858,7 +6892,7 @@
         "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1474,
+        "line_number": 1483,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6868,7 +6902,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 115,
+        "line_number": 116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6876,7 +6910,7 @@
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 116,
+        "line_number": 117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6884,174 +6918,8 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 213,
+        "line_number": 214,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 225,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 104,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 230,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
-      {
-        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 247,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 265,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 311,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 233,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
-      {
-        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 121,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 616,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 801,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 815,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 85,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -7068,7 +6936,7 @@
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 247,
+        "line_number": 199,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7078,7 +6946,7 @@
         "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7086,7 +6954,7 @@
         "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 381,
+        "line_number": 323,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7114,7 +6982,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 63,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7122,7 +6990,7 @@
         "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 144,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7152,7 +7020,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7160,7 +7028,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 186,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7170,7 +7038,7 @@
         "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7178,7 +7046,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 271,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7188,7 +7056,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7196,7 +7064,7 @@
         "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7204,7 +7072,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 701,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7212,7 +7080,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1422,
+        "line_number": 1465,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7220,7 +7088,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1491,
+        "line_number": 1534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7228,7 +7096,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1638,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7236,7 +7104,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1626,
+        "line_number": 1669,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7244,7 +7112,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1686,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7252,7 +7120,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1720,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7260,7 +7128,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2136,
+        "line_number": 2179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7270,7 +7138,7 @@
         "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 532,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7278,7 +7146,7 @@
         "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 538,
+        "line_number": 558,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7288,7 +7156,7 @@
         "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7298,7 +7166,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 373,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7328,7 +7196,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7336,7 +7204,7 @@
         "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 343,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7344,7 +7212,7 @@
         "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7352,7 +7220,7 @@
         "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 431,
+        "line_number": 432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7360,7 +7228,7 @@
         "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 562,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7370,7 +7238,7 @@
         "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 99,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7378,7 +7246,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7386,7 +7254,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 193,
+        "line_number": 218,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7394,7 +7262,7 @@
         "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 413,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7402,7 +7270,7 @@
         "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 389,
+        "line_number": 414,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7410,7 +7278,7 @@
         "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 425,
+        "line_number": 450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7418,7 +7286,7 @@
         "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 452,
+        "line_number": 477,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7426,7 +7294,7 @@
         "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 804,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7434,7 +7302,7 @@
         "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 806,
+        "line_number": 831,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7442,7 +7310,7 @@
         "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2400,
+        "line_number": 2445,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7450,7 +7318,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2409,
+        "line_number": 2454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7458,7 +7326,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3242,
+        "line_number": 3314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7466,7 +7334,7 @@
         "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3403,
+        "line_number": 3475,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7474,7 +7342,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3435,
+        "line_number": 3507,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7568,7 +7436,7 @@
         "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 563,
+        "line_number": 578,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7578,7 +7446,7 @@
         "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 135,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -7586,7 +7454,7 @@
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 136,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7596,7 +7464,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 404,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7604,7 +7472,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 700,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7612,7 +7480,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 785,
+        "line_number": 835,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7622,31 +7490,23 @@
         "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 276,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
+        "hashed_secret": "927ab42cfc3a3f3409f66221d8e37442f3b188e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 701,
+        "line_number": 691,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "454f9bfcc5f7523c755896f9d2c7281f83aec668",
+        "hashed_secret": "d076928bfade831b34f9af755506cd06e8b4dd1b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 727,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 754,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7654,7 +7514,7 @@
         "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 959,
+        "line_number": 923,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7662,7 +7522,7 @@
         "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 991,
+        "line_number": 955,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7670,7 +7530,7 @@
         "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1066,
+        "line_number": 1030,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7678,7 +7538,15 @@
         "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1244,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "39d0a63a567ae11fcf8695abfe19656aa1cbc0ed",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1303,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7686,15 +7554,15 @@
         "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1504,
+        "line_number": 1494,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
+        "hashed_secret": "f302e5128922d4e7acf42d7e22f95a2f001eb14d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1516,
+        "line_number": 1524,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7702,23 +7570,23 @@
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1579,
+        "line_number": 1597,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
+        "hashed_secret": "18d2caf3d1bac7ecb05d4e510dd021477ab55b9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1622,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
+        "hashed_secret": "1a4c1e340613dfefc9b4d4980394879d136e2fbc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1664,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7726,40 +7594,64 @@
         "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1660,
+        "line_number": 1681,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
+        "hashed_secret": "b94e256b5a8102d04799792b284dc44dd58b6609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2392,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
+        "hashed_secret": "b0ee0c442a1a6ea3ecce064786c038eb5c285c24",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2261,
+        "line_number": 3152,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3331f962763e9b59c985f0c18407811ccee92e72",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3187,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f13d82146ff9aa3b08420f15eec4c7a5aab44769",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3221,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_email_auth_service.py": [
       {
-        "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
+        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 389,
+        "line_number": 366,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4cf5ead1df6b23c1309a1eac48fe32ffc6c9ab1d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
       {
-        "hashed_secret": "759521118cabf4f8bbc46e6d6344d0e700aa4be5",
+        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
         "is_secret": false,
         "is_verified": false,
         "line_number": 50,
@@ -7767,7 +7659,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
+        "hashed_secret": "dff88ddbf282dc1477e1e419a7706371e7afba27",
         "is_secret": false,
         "is_verified": false,
         "line_number": 321,
@@ -7775,10 +7667,18 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "6fa5edecdc44e7209e0678c5dea72a95d63bf554",
+        "hashed_secret": "79caf88021d840cf3544d1aae14ae84f58310f8f",
         "is_secret": false,
         "is_verified": false,
         "line_number": 365,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f71ca03855f95d7df834ece97c9e09fc34ce89b9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 493,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7788,7 +7688,7 @@
         "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 155,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7798,7 +7698,7 @@
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 376,
+        "line_number": 378,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7806,7 +7706,7 @@
         "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 380,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7814,7 +7714,7 @@
         "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 418,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7822,7 +7722,7 @@
         "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 417,
+        "line_number": 419,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7830,7 +7730,7 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 420,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -7838,7 +7738,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 734,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7846,7 +7746,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 735,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7854,7 +7754,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 781,
+        "line_number": 797,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7862,7 +7762,7 @@
         "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 782,
+        "line_number": 798,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7870,7 +7770,7 @@
         "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 803,
+        "line_number": 819,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7898,7 +7798,7 @@
         "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 203,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7906,7 +7806,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 227,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7916,7 +7816,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7924,7 +7824,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7932,7 +7832,7 @@
         "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1472,
+        "line_number": 1528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7940,7 +7840,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5046,
+        "line_number": 5185,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7948,7 +7848,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5051,
+        "line_number": 5190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7956,7 +7856,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6592,
+        "line_number": 6731,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7964,7 +7864,7 @@
         "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7189,
+        "line_number": 7328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7972,7 +7872,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7208,
+        "line_number": 7347,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7980,7 +7880,7 @@
         "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7414,
+        "line_number": 7553,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7988,7 +7888,7 @@
         "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7433,
+        "line_number": 7572,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8026,7 +7926,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 615,
+        "line_number": 616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8034,7 +7934,7 @@
         "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 638,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8044,7 +7944,7 @@
         "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 308,
+        "line_number": 288,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8052,7 +7952,7 @@
         "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 517,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8060,7 +7960,7 @@
         "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1449,
+        "line_number": 1390,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8068,7 +7968,7 @@
         "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1602,
+        "line_number": 1543,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8076,7 +7976,7 @@
         "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1554,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8084,7 +7984,7 @@
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2504,
+        "line_number": 2384,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8092,7 +7992,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2521,
+        "line_number": 2401,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8100,7 +8000,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2670,
+        "line_number": 2550,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8110,7 +8010,7 @@
         "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8118,7 +8018,7 @@
         "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 275,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8126,7 +8026,7 @@
         "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 540,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8134,7 +8034,7 @@
         "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 555,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8142,7 +8042,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 769,
+        "line_number": 773,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8150,7 +8050,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 779,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8160,7 +8060,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8168,7 +8068,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 447,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8176,7 +8076,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 460,
+        "line_number": 466,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8194,7 +8094,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 99,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8202,7 +8102,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 123,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8210,7 +8110,7 @@
         "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8218,7 +8118,7 @@
         "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8226,7 +8126,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 185,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8236,7 +8136,7 @@
         "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 256,
+        "line_number": 266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8244,7 +8144,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8252,7 +8152,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 807,
+        "line_number": 821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8260,7 +8160,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8268,7 +8168,7 @@
         "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1229,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8276,7 +8176,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1289,
+        "line_number": 1335,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8284,7 +8184,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8294,7 +8194,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 169,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -8304,7 +8204,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 372,
+        "line_number": 458,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8312,7 +8212,15 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 391,
+        "line_number": 477,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8320,7 +8228,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 640,
+        "line_number": 789,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8328,7 +8236,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 716,
+        "line_number": 865,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8336,7 +8244,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 868,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8346,7 +8254,7 @@
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 67,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8354,7 +8262,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 352,
+        "line_number": 371,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8362,7 +8270,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 475,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8372,7 +8280,7 @@
         "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 410,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8380,7 +8288,7 @@
         "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 406,
+        "line_number": 411,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8390,7 +8298,7 @@
         "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4031,
+        "line_number": 4118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8398,7 +8306,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4046,
+        "line_number": 4133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8406,7 +8314,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4744,
+        "line_number": 4831,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8474,7 +8382,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8482,7 +8390,7 @@
         "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8490,7 +8398,7 @@
         "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
+        "line_number": 335,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8500,23 +8408,15 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 82,
+        "line_number": 83,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 107,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -8524,7 +8424,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 197,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -8532,8 +8432,16 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 211,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 254,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -8542,7 +8450,7 @@
         "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8550,7 +8458,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 255,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8558,7 +8466,7 @@
         "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 322,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8568,7 +8476,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 548,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8576,7 +8484,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 546,
+        "line_number": 549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8584,7 +8492,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 562,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8592,7 +8500,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1977,
+        "line_number": 1984,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8600,7 +8508,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3314,
+        "line_number": 3570,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8608,7 +8516,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3947,
+        "line_number": 4204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8616,7 +8524,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7240,
+        "line_number": 7588,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8624,7 +8532,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7732,
+        "line_number": 8080,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8632,7 +8540,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9079,
+        "line_number": 9427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8640,7 +8548,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9221,
+        "line_number": 9571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8648,7 +8556,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9597,
+        "line_number": 10052,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8658,7 +8566,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2980,
+        "line_number": 2985,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8666,7 +8574,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3666,
+        "line_number": 3671,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8582,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3675,
+        "line_number": 3680,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8682,7 +8590,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4066,
+        "line_number": 4130,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8690,7 +8598,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6993,
+        "line_number": 7057,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8698,7 +8606,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7011,
+        "line_number": 7075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8614,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7035,
+        "line_number": 7099,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8622,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7099,
+        "line_number": 7163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8630,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7110,
+        "line_number": 7174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8638,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7151,
+        "line_number": 7215,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8646,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7157,
+        "line_number": 7221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8746,7 +8654,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8351,
+        "line_number": 8415,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8772,7 +8680,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2780,
+        "line_number": 2775,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8780,7 +8688,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5213,
+        "line_number": 5273,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8788,7 +8696,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5866,
+        "line_number": 5926,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8796,7 +8704,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5930,
+        "line_number": 5990,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8804,7 +8712,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6182,
+        "line_number": 6242,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8812,7 +8720,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9165,
+        "line_number": 9225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8820,7 +8728,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9214,
+        "line_number": 9274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8828,7 +8736,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9253,
+        "line_number": 9313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8836,7 +8744,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9310,
+        "line_number": 9370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8844,7 +8752,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14385,
+        "line_number": 14441,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8852,7 +8760,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17142,
+        "line_number": 17198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8860,7 +8768,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17161,
+        "line_number": 17217,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8880,7 +8788,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 449,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8888,7 +8796,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1104,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9094,7 +9002,7 @@
         "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9102,7 +9010,7 @@
         "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 499,
+        "line_number": 564,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9110,7 +9018,7 @@
         "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 512,
+        "line_number": 577,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9118,7 +9026,7 @@
         "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 518,
+        "line_number": 583,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9126,7 +9034,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 587,
+        "line_number": 652,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9134,7 +9042,7 @@
         "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 647,
+        "line_number": 712,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9142,7 +9050,7 @@
         "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1016,
+        "line_number": 1082,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9150,7 +9058,7 @@
         "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1268,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9224,7 +9132,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9234,7 +9142,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9242,7 +9150,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 139,
+        "line_number": 152,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9250,8 +9158,16 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 165,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "759ea996d3686cbca80b6d412c3cee3faf60c272",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3806,
+        "type": "JSON Web Token",
         "verified_result": null
       }
     ],
@@ -9260,7 +9176,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 25,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9270,7 +9186,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2508,
+        "line_number": 2565,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9278,7 +9194,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2796,
+        "line_number": 2853,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9306,7 +9222,7 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1269,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9314,7 +9230,7 @@
         "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1496,
+        "line_number": 1540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9322,7 +9238,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1964,
+        "line_number": 2008,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9345,12 +9261,22 @@
         "verified_result": null
       }
     ],
+    "tests/unit/mcpgateway/test_password_policy.py": [
+      {
+        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 171,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9378,7 +9304,7 @@
         "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 333,
+        "line_number": 339,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9386,7 +9312,7 @@
         "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 352,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9394,7 +9320,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 377,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9402,7 +9328,7 @@
         "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9412,7 +9338,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 779,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9420,7 +9346,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 956,
+        "line_number": 975,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9428,7 +9354,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 961,
+        "line_number": 980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9436,7 +9362,7 @@
         "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 987,
+        "line_number": 1006,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9444,7 +9370,7 @@
         "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1005,
+        "line_number": 1024,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9452,7 +9378,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1235,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9460,7 +9386,7 @@
         "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9480,7 +9406,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 141,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9490,7 +9416,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 276,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9528,7 +9454,7 @@
         "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9538,7 +9464,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 12928,
+        "line_number": 13172,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9546,7 +9472,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14103,
+        "line_number": 14347,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9566,7 +9492,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 81,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9576,7 +9502,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 38,
         "type": "Private Key",
         "verified_result": null
       }
@@ -9596,7 +9522,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 379,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9604,7 +9530,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 463,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9614,7 +9540,7 @@
         "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9624,7 +9550,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9632,7 +9558,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9640,7 +9566,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9648,7 +9574,7 @@
         "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 66,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9656,7 +9582,7 @@
         "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 81,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9664,7 +9590,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 154,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9672,7 +9598,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 156,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9680,7 +9606,7 @@
         "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 215,
+        "line_number": 216,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9706,7 +9632,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1042,
+        "line_number": 1045,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9714,7 +9640,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1194,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9734,7 +9660,7 @@
         "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 140,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9742,7 +9668,7 @@
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 504,
+        "line_number": 453,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9750,7 +9676,7 @@
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 497,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9758,7 +9684,7 @@
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 561,
+        "line_number": 510,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9766,7 +9692,7 @@
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 930,
+        "line_number": 879,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9774,7 +9700,7 @@
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1179,
+        "line_number": 1128,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9789,12 +9715,22 @@
         "verified_result": null
       }
     ],
+    "tests/unit/plugins/test_secrets_detection.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
     "tests/unit/test_conc_01_helpers.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 167,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-10T06:09:40Z",
+  "generated_at": "2026-04-24T08:41:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 547,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 819,
+        "line_number": 742,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1092,
+        "line_number": 1011,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1118,
+        "line_number": 1037,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1045,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1210,
+        "line_number": 1130,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1215,
+        "line_number": 1135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1221,
+        "line_number": 1141,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1233,
+        "line_number": 1153,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1251,
+        "line_number": 1171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1312,
+        "line_number": 1232,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -216,7 +216,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 198,
+        "line_number": 188,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -224,7 +224,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 272,
+        "line_number": 262,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 273,
+        "line_number": 263,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -250,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1077,
+        "line_number": 765,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1165,
+        "line_number": 853,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1515,
+        "line_number": 1203,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2881,
+        "line_number": 2569,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2972,
+        "line_number": 2660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3015,
+        "line_number": 2703,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3020,
+        "line_number": 2708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3025,
+        "line_number": 2713,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -326,7 +326,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -334,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 991,
+        "line_number": 951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 993,
+        "line_number": 953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1858,
+        "line_number": 1857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6296,
+        "line_number": 6263,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6793,
+        "line_number": 6760,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6805,
+        "line_number": 6772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6877,
+        "line_number": 6844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7958,
+        "line_number": 7923,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -546,7 +546,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1066,
+        "line_number": 994,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -554,7 +554,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1373,
+        "line_number": 1301,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -618,7 +618,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 969,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +626,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1071,
+        "line_number": 1072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1074,
+        "line_number": 1075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1241,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1280,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1329,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1423,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1794,
+        "line_number": 1795,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -684,7 +684,7 @@
         "hashed_secret": "5b204323030835cdda5d258742d1452e812988de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1647,
+        "line_number": 1642,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -694,7 +694,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 123,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -702,7 +702,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 555,
+        "line_number": 546,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,7 +710,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -718,7 +718,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 704,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -726,7 +726,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 754,
+        "line_number": 739,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -734,7 +734,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 978,
+        "line_number": 963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -742,7 +742,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1247,
+        "line_number": 1233,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -752,7 +752,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 81,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -762,7 +762,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 122,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -770,7 +770,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 560,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -778,7 +778,7 @@
         "hashed_secret": "4d4acd9b084d13f5fdb23807d857e1c48a1cfd0f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 610,
+        "line_number": 598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -786,7 +786,7 @@
         "hashed_secret": "db7e2c9fdd884e4d09b55011ee3e1ff27741a1eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 693,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -794,7 +794,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 767,
+        "line_number": 752,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -802,7 +802,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 813,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -810,7 +810,7 @@
         "hashed_secret": "b58991b134e990b6ce9844e054544e2151e48f2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 831,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -818,7 +818,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 884,
+        "line_number": 866,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -826,7 +826,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1128,
+        "line_number": 1110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -834,7 +834,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1380,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -844,7 +844,7 @@
         "hashed_secret": "fdda45b7f6d2ead95d9991fc4678640c3bab0d84",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 227,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 236,
+        "line_number": 233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 237,
+        "line_number": 234,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 684,
+        "line_number": 675,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 784,
+        "line_number": 772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 848,
+        "line_number": 833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 883,
+        "line_number": 868,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -908,7 +908,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1107,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -916,7 +916,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1379,
+        "line_number": 1364,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -926,7 +926,7 @@
         "hashed_secret": "65724217e73023f759367bcb3375ea4c0a618418",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 22,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -936,7 +936,7 @@
         "hashed_secret": "cb58df830a45cc33df1a313e616ecad78cd796c5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -944,7 +944,7 @@
         "hashed_secret": "2e0c522bfe4e7885492862df2e0b987c0ca02623",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 148,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -952,7 +952,7 @@
         "hashed_secret": "d9d007c8de197b3f36a3a0ba4f13c0f7df175d5a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 319,
+        "line_number": 312,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -962,7 +962,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 265,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -970,7 +970,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 349,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -978,7 +978,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 359,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -986,7 +986,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +994,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 405,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 457,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 972,
+        "line_number": 962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1072,
+        "line_number": 1059,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1136,
+        "line_number": 1120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1171,
+        "line_number": 1155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1710,
+        "line_number": 1694,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1771,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2102,
+        "line_number": 2083,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2559,
+        "line_number": 2540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2559,
+        "line_number": 2540,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2572,
+        "line_number": 2553,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2720,
+        "line_number": 2698,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2741,
+        "line_number": 2719,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2749,
+        "line_number": 2727,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2754,
+        "line_number": 2732,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1282,7 +1282,7 @@
         "hashed_secret": "e204d28a2874f6123747650d3e4003d4357d75eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 851,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1290,7 +1290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1147,
+        "line_number": 1146,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1300,7 +1300,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1308,7 +1308,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1770,7 +1770,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2145,6 +2145,16 @@
         "verified_result": null
       }
     ],
+    "docs/docs/development/release-management.md": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 902,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2174,7 +2184,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2182,7 +2192,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2250,7 +2260,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 584,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2333,38 +2343,12 @@
         "verified_result": null
       }
     ],
-    "docs/docs/manage/configurable-auth-header.md": [
-      {
-        "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 215,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 255,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "docs/docs/manage/configuration.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 196,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2372,7 +2356,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 477,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2380,7 +2364,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 793,
+        "line_number": 843,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2388,7 +2372,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1210,
+        "line_number": 1260,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2396,7 +2380,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1214,
+        "line_number": 1264,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2610,7 +2594,7 @@
         "hashed_secret": "29b8dca3de5ff27bcf8bd3b622adf9970f29381c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 468,
+        "line_number": 469,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2618,7 +2602,7 @@
         "hashed_secret": "d62bd0a3fef6be1bb3bb9078b323d87ac9f37f75",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 570,
+        "line_number": 572,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2628,7 +2612,7 @@
         "hashed_secret": "e42972502db194ed2d6521cd5acf594dc1e1c503",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2636,7 +2620,7 @@
         "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2644,7 +2628,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 135,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2652,7 +2636,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2760,7 +2744,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 595,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3078,7 +3062,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3086,7 +3070,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3094,7 +3078,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3102,7 +3086,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3110,7 +3094,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3118,7 +3102,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3126,7 +3110,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3134,7 +3118,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3162,7 +3146,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 152,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -3763,24 +3747,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/using/servers/external/notion-mcp-setup.md": [
-      {
-        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "09a28376ef8de09a0614fa3a62c47beeb525551d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "docs/docs/using/servers/python/csv-pandas-chat-server.md": [
       {
         "hashed_secret": "1d3b1295c282649864a65fe3bd1631bcf7499ef5",
@@ -3847,108 +3813,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 102,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/security/password-policy-pentesting-response.md": [
-      {
-        "hashed_secret": "367ad0449ccb6236d757759bfa2b2e1b17fbe197",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5e79cffd9cec958879476a76bbdb55e13f1ffb56",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 175,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "66bf29d0724bceb3e121126ffda523374a9b209a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 184,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae4b759ed39e6c14f09775a5a2d442178ac57f7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/security/uaid-cross-gateway-auth.md": [
-      {
-        "hashed_secret": "6567ef5b01d3ef05dbabf70de37d042c658e2008",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "29c32f233d04598b3181c0e27ea0ec7a5c949297",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 122,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "51a13bb774ef66e75e0c638fe91ea5bb8341acd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 171,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 223,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 226,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 228,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/testing/manual-test-uaid-cross-gateway-auth.md": [
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 117,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "366307712bf20a9c0759b6d68f68ae14e0e95cb7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4324,7 +4188,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4201,
+        "line_number": 4187,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4332,7 +4196,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4841,
+        "line_number": 4788,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4340,7 +4204,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4843,
+        "line_number": 4790,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4348,7 +4212,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15339,
+        "line_number": 15118,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4368,7 +4232,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4378,7 +4242,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4388,7 +4252,7 @@
         "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4398,7 +4262,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 17,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4406,7 +4270,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4431,22 +4295,12 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/alembic/versions/351b43e1d273_add_password_history_table.py": [
-      {
-        "hashed_secret": "94b7db0891f2b8299f85d622d6e7728db2680ffb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py": [
       {
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4454,7 +4308,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4474,7 +4328,7 @@
         "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4484,17 +4338,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/4842b831d24e_add_on_error_to_tool_plugin_bindings.py": [
-      {
-        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4504,7 +4348,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4514,7 +4358,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4524,7 +4368,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4534,7 +4378,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4542,7 +4386,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4562,7 +4406,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4572,7 +4416,7 @@
         "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4582,43 +4426,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py": [
-      {
-        "hashed_secret": "6fc2a8a23c7db93d6624d3e40d9db9f3157c715e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9c45d2e63bc0_merge_plugin_bindings_and_token_.py": [
-      {
-        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 13,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "37aeb741aa6f0a22a08c218234b31ee891f64400",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4628,7 +4436,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4638,25 +4446,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py": [
-      {
-        "hashed_secret": "77ff62910d759a0d1cc7080497e7b3627a540428",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6fc2a8a23c7db93d6624d3e40d9db9f3157c715e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4666,7 +4456,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4676,7 +4466,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4684,7 +4474,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4694,7 +4484,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 17,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4702,7 +4492,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4712,22 +4502,12 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
       {
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/aa1b2c3d4e5f_add_token_revocation_idle_timeout_fields.py": [
-      {
-        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
         "is_secret": false,
         "is_verified": false,
         "line_number": 20,
@@ -4740,7 +4520,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 14,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4750,7 +4530,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4770,7 +4550,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4778,7 +4558,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4788,7 +4568,17 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 14,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
+      {
+        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4798,7 +4588,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4808,7 +4598,7 @@
         "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4816,7 +4606,7 @@
         "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4836,7 +4626,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4844,7 +4634,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4872,7 +4662,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4880,7 +4670,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4890,7 +4680,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4898,7 +4688,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4926,7 +4716,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4936,7 +4726,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4946,7 +4736,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4954,7 +4744,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4974,7 +4764,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4994,7 +4784,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5004,7 +4794,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 16,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5014,7 +4804,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5024,7 +4814,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 39,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5034,7 +4824,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 16,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5044,7 +4834,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 152,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5054,8 +4844,16 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 699,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1101,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5064,7 +4862,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 248,
+        "line_number": 222,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -5072,7 +4870,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2891,
+        "line_number": 2327,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5118,7 +4916,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5126,7 +4924,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 183,
+        "line_number": 182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5134,8 +4932,38 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 269,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/hooks/policies.py": [
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5144,7 +4972,7 @@
         "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 202,
+        "line_number": 150,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5154,7 +4982,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5162,7 +4990,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 428,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5170,7 +4998,7 @@
         "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 710,
+        "line_number": 680,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5180,7 +5008,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 617,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5190,7 +5018,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4224,
+        "line_number": 4229,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5198,7 +5026,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5358,
+        "line_number": 5361,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5206,7 +5034,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5707,
+        "line_number": 5710,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5214,7 +5042,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5764,
+        "line_number": 5767,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5222,7 +5050,7 @@
         "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5802,
+        "line_number": 5805,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5230,7 +5058,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5803,
+        "line_number": 5806,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5260,7 +5088,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 669,
+        "line_number": 573,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5356,7 +5184,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 356,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5364,7 +5192,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3526,
+        "line_number": 3438,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5496,7 +5324,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5504,7 +5332,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 261,
+        "line_number": 262,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5512,7 +5340,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5636,7 +5464,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 810,
+        "line_number": 572,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5646,7 +5474,7 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 850,
+        "line_number": 851,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5654,8 +5482,18 @@
         "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 912,
+        "line_number": 913,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5948,7 +5786,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 639,
+        "line_number": 448,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5956,7 +5794,7 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 646,
+        "line_number": 455,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6098,7 +5936,7 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 153,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -6106,7 +5944,7 @@
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 202,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6116,7 +5954,7 @@
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6134,7 +5972,17 @@
         "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 766,
+        "line_number": 763,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_mcp_rbac_transport.py": [
+      {
+        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 837,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6144,7 +5992,41 @@
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_translate_dynamic_env_e2e.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 201,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 338,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6164,7 +6046,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6184,7 +6066,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6230,7 +6112,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3780,
+        "line_number": 3783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6238,7 +6120,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6623,
+        "line_number": 6626,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6246,7 +6128,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6979,
+        "line_number": 6982,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6254,7 +6136,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7003,
+        "line_number": 7006,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6264,7 +6146,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 96,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6274,7 +6156,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 103,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6480,7 +6362,7 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 18,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6488,7 +6370,7 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 35,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6554,7 +6436,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 59,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6564,7 +6446,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 70,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6574,7 +6456,7 @@
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6582,7 +6464,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6590,7 +6472,7 @@
         "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6600,7 +6482,7 @@
         "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 528,
+        "line_number": 520,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6608,7 +6490,7 @@
         "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6616,7 +6498,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 629,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6626,7 +6508,7 @@
         "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6646,7 +6528,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6656,7 +6538,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6666,7 +6548,7 @@
         "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 238,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6676,7 +6558,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6684,7 +6566,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 587,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6694,7 +6576,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 36,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6704,7 +6586,7 @@
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6714,7 +6596,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 26,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6724,7 +6606,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 45,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6754,7 +6636,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 42,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6764,7 +6646,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 14,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6774,7 +6656,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6802,7 +6684,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6810,7 +6692,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6830,7 +6712,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6858,7 +6740,7 @@
         "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 52,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6934,7 +6816,7 @@
         "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6942,7 +6824,7 @@
         "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6950,7 +6832,7 @@
         "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6958,7 +6840,7 @@
         "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 674,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6968,7 +6850,7 @@
         "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1396,
+        "line_number": 1387,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6976,7 +6858,7 @@
         "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1483,
+        "line_number": 1474,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6986,7 +6868,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 116,
+        "line_number": 115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6994,7 +6876,7 @@
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7002,8 +6884,174 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 214,
+        "line_number": 213,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 225,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
+      {
+        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 247,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 311,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 233,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 238,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
+      {
+        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 616,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 801,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 815,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -7020,7 +7068,7 @@
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 247,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7030,7 +7078,7 @@
         "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 260,
+        "line_number": 301,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7038,7 +7086,7 @@
         "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 323,
+        "line_number": 381,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7066,7 +7114,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7074,7 +7122,7 @@
         "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 143,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7104,7 +7152,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7112,7 +7160,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 210,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7122,7 +7170,7 @@
         "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 192,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7130,7 +7178,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 271,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7140,7 +7188,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 206,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7148,7 +7196,7 @@
         "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 566,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7156,7 +7204,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 701,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7164,7 +7212,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1465,
+        "line_number": 1422,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7172,7 +7220,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1534,
+        "line_number": 1491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7180,7 +7228,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1638,
+        "line_number": 1595,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7188,7 +7236,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1669,
+        "line_number": 1626,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7196,7 +7244,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1686,
+        "line_number": 1643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7204,7 +7252,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1720,
+        "line_number": 1677,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7212,7 +7260,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2179,
+        "line_number": 2136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7222,7 +7270,7 @@
         "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 532,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7230,7 +7278,7 @@
         "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 558,
+        "line_number": 538,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7240,7 +7288,7 @@
         "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 126,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7250,7 +7298,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 373,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7280,7 +7328,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 278,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7288,7 +7336,7 @@
         "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 343,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7296,7 +7344,7 @@
         "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7304,7 +7352,7 @@
         "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 432,
+        "line_number": 431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7312,7 +7360,7 @@
         "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 563,
+        "line_number": 562,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7322,7 +7370,7 @@
         "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7330,7 +7378,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7338,7 +7386,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 218,
+        "line_number": 193,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7346,7 +7394,7 @@
         "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 413,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7354,7 +7402,7 @@
         "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 389,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7362,7 +7410,7 @@
         "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 425,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7370,7 +7418,7 @@
         "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 477,
+        "line_number": 452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7378,7 +7426,7 @@
         "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 804,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7386,7 +7434,7 @@
         "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 806,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7394,7 +7442,7 @@
         "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2445,
+        "line_number": 2400,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7402,7 +7450,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2454,
+        "line_number": 2409,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7410,7 +7458,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3314,
+        "line_number": 3242,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7418,7 +7466,7 @@
         "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3475,
+        "line_number": 3403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7426,7 +7474,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3507,
+        "line_number": 3435,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7520,7 +7568,7 @@
         "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 578,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7530,7 +7578,7 @@
         "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 129,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -7538,7 +7586,7 @@
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 130,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7548,7 +7596,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 404,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7556,7 +7604,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 700,
+        "line_number": 650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7564,7 +7612,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 835,
+        "line_number": 785,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7574,23 +7622,31 @@
         "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 283,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "927ab42cfc3a3f3409f66221d8e37442f3b188e3",
+        "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 691,
+        "line_number": 701,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "d076928bfade831b34f9af755506cd06e8b4dd1b",
+        "hashed_secret": "454f9bfcc5f7523c755896f9d2c7281f83aec668",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 727,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7598,7 +7654,7 @@
         "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 923,
+        "line_number": 959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7606,7 +7662,7 @@
         "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 955,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7614,7 +7670,7 @@
         "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1030,
+        "line_number": 1066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7622,15 +7678,7 @@
         "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1244,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "39d0a63a567ae11fcf8695abfe19656aa1cbc0ed",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1303,
+        "line_number": 1280,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7638,15 +7686,15 @@
         "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1494,
+        "line_number": 1504,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "f302e5128922d4e7acf42d7e22f95a2f001eb14d",
+        "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1524,
+        "line_number": 1516,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7654,23 +7702,23 @@
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1597,
+        "line_number": 1579,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "18d2caf3d1bac7ecb05d4e510dd021477ab55b9d",
+        "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1622,
+        "line_number": 1601,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "1a4c1e340613dfefc9b4d4980394879d136e2fbc",
+        "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1664,
+        "line_number": 1643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7678,64 +7726,40 @@
         "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1681,
+        "line_number": 1660,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "b94e256b5a8102d04799792b284dc44dd58b6609",
+        "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2392,
+        "line_number": 2176,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "b0ee0c442a1a6ea3ecce064786c038eb5c285c24",
+        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3152,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3331f962763e9b59c985f0c18407811ccee92e72",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3187,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f13d82146ff9aa3b08420f15eec4c7a5aab44769",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3221,
+        "line_number": 2261,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_email_auth_service.py": [
       {
-        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
+        "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4cf5ead1df6b23c1309a1eac48fe32ffc6c9ab1d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 395,
+        "line_number": 389,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
       {
-        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
+        "hashed_secret": "759521118cabf4f8bbc46e6d6344d0e700aa4be5",
         "is_secret": false,
         "is_verified": false,
         "line_number": 50,
@@ -7743,7 +7767,7 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "dff88ddbf282dc1477e1e419a7706371e7afba27",
+        "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
         "is_secret": false,
         "is_verified": false,
         "line_number": 321,
@@ -7751,18 +7775,10 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "79caf88021d840cf3544d1aae14ae84f58310f8f",
+        "hashed_secret": "6fa5edecdc44e7209e0678c5dea72a95d63bf554",
         "is_secret": false,
         "is_verified": false,
         "line_number": 365,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f71ca03855f95d7df834ece97c9e09fc34ce89b9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 493,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7772,7 +7788,7 @@
         "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 154,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7782,7 +7798,7 @@
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 376,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7790,7 +7806,7 @@
         "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 380,
+        "line_number": 378,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7798,7 +7814,7 @@
         "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 416,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7806,7 +7822,7 @@
         "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 419,
+        "line_number": 417,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7814,7 +7830,7 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 420,
+        "line_number": 418,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -7822,7 +7838,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 734,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7830,7 +7846,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 735,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7838,7 +7854,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 797,
+        "line_number": 781,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7846,7 +7862,7 @@
         "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 782,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7854,7 +7870,7 @@
         "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 819,
+        "line_number": 803,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7882,7 +7898,7 @@
         "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7890,7 +7906,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 227,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7900,7 +7916,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 639,
+        "line_number": 636,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7908,7 +7924,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 640,
+        "line_number": 637,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7916,7 +7932,7 @@
         "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1528,
+        "line_number": 1472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7924,7 +7940,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5185,
+        "line_number": 5046,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7932,7 +7948,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5190,
+        "line_number": 5051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7940,7 +7956,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6731,
+        "line_number": 6592,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7948,7 +7964,7 @@
         "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7328,
+        "line_number": 7189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7956,7 +7972,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7347,
+        "line_number": 7208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7964,7 +7980,7 @@
         "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7553,
+        "line_number": 7414,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7972,7 +7988,7 @@
         "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7572,
+        "line_number": 7433,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8010,7 +8026,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 616,
+        "line_number": 615,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8018,7 +8034,7 @@
         "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 638,
+        "line_number": 637,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8028,7 +8044,7 @@
         "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 308,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8036,7 +8052,7 @@
         "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 517,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8044,7 +8060,7 @@
         "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1390,
+        "line_number": 1449,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8052,7 +8068,7 @@
         "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1543,
+        "line_number": 1602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8060,7 +8076,7 @@
         "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1613,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8068,7 +8084,7 @@
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2384,
+        "line_number": 2504,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8076,7 +8092,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2401,
+        "line_number": 2521,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8084,7 +8100,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2550,
+        "line_number": 2670,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8094,7 +8110,7 @@
         "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8102,7 +8118,7 @@
         "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 275,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8110,7 +8126,7 @@
         "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8118,7 +8134,7 @@
         "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 555,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8126,7 +8142,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 773,
+        "line_number": 769,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8134,7 +8150,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 775,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8144,7 +8160,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 440,
+        "line_number": 434,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8152,7 +8168,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8160,7 +8176,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 466,
+        "line_number": 460,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8178,7 +8194,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8186,7 +8202,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 123,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8194,7 +8210,7 @@
         "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 148,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8202,7 +8218,7 @@
         "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8210,7 +8226,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8220,7 +8236,7 @@
         "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 266,
+        "line_number": 256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8228,7 +8244,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 346,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8236,7 +8252,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 821,
+        "line_number": 807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8244,7 +8260,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8252,7 +8268,7 @@
         "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1229,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8260,7 +8276,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1335,
+        "line_number": 1289,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8268,7 +8284,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8278,7 +8294,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 164,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -8288,7 +8304,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 458,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8296,15 +8312,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 477,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 566,
+        "line_number": 391,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8312,7 +8320,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 789,
+        "line_number": 640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8320,7 +8328,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 865,
+        "line_number": 716,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8328,7 +8336,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 868,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8338,7 +8346,7 @@
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 58,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8346,7 +8354,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 352,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8354,7 +8362,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 475,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8364,7 +8372,7 @@
         "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 410,
+        "line_number": 405,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8372,7 +8380,7 @@
         "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 406,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8382,7 +8390,7 @@
         "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4118,
+        "line_number": 4031,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8390,7 +8398,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4133,
+        "line_number": 4046,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8398,7 +8406,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4831,
+        "line_number": 4744,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8466,7 +8474,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8474,7 +8482,7 @@
         "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 198,
+        "line_number": 197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8482,7 +8490,7 @@
         "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 335,
+        "line_number": 334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8492,15 +8500,23 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 82,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 106,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -8508,7 +8524,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 196,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -8516,16 +8532,8 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 210,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 254,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -8534,7 +8542,7 @@
         "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 25,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8542,7 +8550,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 255,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8550,7 +8558,7 @@
         "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 322,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8560,7 +8568,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 545,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8568,7 +8576,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 546,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8576,7 +8584,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 562,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8584,7 +8592,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 1977,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8592,7 +8600,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3570,
+        "line_number": 3314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8600,7 +8608,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4204,
+        "line_number": 3947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8608,7 +8616,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7588,
+        "line_number": 7240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8616,7 +8624,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8080,
+        "line_number": 7732,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8624,7 +8632,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9427,
+        "line_number": 9079,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8632,7 +8640,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9571,
+        "line_number": 9221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8640,7 +8648,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10052,
+        "line_number": 9597,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8650,7 +8658,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2985,
+        "line_number": 2980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8658,7 +8666,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3671,
+        "line_number": 3666,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8666,7 +8674,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3680,
+        "line_number": 3675,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8674,7 +8682,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4130,
+        "line_number": 4066,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8682,7 +8690,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7057,
+        "line_number": 6993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8690,7 +8698,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7075,
+        "line_number": 7011,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8698,7 +8706,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7099,
+        "line_number": 7035,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8706,7 +8714,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7163,
+        "line_number": 7099,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8714,7 +8722,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7174,
+        "line_number": 7110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8722,7 +8730,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7215,
+        "line_number": 7151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8730,7 +8738,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7221,
+        "line_number": 7157,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8738,7 +8746,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8415,
+        "line_number": 8351,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8764,7 +8772,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2775,
+        "line_number": 2780,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8772,7 +8780,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5273,
+        "line_number": 5213,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8780,7 +8788,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5926,
+        "line_number": 5866,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8788,7 +8796,7 @@
         "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5990,
+        "line_number": 5930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8796,7 +8804,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6242,
+        "line_number": 6182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8804,7 +8812,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9225,
+        "line_number": 9165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8812,7 +8820,7 @@
         "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9274,
+        "line_number": 9214,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8820,7 +8828,7 @@
         "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9313,
+        "line_number": 9253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8828,7 +8836,7 @@
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9370,
+        "line_number": 9310,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8836,7 +8844,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14441,
+        "line_number": 14385,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8844,7 +8852,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17198,
+        "line_number": 17142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8852,7 +8860,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17217,
+        "line_number": 17161,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8872,7 +8880,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 449,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8880,7 +8888,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1104,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9086,7 +9094,7 @@
         "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 257,
+        "line_number": 192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9094,7 +9102,7 @@
         "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 499,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9102,7 +9110,7 @@
         "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 577,
+        "line_number": 512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9110,7 +9118,7 @@
         "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 583,
+        "line_number": 518,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9118,7 +9126,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 652,
+        "line_number": 587,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9126,7 +9134,7 @@
         "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 712,
+        "line_number": 647,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9134,7 +9142,7 @@
         "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1082,
+        "line_number": 1016,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9142,7 +9150,7 @@
         "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1268,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9216,7 +9224,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 67,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9226,7 +9234,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 55,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9234,7 +9242,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 139,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9242,16 +9250,8 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 152,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "759ea996d3686cbca80b6d412c3cee3faf60c272",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3806,
-        "type": "JSON Web Token",
         "verified_result": null
       }
     ],
@@ -9260,7 +9260,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9270,7 +9270,7 @@
         "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2565,
+        "line_number": 2508,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9278,7 +9278,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2853,
+        "line_number": 2796,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9306,7 +9306,7 @@
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1313,
+        "line_number": 1269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9314,7 +9314,7 @@
         "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1496,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9322,7 +9322,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1973,
+        "line_number": 1964,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9345,22 +9345,12 @@
         "verified_result": null
       }
     ],
-    "tests/unit/mcpgateway/test_password_policy.py": [
-      {
-        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 184,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 167,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9388,7 +9378,7 @@
         "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 333,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9396,7 +9386,7 @@
         "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 352,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9404,7 +9394,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 377,
+        "line_number": 371,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9412,7 +9402,7 @@
         "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9422,7 +9412,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 775,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9430,7 +9420,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 975,
+        "line_number": 956,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9438,7 +9428,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 980,
+        "line_number": 961,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9446,7 +9436,7 @@
         "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1006,
+        "line_number": 987,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9454,7 +9444,7 @@
         "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1024,
+        "line_number": 1005,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9462,7 +9452,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1235,
+        "line_number": 1218,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9470,7 +9460,7 @@
         "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1351,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9490,7 +9480,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 135,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9500,7 +9490,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 277,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9538,7 +9528,7 @@
         "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 201,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9548,7 +9538,7 @@
         "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13172,
+        "line_number": 12928,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9556,7 +9546,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14347,
+        "line_number": 14103,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9576,7 +9566,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 75,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9586,7 +9576,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 32,
         "type": "Private Key",
         "verified_result": null
       }
@@ -9606,7 +9596,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 379,
+        "line_number": 370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9614,7 +9604,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 463,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9624,7 +9614,7 @@
         "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 50,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9634,7 +9624,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 40,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9642,7 +9632,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9650,7 +9640,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9658,7 +9648,7 @@
         "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9666,7 +9656,7 @@
         "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 80,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9674,7 +9664,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 153,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9682,7 +9672,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 155,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9690,7 +9680,7 @@
         "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 215,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9716,7 +9706,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1045,
+        "line_number": 1042,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9724,7 +9714,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1194,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9744,7 +9734,7 @@
         "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 140,
+        "line_number": 136,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9752,7 +9742,7 @@
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 504,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9760,7 +9750,7 @@
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 497,
+        "line_number": 548,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9768,7 +9758,7 @@
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 510,
+        "line_number": 561,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9776,7 +9766,7 @@
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 879,
+        "line_number": 930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9784,7 +9774,7 @@
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1128,
+        "line_number": 1179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9799,22 +9789,12 @@
         "verified_result": null
       }
     ],
-    "tests/unit/plugins/test_secrets_detection.py": [
-      {
-        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 143,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
     "tests/unit/test_conc_01_helpers.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 160,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/mcpgateway/alembic/versions/351b43e1d273_add_password_history_table.py
+++ b/mcpgateway/alembic/versions/351b43e1d273_add_password_history_table.py
@@ -14,8 +14,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "351b43e1d273"
-down_revision: Union[str, Sequence[str], None] = "w7x8y9z0a1b2"
+revision: str = "351b43e1d273"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "w7x8y9z0a1b2"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/4842b831d24e_add_on_error_to_tool_plugin_bindings.py
+++ b/mcpgateway/alembic/versions/4842b831d24e_add_on_error_to_tool_plugin_bindings.py
@@ -13,8 +13,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "4842b831d24e"
-down_revision: Union[str, Sequence[str], None] = "bb43712cae28"
+revision: str = "4842b831d24e"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "bb43712cae28"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py
+++ b/mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py
@@ -13,8 +13,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "926d3e07d098"
-down_revision: Union[str, Sequence[str], None] = "9c45d2e63bc0"
+revision: str = "926d3e07d098"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "9c45d2e63bc0"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/9c45d2e63bc0_merge_plugin_bindings_and_token_.py
+++ b/mcpgateway/alembic/versions/9c45d2e63bc0_merge_plugin_bindings_and_token_.py
@@ -1,7 +1,7 @@
 """merge plugin_bindings and token_revocation heads
 
 Revision ID: 9c45d2e63bc0
-Revises: 4842b831d24e, aa1b2c3d4e5f
+Revises: 4842b831d24e, c3c3b7f9b014
 Create Date: 2026-05-01 00:35:39.894249
 
 """
@@ -10,8 +10,8 @@ Create Date: 2026-05-01 00:35:39.894249
 from typing import Sequence, Union
 
 # revision identifiers, used by Alembic.
-revision: str = "9c45d2e63bc0"
-down_revision: Union[str, Sequence[str], None] = ("4842b831d24e", "aa1b2c3d4e5f")
+revision: str = "9c45d2e63bc0"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = ("4842b831d24e", "c3c3b7f9b014")  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
+++ b/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
@@ -14,8 +14,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "9fb98535724d"
-down_revision: Union[str, Sequence[str], None] = "926d3e07d098"
+revision: str = "9fb98535724d"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "926d3e07d098"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/c3c3b7f9b014_add_token_revocation_idle_timeout_fields.py
+++ b/mcpgateway/alembic/versions/c3c3b7f9b014_add_token_revocation_idle_timeout_fields.py
@@ -6,7 +6,7 @@ Authors: Mihai Criveti
 
 add_token_revocation_idle_timeout_fields
 
-Revision ID: aa1b2c3d4e5f
+Revision ID: c3c3b7f9b014
 Revises: bb43712cae28
 Create Date: 2026-04-21 12:58:00.000000
 """
@@ -16,8 +16,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision = "aa1b2c3d4e5f"  # pragma: allowlist secret
-down_revision = "bb43712cae28"
+revision = "c3c3b7f9b014"  # pragma: allowlist secret
+down_revision = "bb43712cae28"  # pragma: allowlist secret
 branch_labels = None
 depends_on = None
 

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -1424,9 +1424,10 @@ class OAuthManager:
             code: Authorization code from callback
             code_verifier: Optional PKCE code verifier (RFC 7636)
             ca_certificate: Optional custom CA certificate for SSL verification (PEM format).
-                When provided, creates an isolated HTTP client with custom SSL context
-                instead of using the shared client. This enables OAuth token exchange
-                with self-signed or custom CA upstream OAuth servers.
+                When provided along with ``client_cert``/``client_key``, creates an
+                isolated HTTP client with custom SSL context instead of using the
+                shared client. This enables OAuth token exchange with self-signed or
+                custom CA upstream OAuth servers and/or mTLS authentication.
             client_cert: Optional client certificate for mTLS (PEM format or file path)
             client_key: Optional client private key for mTLS (PEM format or file path)
 

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -244,13 +244,19 @@ class OAuthManager:
     async def _post_token_request(
         self, url: str, data: Any, ca_certificate: Optional[str] = None, client_cert: Optional[str] = None, client_key: Optional[str] = None, headers: Optional[Dict[str, str]] = None
     ) -> httpx.Response:
-        """POST to a token endpoint, using a custom SSL context when CA certs are provided.
+        """POST to a token endpoint, using a custom SSL context when CA certs or mTLS are provided.
 
-        When ``ca_certificate`` is supplied, an isolated ``httpx.AsyncClient``
-        is created with the corresponding SSL context so that OAuth token
-        exchange works against self-signed or custom-CA upstream servers.
+        When ``ca_certificate``, ``client_cert``, or ``client_key`` is supplied,
+        an isolated ``httpx.AsyncClient`` is created with the corresponding SSL
+        context so that OAuth token exchange works against self-signed or
+        custom-CA upstream servers and/or presents client certificates for mTLS.
         Otherwise the shared HTTP client (which respects the global
         ``SKIP_SSL_VERIFY`` setting) is used.
+
+        Note:
+            When only ``client_cert``/``client_key`` are provided (no custom CA),
+            the isolated client uses the system's default trust store and does
+            not honour ``SKIP_SSL_VERIFY``.
 
         Args:
             url: Token endpoint URL.

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -263,7 +263,7 @@ class OAuthManager:
         Returns:
             The HTTP response from the token endpoint.
         """
-        if ca_certificate:
+        if ca_certificate or client_cert or client_key:
             ssl_context = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
             async with httpx.AsyncClient(verify=ssl_context) as client:
                 return await client.post(url, data=data, headers=headers, timeout=self.request_timeout)

--- a/mcpgateway/utils/ssl_context_cache.py
+++ b/mcpgateway/utils/ssl_context_cache.py
@@ -159,7 +159,9 @@ def get_cached_ssl_context(
         avoid repeated expensive SSL setup operations.
     """
     # Ensure CA certificate is normalized to bytes for hash calculation
-    if isinstance(ca_certificate, bytes):
+    if ca_certificate is None:
+        ca_cert_bytes = b""
+    elif isinstance(ca_certificate, bytes):
         ca_cert_bytes = ca_certificate
     elif isinstance(ca_certificate, str):
         ca_cert_bytes = ca_certificate.encode()

--- a/mcpgateway/utils/ssl_context_cache.py
+++ b/mcpgateway/utils/ssl_context_cache.py
@@ -191,14 +191,14 @@ def get_cached_ssl_context(
         _ssl_context_cache.pop(cache_key, None)
         _ssl_context_cache_timestamps.pop(cache_key, None)
 
+    # Validate mTLS: require both or neither
+    if bool(client_cert) != bool(client_key):
+        raise ValueError("mTLS requires both client_cert and client_key; got only one")
+
     # Create new SSL context and configure CA cert
     ctx = ssl.create_default_context()
     if ca_certificate:
         ctx.load_verify_locations(cadata=ca_certificate)
-
-    # Validate mTLS: require both or neither
-    if bool(client_cert) != bool(client_key):
-        raise ValueError("mTLS requires both client_cert and client_key; got only one")
 
     # Load client certificates for mTLS when provided
     if client_cert and client_key:

--- a/mcpgateway/utils/ssl_context_cache.py
+++ b/mcpgateway/utils/ssl_context_cache.py
@@ -121,14 +121,14 @@ def _load_client_cert_chain(ctx: ssl.SSLContext, client_cert: str, client_key: s
 
 
 def get_cached_ssl_context(
-    ca_certificate: str,
+    ca_certificate: str | bytes | None,
     client_cert: str | None = None,
     client_key: str | None = None,
 ) -> ssl.SSLContext:
     """Get or create cached SSL context for a CA certificate.
 
     Args:
-        ca_certificate: CA certificate in PEM format (str or bytes)
+        ca_certificate: Optional CA certificate in PEM format (str or bytes)
         client_cert: Optional client cert path or PEM for mTLS
         client_key: Optional client key path or PEM for mTLS
 
@@ -191,7 +191,8 @@ def get_cached_ssl_context(
 
     # Create new SSL context and configure CA cert
     ctx = ssl.create_default_context()
-    ctx.load_verify_locations(cadata=ca_certificate)
+    if ca_certificate:
+        ctx.load_verify_locations(cadata=ca_certificate)
 
     # Validate mTLS: require both or neither
     if bool(client_cert) != bool(client_key):

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -1475,6 +1475,41 @@ class TestOAuthManager:
                 mock_get_ssl.assert_called_once_with(ca_cert, client_cert=client_cert, client_key=client_key)
 
     @pytest.mark.asyncio
+    async def test_client_credentials_flow_with_client_certificate_only(self):
+        """Test client credentials flow still uses mTLS when no custom CA is configured."""
+        manager = OAuthManager()
+        credentials = {
+            "grant_type": "client_credentials",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "token_url": "https://oauth.example.com/token",
+        }
+        _, mock_ssl_context, mock_client, _, client_cert, client_key = self._make_ca_cert_mocks({"access_token": "mtls_token"})
+
+        with patch("mcpgateway.services.oauth_manager.get_cached_ssl_context", return_value=mock_ssl_context) as mock_get_ssl:
+            with patch("mcpgateway.services.oauth_manager.httpx.AsyncClient", return_value=mock_client):
+                result = await manager.get_access_token(credentials, client_cert=client_cert, client_key=client_key)
+                assert result == "mtls_token"
+                mock_get_ssl.assert_called_once_with(None, client_cert=client_cert, client_key=client_key)
+
+    @pytest.mark.asyncio
+    async def test_client_credentials_flow_with_partial_mtls_config_raises(self):
+        """Test mTLS validation runs when only one client certificate field is configured."""
+        manager = OAuthManager()
+        credentials = {
+            "grant_type": "client_credentials",
+            "client_id": "test_client",
+            "client_secret": "test_secret",
+            "token_url": "https://oauth.example.com/token",
+        }
+        _, _, _, _, client_cert, _ = self._make_ca_cert_mocks()
+
+        with patch("mcpgateway.services.oauth_manager.get_cached_ssl_context", side_effect=ValueError("mTLS requires both client_cert and client_key")):
+            with patch.object(manager, "_get_client", side_effect=AssertionError("shared client should not be used")):
+                with pytest.raises(ValueError, match="mTLS requires both"):
+                    await manager.get_access_token(credentials, client_cert=client_cert)
+
+    @pytest.mark.asyncio
     async def test_refresh_token_with_ca_certificate(self):
         """Test refresh token with custom CA certificate."""
         manager = OAuthManager()

--- a/tests/unit/mcpgateway/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/test_oauth_manager.py
@@ -1505,7 +1505,7 @@ class TestOAuthManager:
         _, _, _, _, client_cert, _ = self._make_ca_cert_mocks()
 
         with patch("mcpgateway.services.oauth_manager.get_cached_ssl_context", side_effect=ValueError("mTLS requires both client_cert and client_key")):
-            with patch.object(manager, "_get_client", side_effect=AssertionError("shared client should not be used")):
+            with patch.object(manager, "_get_client", side_effect=RuntimeError("shared client should not be used")):
                 with pytest.raises(ValueError, match="mTLS requires both"):
                     await manager.get_access_token(credentials, client_cert=client_cert)
 

--- a/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
+++ b/tests/unit/mcpgateway/utils/test_ssl_context_cache.py
@@ -45,6 +45,23 @@ def test_get_cached_ssl_context_caches_by_sha_for_str_and_bytes() -> None:
     ctx.load_verify_locations.assert_called_once()
 
 
+def test_get_cached_ssl_context_with_none_ca_and_client_certs() -> None:
+    """When CA is None but client_cert/client_key are provided, create context without load_verify_locations."""
+    pem_cert = "-----BEGIN CERTIFICATE-----\nFAKECERT\n-----END CERTIFICATE-----"
+    pem_key = _fake_pem_key("FAKEKEY")
+
+    with patch("mcpgateway.utils.ssl_context_cache.ssl.create_default_context") as mock_create:
+        ctx = Mock()
+        mock_create.return_value = ctx
+
+        result = ssl_context_cache.get_cached_ssl_context(None, client_cert=pem_cert, client_key=pem_key)
+
+    assert result is ctx
+    ctx.load_verify_locations.assert_not_called()
+    ctx.load_cert_chain.assert_called_once()
+    assert mock_create.call_count == 1
+
+
 def test_get_cached_ssl_context_handles_non_string_objects_via_str() -> None:
     class CertObj(SimpleNamespace):
         def __str__(self) -> str:  # pragma: no cover - method invoked by production code


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - not run; pre-commit hooks ran during commit
2. `make test`            - not run; targeted OAuth manager unit file passed
3. `make coverage`        - not run
4. `make docker docker-run-ssl` or `make podman podman-run-ssl` - not run
5. Update relevant documentation - not applicable
6. Tested with sqlite and postgres + redis - not run
7. Manual regression no longer fails - covered by regression tests

---

## 📌 Summary

Closes #4426

OAuth token requests now use the isolated TLS client whenever a gateway provides TLS material, including client-cert-only mTLS configurations that rely on the platform trust store.

## 🔁 Reproduction Steps

Issue #4426 describes the minimal reproduction: configure an OAuth gateway with `client_cert` and `client_key`, leave `ca_certificate` unset, then trigger an OAuth token request. Before this change, token acquisition used the shared HTTP client and skipped mTLS.

## 🐞 Root Cause

`OAuthManager._post_token_request()` only selected the custom TLS path when `ca_certificate` was set. Gateway OAuth call sites can pass `client_cert` and `client_key` independently of `ca_certificate`, so client-cert-only token requests silently lost mTLS.

## 💡 Fix Description

`_post_token_request()` now enters the TLS helper path when any TLS material is configured: `ca_certificate`, `client_cert`, or `client_key`. `get_cached_ssl_context()` now accepts a missing custom CA bundle and uses the default trust store while still loading the configured client certificate and key. Partial mTLS configuration continues to raise the existing validation error.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | `pytest -q tests/unit/mcpgateway/test_oauth_manager.py` | Passed |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | regression tests     | Passed |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
