### PR TITLE
fix(metrics): split metrics flush into separate transactions to prevent FK violation rollbacks

### DIFF
--- a/mcpgateway/services/metrics_buffer_service.py
+++ b/mcpgateway/services/metrics_buffer_service.py
@@ -580,6 +580,13 @@ class MetricsBufferService:
     ) -> None:
         """Write buffered metrics to database (runs in thread).
 
+        Each metric type is written in its own transaction so that a
+        foreign-key violation on one type (e.g., a ``tool_id`` whose row was
+        deleted between buffering and flushing) does not roll back unrelated
+        metrics.  ``fresh_db_session()`` commits on successful context exit
+        and rolls back on exception, so explicit ``db.commit()`` is not
+        needed inside the ``with`` blocks.
+
         Args:
             tool_metrics: List of buffered tool metrics to write.
             resource_metrics: List of buffered resource metrics to write.
@@ -587,9 +594,6 @@ class MetricsBufferService:
             server_metrics: List of buffered server metrics to write.
             a2a_agent_metrics: List of buffered A2A agent metrics to write.
         """
-        # Flush tool metrics in a separate transaction so that an invalid
-        # tool_id (FK violation) does not roll back other metric types.
-        # Tools can be deleted between buffering and flushing.
         if tool_metrics:
             try:
                 with fresh_db_session() as db:
@@ -606,13 +610,9 @@ class MetricsBufferService:
                             for m in tool_metrics
                         ],
                     )
-                    db.commit()
             except Exception as e:
                 logger.error(f"Failed to flush tool metrics to database: {e}", exc_info=True)
 
-        # Flush resource metrics in a separate transaction so that an invalid
-        # resource_id (FK violation) does not roll back other metric types.
-        # Resources can be deleted between buffering and flushing.
         if resource_metrics:
             try:
                 with fresh_db_session() as db:
@@ -629,13 +629,9 @@ class MetricsBufferService:
                             for m in resource_metrics
                         ],
                     )
-                    db.commit()
             except Exception as e:
                 logger.error(f"Failed to flush resource metrics to database: {e}", exc_info=True)
 
-        # Flush prompt metrics in a separate transaction so that an invalid
-        # prompt_id (FK violation) does not roll back other metric types.
-        # Prompts can be deleted between buffering and flushing.
         if prompt_metrics:
             try:
                 with fresh_db_session() as db:
@@ -652,13 +648,9 @@ class MetricsBufferService:
                             for m in prompt_metrics
                         ],
                     )
-                    db.commit()
             except Exception as e:
                 logger.error(f"Failed to flush prompt metrics to database: {e}", exc_info=True)
 
-        # Flush A2A agent metrics in a separate transaction so that an invalid
-        # a2a_agent_id (FK violation) does not roll back other metric types.
-        # A2A agents can be deleted between buffering and flushing.
         if a2a_agent_metrics:
             try:
                 with fresh_db_session() as db:
@@ -676,14 +668,12 @@ class MetricsBufferService:
                             for m in a2a_agent_metrics
                         ],
                     )
-                    db.commit()
             except Exception as e:
                 logger.error(f"Failed to flush A2A agent metrics to database: {e}", exc_info=True)
 
-        # Flush server metrics in a separate transaction so that an invalid
-        # server_id (FK violation) does not roll back tool/resource/prompt/a2a
-        # metrics.  server_id can originate from untrusted headers (X-Server-ID)
-        # in admin API paths, so it may reference a nonexistent server.
+        # ``server_id`` can originate from untrusted headers (X-Server-ID) in
+        # admin API paths, so it may reference a nonexistent server.  Same
+        # isolation guarantee as the other metric types above.
         if server_metrics:
             try:
                 with fresh_db_session() as db:
@@ -700,7 +690,6 @@ class MetricsBufferService:
                             for m in server_metrics
                         ],
                     )
