### PR TITLE
fix(bootstrap): skip Alembic advisory lock when schema is at head (#4051)

### DIFF
--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -202,6 +202,13 @@ spec:
             - name: PLUGINS_CONFIG_FILE
               value: {{ $pluginsConfigFile | quote }}
             {{- end }}
+            # Migration runner ownership — wired from .Values.migration.enabled
+            # so app pods skip the in-pod bootstrap when the pre-install Job
+            # is responsible for the schema. Placed after extraEnv so users
+            # cannot accidentally drop the contract by overriding it. See
+            # issue #4051 (Layer 2).
+            - name: MCPGATEWAY_SKIP_MIGRATIONS
+              value: {{ ternary "true" "false" .Values.migration.enabled | quote }}
 
           ################################################################
           # BULK ENV-VARS - pulled from ConfigMap + Secret

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -45,6 +45,8 @@ from typing import cast
 # Third-Party
 from alembic import command
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from filelock import FileLock
 from sqlalchemy import create_engine, inspect, or_, text
 from sqlalchemy.engine import Connection
@@ -97,6 +99,62 @@ def _schema_looks_current(inspector) -> bool:
         and _column_exists(inspector, "prompts", "custom_name")
         and _column_exists(inspector, "sso_providers", "jwks_uri")
     )
+
+
+def _alembic_at_head(conn: Connection, cfg: Config) -> bool:
+    """Return True when ``alembic_version`` in the DB matches the script directory head(s).
+
+    Used by ``main()`` to skip the migration advisory lock entirely when no
+    schema work is needed. This is the fast-path that keeps replicas 2..N
+    of a multi-pod deployment from serializing (and potentially hanging)
+    on a lock behind a transaction-pooling connection pooler (issue #4051).
+
+    Any error while probing — missing ``alembic_version`` table, connection
+    issue, unexpected Alembic state — causes this to return ``False`` so
+    the caller falls through to the fully-locked slow path, which handles
+    empty/partial/out-of-date databases explicitly.
+
+    Args:
+        conn: Active SQLAlchemy connection (not necessarily locked).
+        cfg: Alembic Config instance for this project.
+
+    Returns:
+        True if the DB schema is at the Alembic script directory's head;
+        False on mismatch, empty DB, or any error while probing.
+    """
+    try:
+        script_heads = set(ScriptDirectory.from_config(cfg).get_heads())
+        if not script_heads:
+            return False
+        context = MigrationContext.configure(conn)
+        db_heads = set(context.get_current_heads())
+        return bool(db_heads) and db_heads == script_heads
+    except Exception as exc:  # noqa: BLE001 - intentionally broad; fall through to slow path
+        logger.debug("Could not probe alembic head state: %s", exc)
+        return False
+
+
+async def _run_post_migration_bootstrap(conn: Connection) -> None:
+    """Run the idempotent post-migration bootstrap steps.
+
+    These steps (team-visibility normalization, admin user, default roles,
+    orphaned-resource assignment) are designed to be safe to re-run on
+    every startup — each checks for existing state and skips if already
+    populated. They must run on replicas that take the fast-path so that a
+    prior replica crashing mid-bootstrap doesn't leave downstream state
+    unpopulated.
+
+    Args:
+        conn: Active SQLAlchemy connection (locked on the slow path,
+            unlocked on the fast path). Writes are idempotent either way.
+    """
+    updated = normalize_team_visibility(conn)
+    if updated:
+        logger.info(f"Normalized {updated} team record(s) to supported visibility values")
+
+    await bootstrap_admin_user(conn)
+    await bootstrap_default_roles(conn)
+    await bootstrap_resource_assignments(conn)
 
 
 @contextmanager
@@ -706,8 +764,27 @@ async def main() -> None:
     cfg = Config(str(ini_path))  # path in container
     cfg.attributes["configure_logger"] = True
 
-    # Use advisory lock to prevent concurrent migrations
+    # Escape '%' characters in URL to avoid configparser interpolation errors
+    # (e.g., URL-encoded passwords like %40 for '@')
+    escaped_url = settings.database_url.replace("%", "%%")
+    cfg.set_main_option("sqlalchemy.url", escaped_url)
+
     try:
+        # Fast path: if the schema is already at the current Alembic head,
+        # skip the migration advisory lock entirely. This is critical for
+        # deployments behind a transaction-pooling connection pooler — the
+        # session-scoped advisory lock can be orphaned across pgbouncer's
+        # backend handoffs, causing N-th pod startup to spin indefinitely
+        # (issue #4051). Replicas 2..N take this branch on normal restarts.
+        with engine.connect() as probe_conn:
+            probe_conn.commit()
+            if _alembic_at_head(probe_conn, cfg):
+                logger.info("Schema already at Alembic head; skipping migration lock")
+                await _run_post_migration_bootstrap(probe_conn)
+                probe_conn.commit()
+                return
+
+        # Slow path: acquire the migration advisory lock and run schema work.
         with engine.connect() as conn:
             # Commit any open transaction on the connection before locking (though it should be fresh)
             conn.commit()
@@ -717,11 +794,6 @@ async def main() -> None:
 
                 # Pass the LOCKED connection to Alembic config
                 cfg.attributes["connection"] = conn
-
-                # Escape '%' characters in URL to avoid configparser interpolation errors
-                # (e.g., URL-encoded passwords like %40 for '@')
-                escaped_url = settings.database_url.replace("%", "%%")
-                cfg.set_main_option("sqlalchemy.url", escaped_url)
 
                 insp = inspect(conn)
                 table_names = insp.get_table_names()
@@ -746,20 +818,7 @@ async def main() -> None:
                         logger.info("Running Alembic migrations to ensure schema is up to date")
                         command.upgrade(cfg, "head")
 
-                # Post-upgrade normalization passes (inside lock to be safe)
-                updated = normalize_team_visibility(conn)
-                if updated:
-                    logger.info(f"Normalized {updated} team record(s) to supported visibility values")
-
-                # Bootstrap admin user after database is ready, using the LOCKED connection
-                await bootstrap_admin_user(conn)
-
-                # Bootstrap default RBAC roles after admin user is created
-                await bootstrap_default_roles(conn)
-
-                # Assign orphaned resources to admin personal team after all setup is complete
-                await bootstrap_resource_assignments(conn)
-
+                await _run_post_migration_bootstrap(conn)
                 conn.commit()  # Ensure all migration changes are permanently committed
 
     except Exception as e:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -776,6 +776,25 @@ class Settings(BaseSettings):
     # UI/Admin Feature Flags
     mcpgateway_ui_enabled: bool = False
     mcpgateway_admin_api_enabled: bool = False
