### PR TITLE
fix(test): establish MCP session before notification/id-less envelope tests

### DIFF
--- a/tests/protocol_compliance/COMPLIANCE_GAPS.md
+++ b/tests/protocol_compliance/COMPLIANCE_GAPS.md
@@ -401,6 +401,42 @@ method. Once fixed, remove the `xfail_on` from this test.
 
 ---
 
+### GAP-013 — Id-less JSON-RPC messages treated as requests instead of notifications
+
+| | |
+|---|---|
+| **Targets affected** | `gateway_proxy`, `gateway_virtual` |
+| **Tests** | `test_jsonrpc_envelope.py::test_request_without_id_is_rejected_or_treated_as_notification` |
+| **Spec** | [JSON-RPC 2.0 § 4.1 Notification](https://www.jsonrpc.org/specification#notification), referenced by MCP 2025-11-25 base protocol (REQ-007, REQ-008) |
+| **Related** | [#4438](https://github.com/IBM/mcp-context-forge/issues/4438) |
+
+**Observed**: POSTing a JSON-RPC message without an `id` field (e.g.
+`{"jsonrpc":"2.0","method":"ping","params":{}}`) returns a successful
+result envelope with a server-fabricated UUID as the `id`:
+
+```json
+{"jsonrpc": "2.0", "result": {}, "id": "5baca3f1-a093-40f2-b76f-cb4e1afb0c29"}
+```
+
+**Expected**: JSON-RPC 2.0 § 4.1 defines a message without `id` as a
+*Notification* — "the Server MUST NOT reply to a Notification." The
+server should either reject the message (HTTP 4xx) or accept it as a
+notification (HTTP 202 Accepted with no id-bearing body).
+
+**Why**: the gateway's MCP handler (`main.py:10201-10202`) unconditionally
+auto-generates a UUID when `req_id is None`, then processes the message
+as a normal request. This erases the JSON-RPC distinction between
+requests and notifications.
+
+**How to close**: guard the `req_id is None` → `uuid4()` fallback so it
+only fires for messages that already have an `id` field set to a
+non-None value (i.e. the field is present but needs normalization).
+Messages with no `id` at all should be dispatched as notifications
+(return 202, no response envelope). Once fixed, drop the `@pytest.mark.xfail`
+on this test.
+
+---
+
 ## Closed gaps
 
 ### GAP-007 — `tools/list` pagination cap below upstream tool count *(closed 2026-04-18)*

--- a/tests/protocol_compliance/test_jsonrpc_envelope.py
+++ b/tests/protocol_compliance/test_jsonrpc_envelope.py
@@ -102,10 +102,25 @@ def test_notification_receives_no_response_body(gateway_http_client: httpx.Clien
     Asserts the HTTP response is 202 Accepted (the Streamable HTTP spec's way
     of acknowledging receipt with no body). Any envelope in the body would
     be a spec violation.
+
+    Per the MCP Streamable HTTP spec, clients MUST include the
+    ``Mcp-Session-Id`` header on all requests after initialization, so we
+    first establish a session via ``initialize`` before sending the
+    notification.
     """
+    # Establish a session — the spec requires Mcp-Session-Id on all
+    # post-initialization messages, including notifications.
+    init_resp = gateway_http_client.post("/mcp/", headers=_MCP_HEADERS, json=_initialize_body())
+    assert init_resp.status_code == 200, f"initialize failed: {init_resp.status_code}: {init_resp.text[:200]}"
+    session_id = init_resp.headers.get("mcp-session-id")
+
+    notify_headers = dict(_MCP_HEADERS)
+    if session_id:
+        notify_headers["mcp-session-id"] = session_id
+
     # notifications/initialized is the canonical always-safe notification.
     body = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
-    resp = gateway_http_client.post("/mcp/", headers=_MCP_HEADERS, json=body)
+    resp = gateway_http_client.post("/mcp/", headers=notify_headers, json=body)
     assert resp.status_code == 202, f"notification should produce 202 Accepted, got {resp.status_code}: {resp.text[:200]}"
     # The body may be empty, an empty JSON object, or omitted — but it MUST NOT contain
     # a JSON-RPC response envelope keyed by an id.
@@ -117,6 +132,14 @@ def test_notification_receives_no_response_body(gateway_http_client: httpx.Clien
             pass  # empty or non-JSON body is acceptable
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "GAP-013: gateway auto-generates a UUID for id-less JSON-RPC messages "
+        "instead of treating them as notifications (returns result with "
+        "fabricated id rather than 202 Accepted or 4xx rejection)."
+    ),
+)
 def test_request_without_id_is_rejected_or_treated_as_notification(
     gateway_http_client: httpx.Client,
 ) -> None:
@@ -127,8 +150,17 @@ def test_request_without_id_is_rejected_or_treated_as_notification(
     response). Either is spec-compatible; a *successful* id-bearing response
     would be a violation.
     """
+    # Establish a session so a missing session ID doesn't mask the real test.
+    init_resp = gateway_http_client.post("/mcp/", headers=_MCP_HEADERS, json=_initialize_body())
+    assert init_resp.status_code == 200, f"initialize failed: {init_resp.status_code}: {init_resp.text[:200]}"
+    session_id = init_resp.headers.get("mcp-session-id")
+
+    call_headers = dict(_MCP_HEADERS)
+    if session_id:
+        call_headers["mcp-session-id"] = session_id
+
     body = {"jsonrpc": "2.0", "method": "ping", "params": {}}  # no id
-    resp = gateway_http_client.post("/mcp/", headers=_MCP_HEADERS, json=body)
+    resp = gateway_http_client.post("/mcp/", headers=call_headers, json=body)
     if resp.status_code >= 400:
         return  # acceptable: server rejected the malformed request
     # Otherwise it was accepted as a notification; body must not echo an id.


### PR DESCRIPTION
## Summary

- Fix two protocol compliance tests that were sending post-initialization messages without the `Mcp-Session-Id` header required by the MCP Streamable HTTP spec, causing the SDK to reject them with 400 before the actual assertions could run.
- Document GAP-013: the gateway auto-generates a UUID for id-less JSON-RPC messages instead of treating them as notifications per JSON-RPC 2.0 § 4.1.

## Changes

### `test_notification_receives_no_response_body` (REQ-016)
Was sending `notifications/initialized` without a session ID. The MCP SDK's `_validate_session()` rejected it with 400 "Bad Request: Missing session ID" before the 202-notification path could run. Now initializes a session first and forwards the `Mcp-Session-Id` header.

### `test_request_without_id_is_rejected_or_treated_as_notification` (REQ-007, REQ-008)
Same session-ID fix. With the session established, the test now reaches its real assertion — and surfaces a spec compliance gap: the gateway's MCP handler (`main.py:10201-10202`) unconditionally auto-generates a UUID for id-less messages, returning a result with a fabricated `id` instead of treating the message as a notification. Marked `xfail(strict=False)` with GAP-013 reference.

### `COMPLIANCE_GAPS.md`
Added GAP-013 entry with observed/expected behavior, root cause, and fix outline.

## Related

- References #4438 (GAP-013 tracking issue — server-side fix still needed)