-                    db.commit()
             except Exception as e:
                 logger.error(f"Failed to flush server metrics to database: {e}", exc_info=True)
 
@@ -729,7 +718,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write tool metric: {e}")
 
@@ -758,7 +746,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write tool metric: {e}")
 
@@ -787,7 +774,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write resource metric: {e}")
 
@@ -816,7 +802,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write prompt metric: {e}")
 
@@ -845,7 +830,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write server metric: {e}")
 
@@ -874,7 +858,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write server metric: {e}")
 
@@ -906,7 +889,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write A2A agent metric: {e}")
 
@@ -938,7 +920,6 @@ class MetricsBufferService:
                     error_message=error_message,
                 )
                 db.add(metric)
-                db.commit()
         except Exception as e:
             logger.error(f"Failed to write A2A agent metric: {e}")
 

--- a/mcpgateway/services/metrics_buffer_service.py
+++ b/mcpgateway/services/metrics_buffer_service.py
@@ -587,10 +587,12 @@ class MetricsBufferService:
             server_metrics: List of buffered server metrics to write.
             a2a_agent_metrics: List of buffered A2A agent metrics to write.
         """
-        try:
-            with fresh_db_session() as db:
-                # Bulk insert tool metrics
-                if tool_metrics:
+        # Flush tool metrics in a separate transaction so that an invalid
+        # tool_id (FK violation) does not roll back other metric types.
+        # Tools can be deleted between buffering and flushing.
+        if tool_metrics:
+            try:
+                with fresh_db_session() as db:
                     db.bulk_insert_mappings(
                         ToolMetric,
                         [
@@ -604,9 +606,16 @@ class MetricsBufferService:
                             for m in tool_metrics
                         ],
                     )
+                    db.commit()
+            except Exception as e:
+                logger.error(f"Failed to flush tool metrics to database: {e}", exc_info=True)
 
-                # Bulk insert resource metrics
-                if resource_metrics:
+        # Flush resource metrics in a separate transaction so that an invalid
+        # resource_id (FK violation) does not roll back other metric types.
+        # Resources can be deleted between buffering and flushing.
+        if resource_metrics:
+            try:
+                with fresh_db_session() as db:
                     db.bulk_insert_mappings(
                         ResourceMetric,
                         [
@@ -620,9 +629,16 @@ class MetricsBufferService:
                             for m in resource_metrics
                         ],
                     )
+                    db.commit()
+            except Exception as e:
+                logger.error(f"Failed to flush resource metrics to database: {e}", exc_info=True)
 
-                # Bulk insert prompt metrics
-                if prompt_metrics:
+        # Flush prompt metrics in a separate transaction so that an invalid
+        # prompt_id (FK violation) does not roll back other metric types.
+        # Prompts can be deleted between buffering and flushing.
+        if prompt_metrics:
+            try:
+                with fresh_db_session() as db:
                     db.bulk_insert_mappings(
                         PromptMetric,
                         [
@@ -636,9 +652,16 @@ class MetricsBufferService:
                             for m in prompt_metrics
                         ],
                     )
+                    db.commit()
+            except Exception as e:
+                logger.error(f"Failed to flush prompt metrics to database: {e}", exc_info=True)
 
-                # Bulk insert A2A agent metrics
-                if a2a_agent_metrics:
+        # Flush A2A agent metrics in a separate transaction so that an invalid
+        # a2a_agent_id (FK violation) does not roll back other metric types.
+        # A2A agents can be deleted between buffering and flushing.
+        if a2a_agent_metrics:
+            try:
+                with fresh_db_session() as db:
                     db.bulk_insert_mappings(
                         A2AAgentMetric,
                         [
@@ -653,13 +676,9 @@ class MetricsBufferService:
                             for m in a2a_agent_metrics
                         ],
                     )
-
-                db.commit()
-
-        except Exception as e:
-            logger.error(f"Failed to flush metrics to database: {e}", exc_info=True)
-            # Metrics are lost on failure - acceptable trade-off for performance
-            # Could implement retry queue if needed
+                    db.commit()
+            except Exception as e:
+                logger.error(f"Failed to flush A2A agent metrics to database: {e}", exc_info=True)
 
         # Flush server metrics in a separate transaction so that an invalid
         # server_id (FK violation) does not roll back tool/resource/prompt/a2a

--- a/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
+++ b/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
@@ -1036,3 +1036,76 @@ def test_flush_to_db_a2a_agent_metrics_exception_is_logged(monkeypatch):
 
     # Verify A2A agent metrics were attempted
     assert A2AAgentMetric in attempted_types
+
+def test_flush_to_db_tool_metrics_exception_is_logged(monkeypatch):
+    """Test that exceptions during tool metrics flush are logged but don't crash."""
+    # First-Party
+    from mcpgateway.db import ToolMetric
+
+    service = MetricsBufferService(enabled=True)
+
+    attempted_types = []
+
+    class DummyDB:
+        def __init__(self):
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            attempted_types.append(model)
+            if model == ToolMetric:
+                raise Exception("FK violation on tool_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __enter__(self):
+            return DummyDB()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    tool_metric = SimpleNamespace(tool_id="t1", timestamp=time.time(), response_time=0.1, is_success=True, error_message=None)
+
+    service._flush_to_db([tool_metric], [], [], [], [])
+
+    assert ToolMetric in attempted_types
+
+
+def test_flush_to_db_resource_metrics_exception_is_logged(monkeypatch):
+    """Test that exceptions during resource metrics flush are logged but don't crash."""
+    # First-Party
+    from mcpgateway.db import ResourceMetric
+
+    service = MetricsBufferService(enabled=True)
+
+    attempted_types = []
+
+    class DummyDB:
+        def __init__(self):
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            attempted_types.append(model)
+            if model == ResourceMetric:
+                raise Exception("FK violation on resource_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __enter__(self):
+            return DummyDB()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    resource_metric = SimpleNamespace(resource_id="r1", timestamp=time.time(), response_time=0.2, is_success=False, error_message="err")
+
+    service._flush_to_db([], [resource_metric], [], [], [])
+
+    assert ResourceMetric in attempted_types

--- a/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
+++ b/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
@@ -266,6 +266,9 @@ class TestImmediateWritesWhenDisabled:
                 return self._session
 
             def __exit__(self, exc_type, exc, tb):
+                # Faithfully simulate fresh_db_session(): commit on success.
+                if exc_type is None:
+                    self._session.commit()
                 return False
 
         dummy_session = DummySession()
@@ -640,9 +643,12 @@ def test_flush_to_db_writes_batches(monkeypatch):
             return holder["db"]
 
         def __exit__(self, exc_type, exc, tb):
+            # Faithfully simulate fresh_db_session(): commit on success.
+            if exc_type is None:
+                holder["db"].commit()
             return False
 
-    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", lambda: DummySession())
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
 
     tool_metric = SimpleNamespace(tool_id="t1", timestamp=time.time(), response_time=0.1, is_success=True, error_message=None)
     resource_metric = SimpleNamespace(resource_id="r1", timestamp=time.time(), response_time=0.2, is_success=False, error_message="err")
@@ -658,7 +664,8 @@ def test_flush_to_db_writes_all_metric_types(monkeypatch):
 
     service = MetricsBufferService(enabled=True)
 
-    # Track ALL sessions (server metrics use a separate transaction)
+    # One DummyDB per fresh_db_session() call - the fix splits the flush into
+    # five independent transactions, one per metric type.
     all_dbs = []
 
     class DummyDB:
@@ -673,15 +680,20 @@ def test_flush_to_db_writes_all_metric_types(monkeypatch):
             self.committed = True
 
     class DummySession:
+        def __init__(self):
+            self.db = DummyDB()
+            all_dbs.append(self.db)
+
         def __enter__(self):
-            db = DummyDB()
-            all_dbs.append(db)
-            return db
+            return self.db
 
         def __exit__(self, exc_type, exc, tb):
+            # Faithfully simulate fresh_db_session(): commit on success.
+            if exc_type is None:
+                self.db.commit()
             return False
 
-    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", lambda: DummySession())
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
 
     tool_metric = SimpleNamespace(tool_id="t1", timestamp=time.time(), response_time=0.1, is_success=True, error_message=None)
     resource_metric = SimpleNamespace(resource_id="r1", timestamp=time.time(), response_time=0.2, is_success=False, error_message="err")
@@ -691,12 +703,9 @@ def test_flush_to_db_writes_all_metric_types(monkeypatch):
 
     service._flush_to_db([tool_metric], [resource_metric], [prompt_metric], [server_metric], [a2a_metric])
 
-    # Five separate transactions: one for each metric type (tool, resource, prompt, a2a, server)
-    # This prevents FK violations on one type from rolling back other types
     assert len(all_dbs) == 5
     assert all(db.committed for db in all_dbs)
 
-    # Collect models across all transactions
     models = [call[0] for db in all_dbs for call in db.bulk_calls]
     assert ToolMetric in models
     assert ResourceMetric in models
@@ -862,7 +871,10 @@ class TestImmediateWriteMethods:
             def __enter__(self_inner):
                 return mock_db
 
-            def __exit__(self_inner, *args):
+            def __exit__(self_inner, exc_type, exc, tb):
+                # Faithfully simulate fresh_db_session(): commit on success.
+                if exc_type is None:
+                    mock_db.commit()
                 return False
 
         return Ctx(), mock_db
@@ -1037,6 +1049,7 @@ def test_flush_to_db_a2a_agent_metrics_exception_is_logged(monkeypatch):
     # Verify A2A agent metrics were attempted
     assert A2AAgentMetric in attempted_types
 
+
 def test_flush_to_db_tool_metrics_exception_is_logged(monkeypatch):
     """Test that exceptions during tool metrics flush are logged but don't crash."""
     # First-Party
@@ -1109,3 +1122,102 @@ def test_flush_to_db_resource_metrics_exception_is_logged(monkeypatch):
     service._flush_to_db([], [resource_metric], [], [], [])
 
     assert ResourceMetric in attempted_types
+
+
+def test_flush_to_db_server_metrics_exception_is_logged(monkeypatch):
+    """Test that exceptions during server metrics flush are logged but don't crash."""
+    # First-Party
+    from mcpgateway.db import ServerMetric
+
+    service = MetricsBufferService(enabled=True)
+
+    attempted_types = []
+
+    class DummyDB:
+        def __init__(self):
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            attempted_types.append(model)
+            if model == ServerMetric:
+                raise Exception("FK violation on server_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __enter__(self):
+            return DummyDB()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    server_metric = SimpleNamespace(server_id="s1", timestamp=time.time(), response_time=0.4, is_success=True, error_message=None)
+
+    service._flush_to_db([], [], [], [server_metric], [])
+
+    assert ServerMetric in attempted_types
+
+
+def test_flush_to_db_isolates_failed_metric_type(monkeypatch):
+    """Regression for issue #4420: a FK violation on one metric type must not roll back others.
+
+    This is the core property the fix delivers - splitting the single flush
+    transaction into one transaction per metric type.  If any future change
+    re-grouped two metric types into a shared transaction, this test would
+    catch the regression where one type's failure poisons the other.
+    """
+    # First-Party
+    from mcpgateway.db import A2AAgentMetric, PromptMetric, ResourceMetric, ServerMetric, ToolMetric
+
+    sessions_by_model = {}
+
+    class DummyDB:
+        def __init__(self):
+            self.attempted_model = None
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            self.attempted_model = model
+            if model is ToolMetric:
+                raise Exception("simulated FK violation on tool_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __init__(self):
+            self.db = DummyDB()
+
+        def __enter__(self):
+            return self.db
+
+        def __exit__(self, exc_type, exc, tb):
+            # Faithfully simulate fresh_db_session(): commit on success.
+            if exc_type is None:
+                self.db.commit()
+            if self.db.attempted_model is not None:
+                sessions_by_model[self.db.attempted_model] = self.db
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    service = MetricsBufferService(enabled=True)
+
+    tool_metric = SimpleNamespace(tool_id="t1", timestamp=time.time(), response_time=0.1, is_success=True, error_message=None)
+    resource_metric = SimpleNamespace(resource_id="r1", timestamp=time.time(), response_time=0.2, is_success=False, error_message="err")
+    prompt_metric = SimpleNamespace(prompt_id="p1", timestamp=time.time(), response_time=0.3, is_success=True, error_message=None)
+    server_metric = SimpleNamespace(server_id="s1", timestamp=time.time(), response_time=0.4, is_success=True, error_message=None)
+    a2a_metric = SimpleNamespace(a2a_agent_id="a1", timestamp=time.time(), response_time=0.5, is_success=True, interaction_type="invoke", error_message=None)
+
+    # Tool flush will raise; the call must still succeed and flush the other four types.
+    service._flush_to_db([tool_metric], [resource_metric], [prompt_metric], [server_metric], [a2a_metric])
+
+    assert set(sessions_by_model.keys()) == {ToolMetric, ResourceMetric, PromptMetric, ServerMetric, A2AAgentMetric}
+    assert sessions_by_model[ToolMetric].committed is False
+    assert sessions_by_model[ResourceMetric].committed is True
+    assert sessions_by_model[PromptMetric].committed is True
+    assert sessions_by_model[ServerMetric].committed is True
+    assert sessions_by_model[A2AAgentMetric].committed is True

--- a/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
+++ b/tests/unit/mcpgateway/services/test_metrics_buffer_service.py
@@ -691,11 +691,12 @@ def test_flush_to_db_writes_all_metric_types(monkeypatch):
 
     service._flush_to_db([tool_metric], [resource_metric], [prompt_metric], [server_metric], [a2a_metric])
 
-    # Two transactions: main (tool/resource/prompt/a2a) + server metrics
-    assert len(all_dbs) == 2
+    # Five separate transactions: one for each metric type (tool, resource, prompt, a2a, server)
+    # This prevents FK violations on one type from rolling back other types
+    assert len(all_dbs) == 5
     assert all(db.committed for db in all_dbs)
 
-    # Collect models across both transactions
+    # Collect models across all transactions
     models = [call[0] for db in all_dbs for call in db.bulk_calls]
     assert ToolMetric in models
     assert ResourceMetric in models
@@ -715,6 +716,7 @@ def test_record_tool_metric_falls_back_to_immediate_write(monkeypatch):
 
 
 def test_get_metrics_buffer_service_singleton(monkeypatch):
+    # First-Party
     from mcpgateway.services import metrics_buffer_service as mbs
 
     mbs._metrics_buffer_service = None
@@ -809,8 +811,8 @@ class TestMetricsSetup:
         from fastapi import FastAPI
 
         # First-Party
-        from mcpgateway.services import metrics as metrics_module
         from mcpgateway.services import http_client_service
+        from mcpgateway.services import metrics as metrics_module
 
         class DummyGauge:
             def __init__(self, _name, _doc, labelnames=None, registry=None):  # noqa: ARG002
@@ -953,3 +955,84 @@ class TestImmediateWriteMethods:
         )
         service = MetricsBufferService(enabled=False)
         service._write_a2a_agent_metric_immediately("a1", time.monotonic(), False, "invoke", "err")
+        # Should not raise
+
+
+def test_flush_to_db_prompt_metrics_exception_is_logged(monkeypatch):
+    """Test that exceptions during prompt metrics flush are logged but don't crash."""
+    # First-Party
+    from mcpgateway.db import PromptMetric
+
+    service = MetricsBufferService(enabled=True)
+
+    # Track which metric types were attempted
+    attempted_types = []
+
+    class DummyDB:
+        def __init__(self):
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            attempted_types.append(model)
+            if model == PromptMetric:
+                raise Exception("FK violation on prompt_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __enter__(self):
+            return DummyDB()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    prompt_metric = SimpleNamespace(prompt_id="p1", timestamp=time.time(), response_time=0.3, is_success=True, error_message=None)
+
+    # Should not raise despite the exception
+    service._flush_to_db([], [], [prompt_metric], [], [])
+
+    # Verify prompt metrics were attempted
+    assert PromptMetric in attempted_types
+
+
+def test_flush_to_db_a2a_agent_metrics_exception_is_logged(monkeypatch):
+    """Test that exceptions during A2A agent metrics flush are logged but don't crash."""
+    # First-Party
+    from mcpgateway.db import A2AAgentMetric
+
+    service = MetricsBufferService(enabled=True)
+
+    # Track which metric types were attempted
+    attempted_types = []
+
+    class DummyDB:
+        def __init__(self):
+            self.committed = False
+
+        def bulk_insert_mappings(self, model, payload):
+            attempted_types.append(model)
+            if model == A2AAgentMetric:
+                raise Exception("FK violation on a2a_agent_id")
+
+        def commit(self):
+            self.committed = True
+
+    class DummySession:
+        def __enter__(self):
+            return DummyDB()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("mcpgateway.services.metrics_buffer_service.fresh_db_session", DummySession)
+
+    a2a_metric = SimpleNamespace(a2a_agent_id="a1", timestamp=time.time(), response_time=0.5, is_success=True, interaction_type="invoke", error_message=None)
+
+    # Should not raise despite the exception
+    service._flush_to_db([], [], [], [], [a2a_metric])
+
+    # Verify A2A agent metrics were attempted
+    assert A2AAgentMetric in attempted_types


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4420

---

## 📝 Summary

Fixed a critical bug in `MetricsBufferService._flush_to_db()` where FK violations on one metric type would roll back all buffered metrics in the batch, causing data loss.

**Problem**: The method used a single transaction to bulk-insert tool, resource, prompt, and A2A metrics. When a tool/resource/prompt/agent was deleted between buffering and flushing (common in E2E tests and production gateway sync), the INSERT would fail with an `IntegrityError` on the FK constraint, rolling back **all** metrics in the batch—including unrelated ones.

**Solution**: Split the flush operation into 5 independent transactions (one per metric type), matching the existing server metrics pattern. Now FK violations only affect the specific metric type that failed, preserving all other buffered metrics.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Changes Made

**1. `mcpgateway/services/metrics_buffer_service.py` (lines 590-681)**
- Split single transaction into 5 separate transactions:
  - Tool metrics (lines 590-611)
  - Resource metrics (lines 613-634)
  - Prompt metrics (lines 636-657)
  - A2A agent metrics (lines 659-681)
  - Server metrics (lines 683-704) - already separate
- Each transaction has independent error handling with descriptive logging
- Added explanatory comments for each transaction block

**2. `tests/unit/mcpgateway/services/test_metrics_buffer_service.py`**
- Added `test_flush_to_db_prompt_metrics_exception_is_logged` (line 961)
- Added `test_flush_to_db_a2a_agent_metrics_exception_is_logged` (line 1001)
- Updated `test_flush_to_db_writes_all_metric_types` to expect 5 transactions instead of 2

### Impact

- **E2E tests**: No longer lose metrics when tools are deleted during cleanup
- **Production**: Gateway sync can safely remove stale entities without losing observability data
- **Performance**: Minimal impact - 5 small transactions vs 1 large transaction
- **Observability**: Better error visibility with specific log messages per metric type