+
+    # Migration runner ownership.
+    # When True, the gateway lifespan does NOT call bootstrap_db.main();
+    # the deployment is expected to run migrations as a separate step
+    # (Helm pre-install Job, init container, CI step, etc.). The library
+    # default is False so `docker run mcpgateway:latest` continues to
+    # bootstrap its own schema without operator action. The Helm chart
+    # ships this as True when the migration Job is enabled, so the
+    # contract "Job runs migrations, app pods skip" is enforced at the
+    # chart layer. See issue #4051 (Layer 2).
+    mcpgateway_skip_migrations: bool = Field(
+        default=False,
+        description=(
+            "When True, gateway pods skip the in-pod bootstrap_db call. "
+            "Pair with a dedicated migration runner (Helm pre-install Job, "
+            "init container, etc.) that ensures the schema is at head before "
+            "pods start."
+        ),
+    )
     mcpgateway_ui_airgapped: bool = Field(default=False, description="Use local CDN assets instead of external CDNs for airgapped deployments")
     mcpgateway_ui_embedded: bool = Field(default=False, description="Enable embedded UI mode (hides select header controls by default)")
     mcpgateway_ui_hide_sections: Annotated[list[str], NoDecode] = Field(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1583,6 +1583,33 @@ def _restore_default_sighup_handler() -> None:
     signal.signal(signal.SIGHUP, signal.SIG_DFL)
 
 
+async def _run_initial_db_bootstrap() -> None:
+    """Run ``bootstrap_db.main()`` unless ``MCPGATEWAY_SKIP_MIGRATIONS`` is set.
+
+    The flag tells the gateway that a separate migration runner — typically
+    a Helm pre-install Job, an init container, or a CI step — has already
+    populated the schema, so the in-pod bootstrap is redundant. When the
+    flag is True the call is suppressed and a single INFO line is emitted
+    so operators can audit the choice in pod logs.
+
+    Library default is False (preserves the ``docker run`` happy path);
+    Helm chart and compose overlays flip it to True when they pair the
+    gateway Deployment with a dedicated migration runner. See issue #4051
+    Layer 2.
+    """
+    if settings.mcpgateway_skip_migrations:
+        logger.info(
+            "Skipping in-pod migration bootstrap (MCPGATEWAY_SKIP_MIGRATIONS=true). "
+            "A dedicated migration runner is expected to have populated the schema."
+        )
+        return
+    # First-Party (deferred to keep import-time light for tests that don't
+    # need to pay the migration cost just by importing mcpgateway.main).
+    from mcpgateway.bootstrap_db import main as bootstrap_db_main  # pylint: disable=import-outside-toplevel
+
+    await bootstrap_db_main()
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """
@@ -1617,7 +1644,6 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # `wait_for_db_ready(sync=True)` is a blocking probe, so offload it to
     # a worker thread to avoid stalling the event loop during startup.
     # First-Party
-    from mcpgateway.bootstrap_db import main as bootstrap_db  # pylint: disable=import-outside-toplevel
     from mcpgateway.utils.db_isready import wait_for_db_ready  # pylint: disable=import-outside-toplevel
 
     await asyncio.to_thread(
@@ -1626,7 +1652,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         interval=int(settings.db_retry_interval_ms) / 1000,
         sync=True,
     )
-    await bootstrap_db()
+    await _run_initial_db_bootstrap()
 
     # Initialize Redis client early (shared pool for all services)
     await get_redis_client()

--- a/tests/integration/fixtures/transaction_pool/docker-compose.yml
+++ b/tests/integration/fixtures/transaction_pool/docker-compose.yml
@@ -1,0 +1,81 @@
+# Reproduction harness for issue #4051.
+#
+# Minimal stack to reproduce the Alembic advisory-lock hang when multiple
+# gateway replicas start concurrently behind PgBouncer in transaction-pooling
+# mode. Intentionally excludes everything unrelated (redis, nginx, monitoring,
+# admin UI) so the failure mode is attributable.
+
+name: mcf4051
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: reprosecret
+      POSTGRES_DB: mcp
+    ports:
+      - "54320:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mcp"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:reprosecret@postgres:5432/mcp
+      LISTEN_PORT: 6432
+      # The setting that makes this bug reproducible. In transaction pooling
+      # mode, PgBouncer hands the server backend to another client between
+      # transactions — so the session-scoped advisory lock Alembic acquires
+      # outlives the pooler "session" of the original caller.
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: "200"
+      # Force multiplexing: keep server-side backends well below total client
+      # connections. With N replicas × M gunicorn workers competing, PgBouncer
+      # must hand the same server backend to multiple clients between
+      # transactions — which is how session-scoped advisory locks get orphaned.
+      # Production OCP/Helm deployments that hit this bug see the same ratio.
+      DEFAULT_POOL_SIZE: "2"
+      MIN_POOL_SIZE: "1"
+      AUTH_TYPE: scram-sha-256
+    ports:
+      - "64320:6432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  gateway:
+    image: ${IMAGE_LOCAL:-mcpgateway/mcpgateway:latest}
+    depends_on:
+      pgbouncer:
+        condition: service_healthy
+    restart: "no"
+    environment:
+      # Route gateway traffic through PgBouncer (transaction pool). This is
+      # the scenario documented in the issue.
+      DATABASE_URL: postgresql+psycopg://postgres:reprosecret@pgbouncer:6432/mcp
+      HOST: 0.0.0.0
+      PORT: "4444"
+      LOG_LEVEL: INFO
+      # Strip the gateway down to just the bootstrap path we care about.
+      AUTH_REQUIRED: "false"
+      MCPGATEWAY_UI_ENABLED: "false"
+      MCPGATEWAY_ADMIN_API_ENABLED: "false"
+      MCPGATEWAY_A2A_ENABLED: "false"
+      PLUGINS_ENABLED: "false"
+      CACHE_TYPE: none
+      FEDERATION_ENABLED: "false"
+      REDIS_URL: "redis://127.0.0.1:6379/0"
+      # Keep bootstrap quiet on the retry side so the hang is obvious.
+      DB_MAX_RETRIES: "10"
+      # Several workers per replica so total client connections comfortably
+      # exceed PgBouncer's DEFAULT_POOL_SIZE, forcing backend multiplexing.
+      GUNICORN_WORKERS: "4"

--- a/tests/integration/test_migrations_under_transaction_pool.py
+++ b/tests/integration/test_migrations_under_transaction_pool.py
@@ -352,3 +352,76 @@ def test_bootstrap_db_skips_lock_when_schema_already_at_head(
         )
     finally:
         holder.close()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+def test_bootstrap_db_is_idempotent_once_schema_is_at_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second ``bootstrap_db.main()`` call must not touch ``advisory_lock``.
+
+    The first invocation populates the schema and stamps ``alembic_version``.
+    The second should recognise the DB is at head and take the fast-path
+    exclusively — never entering the ``advisory_lock`` context manager at
+    all. Pins the fast-path wiring against regressions that would re-route
+    bootstrap through the lock even when no schema work is needed.
+    """
+    # Standard
+    import asyncio
+    import time
+    from contextlib import contextmanager
+
+    # First-Party
+    from mcpgateway import bootstrap_db as bootstrap_module  # pylint: disable=import-outside-toplevel
+    from mcpgateway import config as mcp_config  # pylint: disable=import-outside-toplevel
+
+    _drop_public_schema()
+
+    monkeypatch.setattr(
+        mcp_config.settings,
+        "database_url",
+        _as_sqlalchemy_url(PGBOUNCER_URL),
+    )
+    monkeypatch.setattr(mcp_config.settings, "email_auth_enabled", False)
+
+    # First call: real advisory_lock (slow path on empty DB is expected).
+    asyncio.run(bootstrap_module.main())
+
+    # Install a spy that wraps the real advisory_lock so we can assert
+    # whether the second call entered it. We keep the wrapped behavior
+    # (rather than replacing with a no-op) so that if the spy IS hit, the
+    # test can still tear down cleanly.
+    advisory_lock_entries: list[object] = []
+    original_advisory_lock = bootstrap_module.advisory_lock
+
+    @contextmanager
+    def spy_advisory_lock(conn: object):
+        advisory_lock_entries.append(conn)
+        with original_advisory_lock(conn):  # type: ignore[arg-type]
+            yield
+
+    monkeypatch.setattr(bootstrap_module, "advisory_lock", spy_advisory_lock)
+
+    # Second call: schema is at head, fast-path should fire exclusively.
+    start = time.monotonic()
+    asyncio.run(bootstrap_module.main())
+    elapsed = time.monotonic() - start
+
+    assert advisory_lock_entries == [], (
+        f"bootstrap_db.main() entered advisory_lock {len(advisory_lock_entries)} "
+        f"time(s) on the second invocation, when the schema was already at head. "
+        f"Expected zero entries via the fast-path. This is a regression of the "
+        f"issue #4051 fast-path."
+    )
+
+    assert elapsed < 3.0, (
+        f"Second bootstrap_db.main() took {elapsed:.1f}s; expected < 3s via the "
+        f"fast-path. Either the probe connection or the post-migration bootstrap "
+        f"has acquired hidden cost — investigate before relaxing this threshold."
+    )
+
+    assert _count_advisory_locks_held(42_424_242_424_242) == 0, (
+        "Fast-path must not leave any advisory locks held after bootstrap_db "
+        "completes."
+    )

--- a/tests/integration/test_migrations_under_transaction_pool.py
+++ b/tests/integration/test_migrations_under_transaction_pool.py
@@ -62,6 +62,20 @@ POSTGRES_URL = os.environ.get(
 LOCK_ID = 42_424_242_424_242
 
 
+def _as_sqlalchemy_url(url: str) -> str:
+    """Add SQLAlchemy's ``+psycopg`` driver hint.
+
+    The ``PGBOUNCER_URL`` / ``POSTGRES_URL`` env vars are written in plain
+    ``postgresql://`` form so that ``psycopg.connect()`` accepts them
+    directly. SQLAlchemy's default Postgres dialect tries to import
+    ``psycopg2`` — not installed in this project — so we tell it to use
+    psycopg3 explicitly when feeding a URL into ``create_engine()``.
+    """
+    if url.startswith("postgresql+"):
+        return url
+    return url.replace("postgresql://", "postgresql+psycopg://", 1)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -226,3 +240,115 @@ def test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example():
         "A fresh direct session must still be blocked — otherwise the "
         "orphaning invariant from the previous test no longer holds."
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant test — the actual regression gate for issue #4051.
+#
+# Red on main (bootstrap_db always takes the advisory-lock path, blocks on
+# the orphan, exhausts retries). Green once the Layer-1 fast-path skip for
+# "schema already at head" is implemented.
+# ---------------------------------------------------------------------------
+
+
+def _drop_public_schema() -> None:
+    """Reset the test database to an empty state."""
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        conn.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        conn.execute("CREATE SCHEMA public")
+
+
+def _hold_advisory_lock_in_separate_session(lock_id: int):
+    """Open a direct (non-pgbouncer) Postgres session, take ``lock_id``, and
+    return the connection so the caller can close it when done.
+
+    Using a direct connection — rather than taking the lock through pgbouncer
+    and disconnecting — guarantees the holder's Postgres session is distinct
+    from whatever backend pgbouncer hands to a subsequent client. Without
+    that guarantee, pgbouncer may assign the same backend twice and
+    pg_try_advisory_lock succeeds via PostgreSQL's reentrant-within-session
+    semantics (see test_reentrant_acquire_through_same_pgbouncer_is_not_a_
+    counter_example), masking the hang this test is trying to catch.
+    """
+    holder = psycopg.connect(POSTGRES_URL, autocommit=True)
+    holder.execute("SELECT pg_advisory_lock(%s)", (lock_id,))
+    return holder
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(240)
+def test_bootstrap_db_skips_lock_when_schema_already_at_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bootstrap_db.main()`` must complete quickly when the schema is at
+    head, even if the migration advisory lock is held by another session.
+
+    In production (issue #4051), the "other session" is an orphaned server
+    backend whose pgbouncer client disconnected without DISCARD ALL
+    clearing the lock. We synthesize the same condition more reliably by
+    holding the lock in a distinct, still-alive Postgres session — that
+    way pg_try_advisory_lock from bootstrap's pgbouncer-facing session
+    must return FALSE regardless of which server backend pgbouncer hands
+    us.
+
+    Pre-fix: bootstrap_db always enters the advisory-lock retry loop; it
+    sees the lock as held, spins for ~10 minutes, then raises TimeoutError.
+    (pytest.mark.timeout cuts us off at 240s.)
+
+    Post-fix: the fast-path short-circuits on ``alembic_version == head``
+    before any lock is attempted; the second bootstrap completes in under
+    a second.
+    """
+    # Standard
+    import asyncio
+    import time
+
+    # First-Party (deferred so import-time failures inside mcpgateway don't
+    # break collection for this module).
+    from mcpgateway import config as mcp_config  # pylint: disable=import-outside-toplevel
+    from mcpgateway.bootstrap_db import main as bootstrap_db  # pylint: disable=import-outside-toplevel
+
+    # --- Preconditions ----------------------------------------------------
+    _drop_public_schema()
+
+    # Point the gateway's ORM at pgbouncer (transaction pool). tests/conftest.py
+    # normally forces DATABASE_URL to in-memory SQLite; overriding the live
+    # settings object is enough — bootstrap_db reads settings.database_url at
+    # call time. SQLAlchemy needs the +psycopg driver hint so it doesn't try
+    # to import psycopg2 (not installed in this project).
+    monkeypatch.setattr(
+        mcp_config.settings,
+        "database_url",
+        _as_sqlalchemy_url(PGBOUNCER_URL),
+    )
+    monkeypatch.setattr(mcp_config.settings, "email_auth_enabled", False)
+
+    # First bootstrap seeds the schema and stamps alembic_version to head.
+    # This is the "replica 1 wins the race" moment in production.
+    asyncio.run(bootstrap_db())
+
+    # --- Synthesize the held-lock precondition ---------------------------
+    # Lock id matches the sentinel used by advisory_lock() in bootstrap_db.
+    BOOTSTRAP_LOCK_ID = 42_424_242_424_242
+    holder = _hold_advisory_lock_in_separate_session(BOOTSTRAP_LOCK_ID)
+    try:
+        assert _count_advisory_locks_held(BOOTSTRAP_LOCK_ID) == 1, (
+            "Test setup failed: expected the advisory lock to be held by the "
+            "holder session before running the second bootstrap."
+        )
+
+        # --- The invariant -----------------------------------------------
+        # Post-fix: fast-path skips the lock entirely; completes in ms.
+        # Pre-fix: advisory_lock retry loop sees FALSE, spins for minutes.
+        start = time.monotonic()
+        asyncio.run(bootstrap_db())
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 10.0, (
+            f"bootstrap_db.main() took {elapsed:.1f}s with the schema at head "
+            f"and the migration advisory lock held by another session. "
+            f"Expected < 10s via the fast-path skip. This is the regression "
+            f"gate for issue #4051."
+        )
+    finally:
+        holder.close()

--- a/tests/integration/test_migrations_under_transaction_pool.py
+++ b/tests/integration/test_migrations_under_transaction_pool.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+"""Integration test documenting the mechanism behind issue #4051.
+
+PgBouncer in ``pool_mode=transaction`` shares one Postgres server backend
+across many pgbouncer "client" connections. Session-scoped Postgres advisory
+locks (``pg_advisory_lock``) live on the server backend, not on the pgbouncer
+client connection — so when a client disconnects, the server backend goes
+back into pgbouncer's pool *with the lock still held*. A subsequent client
+that happens to land on a different backend cannot take the same lock: from
+Postgres's point of view, the lock is held by the orphaned session.
+
+That is the mechanism that makes ``mcpgateway.bootstrap_db.main()`` hang
+when multiple gateway replicas start concurrently behind a transaction-
+pooling PgBouncer: N replicas race for ``pg_try_advisory_lock``, one wins,
+another client reuses that server backend mid-upgrade, and the remaining
+replicas then spin against an orphaned lock until the retry loop gives up.
+
+This module pins the mechanism as a first-class fact so future refactors
+to ``bootstrap_db.py`` can be validated against the same known-bad
+substrate.
+
+This test documents the PgBouncer mechanism and should keep passing even
+after the fix lands — the fix works *around* this behavior, it does not
+eliminate it.
+
+Requirements:
+    - Reproduction stack running:
+
+        docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \\
+            up -d postgres pgbouncer
+
+    - ``PGBOUNCER_URL`` / ``POSTGRES_URL`` point at that stack (defaults match
+      the ports exposed in the fixture compose file).
+
+Usage:
+    uv run pytest tests/integration/test_migrations_under_transaction_pool.py -v --with-integration
+"""
+
+# Standard
+import os
+
+# Third-Party
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+PGBOUNCER_URL = os.environ.get(
+    "PGBOUNCER_URL",
+    "postgresql://postgres:reprosecret@localhost:64320/mcp",
+)
+POSTGRES_URL = os.environ.get(
+    "POSTGRES_URL",
+    "postgresql://postgres:reprosecret@localhost:54320/mcp",
+)
+
+# Any 64-bit int works; we use the same sentinel as bootstrap_db so an
+# operator inspecting pg_locks sees the familiar value.
+LOCK_ID = 42_424_242_424_242
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _acquire_lock_via_pgbouncer_and_disconnect(lock_id: int) -> None:
+    """Open one pgbouncer connection, take an advisory lock, close the connection.
+
+    The connection is closed by ``with`` unwind; the server backend goes back
+    into pgbouncer's pool with the lock still held at the Postgres level.
+    """
+    with psycopg.connect(PGBOUNCER_URL, autocommit=True) as conn:
+        conn.execute("SELECT pg_advisory_lock(%s)", (lock_id,))
+
+
+def _count_advisory_locks_held(lock_id: int) -> int:
+    """Return the number of advisory locks matching ``lock_id`` currently held.
+
+    ``pg_locks.classid`` and ``pg_locks.objid`` are 32-bit OIDs; a 64-bit
+    advisory lock ID is split across them (high 32 bits → classid, low 32
+    bits → objid). We reconstruct the 64-bit ID in SQL to filter precisely.
+    """
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        row = conn.execute(
+            """
+            SELECT count(*)
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND granted
+              AND ((classid::bigint << 32) | objid::bigint) = %s
+            """,
+            (lock_id,),
+        ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _release_any_lingering_lock(lock_id: int) -> None:
+    """Kill the Postgres session that still holds the test's advisory lock.
+
+    Run as a fixture teardown so one failed test does not wedge the next
+    one behind the same orphan. ``pg_terminate_backend`` releases session-
+    scoped advisory locks as a side effect.
+    """
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND ((classid::bigint << 32) | objid::bigint) = %s
+            """,
+            (lock_id,),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_orphaned_lock():  # noqa: PT004 - autouse teardown, no return value
+    """Ensure we start and end each test with no lingering advisory lock."""
+    _release_any_lingering_lock(LOCK_ID)
+    yield
+    _release_any_lingering_lock(LOCK_ID)
+
+
+# Pyright cannot see pytest's autouse wiring; assert at import time that the
+# fixture is present so a future refactor can't silently drop the teardown.
+assert callable(_clean_orphaned_lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_session_advisory_lock_persists_across_pgbouncer_client_disconnect():
+    """A client disconnect through PgBouncer does NOT release its advisory lock.
+
+    Mirrors step 1 → step 2 of ``demonstrate_orphan.sh``. The pgbouncer
+    client is gone by the time we check, but Postgres still shows the lock
+    as held by the (now orphaned) server-side session.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    held = _count_advisory_locks_held(LOCK_ID)
+
+    assert held == 1, (
+        "Expected the advisory lock to still be held on Postgres after the "
+        "pgbouncer client disconnected (this is the orphaning that makes "
+        "bootstrap_db hang). Found %d held locks for id=%d." % (held, LOCK_ID)
+    )
+
+
+@pytest.mark.integration
+def test_orphaned_lock_blocks_a_fresh_postgres_session():
+    """A fresh Postgres session cannot acquire the orphaned lock.
+
+    This is the assertion that maps directly to the bug symptom: the N-th
+    gateway replica's Alembic bootstrap sees ``pg_try_advisory_lock`` return
+    FALSE and spins in its retry loop until it times out.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    # Fresh direct-to-postgres connection = guaranteed distinct session.
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)
+        ).fetchone()
+        assert row is not None
+        acquired = bool(row[0])
+
+    assert not acquired, (
+        "Expected pg_try_advisory_lock to return FALSE from a fresh session "
+        "because the lock is held by the orphaned backend. Got TRUE — either "
+        "pgbouncer is not configured with pool_mode=transaction, or "
+        "server_reset_query is clearing advisory locks between clients. "
+        "Check tests/integration/fixtures/transaction_pool/docker-compose.yml."
+    )
+
+
+@pytest.mark.integration
+def test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example():
+    """Same-session reentrance explains the 'sometimes it works' confusion.
+
+    When a subsequent pgbouncer client happens to land on the *same* server
+    backend that still holds the lock, ``pg_try_advisory_lock`` returns TRUE
+    because Postgres advisory locks are reentrant within a session.
+
+    This is not contradictory evidence: it's why the bug is intermittent
+    under load, and why our repro had to pin pool sizing to force a handoff.
+    This test exists so a future reader who reruns ``pg_try_advisory_lock``
+    via pgbouncer and sees TRUE does not conclude "no bug". With
+    ``DEFAULT_POOL_SIZE=2`` (our repro config) and only one client active,
+    the second pgbouncer connection will reuse the same backend.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    with psycopg.connect(PGBOUNCER_URL, autocommit=True) as conn:
+        row = conn.execute(
+            "SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)
+        ).fetchone()
+        assert row is not None
+        acquired_via_bouncer = bool(row[0])
+
+        # The pgbouncer client's view (reentrant) differs from a fresh
+        # direct session's view (blocked) — that divergence is what makes
+        # the bug hard to debug.
+        with psycopg.connect(POSTGRES_URL, autocommit=True) as direct:
+            row = direct.execute(
+                "SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)
+            ).fetchone()
+            assert row is not None
+            acquired_direct = bool(row[0])
+
+    assert acquired_via_bouncer, (
+        "Expected same-backend reentrance via pgbouncer to succeed. If this "
+        "fails, pgbouncer may not be reusing the same server backend for a "
+        "sequential client — check DEFAULT_POOL_SIZE in "
+        "tests/integration/fixtures/transaction_pool/docker-compose.yml."
+    )
+    assert not acquired_direct, (
+        "A fresh direct session must still be blocked — otherwise the "
+        "orphaning invariant from the previous test no longer holds."
+    )

--- a/tests/reproduction/issue-4051/README.md
+++ b/tests/reproduction/issue-4051/README.md
@@ -1,0 +1,119 @@
+# Reproduction — Issue #4051
+
+Alembic migration advisory lock hangs when multiple gateway replicas start
+concurrently through PgBouncer in transaction-pooling mode.
+
+Issue: https://github.com/IBM/mcp-context-forge/issues/4051
+
+## What's here
+
+Three ways to observe / prove the bug, in increasing order of abstraction:
+
+| Artifact | Scope | When to use |
+|---|---|---|
+| `demonstrate_orphan.sh` | Mechanism proof | Fastest, deterministic. Proves the PgBouncer session-advisory-lock orphan exists. Runs in ~10s against just postgres + pgbouncer. |
+| `reproduce.sh` | End-to-end symptom | Scales gateway to N replicas through PgBouncer and watches for the hang. Matches the issue reporter's OCP symptoms. |
+| `tests/integration/test_migrations_under_transaction_pool.py` | Pinned regression | The mechanism as three pytest assertions. Keeps the invariants enforceable as the stack evolves. |
+
+All three drive the same `tests/integration/fixtures/transaction_pool/docker-compose.yml` stack:
+
+- `postgres:17`
+- `edoburu/pgbouncer:latest` with `POOL_MODE=transaction` and a deliberately small `DEFAULT_POOL_SIZE=2` to force backend multiplexing
+- N gateway replicas (default 3) pointed at `pgbouncer:6432` (only used by `reproduce.sh`)
+
+## Prerequisites
+
+- Docker and Docker Compose v2.
+- For `reproduce.sh` only: a local gateway image tagged `mcpgateway/mcpgateway:latest`. Build from the repo root with `make docker` (or `make docker-prod`); override the tag via `IMAGE_LOCAL` if needed.
+- For the pytest regression test: the `postgres` optional extra — `uv sync --extra postgres`.
+
+## 1. Mechanism proof — `demonstrate_orphan.sh`
+
+Start here. Fastest, always deterministic, doesn't need the gateway image.
+
+```bash
+cd tests/reproduction/issue-4051
+./demonstrate_orphan.sh
+```
+
+Three steps:
+
+1. Through PgBouncer, take advisory lock `42424242424242`, close the connection.
+2. Query `pg_locks` directly on Postgres → lock is still held by the orphaned backend.
+3. From a fresh direct-to-Postgres session, `pg_try_advisory_lock(...)` returns `f`.
+
+Step 3 returning `f` is the exact condition that makes `bootstrap_db.main()` hang: a new gateway pod spinning on a lock no-one owns anymore.
+
+## 2. Symptom reproduction — `reproduce.sh`
+
+Scales gateway replicas through PgBouncer and reports whether all replicas reached `"Database ready"`.
+
+```bash
+cd tests/reproduction/issue-4051
+./reproduce.sh
+```
+
+Environment knobs:
+
+| Variable           | Default | Purpose |
+|--------------------|---------|---------|
+| `REPLICAS`         | `3`     | Number of concurrent gateway replicas. |
+| `TIMEOUT_SECONDS`  | `600`   | How long to wait before declaring a hang. |
+| `POLL_INTERVAL`    | `10`    | Log-sampling interval during the wait loop. |
+| `IMAGE_LOCAL`      | `mcpgateway/mcpgateway:latest` | Gateway image under test. |
+
+### What you'll see
+
+- **Full hang** (matches reporter's OCP symptom): `reproduce.sh` exits `1`, one container shows `"Database ready"` in its log, the others end at `INFO  [alembic.runtime.migration] Will assume transactional DDL.`, and `pg_locks` has one granted advisory row plus many backends `idle in transaction` on `SELECT pg_try_advisory_lock(...)`.
+- **Partial hang**: multiple workers inside each replica race; "lucky" workers finish and the pod reports healthy, but `pg_stat_activity` reveals several backends still wedged on the lock. This is the residue that poisons the next pod that starts.
+
+Either observation confirms the mechanism. `demonstrate_orphan.sh` gives you the deterministic-every-time version of the same signal.
+
+### Expected behavior after the fix lands
+
+All N replicas log `Database ready` within the timeout, `pg_stat_activity` shows no backends stuck on `pg_try_advisory_lock`, and the script exits `0`.
+
+## 3. Pinned regression test
+
+```bash
+# stack must be up first (postgres + pgbouncer are enough)
+docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml up -d postgres pgbouncer
+
+# from repo root
+uv run pytest tests/integration/test_migrations_under_transaction_pool.py -v --with-integration
+```
+
+Three assertions, each under one second:
+
+- A disconnected PgBouncer client's advisory lock remains held on Postgres.
+- A fresh Postgres session is blocked from acquiring the orphaned lock.
+- A same-backend PgBouncer reuse *can* reacquire the lock (documents the reentrant-session gotcha so future readers aren't confused).
+
+The test is marked `@pytest.mark.integration`; it's skipped by default unless `--with-integration` is passed. It keeps passing after the fix lands — it documents the PgBouncer behavior, not the bug itself.
+
+## Tear down
+
+```bash
+docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml down -v
+```
+
+## Host-exposed ports
+
+So you can attach `psql` / `pgbouncer admin` from the host while the stack runs:
+
+| Service   | Host port | In-network port |
+|-----------|-----------|-----------------|
+| postgres  | `54320`   | `5432`          |
+| pgbouncer | `64320`   | `6432`          |
+
+```bash
+PGPASSWORD=reprosecret psql -h localhost -p 54320 -U postgres -d mcp   # direct to postgres
+PGPASSWORD=reprosecret psql -h localhost -p 64320 -U postgres -d mcp   # through pgbouncer
+PGPASSWORD=reprosecret psql -h localhost -p 64320 -U postgres -d pgbouncer -c 'SHOW pools;'   # pgbouncer admin
+```
+
+## Notes
+
+- The stack deliberately omits Redis, the admin UI, plugins, federation, and A2A — they're not required to trigger the bug and would only add noise to the logs.
+- `PgBouncer`'s `DEFAULT_POOL_SIZE` is set low (`2`) so total client connections comfortably exceed it; without multiplexing pressure the bug is hard to trigger locally because bootstrap can finish before any backend handoff happens.
+- Production OCP/Helm deployments hit this reliably because real migrations take seconds to tens of seconds (plenty of handoff opportunities) and pool sizes are often sized for steady-state, not for migration bursts.

--- a/tests/reproduction/issue-4051/demonstrate_orphan.sh
+++ b/tests/reproduction/issue-4051/demonstrate_orphan.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Direct demonstration of the mechanism behind issue #4051.
+#
+# Three steps against the same stack that reproduce.sh uses:
+#
+#   1. Through PgBouncer (transaction pool, POOL_SIZE=2), take a Postgres
+#      session-scoped advisory lock, then close the connection. PgBouncer
+#      returns the backend to its pool.
+#   2. Query pg_locks on Postgres directly. The lock is STILL HELD — the
+#      pgbouncer "session" is gone but the server session on the backend
+#      is still alive.
+#   3. Open a fresh connection through PgBouncer and try to acquire the
+#      SAME lock. Returns FALSE because the backend PgBouncer hands us is
+#      the same one that still holds it.
+#
+# That "FALSE in step 3 even though no-one is actually doing anything" is
+# what makes bootstrap_db.main() hang: the advisory-lock retry loop spins
+# forever because the lock is orphaned on a backend no client owns.
+#
+# Requires:
+#   - docker compose with the stack defined in
+#     tests/integration/fixtures/transaction_pool/docker-compose.yml
+#     (postgres + pgbouncer only; no gateway needed).
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+COMPOSE_FILE="${REPO_ROOT}/tests/integration/fixtures/transaction_pool/docker-compose.yml"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+LOCK_ID="${LOCK_ID:-42424242424242}"
+
+log() { printf '[demo] %s\n' "$*"; }
+
+PSQL_PGBOUNCER=("${COMPOSE[@]}" exec -T -e PGPASSWORD=reprosecret postgres
+                psql -h pgbouncer -p 6432 -U postgres -d mcp -t -A)
+PSQL_DIRECT=("${COMPOSE[@]}" exec -T -e PGPASSWORD=reprosecret postgres
+             psql -h postgres -p 5432 -U postgres -d mcp -t -A)
+
+log "clean slate"
+"${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+
+log "start postgres + pgbouncer"
+"${COMPOSE[@]}" up -d --wait postgres pgbouncer
+
+# Sanity: confirm both are reachable.
+"${PSQL_DIRECT[@]}" -c "SELECT 1;" >/dev/null
+"${PSQL_PGBOUNCER[@]}" -c "SELECT 1;" >/dev/null
+
+echo
+log "=== STEP 1: through PgBouncer, acquire advisory lock ${LOCK_ID}, then disconnect"
+"${PSQL_PGBOUNCER[@]}" -c "SELECT pg_advisory_lock(${LOCK_ID});" >/dev/null
+log "    done (pgbouncer-facing connection closed)"
+
+echo
+log "=== STEP 2: direct to Postgres, check pg_locks for any advisory lock"
+# pg_locks splits a 64-bit advisory lock id across classid (high 32 bits) and
+# objid (low 32 bits) — both columns are 32-bit OIDs, so we can't compare
+# either column to the 64-bit LOCK_ID directly. Filtering by locktype is
+# enough: no one else in this stack holds advisory locks.
+direct_locks=$("${PSQL_DIRECT[@]}" -c \
+    "SELECT pid::text||'|'||locktype||'|'||classid::text||'|'||objid::text||'|'||granted::text FROM pg_locks WHERE locktype='advisory';")
+if [ -z "$direct_locks" ]; then
+    log "    NO advisory lock found on Postgres — backend was fully reset. Bug not reproducible with this pgbouncer config."
+    exit 1
+fi
+log "    lock still held at server level (classid<<32 | objid == ${LOCK_ID}):"
+printf '      %s\n' "$direct_locks" | awk -F'|' '{printf "pid=%s type=%s classid=%s objid=%s granted=%s\n", $1,$2,$3,$4,$5}'
+
+echo
+log "=== STEP 3: from a DIFFERENT Postgres session (direct, bypass PgBouncer),"
+log "           try to take the same advisory lock"
+# Why direct, not through PgBouncer? Advisory locks are reentrant within the
+# same session — so if PgBouncer happens to hand us the SAME server backend
+# that took the lock in step 1, pg_try_advisory_lock returns TRUE (the lock
+# is "already held by this session"). That's misleading. Connecting directly
+# to Postgres guarantees a brand-new session, which is exactly the condition
+# a new gateway pod hits when its Alembic tries to acquire the lock.
+result=$("${PSQL_DIRECT[@]}" -c "SELECT pg_try_advisory_lock(${LOCK_ID});" | tr -d '[:space:]')
+log "    pg_try_advisory_lock (from fresh session) -> ${result}"
+
+# Bonus: try the pgbouncer side too, so readers see the reentrant-TRUE effect.
+result_via_bouncer=$("${PSQL_PGBOUNCER[@]}" -c "SELECT pg_try_advisory_lock(${LOCK_ID});" | tr -d '[:space:]')
+log "    pg_try_advisory_lock (via pgbouncer, may reuse same backend) -> ${result_via_bouncer}"
+
+echo
+case "$result" in
+    f)
+        log "RESULT: ORPHANED. The lock set in step 1 is held by a backend"
+        log "        that no pgbouncer client still owns, and a different"
+        log "        postgres session cannot acquire it. A new gateway pod"
+        log "        taking this path would spin on pg_try_advisory_lock"
+        log "        until the advisory_lock retry timeout fires — exactly"
+        log "        the symptom described in issue #4051."
+        log ""
+        if [ "$result_via_bouncer" = "t" ]; then
+            log "        (The pgbouncer-side TRUE above is reentrance — it landed"
+            log "         on the same backend that still holds the lock. That's"
+            log "         a PostgreSQL feature, not contradictory evidence.)"
+            log ""
+        fi
+        log "        tear down with: ${COMPOSE[*]} down -v"
+        exit 0
+        ;;
+    t)
+        log "RESULT: lock was NOT orphaned. PgBouncer cleared it between"
+        log "        clients (likely via DISCARD ALL on server_reset_query)."
+        log "        The bug mechanism does not manifest in this config."
+        exit 1
+        ;;
+    *)
+        log "RESULT: unexpected psql output: '${result}'"
+        exit 2
+        ;;
+esac

--- a/tests/reproduction/issue-4051/reproduce.sh
+++ b/tests/reproduction/issue-4051/reproduce.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Reproduces issue #4051.
+#
+# Brings up postgres + pgbouncer (transaction pool) + N gateway replicas and
+# reports how many of them reached "Database ready" within TIMEOUT_SECONDS.
+# When the bug is present the first replica finishes bootstrap; the rest hang
+# at Alembic's advisory-lock acquisition.
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+COMPOSE_FILE="${REPO_ROOT}/tests/integration/fixtures/transaction_pool/docker-compose.yml"
+COMPOSE=(docker compose -f "${COMPOSE_FILE}")
+REPLICAS="${REPLICAS:-3}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
+POLL_INTERVAL="${POLL_INTERVAL:-10}"
+
+# bootstrap_db.main() emits exactly one of these per replica on success. The
+# match is scoped to the bootstrap_db logger so it does NOT collide with
+# db_isready's "Database ready after X.XXs" probe messages.
+READY_PATTERN='"name": "mcpgateway.bootstrap_db".*"message": "Database ready"'
+
+log() { printf '[repro] %s\n' "$*"; }
+
+count_ready() {
+    "${COMPOSE[@]}" logs --no-log-prefix gateway 2>/dev/null \
+        | grep -cE "${READY_PATTERN}" || true
+}
+
+log "clean slate (docker compose down -v)"
+"${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+
+log "start postgres + pgbouncer (healthchecks block until ready)"
+"${COMPOSE[@]}" up -d postgres pgbouncer
+
+log "scale gateway to ${REPLICAS}"
+"${COMPOSE[@]}" up -d --scale gateway="${REPLICAS}" --no-recreate gateway
+
+log "waiting up to ${TIMEOUT_SECONDS}s for all replicas to log 'Database ready'..."
+elapsed=0
+ready=0
+while (( elapsed < TIMEOUT_SECONDS )); do
+    ready=$(count_ready)
+    running=$("${COMPOSE[@]}" ps -q gateway | wc -l | tr -d ' ')
+    printf '  t=%4ds  ready=%s/%s  running=%s/%s\n' "$elapsed" "$ready" "$REPLICAS" "$running" "$REPLICAS"
+    if (( ready >= REPLICAS )); then break; fi
+    sleep "$POLL_INTERVAL"
+    elapsed=$((elapsed + POLL_INTERVAL))
+done
+
+echo
+echo "=============== gateway replica status ==============="
+"${COMPOSE[@]}" ps gateway
+
+echo
+echo "=============== advisory locks on postgres ==============="
+"${COMPOSE[@]}" exec -T postgres psql -U postgres -d mcp -c \
+    "SELECT locktype, mode, pid, granted, objid, classid FROM pg_locks WHERE locktype='advisory';" \
+    || true
+
+echo
+echo "=============== active backends on postgres ==============="
+"${COMPOSE[@]}" exec -T postgres psql -U postgres -d mcp -c \
+    "SELECT pid, application_name, state, wait_event_type, wait_event, left(query, 80) AS query FROM pg_stat_activity WHERE datname='mcp';" \
+    || true
+
+echo
+echo "=============== last 40 log lines per replica ==============="
+for cid in $("${COMPOSE[@]}" ps -q gateway); do
+    name=$(docker inspect --format '{{.Name}}' "$cid" | sed 's#^/##')
+    echo "----- $name -----"
+    docker logs --tail 40 "$cid" 2>&1 || true
+done
+
+echo
+if (( ready >= REPLICAS )); then
+    log "RESULT: all ${REPLICAS} replicas reached 'Database ready' (BUG NOT REPRODUCED)"
+    exit 0
+else
+    log "RESULT: only ${ready}/${REPLICAS} replicas reached 'Database ready' (BUG REPRODUCED)"
+    log "stack left running for inspection. tear down with:"
+    log "  ${COMPOSE[*]} down -v"
+    exit 1
+fi

--- a/tests/unit/charts/test_deployment_mcpgateway.py
+++ b/tests/unit/charts/test_deployment_mcpgateway.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""Helm chart render tests — gateway Deployment env wiring.
+
+Pins the contract introduced by issue #4051 Layer 2:
+
+    "When the chart enables the migration Job, the gateway Deployment must
+     set MCPGATEWAY_SKIP_MIGRATIONS=true so app pods don't redundantly
+     bootstrap the schema. When the Job is disabled, the gateway must
+     either omit the env var or set it to false so pods bootstrap
+     themselves via the L1 fast-path."
+
+Tests are skipped automatically when ``helm`` is not on PATH; they don't
+require a Kubernetes cluster — only chart rendering.
+"""
+
+# Standard
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+# Third-Party
+import pytest
+import yaml
+
+CHART_DIR = Path(__file__).resolve().parents[3] / "charts" / "mcp-stack"
+GATEWAY_DEPLOYMENT_NAME_SUFFIX = "mcp-stack-mcpgateway"
+
+# Helm refuses to render without these, so populate with throwaway values.
+# Values must be strings — the chart's schema is strict about types.
+REQUIRED_SECRETS = {
+    "mcpContextForge.secret.JWT_SECRET_KEY": "x" * 32,
+    "mcpContextForge.secret.AUTH_ENCRYPTION_SECRET": "y" * 32,
+    "mcpContextForge.secret.BASIC_AUTH_PASSWORD": "throwaway-pass-1234567",
+    "mcpContextForge.secret.PLATFORM_ADMIN_PASSWORD": "throwaway-pass-1234567",
+    "mcpContextForge.secret.REQUIRE_STRONG_SECRETS": '"false"',  # quoted: schema demands string
+}
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed; chart-render tests cannot run",
+)
+
+
+def _helm_template(*set_overrides: str) -> list[dict[str, Any]]:
+    """Render the chart with the given --set overrides, return parsed manifests."""
+    sets: list[str] = []
+    for k, v in REQUIRED_SECRETS.items():
+        sets.extend(["--set", f"{k}={v}"])
+    for override in set_overrides:
+        sets.extend(["--set", override])
+
+    result = subprocess.run(
+        ["helm", "template", "release-test", str(CHART_DIR), *sets],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _gateway_deployment(manifests: list[dict[str, Any]]) -> dict[str, Any]:
+    for m in manifests:
+        if (
+            m.get("kind") == "Deployment"
+            and m.get("metadata", {}).get("name", "").endswith(GATEWAY_DEPLOYMENT_NAME_SUFFIX)
+        ):
+            return m
+    raise AssertionError(
+        "gateway Deployment not found in rendered chart — selector may have drifted"
+    )
+
+
+def _gateway_env(manifests: list[dict[str, Any]]) -> dict[str, str]:
+    """Return the gateway container's ``env`` list as a dict for easy assertions."""
+    deploy = _gateway_deployment(manifests)
+    containers = deploy["spec"]["template"]["spec"]["containers"]
+    gateway_container = next(
+        c for c in containers if c["name"] in ("mcp-context-forge", "mcpgateway", "gateway")
+    )
+    out: dict[str, str] = {}
+    for entry in gateway_container.get("env", []) or []:
+        # Plain string values only — env entries with valueFrom are skipped.
+        if "value" in entry:
+            out[entry["name"]] = str(entry["value"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_skip_migrations_set_to_true_when_migration_job_enabled():
+    """When the chart's migration Job is enabled, app pods must skip
+    in-pod bootstrap so they don't race the Job's schema work."""
+    env = _gateway_env(_helm_template("migration.enabled=true"))
+    assert env.get("MCPGATEWAY_SKIP_MIGRATIONS") == "true", (
+        "Expected MCPGATEWAY_SKIP_MIGRATIONS=true on the gateway Deployment "
+        "when migration.enabled=true (issue #4051 Layer 2 contract). "
+        f"Got: {env.get('MCPGATEWAY_SKIP_MIGRATIONS')!r}. Full env keys: {sorted(env)}"
+    )
+
+
+def test_skip_migrations_off_when_migration_job_disabled():
+    """When the chart's migration Job is disabled, gateway pods are the
+    sole bootstrap path. The L1 fast-path makes the in-pod path safe."""
+    env = _gateway_env(_helm_template("migration.enabled=false"))
+    value = env.get("MCPGATEWAY_SKIP_MIGRATIONS", "false")
+    assert value == "false", (
+        "Expected MCPGATEWAY_SKIP_MIGRATIONS to be absent or false when "
+        "migration.enabled=false (the gateway is the only bootstrap path "
+        f"in this configuration). Got: {value!r}"
+    )
+
+
+def test_skip_migrations_default_matches_migration_enabled_default():
+    """The chart's default for migration.enabled is True (see values.yaml).
+    Default render therefore must set SKIP=true."""
+    env = _gateway_env(_helm_template())
+    assert env.get("MCPGATEWAY_SKIP_MIGRATIONS") == "true", (
+        "Default chart values render to migration.enabled=true, so "
+        "MCPGATEWAY_SKIP_MIGRATIONS must default to 'true'. Got: "
+        f"{env.get('MCPGATEWAY_SKIP_MIGRATIONS')!r}"
+    )

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -1702,6 +1702,96 @@ class TestMain:
                                                         mock_logger.info.assert_any_call("Database ready")
 
 
+class TestAlembicAtHead:
+    """Unit tests for the ``_alembic_at_head`` fast-path probe.
+
+    ``_alembic_at_head`` decides whether ``main()`` skips the migration
+    advisory lock (issue #4051). Its truth-table needs pinning independently
+    of the integration test so a future refactor cannot silently widen or
+    narrow the fast-path's trigger.
+    """
+
+    def test_returns_true_when_db_heads_match_script_heads(self):
+        """At-head DB → fast-path fires."""
+        # First-Party
+        from mcpgateway.bootstrap_db import _alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_conn = Mock()
+        mock_cfg = Mock()
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("abc123",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ("abc123",)
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert _alembic_at_head(mock_conn, mock_cfg) is True
+
+        mock_sd.from_config.assert_called_once_with(mock_cfg)
+        mock_mc.configure.assert_called_once_with(mock_conn)
+
+    def test_returns_false_when_db_has_no_alembic_version(self):
+        """Empty DB or missing ``alembic_version`` row → must take slow path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import _alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("abc123",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ()  # no version rows
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert _alembic_at_head(Mock(), Mock()) is False
+
+    def test_returns_false_when_db_head_does_not_match_script_head(self):
+        """Out-of-date DB → must take slow path so migrations actually run."""
+        # First-Party
+        from mcpgateway.bootstrap_db import _alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("newhead",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ("oldhead",)
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert _alembic_at_head(Mock(), Mock()) is False
+
+    def test_returns_false_when_script_directory_has_no_heads(self):
+        """Defensive: a zero-revision script dir must not fast-path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import _alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ()
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            # MigrationContext must never be consulted in this case.
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                assert _alembic_at_head(Mock(), Mock()) is False
+                mock_mc.configure.assert_not_called()
+
+    def test_returns_false_on_probe_exception(self):
+        """Any error while probing falls through to the slow path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import _alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        with patch(
+            "mcpgateway.bootstrap_db.ScriptDirectory.from_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _alembic_at_head(Mock(), Mock()) is False
+
+
 class TestModuleLevel:
     """Test module-level code and imports."""
 

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -218,6 +218,48 @@ def test_api_key_property():
     assert settings.api_key == "u:p"
 
 
+# --------------------------------------------------------------------------- #
+#                  MCPGATEWAY_SKIP_MIGRATIONS — issue #4051 (L2)              #
+# --------------------------------------------------------------------------- #
+def test_skip_migrations_defaults_to_false():
+    """Library default keeps the in-pod bootstrap path on so users running
+    the gateway image directly (no migration runner in front) still get a
+    populated schema. Helm chart and compose overlays ship with the env
+    set to True when they pair with a dedicated migration step.
+    """
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is False
+
+
+def test_skip_migrations_env_true_flips_flag():
+    """MCPGATEWAY_SKIP_MIGRATIONS=true → in-pod bootstrap is suppressed."""
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+        "MCPGATEWAY_SKIP_MIGRATIONS": "true",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is True
+
+
+def test_skip_migrations_env_false_keeps_flag_off():
+    """Explicit MCPGATEWAY_SKIP_MIGRATIONS=false matches the default."""
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+        "MCPGATEWAY_SKIP_MIGRATIONS": "false",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is False
+
+
 def test_supports_transport_properties():
     s_all = Settings(transport_type="all")
     assert (s_all.supports_http, s_all.supports_websocket, s_all.supports_sse) == (True, True, True)

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -261,6 +261,56 @@ def _make_request(path: str = "/", headers: dict | None = None) -> Request:
     return Request(scope)
 
 
+# --------------------------------------------------------------------------- #
+#       MCPGATEWAY_SKIP_MIGRATIONS — issue #4051 Layer 2 lifespan gate         #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_run_initial_db_bootstrap_invokes_bootstrap_when_flag_off(monkeypatch):
+    """Default behavior: lifespan calls ``bootstrap_db.main()``.
+
+    The library default for ``mcpgateway_skip_migrations`` is False so that
+    direct ``docker run mcpgateway`` users still get the schema populated
+    by the gateway itself.
+    """
+    # First-Party
+    import mcpgateway.main as main_mod  # pylint: disable=import-outside-toplevel
+    from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setattr(settings, "mcpgateway_skip_migrations", False, raising=False)
+    spy = AsyncMock()
+    monkeypatch.setattr("mcpgateway.bootstrap_db.main", spy)
+
+    await main_mod._run_initial_db_bootstrap()  # pylint: disable=protected-access
+
+    spy.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_initial_db_bootstrap_skips_when_flag_on(monkeypatch, caplog):
+    """When ``MCPGATEWAY_SKIP_MIGRATIONS=true``, bootstrap_db is NOT called.
+
+    Helm chart and compose overlays set this when a dedicated migration
+    runner (Helm pre-install Job, init container, etc.) has already
+    populated the schema. See issue #4051 Layer 2.
+    """
+    # First-Party
+    import logging  # pylint: disable=import-outside-toplevel
+    import mcpgateway.main as main_mod  # pylint: disable=import-outside-toplevel
+    from mcpgateway.config import settings  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.setattr(settings, "mcpgateway_skip_migrations", True, raising=False)
+    spy = AsyncMock()
+    monkeypatch.setattr("mcpgateway.bootstrap_db.main", spy)
+
+    with caplog.at_level(logging.INFO, logger="mcpgateway"):
+        await main_mod._run_initial_db_bootstrap()  # pylint: disable=protected-access
+
+    spy.assert_not_awaited()
+    assert any(
+        "MCPGATEWAY_SKIP_MIGRATIONS" in record.message for record in caplog.records
+    ), "Expected an INFO log line announcing the skip; helps operators audit the choice"
+
+
 def test_main_registers_otel_request_middleware_when_tracing_is_enabled():
     """Import-time app setup should register the OTEL request middleware when enabled."""
     # First-Party


### PR DESCRIPTION
## Summary

Fixes issue #4051 — Alembic migration advisory lock hangs when multiple gateway replicas start through PgBouncer in transaction-pooling mode. The session-scoped `pg_advisory_lock` is orphaned across PgBouncer's backend handoffs; the N-th gateway pod sees the lock held by an effectively-dead session and spins in its retry loop until the ~10-minute timeout fires.

This PR closes the bug along two layers and ships them together so the chart is safe under both deployment patterns:

- **Layer 1 (correctness)** — `bootstrap_db.main()` now probes `alembic_version` *before* attempting the advisory lock. When the schema is at the script directory's head, the lock acquisition is skipped entirely. Replicas 2..N never participate in the race.
- **Layer 2 (operator ergonomics)** — new `MCPGATEWAY_SKIP_MIGRATIONS` settings flag suppresses the in-pod `bootstrap_db.main()` call entirely. The `mcp-stack` Helm chart wires it from `migration.enabled` so the contract "the pre-install Job owns migrations, app pods skip" is enforced at the chart layer rather than left to operators to coordinate.

Library defaults preserve backward compatibility: a direct `docker run mcpgateway:latest` continues to bootstrap its own schema. Only the chart and (future) compose overlays opt into `SKIP_MIGRATIONS=true`.

Related: existing `migration.hostKey: host` / `portKey: port` knobs in `charts/mcp-stack/profiles/ocp/values-pgo.yaml` already let the migration Job bypass PgBouncer; that workaround stays in place but is no longer load-bearing.

### Approach

The fix was built **reproduction-first**: rather than implement against the issue text alone, the bug was first reproduced deterministically in docker-compose (`tests/reproduction/issue-4051/`) and then again on a real OpenShift cluster against CrunchyData PGO + transaction-pool PgBouncer. Both reproductions are documented in `todo/issue-4051-ocp-reproduction.md`, and the compose-side artifact lives permanently in the repo as a test fixture.

For each layer (L1 fast-path, L2 chart-wired skip), the cycle was:

```
   1. write a failing test that captures the invariant ──────► RED
   2. implement just enough to make it pass ─────────────────► GREEN
   3. verify on the OCP cluster against pre-fix and post-fix
      images, side-by-side, on the same stack ──────────────► EVIDENCE
   4. commit
```

The regression test for the bug — `test_bootstrap_db_skips_lock_when_schema_already_at_head` — is **reliably RED** pre-fix (240s timeout, 29/60 retry attempts visible in logs) and **reliably GREEN** post-fix (~1.4s). It's not a flaky timing-based test: it synthesizes the held-lock condition deterministically by holding the advisory lock in a distinct, still-alive Postgres session for the duration of the second `bootstrap_db.main()` call. That guarantees the bootstrap's PgBouncer-side session sees `pg_try_advisory_lock` return FALSE regardless of PgBouncer's internal backend assignment — without that guarantee, PgBouncer can hand the bootstrap the *same* server backend that the holder used, and `pg_try_advisory_lock` succeeds via PostgreSQL's reentrant-within-session semantics, masking the bug. (We landed on this design after observing a passing test that should have failed; the false-positive is documented as `test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example` so a future reader who hits the same gotcha understands what they're seeing.)

---

## Gaps closed

### HIGH — Bug correctness

**Gap 1 (HIGH)** — Advisory lock orphan via PgBouncer transaction-pool handoffs: `bootstrap_db.advisory_lock` always called `pg_try_advisory_lock` and retried up to 60 times with exponential backoff. When PgBouncer reused a backend whose previous client took the lock, new clients saw it held by an unreachable session and spun until timeout. Fixed with a `_alembic_at_head` probe that runs before the lock — when the DB is at the script-directory head, the lock is never attempted. The probe uses Alembic's `MigrationContext.get_current_heads()` and `ScriptDirectory.from_config(cfg).get_heads()` for the canonical source of truth; any error during probing falls through to the existing slow path so empty / partial / out-of-date databases still go through the explicit handling.

**Gap 2 (HIGH)** — Worker-level fan-out under-stated in the issue text: each gateway pod runs N gunicorn workers (default 8 in the OCP profile), and each worker calls `bootstrap_db.main()` in its own lifespan. So a 3-replica deployment produces 24 racing acquirers, not 3. Reproduction on OpenShift confirmed the fan-out: pre-fix, the same pod's logs show interleaved `Acquired lock on attempt N` and `Lock held by another instance, attempt N/60` at the same timestamps — different workers in the same gunicorn process. The L1 fast-path eliminates the race for replicas 2..N entirely; for replica 1 the within-pod race is bounded to a sub-second seed window.

**Gap 3 (HIGH)** — Chart safety today depends on the OCP-only workaround: `migration.hostKey: host` / `portKey: port` route the pre-install Job direct to Postgres (bypassing PgBouncer), masking the bug whenever the Job is enabled. A community user setting `migration.enabled=false` (because they manage migrations externally, or run the chart in compose-flavoured contexts) loses that protection. Layer 1 makes `migration.enabled=false` safe.

### HIGH — Operator ergonomics

**Gap 4 (HIGH)** — In-pod bootstrap runs even when a dedicated migration runner has already populated the schema: redundant probe activity per worker, plus the within-pod race for replica 1's seed window. Fixed with `MCPGATEWAY_SKIP_MIGRATIONS=true` which short-circuits the lifespan call to `bootstrap_db.main()` and emits a single audit-log line so operators can see the choice in pod logs.

**Gap 5 (HIGH)** — No chart wiring for the SKIP/Job pairing: even if the env var existed, expecting operators to set both `migration.enabled=true` AND `MCPGATEWAY_SKIP_MIGRATIONS=true` is a foot-gun (forgetting one means redundant in-pod bootstrap; forgetting the other means schema never populated). Fixed in `charts/mcp-stack/templates/deployment-mcpgateway.yaml`: the env var is rendered as `{{ ternary "true" "false" .Values.migration.enabled }}` and placed *after* `extraEnv` so a user override cannot accidentally undo the contract.

### MEDIUM — Test infrastructure

**Gap 6 (MEDIUM)** — No regression test for the advisory-lock invariant: no existing test exercised concurrent `bootstrap_db.main()` callers through PgBouncer. Fixed with `tests/integration/test_migrations_under_transaction_pool.py` containing five `@pytest.mark.integration` tests: three pinning the PgBouncer mechanism (so the substrate behavior is captured for posterity even if PgBouncer changes), one regression gate (synthesizes the orphaned-lock condition and asserts `bootstrap_db.main()` returns within 10s — fails in 240s pre-fix), and one idempotency invariant (asserts a second call after schema is at head never enters the `advisory_lock` context manager). Tests skip cleanly without `--with-integration`.

**Gap 7 (MEDIUM)** — No reproduction artifact in the repo: future debuggers had nothing to anchor on. Fixed with `tests/reproduction/issue-4051/` containing a docker-compose stack (postgres + pgbouncer + gateway), a deterministic `demonstrate_orphan.sh` (proves the PgBouncer mechanism in 3 psql calls), and a `reproduce.sh` (scales gateway replicas through PgBouncer and reports per-pod hangs). The compose file lives at `tests/integration/fixtures/transaction_pool/` so the integration tests can drive the same stack. The shell scripts are slated for deletion before this PR merges; their evidence will be preserved in the issue thread.

### LOW — Documentation and observability

**Gap 8 (LOW)** — Two readiness markers, one log-line: the L1 fast-path returns without emitting `"Database ready"` (only the slow-path return logs it). Operators reading pod logs see *either* the slow-path marker or the fast-path skip line, not a single canonical "bootstrap finished" line. **Tracked as a tiny follow-up; not blocking.**

---

## Architecture

### Before — every replica × every worker races for the lock

```text
                        DB schema starts populated (alembic_version at head)
                                                │
                                                ▼
   ┌────────── pod 1 (8 gunicorn workers) ──────────┐
   │  W1 → SELECT pg_try_advisory_lock(42…42) → t   │ ─┐
   │  W2 → SELECT pg_try_advisory_lock(42…42) → f   │ ─┤
   │  W3 → SELECT pg_try_advisory_lock(42…42) → f   │ ─┤
   │  …                                              │  │
   └─────────────────────────────────────────────────┘  │
                                                        │ all 24 workers
   ┌────────── pod 2 (8 gunicorn workers) ──────────┐  │ converge through
   │  W1..W8 → all 'f', spin in retry loop          │ ─┤ the same pgbouncer
   └─────────────────────────────────────────────────┘  │ pool
                                                        │
   ┌────────── pod 3 (8 gunicorn workers) ──────────┐  │
   │  W1..W8 → all 'f', spin in retry loop          │ ─┘
   └─────────────────────────────────────────────────┘
                                                        │
                                                        ▼
                        ┌──────────────────────────────────────────┐
                        │ PgBouncer (transaction pool)             │
                        │   each transaction commit → backend      │
                        │   handed to next client                  │
                        │   advisory lock outlives client session  │
                        └──────────────────────────────────────────┘
                                                        │
                                                        ▼
                        ┌──────────────────────────────────────────┐
                        │ Postgres                                  │
                        │   1 backend granted advisory lock         │
                        │   N–1 backends "idle in transaction" on   │
                        │   pg_try_advisory_lock(42424242424242)    │
                        └──────────────────────────────────────────┘

   Observable on OCP (issue reporter + our reproduction):
     · pods cycle 0/1 Running → CrashLoopBackOff → … → Ready over ~13 min
     · 7 restarts per pod (×3 = 21 restart events)
     · 60+ visible "Lock held by another instance" retries per restart
     · helm release status: failed
```

### After Layer 1 — fast-path before the lock

```text
   ┌────────── pod 1 worker ─────────────────────────────────────┐
   │  bootstrap_db.main()                                         │
   │    ┌─ probe (read-only) ─────────────────────────────────┐  │
   │    │  alembic_version == script_dir.get_heads() ?        │  │
   │    │       │                                              │  │
   │    │       ├── YES → return early, no lock involved      │  │
   │    │       │                                              │  │
   │    │       └── NO → fall through to advisory_lock path   │  │
   │    │              (existing slow path, unchanged)         │  │
   │    └─────────────────────────────────────────────────────┘  │
   └──────────────────────────────────────────────────────────────┘

   On a fresh deploy (empty DB), only the FIRST worker that wins the
   lock runs the slow path; replicas 2..N probe AFTER the seed and
   skip the lock entirely.

   Observed on OCP (verified end-to-end on context-forge-test-pg1):
     · pod 1 (seed):    0 retries → completes in ~1s
     · pods 2 & 3:      0 retries, 8 fast-path firings each
     · all 3 pods 1/1 Ready in 56 seconds, 0 restarts
     · helm release status: deployed
```

### After Layer 2 — pods don't even probe when the Job owns it

```text
                                                       Helm pre-install Job
                                                       ─────────────────────
                                                       direct to postgres :5432
                                                       runs bootstrap_db,
                                                       exits 0
                                                              │
                                                              ▼
                                              alembic_version at head
                                                              │
                                                              ▼
   ┌────────── gateway Deployment (chart-rendered) ────────────┐
   │  env:                                                      │
   │    - MCPGATEWAY_SKIP_MIGRATIONS: "true"   ← from           │
   │                                              .Values.      │
   │                                              migration.    │
   │                                              enabled       │
   │                                                            │
   │  lifespan:                                                 │
   │    wait_for_db_ready()                                     │
   │    if settings.mcpgateway_skip_migrations:                 │
   │        logger.info("Skipping in-pod migration              │
   │                     bootstrap (MCPGATEWAY_                 │
   │                     SKIP_MIGRATIONS=true)…")               │
   │        return                                              │
   │    else:                                                   │
   │        await bootstrap_db.main()                           │
   └────────────────────────────────────────────────────────────┘

   No probe. No lock. No worker fan-out.
   Single audit-log line per pod so operators can see the choice.
```

---

## Test results

The change ships with three layers of verification, each addressing a different failure mode:

```
   ┌──────────────────────────────────────────────────────────────────────┐
   │ Layer            │ Catches                                            │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Unit (13 tests)  │ Fast-path predicate logic; settings field          │
   │                  │ defaults; lifespan helper gate; chart render       │
   │                  │ outputs the right env var.                         │
   │                  │                                                    │
   │                  │ A future refactor that breaks ANY of these gets a  │
   │                  │ red unit test in seconds.                          │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Integration      │ The actual bug surface: bootstrap_db running       │
   │ (5 tests)        │ against a real Postgres + PgBouncer stack with     │
   │                  │ the held-lock precondition synthesized.            │
   │                  │                                                    │
   │                  │ Reliably RED on main (240s timeout). Reliably      │
   │                  │ GREEN with the L1 fast-path. Plus 3 mechanism      │
   │                  │ tests pinning PgBouncer's transaction-pool         │
   │                  │ semantics for documentation-as-code.               │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Cluster smoke    │ End-to-end on OpenShift with CrunchyData PGO +     │
   │ (manual)         │ transaction-pool PgBouncer. Same image, same       │
   │                  │ stack, only the gateway code differs between       │
   │                  │ pre- and post-fix runs. Concrete numbers below.    │
   └──────────────────────────────────────────────────────────────────────┘
```

The integration tests sit behind `--with-integration`; the unit tests run on every CI pass. The cluster smoke is documented evidence, not automated, and lives as `todo/issue-4051-ocp-reproduction.md` for the PR record.

<details>
<summary>Reproduction harness — how the bug was demonstrated end-to-end</summary>

Two artifacts live under `tests/reproduction/issue-4051/`. They will be removed before this PR merges (their evidence preserved in the issue thread):

```
   demonstrate_orphan.sh   ── deterministic mechanism proof (3 psql calls)
                              · step 1: through PgBouncer, take advisory lock,
                                disconnect
                              · step 2: directly query pg_locks → lock STILL
                                held by orphaned backend
                              · step 3: from a fresh Postgres session,
                                pg_try_advisory_lock → FALSE
                              always passes; documents PgBouncer behavior

   reproduce.sh            ── replica-scaling symptom reproduction
                              · scales 3 gateway replicas through PgBouncer
                              · watches each pod's logs for the retry storm
                              · dumps pg_locks + pg_stat_activity on hang
                              fails on pre-fix images, succeeds on post-fix
```

The compose stack itself was promoted to `tests/integration/fixtures/transaction_pool/docker-compose.yml` so the integration test can drive the same infrastructure that the shell scripts do. PgBouncer's `default_pool_size` is deliberately small (2) so total client connections comfortably exceed it, forcing backend multiplexing — without that pressure, the bug was hard to trigger locally because bootstrap can finish before any backend handoff happens.

Why two harnesses for one bug? `demonstrate_orphan.sh` proves the *PgBouncer mechanism* exists (orphaned advisory locks); `reproduce.sh` proves the *operational symptom* exists (replicas hang). Together they answer two questions any reviewer might ask: "is this a real PgBouncer property?" and "does it actually cause user-visible breakage?" — without making us guess timing.

</details>

<details>
<summary>Why the regression test is deterministic (not flaky)</summary>

Three ideas had to land before `test_bootstrap_db_skips_lock_when_schema_already_at_head` was reliably RED on main:

```
   ❌ First attempt — race the bootstrap calls
       Open 3 concurrent gateway processes, hope one wins the lock and
       the others spin. Worked sometimes (lucky timing) → fragile.

   ❌ Second attempt — synthesize an orphan via PgBouncer
       Take the lock through PgBouncer, disconnect, then call
       bootstrap_db.main() through PgBouncer. PgBouncer reused the same
       server backend for the bootstrap → pg_try_advisory_lock returned
       TRUE (reentrant within the same Postgres session) → FALSE
       POSITIVE (test passed when bug was present).

   ✅ Final design — hold the lock in a distinct postgres session
       Open a direct postgres connection (NOT through PgBouncer), take
       the advisory lock, KEEP the connection alive. Now run
       bootstrap_db.main() through PgBouncer. The bootstrap's session
       is guaranteed different from the holder's session, so
       pg_try_advisory_lock MUST return FALSE → bootstrap retries →
       240s pytest.mark.timeout fires. RED, every time.
```

The middle attempt's false-positive is captured as a permanent test (`test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example`) so future readers who see "but I called pg_try_advisory_lock through PgBouncer and it returned TRUE!" understand the reentrant-session gotcha.

The same logic underpins the `_clean_orphaned_lock` autouse fixture: it runs `pg_terminate_backend` on any session still holding the test lock id between tests, so a single failed test cannot wedge the next one behind a leaked orphan.

</details>

<details>
<summary>Unit — `_alembic_at_head` truth table (5 tests)</summary>

```
tests/unit/mcpgateway/test_bootstrap_db.py::TestAlembicAtHead

  test_returns_true_when_db_heads_match_script_heads          PASSED
  test_returns_false_when_db_has_no_alembic_version           PASSED
  test_returns_false_when_db_head_does_not_match_script_head  PASSED
  test_returns_false_when_script_directory_has_no_heads       PASSED
  test_returns_false_on_probe_exception                       PASSED

5 passed
```

Pins each branch of the fast-path predicate independently of the integration test, so a future refactor that widens or narrows the trigger condition is caught locally.

</details>

<details>
<summary>Unit — `MCPGATEWAY_SKIP_MIGRATIONS` settings field (3 tests)</summary>

```
tests/unit/mcpgateway/test_config.py

  test_skip_migrations_defaults_to_false        PASSED
  test_skip_migrations_env_true_flips_flag      PASSED
  test_skip_migrations_env_false_keeps_flag_off PASSED

3 passed
```

Library default stays False (the `docker run mcpgateway` happy path), env var override flips True, explicit False matches the default. No accidental coercion.

</details>

<details>
<summary>Unit — lifespan helper respects the flag (2 tests)</summary>

```
tests/unit/mcpgateway/test_main.py

  test_run_initial_db_bootstrap_invokes_bootstrap_when_flag_off  PASSED
  test_run_initial_db_bootstrap_skips_when_flag_on               PASSED

2 passed
```

The skip-case test also asserts the audit-log line is emitted so operators can see the choice in pod logs.

</details>

<details>
<summary>Unit — Helm chart render (3 tests)</summary>

```
tests/unit/charts/test_deployment_mcpgateway.py

  test_skip_migrations_set_to_true_when_migration_job_enabled        PASSED
  test_skip_migrations_off_when_migration_job_disabled               PASSED
  test_skip_migrations_default_matches_migration_enabled_default     PASSED

3 passed
```

Tests run `helm template` as a subprocess, parse the rendered manifests, and assert on the gateway Deployment's env block. Skipped automatically when `helm` is not on PATH; no cluster needed.

</details>

<details>
<summary>Integration — PgBouncer mechanism + bootstrap regression (5 tests, gated by `--with-integration`)</summary>

```
tests/integration/test_migrations_under_transaction_pool.py

  test_session_advisory_lock_persists_across_pgbouncer_client_disconnect  PASSED
  test_orphaned_lock_blocks_a_fresh_postgres_session                       PASSED
  test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example  PASSED
  test_bootstrap_db_skips_lock_when_schema_already_at_head                 PASSED
  test_bootstrap_db_is_idempotent_once_schema_is_at_head                   PASSED

5 passed in 1.47s   (post-fix)
1 fails in 240.34s  (pre-fix, hits pytest.mark.timeout — confirmed RED on main)
```

The mechanism tests document what PgBouncer does (lock orphaning is a real, named property of transaction-pool handoffs) so a future reader who sees "but pg_try_advisory_lock returned TRUE through PgBouncer!" understands the reentrance gotcha. The regression tests gate the actual fix.

Run with the docker-compose stack from `tests/integration/fixtures/transaction_pool/docker-compose.yml`.

</details>

<details>
<summary>OCP verification — L1 fix on real OpenShift + CrunchyData PGO (cluster: context-forge-test-pg1.cp.fyre.ibm.com)</summary>

```
Image:    docker.io/gandhipratik203/mcp-context-forge:4051-l1-fix-1777129453
Stack:    mcp-stack chart, default values + migration.enabled=false
Initial:  empty DB (DROP SCHEMA public CASCADE; CREATE SCHEMA public; …)

                                       PRE-FIX            POST-L1
                                       ───────            ───────
   Helm release status                 failed             deployed
   Pod restarts before Ready           7 each (21 total)  0
   Wall-clock to 3/3 Ready             ~13 min            56 sec
   Pods using fast-path                n/a                2 of 3, every worker
   Total visible retry messages        64+                28 (all confined to one pod's
                                                              worker-race during a
                                                              sub-second seed window)
   Advisory locks held at sample time  0 (after storm)    0 (no storm)

Per-pod log signature — post-L1
─────────────────────────────────
Pod 9jvtd  (won the seed race — slow path expected here):
  Empty DB detected:           1
  Acquired migration lock:     8
  Lock held by another:       28   ← within-pod race during ~1s seed window
  Schema already at head:      0
  Database ready:              8

Pods 2p9ls and jvb4t  (replicas 2 & 3):
  Empty DB detected:           0
  Acquired migration lock:     0   ← skipped the lock entirely
  Lock held by another:        0   ← no retries
  Schema already at head:      8   ← fast-path fired for every worker
  Database ready:              0
```

Full reproduction-vs-fix evidence in `todo/issue-4051-ocp-reproduction.md`.

</details>

<details>
<summary>OCP verification — L2 (chart-wired SKIP_MIGRATIONS) on real OpenShift</summary>

```
Image:    docker.io/gandhipratik203/mcp-context-forge:4051-l1-l2-fix-1777186436
Stack:    mcp-stack chart, DEFAULT values (migration.enabled=true), so the
          chart's pre-install Job runs the migration and the gateway
          Deployment is rendered with MCPGATEWAY_SKIP_MIGRATIONS=true.
Initial:  empty DB (DROP SCHEMA public CASCADE; CREATE SCHEMA public; …)

                                       PRE-FIX            POST-L1            POST-L2
                                       ───────            ───────            ───────
   Helm release status                 failed             deployed           deployed*
   Pod restarts before Ready           7 each (21 total)  0                  0
   Wall-clock to 3/3 Ready             ~13 min            56 sec             91 sec
   bootstrap_db activity in pods       very high          slow-path on 1     ZERO
   Advisory lock acquisitions in pods  many               8 (1 pod's race)   0
   Workers using fast-path             n/a                16 of 24           n/a (skipped)
   Workers using SKIP path             n/a                n/a                24 of 24
   Migration Job runs                  no (disabled)      no (disabled)      yes (Complete)

   * register-fast-time post-install Job failed; it's unrelated to the
     migration/skip story (registers the test fast-time-server via gateway
     API call). Doesn't affect L2 contract verification. Tracked separately.

Per-pod log signature — post-L2 (all 3 pods identical)
──────────────────────────────────────────────────────
  Skipping in-pod migration bootstrap:   8   ← one per gunicorn worker
  Acquired migration lock:               0
  Schema already at Alembic head:        0
  Lock held by another instance:         0
  Empty DB detected:                     0
  Database ready:                        0

DB state after pods Ready:
  Tables in public schema:               61
  alembic_version:                       d3e4f5a6b7c8 (at head)
  Advisory locks held:                   0
```

The 3-way pre-fix / post-L1 / post-L2 comparison is the headline win. The chart's contract — migration Job runs → app pods skip — is honored automatically; operators don't have to remember to set both `migration.enabled` AND `MCPGATEWAY_SKIP_MIGRATIONS` because the chart wires them together.

Full reproduction-vs-fix evidence in `todo/issue-4051-ocp-reproduction.md`.

</details>

---

## Additional improvements

- **Idempotent post-migration bootstrap extracted to `_run_post_migration_bootstrap()`** — admin-user creation, default-role seeding, and orphaned-resource assignment are now called from both the fast-path and slow-path branches. Previously these were only inside the `advisory_lock` block, so a fast-path skip would have missed them on a partial-startup edge case (replica 1 stamps head then crashes before bootstrapping the admin user → replica 2 fast-paths and runs the bootstrap steps to fill the gap).

- **Reproduction harness lives at `tests/reproduction/issue-4051/`** — `docker-compose.repro.yml` was promoted to a permanent test fixture under `tests/integration/fixtures/transaction_pool/`. Shell scripts (`reproduce.sh`, `demonstrate_orphan.sh`, `README.md`) are temporary; they will be removed before this PR merges, with their evidence preserved in the issue thread.

- **Module docstrings reference the issue number** — both the helper functions and the integration test module carry an inline reference to issue #4051 so a future reader greps once and lands in the right context.

---

## Limitations

1. **Fast-path returns without emitting `"Database ready"`** — the canonical readiness marker only fires on the slow-path return. Operators reading pod logs see *either* `Database ready` *or* `Schema already at Alembic head; skipping migration lock`. Both signal "bootstrap finished," but inconsistently. Captured as Gap 8 above; trivial follow-up.

2. **Layer 3 not included** — the original plan considered a table-based mutex fallback for environments where `migration_database_url` (direct-Postgres bypass) isn't available AND the chart's pre-install Job is disabled. With L1+L2 in place, that combination is well-covered: L1 makes the in-pod path safe, L2 lets the chart guarantee the in-pod path is skipped when the Job runs. Reopening if a real-world report justifies it.

3. **DROP SCHEMA in PGO setups requires ownership restoration** — observed during the OCP reproduction. CrunchyData PGO assigns schema ownership to a service user; a manual `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` re-creates the schema owned by `postgres`, so the service user can't create tables in it until ownership is restored:

   ```sql
   ALTER SCHEMA public OWNER TO admin;
   GRANT ALL ON SCHEMA public TO admin;
   GRANT ALL ON SCHEMA public TO public;
   ```

   Documented in the OCP reproduction notes; not a code fix.

4. **Pod readiness can be misleading during pre-fix cycling** — observed pods show `1/1 Ready` even while several gunicorn workers are still in their retry loop. One worker's lifespan completing seems sufficient to satisfy the readiness probe. With L1+L2 the storm window is gone; this is captured here for operator awareness when reading historical pre-fix logs.

---

## Future work

### Compose-side L2 (deferred)

The root `docker-compose.yml` was left unchanged. It's currently safe thanks to L1 alone (the fast-path makes in-pod bootstrap pgbouncer-safe). Adding a dedicated `migrate` service in compose plus `MCPGATEWAY_SKIP_MIGRATIONS=true` on the gateway would mirror the chart's contract one-to-one — useful for users who want production-shaped semantics in dev. Tracked as a separate issue if there's appetite; deliberately out-of-scope here to keep `docker-compose.yml` touch-free for existing users.

### Unify the readiness log line

Per Gap 8 above. Either:

- emit `"Database ready"` from both paths (fast and slow), or
- replace it with a single richer line carrying the path taken (`"Database ready (fast-path)"` / `"Database ready (slow-path)"`).

Either change is a one-line edit; deferred so this PR stays scoped to the bug fix.

### `MIGRATION_DATABASE_URL` (only if requested)

The Helm chart already exposes `migration.hostKey` / `portKey` to point the pre-install Job direct to Postgres (bypassing PgBouncer). A code-level `MIGRATION_DATABASE_URL` setting would let docker-compose users do the same without two `DATABASE_URL` definitions. Not necessary for the bug fix; deferred unless someone explicitly asks for it.

---

Closes #4051
