### PR TITLE
fix(bootstrap): improve startup reliability for multi-replica deploys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-21T10:55:45Z",
+  "generated_at": "2026-05-22T06:22:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4986,7 +4986,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2955,
+        "line_number": 2965,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8950,7 +8950,7 @@
         "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 256,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8958,7 +8958,7 @@
         "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 640,
+        "line_number": 682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8966,7 +8966,7 @@
         "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 653,
+        "line_number": 695,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8974,7 +8974,7 @@
         "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 659,
+        "line_number": 701,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8982,7 +8982,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 728,
+        "line_number": 770,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -8990,7 +8990,7 @@
         "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 788,
+        "line_number": 830,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8998,7 +8998,7 @@
         "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1158,
+        "line_number": 1200,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9006,7 +9006,7 @@
         "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1410,
+        "line_number": 1452,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -199,6 +199,12 @@ spec:
             - name: PLUGINS_CONFIG_FILE
               value: {{ $pluginsConfigFile | quote }}
             {{- end }}
+            # Migration runner ownership — wired from .Values.migration.enabled
+            # so app pods skip the in-pod bootstrap when the pre-install Job
+            # is responsible for the schema. Placed after extraEnv so users
+            # cannot accidentally drop the contract by overriding it.
+            - name: MCPGATEWAY_SKIP_MIGRATIONS
+              value: {{ ternary "true" "false" .Values.migration.enabled | quote }}
 
           ################################################################
           # BULK ENV-VARS - pulled from ConfigMap + Secret
@@ -222,18 +228,21 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  # Check if migration check already passed
-                  if [ -f /tmp/migration_check_done ]; then
+                  # Schema-at-head guard: refuse Ready until alembic_version
+                  # matches the script-directory head. This is the chart-level
+                  # invariant — pods cannot serve traffic against a half-
+                  # migrated DB regardless of which entity (pre-install Job,
+                  # post-install Job, init container, external CD pipeline)
+                  # is responsible for running migrations.
+                  if [ -f /tmp/schema_at_head_done ]; then
                     exit 0
                   fi
-                  # Wait for database to be ready (implies migration completed)
-                  python3 /app/mcpgateway/utils/db_isready.py --max-tries 1 --interval 1 --timeout 2 || exit 1
-                  # Mark check as done to avoid repeated database calls
-                  touch /tmp/migration_check_done
+                  python3 -m mcpgateway.utils.check_schema_at_head || exit 1
+                  touch /tmp/schema_at_head_done
                   exit 0
             initialDelaySeconds: 10
             periodSeconds: 5
-            timeoutSeconds: 10
+            timeoutSeconds: 15
             failureThreshold: 60    # Allow up to 5 minutes for migration to complete
           {{- else }}
           {{- with .Values.mcpContextForge.probes.startup }}

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -43,6 +43,7 @@ from typing import cast
 from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from filelock import FileLock
 from sqlalchemy import create_engine, or_, text
 from sqlalchemy.engine import Connection
@@ -97,46 +98,102 @@ def _schema_looks_current(inspector) -> bool:
     )
 
 
-def _is_at_alembic_head(conn: Connection, cfg: Config) -> bool:
-    """Return True if the database alembic_version already points to the current head revision.
+def make_alembic_cfg(database_url: str, *, configure_logger: bool = False) -> Config:
+    """Build an Alembic ``Config`` wired to ``database_url`` for this project.
 
-    Uses Alembic's own MigrationContext and ScriptDirectory for an authoritative check
-    rather than a column heuristic, so it stays accurate as new migrations are added.
+    Centralises two pieces of Alembic-config setup that must be identical
+    across every entry-point (``bootstrap_db.main()`` and the schema-at-head
+    startup probe in ``mcpgateway.utils.check_schema_at_head``):
 
-    A False return is always safe — it causes the caller to fall through to the full
-    advisory-lock + upgrade path.
+      * locating ``alembic.ini`` via ``importlib.resources`` so it works the
+        same way inside the Python wheel and inside the container image;
+      * doubling ``%`` characters in the URL before handing it to
+        ``cfg.set_main_option(...)`` so configparser doesn't choke on
+        URL-encoded passwords (e.g., ``%40`` for ``@``).
+
+    Both call sites had this block inlined; reviewer flagged the duplication.
+    Keeping the helper public (no leading underscore) so it is intentional
+    shared API — anyone refactoring ``bootstrap_db.py`` can see at a glance
+    that external code depends on this name.
 
     Args:
-        conn: Active SQLAlchemy connection.
-        cfg: Alembic Config object with sqlalchemy.url already set.
+        database_url: SQLAlchemy URL for the target database.
+        configure_logger: When True, set ``cfg.attributes["configure_logger"] = True``.
+            ``bootstrap_db.main()`` opts in (Alembic command-line UX);
+            the startup probe leaves it off (it should not emit Alembic
+            INFO logs on every K8s probe tick).
 
     Returns:
-        True when the database is already at head (safe to skip migration lock).
-        False when the database is fresh, behind, or the check itself fails.
+        Configured ``alembic.config.Config`` ready for use with the Alembic
+        runtime API or command layer.
     """
-    # pylint: disable=import-outside-toplevel
-    # Third-Party
+    ini_path = files("mcpgateway").joinpath("alembic.ini")
+    cfg = Config(str(ini_path))
+    if configure_logger:
+        cfg.attributes["configure_logger"] = True
+    # Escape '%' characters in URL to avoid configparser interpolation errors
+    # (e.g., URL-encoded passwords like %40 for '@').
+    escaped_url = database_url.replace("%", "%%")
+    cfg.set_main_option("sqlalchemy.url", escaped_url)
+    return cfg
 
-    # Third-Party
-    from alembic.script import ScriptDirectory
-    import sqlalchemy as sa
 
+def alembic_at_head(conn: Connection, cfg: Config) -> bool:
+    """Return True when ``alembic_version`` in the DB matches the script directory head(s).
+
+    Used by ``main()`` to skip the migration advisory lock entirely when no
+    schema work is needed. This is the fast-path that keeps replicas 2..N
+    of a multi-pod deployment from serializing (and potentially hanging)
+    on a session-scoped advisory lock that a transaction-pooling connection
+    pooler (e.g., PgBouncer in pool_mode=transaction) can orphan across its
+    backend handoffs.
+
+    Any error while probing — missing ``alembic_version`` table, connection
+    issue, unexpected Alembic state — causes this to return ``False`` so
+    the caller falls through to the fully-locked slow path, which handles
+    empty/partial/out-of-date databases explicitly.
+
+    Args:
+        conn: Active SQLAlchemy connection (not necessarily locked).
+        cfg: Alembic Config instance for this project.
+
+    Returns:
+        True if the DB schema is at the Alembic script directory's head;
+        False on mismatch, empty DB, or any error while probing.
+    """
     try:
-        inspector = sa.inspect(conn)
-        if "alembic_version" not in inspector.get_table_names():
+        script_heads = set(ScriptDirectory.from_config(cfg).get_heads())
+        if not script_heads:
             return False
-
-        migration_ctx = MigrationContext.configure(conn)
-        current_heads = set(migration_ctx.get_current_heads())
-        if not current_heads:
-            return False
-
-        script = ScriptDirectory.from_config(cfg)
-        target_heads = set(script.get_heads())
-        return current_heads == target_heads
-    except Exception as exc:
-        logger.warning("Could not determine alembic head state (%s) — falling through to migration lock", exc)
+        context = MigrationContext.configure(conn)
+        db_heads = set(context.get_current_heads())
+        return bool(db_heads) and db_heads == script_heads
+    except Exception as exc:  # noqa: BLE001 - intentionally broad; fall through to slow path
+        logger.warning("Fast-path head probe failed, falling back to advisory-lock path: %s", exc)
         return False
+
+
+async def _run_post_migration_bootstrap(conn: Connection) -> None:
+    """Run the idempotent post-migration bootstrap steps.
+
+    These steps (team-visibility normalization, admin user, default roles,
+    orphaned-resource assignment) are designed to be safe to re-run on
+    every startup — each checks for existing state and skips if already
+    populated. They must run on replicas that take the fast-path so that a
+    prior replica crashing mid-bootstrap doesn't leave downstream state
+    unpopulated.
+
+    Args:
+        conn: Active SQLAlchemy connection (locked on the slow path,
+            unlocked on the fast path). Writes are idempotent either way.
+    """
+    updated = normalize_team_visibility(conn)
+    if updated:
+        logger.info(f"Normalized {updated} team record(s) to supported visibility values")
+
+    await bootstrap_admin_user(conn)
+    await bootstrap_default_roles(conn)
+    await bootstrap_resource_assignments(conn)
 
 
 @contextmanager
@@ -756,14 +813,10 @@ async def main() -> None:
         Exception: If migration or bootstrap fails
     """
     engine = create_engine(settings.database_url)
-    ini_path = files("mcpgateway").joinpath("alembic.ini")
-    cfg = Config(str(ini_path))  # path in container
-    cfg.attributes["configure_logger"] = True
-    escaped_url = settings.database_url.replace("%", "%%")
-    cfg.set_main_option("sqlalchemy.url", escaped_url)
+    cfg = make_alembic_cfg(settings.database_url, configure_logger=True)
 
     # SQLite multi-replica guard: /tmp is per-container, so FileLock provides no
-    # cross-container coordination.  All replicas run migrations concurrently
+    # cross-container coordination. All replicas run migrations concurrently
     # against the same SQLite file — a silent correctness bug.
     is_sqlite = settings.database_url.startswith("sqlite")
     gateway_replicas = int(os.environ.get("GATEWAY_REPLICAS", "1"))
@@ -777,24 +830,20 @@ async def main() -> None:
             _MIGRATION_LOCK_PATH,
         )
 
-    # SKIP_MIGRATION: external tooling (init container, CI pipeline) already ran
-    # alembic upgrade head — skip schema migration and run only the idempotent
-    # bootstrap helpers.  If the schema is NOT at head, the init container failed
-    # or the wrong DB was targeted; fail fast so the deployment error is visible.
-    if settings.skip_migration:
+    # MCPGATEWAY_SKIP_MIGRATIONS: external tooling (init container, CI pipeline)
+    # already ran alembic upgrade head — skip schema migration and run only the
+    # idempotent bootstrap helpers. If the schema is NOT at head, the init
+    # container failed or the wrong DB was targeted; fail fast so the deployment
+    # error is visible.
+    if settings.mcpgateway_skip_migrations:
         try:
             with engine.connect() as conn:
                 conn.commit()
-                if not _is_at_alembic_head(conn, cfg):
-                    logger.error("SKIP_MIGRATION=true but schema is not at head — " "run 'alembic upgrade head' before starting the application")
+                if not alembic_at_head(conn, cfg):
+                    logger.error("MCPGATEWAY_SKIP_MIGRATIONS=true but schema is not at head — run 'alembic upgrade head' before starting the application")
                     raise RuntimeError("Schema not at head; migrations required before startup")
-                logger.info("SKIP_MIGRATION=true — schema already at head, skipping migration")
-                updated = normalize_team_visibility(conn)
-                if updated:
-                    logger.info(f"Normalized {updated} team record(s) to supported visibility values")
-                await bootstrap_admin_user(conn)
-                await bootstrap_default_roles(conn)
-                await bootstrap_resource_assignments(conn)
+                logger.info("MCPGATEWAY_SKIP_MIGRATIONS=true — schema already at head, skipping migration")
+                await _run_post_migration_bootstrap(conn)
                 conn.commit()
         except Exception as e:
             logger.error(f"Bootstrap failed: {e}")
@@ -805,46 +854,36 @@ async def main() -> None:
         return
 
     try:
+        # Fast path: if the schema is already at the current Alembic head,
+        # skip the migration advisory lock entirely. This is critical for
+        # deployments behind a transaction-pooling connection pooler — the
+        # session-scoped advisory lock can be orphaned across pgbouncer's
+        # backend handoffs, which would otherwise make N-th pod startup
+        # spin indefinitely. Replicas 2..N take this branch on normal
+        # restarts.
+        with engine.connect() as probe_conn:
+            probe_conn.commit()
+            if alembic_at_head(probe_conn, cfg):
+                logger.info("Schema already at Alembic head; skipping migration lock")
+                await _run_post_migration_bootstrap(probe_conn)
+                probe_conn.commit()
+                return
+
+        # Slow path: acquire the migration advisory lock and run schema work.
         with engine.connect() as conn:
             # Commit any open transaction on the connection before locking (though it should be fresh)
             conn.commit()
 
-            # Fast-path: schema already at head — skip advisory lock and alembic upgrade entirely.
-            # Replicas 2+ on rolling restarts or after an init container has run take this path,
-            # reducing per-replica startup cost from ~lock_wait + upgrade_time to a single SELECT.
-            if _is_at_alembic_head(conn, cfg):
-                logger.info("Schema already at migration head — skipping advisory lock and alembic upgrade")
-                updated = normalize_team_visibility(conn)
-                if updated:
-                    logger.info(f"Normalized {updated} team record(s) to supported visibility values")
-                await bootstrap_admin_user(conn)
-                await bootstrap_default_roles(conn)
-                await bootstrap_resource_assignments(conn)
-                conn.commit()
-            else:
-                with advisory_lock(conn):
-                    logger.info("Acquired migration lock, checking database schema...")
+            with advisory_lock(conn):
+                logger.info("Acquired migration lock, checking database schema...")
 
-                    # Pass the LOCKED connection to Alembic config
-                    cfg.attributes["connection"] = conn
-                    logger.info("Running Alembic migrations to ensure schema is up to date")
-                    command.upgrade(cfg, "head")
+                # Pass the LOCKED connection to Alembic config
+                cfg.attributes["connection"] = conn
+                logger.info("Running Alembic migrations to ensure schema is up to date")
+                command.upgrade(cfg, "head")
 
-                    # Post-upgrade normalization passes (inside lock to be safe)
-                    updated = normalize_team_visibility(conn)
-                    if updated:
-                        logger.info(f"Normalized {updated} team record(s) to supported visibility values")
-
-                    # Bootstrap admin user after database is ready, using the LOCKED connection
-                    await bootstrap_admin_user(conn)
-
-                    # Bootstrap default RBAC roles after admin user is created
-                    await bootstrap_default_roles(conn)
-
-                    # Assign orphaned resources to admin personal team after all setup is complete
-                    await bootstrap_resource_assignments(conn)
-
-                    conn.commit()  # Ensure all migration changes are permanently committed
+                await _run_post_migration_bootstrap(conn)
+                conn.commit()  # Ensure all migration changes are permanently committed
 
     except Exception as e:
         logger.error(f"Database migration failed: {e}")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -250,15 +250,6 @@ class Settings(BaseSettings):
             "(See Issue #1535 for details)"
         ),
     )
-    skip_migration: bool = Field(
-        default=False,
-        description=(
-            "Skip alembic upgrade head on startup. Use when migrations are managed externally "
-            "(e.g., a dedicated init container or CI pipeline step). "
-            "The idempotent bootstrap helpers (admin user, RBAC roles, resource assignments) still run."
-        ),
-    )
-
     # Absolute paths resolved at import-time (still override-able via env vars)
     templates_dir: Path = Field(default_factory=lambda: Path(str(files("mcpgateway") / "templates")))
     static_dir: Path = Field(default_factory=lambda: Path(str(files("mcpgateway") / "static")))
@@ -1050,6 +1041,25 @@ class Settings(BaseSettings):
     # UI/Admin Feature Flags
     mcpgateway_ui_enabled: bool = False
     mcpgateway_admin_api_enabled: bool = False
+
+    # Migration runner ownership.
+    # When True, the gateway lifespan does NOT call bootstrap_db.main();
+    # the deployment is expected to run migrations as a separate step
+    # (Helm pre-install Job, init container, CI step, etc.). The library
+    # default is False so `docker run mcpgateway:latest` continues to
+    # bootstrap its own schema without operator action. The Helm chart
+    # ships this as True when the migration Job is enabled, so the
+    # contract "Job runs migrations, app pods skip" is enforced at the
+    # chart layer.
+    mcpgateway_skip_migrations: bool = Field(
+        default=False,
+        description=(
+            "When True, gateway pods skip the in-pod bootstrap_db call. "
+            "Pair with a dedicated migration runner (Helm pre-install Job, "
+            "init container, etc.) that ensures the schema is at head before "
+            "pods start."
+        ),
+    )
     mcpgateway_ui_airgapped: bool = Field(default=False, description="Use local CDN assets instead of external CDNs for airgapped deployments")
     mcpgateway_ui_embedded: bool = Field(default=False, description="Enable embedded UI mode (hides select header controls by default)")
     mcpgateway_ui_hide_sections: Annotated[list[str], NoDecode] = Field(

--- a/mcpgateway/utils/check_schema_at_head.py
+++ b/mcpgateway/utils/check_schema_at_head.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""CLI: exit 0 iff the database schema is at the Alembic script-directory head.
+
+Used as the gateway pod's startup-probe command in the Helm chart so that
+pods refuse Ready until the schema has been migrated — regardless of which
+migration runner did the work (Helm pre/post-install Job, init container,
+external CD pipeline, manual operator step).
+
+Exits:
+    0  schema is at head
+    1  schema is missing, mismatched, or any error encountered
+
+Usage::
+
+    python3 -m mcpgateway.utils.check_schema_at_head
+"""
+
+# Standard
+from __future__ import annotations
+
+import logging
+import sys
+
+# Third-Party
+from sqlalchemy import create_engine
+from sqlalchemy.pool import NullPool
+
+# First-Party
+from mcpgateway.bootstrap_db import alembic_at_head, make_alembic_cfg
+from mcpgateway.config import settings
+from mcpgateway.db import connect_args
+
+logger = logging.getLogger("mcpgateway.check_schema_at_head")
+
+
+def main() -> int:
+    """Probe entry-point. See module docstring for exit semantics."""
+    # Align connection-establishment behavior with the production engine in
+    # ``mcpgateway.db``. Pool internals (``pool_size`` / ``pool_timeout`` /
+    # ``pool_recycle``) don't apply: the probe opens one connection per K8s
+    # tick and disposes the engine, so ``NullPool`` truthfully describes the
+    # lifetime. ``connect_args`` carries production-side parameters that *do*
+    # matter on every connect call (psycopg TCP keepalives + prepare_threshold
+    # for PostgreSQL, ``check_same_thread`` for SQLite) — alignment here keeps
+    # probe-vs-prod connect behavior identical.
+    engine = create_engine(
+        settings.database_url,
+        poolclass=NullPool,
+        connect_args=connect_args,
+    )
+    cfg = make_alembic_cfg(settings.database_url)
+
+    try:
+        with engine.connect() as conn:
+            return 0 if alembic_at_head(conn, cfg) else 1
+    except Exception as exc:  # noqa: BLE001 - probe must never raise
+        logger.warning("schema-at-head probe failed: %s", exc)
+        return 1
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/fixtures/transaction_pool/docker-compose.yml
+++ b/tests/integration/fixtures/transaction_pool/docker-compose.yml
@@ -1,0 +1,119 @@
+# ===========================================================================
+# !! TEST FIXTURE ONLY — DO NOT USE IN PRODUCTION OR EXPOSE BEYOND LOCALHOST !!
+# ===========================================================================
+# AUTH_REQUIRED=false and the postgres password default (`reprosecret`) are
+# committed verbatim because integration tests need a deterministic
+# substrate without env-setup. Docker binds the published host ports
+# (54320 / 64320 / 4444) to 0.0.0.0 by default — on a machine with an
+# exposed external IP, that's a publicly reachable unauthenticated
+# gateway. Use the root docker-compose.yml for local development; this
+# fixture exists solely for the integration tests in
+# tests/integration/test_migrations_under_transaction_pool.py.
+#
+# Credentials use the same ``${POSTGRES_PASSWORD:-reprosecret}``  # pragma: allowlist secret
+# env-var-with-default pattern as the repository's root docker-compose.yml,
+# so a developer can override at compose-up time without editing the file.
+# ===========================================================================
+
+# Test fixture: minimal Postgres + transaction-pool PgBouncer + gateway stack
+# used by the integration tests in
+# tests/integration/test_migrations_under_transaction_pool.py to validate
+# Alembic bootstrap behavior under multi-replica startup.
+#
+# Intentionally excludes everything unrelated (redis, nginx, monitoring,
+# admin UI) so the failure modes the tests target are attributable.
+
+name: transaction-pool-fixture
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-reprosecret}  # pragma: allowlist secret
+      POSTGRES_DB: mcp
+    ports:
+      - "54320:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d mcp"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  pgbouncer:
+    # Substrate: edoburu/pgbouncer:latest — same image as the repository's
+    # root docker-compose.yml (and the docker-compose-debug.yml /
+    # -performance.yml / -verbose-logging.yml variants alongside it, plus
+    # the helm chart's pgbouncer.image.tag default in
+    # charts/mcp-stack/values.yaml).
+    # As of 2026-05-01, :latest resolved to PgBouncer 1.25.1 (verified via
+    # `docker run --rm --entrypoint pgbouncer edoburu/pgbouncer:latest
+    # --version`). Bump the date when re-verifying against a new pull.
+    #
+    # We deliberately track :latest on this fixture rather than pinning
+    # it in isolation: pinning only here would diverge from the substrate
+    # every other deployment of this project uses, which is a worse
+    # failure mode than the drift risk — tests would no longer exercise
+    # what users actually run.
+    #
+    # The orphaned-advisory-lock condition this fixture exists to
+    # reproduce is asserted *behaviorally* by the tests in
+    # test_migrations_under_transaction_pool.py — if an upstream republish
+    # ever changed pool_mode=transaction semantics, those tests would fail
+    # loudly rather than silently pass incorrectly.
+    image: edoburu/pgbouncer:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD:-reprosecret}@postgres:5432/mcp  # pragma: allowlist secret
+      LISTEN_PORT: 6432
+      # The setting that makes this bug reproducible. In transaction pooling
+      # mode, PgBouncer hands the server backend to another client between
+      # transactions — so the session-scoped advisory lock Alembic acquires
+      # outlives the pooler "session" of the original caller.
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: "200"
+      # Force multiplexing: keep server-side backends well below total client
+      # connections. With N replicas × M gunicorn workers competing, PgBouncer
+      # must hand the same server backend to multiple clients between
+      # transactions — which is how session-scoped advisory locks get orphaned.
+      # Production OCP/Helm deployments that hit this bug see the same ratio.
+      DEFAULT_POOL_SIZE: "2"
+      MIN_POOL_SIZE: "1"
+      AUTH_TYPE: scram-sha-256
+    ports:
+      - "64320:6432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-h", "localhost", "-p", "6432"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  gateway:
+    image: ${IMAGE_LOCAL:-mcpgateway/mcpgateway:latest}
+    depends_on:
+      pgbouncer:
+        condition: service_healthy
+    restart: "no"
+    environment:
+      # Route gateway traffic through PgBouncer (transaction pool). This is
+      # the scenario documented in the issue.
+      DATABASE_URL: postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-reprosecret}@pgbouncer:6432/mcp  # pragma: allowlist secret
+      HOST: 0.0.0.0
+      PORT: "4444"
+      LOG_LEVEL: INFO
+      # Strip the gateway down to just the bootstrap path we care about.
+      AUTH_REQUIRED: "false"
+      MCPGATEWAY_UI_ENABLED: "false"
+      MCPGATEWAY_ADMIN_API_ENABLED: "false"
+      MCPGATEWAY_A2A_ENABLED: "false"
+      PLUGINS_ENABLED: "false"
+      CACHE_TYPE: none
+      FEDERATION_ENABLED: "false"
+      REDIS_URL: "redis://127.0.0.1:6379/0"
+      # Keep bootstrap quiet on the retry side so the hang is obvious.
+      DB_MAX_RETRIES: "10"
+      # Several workers per replica so total client connections comfortably
+      # exceed PgBouncer's DEFAULT_POOL_SIZE, forcing backend multiplexing.
+      GUNICORN_WORKERS: "4"

--- a/tests/integration/test_migrations_under_transaction_pool.py
+++ b/tests/integration/test_migrations_under_transaction_pool.py
@@ -1,0 +1,606 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for Alembic bootstrap under transaction-pool PgBouncer.
+
+PgBouncer in ``pool_mode=transaction`` shares one Postgres server backend
+across many pgbouncer "client" connections. Session-scoped Postgres advisory
+locks (``pg_advisory_lock``) live on the server backend, not on the pgbouncer
+client connection — so when a client disconnects, the server backend goes
+back into pgbouncer's pool *with the lock still held*. A subsequent client
+that happens to land on a different backend cannot take the same lock: from
+Postgres's point of view, the lock is held by the orphaned session.
+
+That is the mechanism that makes ``mcpgateway.bootstrap_db.main()`` hang
+when multiple gateway replicas start concurrently behind a transaction-
+pooling PgBouncer: N replicas race for ``pg_try_advisory_lock``, one wins,
+another client reuses that server backend mid-upgrade, and the remaining
+replicas then spin against an orphaned lock until the retry loop gives up.
+
+This module pins the mechanism as a first-class fact so future refactors
+to ``bootstrap_db.py`` can be validated against the same known-bad
+substrate.
+
+This test documents the PgBouncer mechanism and should keep passing even
+after the fix lands — the fix works *around* this behavior, it does not
+eliminate it.
+
+Requirements:
+    - Reproduction stack running:
+
+        docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \\
+            up -d postgres pgbouncer
+
+    - ``PGBOUNCER_URL`` / ``POSTGRES_URL`` point at that stack (defaults match
+      the ports exposed in the fixture compose file).
+
+    - **For the end-to-end compose test only**: a built local gateway image
+      (``mcpgateway/mcpgateway:latest`` — produced by ``make docker``) AND
+      ``MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1`` to opt into the destructive
+      path. Without the env var the e2e test skips with a clear message.
+
+Usage:
+    uv run pytest tests/integration/test_migrations_under_transaction_pool.py -v --with-integration
+
+    # Including the destructive end-to-end test:
+    MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1 uv run pytest \\
+        tests/integration/test_migrations_under_transaction_pool.py -v --with-integration
+"""
+
+# Standard
+import os
+
+# Third-Party
+import pytest
+
+psycopg = pytest.importorskip("psycopg")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+PGBOUNCER_URL = os.environ.get(
+    "PGBOUNCER_URL",
+    "postgresql://postgres:reprosecret@localhost:64320/mcp",  # pragma: allowlist secret
+)
+POSTGRES_URL = os.environ.get(
+    "POSTGRES_URL",
+    "postgresql://postgres:reprosecret@localhost:54320/mcp",  # pragma: allowlist secret
+)
+
+# Any 64-bit int works; we use the same sentinel as bootstrap_db so an
+# operator inspecting pg_locks sees the familiar value.
+LOCK_ID = 42_424_242_424_242
+
+
+def _as_sqlalchemy_url(url: str) -> str:
+    """Add SQLAlchemy's ``+psycopg`` driver hint.
+
+    The ``PGBOUNCER_URL`` / ``POSTGRES_URL`` env vars are written in plain
+    ``postgresql://`` form so that ``psycopg.connect()`` accepts them
+    directly. SQLAlchemy's default Postgres dialect tries to import
+    ``psycopg2`` — not installed in this project — so we tell it to use
+    psycopg3 explicitly when feeding a URL into ``create_engine()``.
+    """
+    if url.startswith("postgresql+"):
+        return url
+    return url.replace("postgresql://", "postgresql+psycopg://", 1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _acquire_lock_via_pgbouncer_and_disconnect(lock_id: int) -> None:
+    """Open one pgbouncer connection, take an advisory lock, close the connection.
+
+    The connection is closed by ``with`` unwind; the server backend goes back
+    into pgbouncer's pool with the lock still held at the Postgres level.
+    """
+    with psycopg.connect(PGBOUNCER_URL, autocommit=True) as conn:
+        conn.execute("SELECT pg_advisory_lock(%s)", (lock_id,))
+
+
+def _count_advisory_locks_held(lock_id: int) -> int:
+    """Return the number of advisory locks matching ``lock_id`` currently held.
+
+    ``pg_locks.classid`` and ``pg_locks.objid`` are 32-bit OIDs; a 64-bit
+    advisory lock ID is split across them (high 32 bits → classid, low 32
+    bits → objid). We reconstruct the 64-bit ID in SQL to filter precisely.
+    """
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        row = conn.execute(
+            """
+            SELECT count(*)
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND granted
+              AND ((classid::bigint << 32) | objid::bigint) = %s
+            """,
+            (lock_id,),
+        ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _release_any_lingering_lock(lock_id: int) -> None:
+    """Kill the Postgres session that still holds the test's advisory lock.
+
+    Run as a fixture teardown so one failed test does not wedge the next
+    one behind the same orphan. ``pg_terminate_backend`` releases session-
+    scoped advisory locks as a side effect.
+    """
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND ((classid::bigint << 32) | objid::bigint) = %s
+            """,
+            (lock_id,),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_orphaned_lock():  # noqa: PT004 - autouse teardown, no return value
+    """Ensure we start and end each test with no lingering advisory lock."""
+    _release_any_lingering_lock(LOCK_ID)
+    yield
+    _release_any_lingering_lock(LOCK_ID)
+
+
+# Pyright cannot see pytest's autouse wiring; assert at import time that the
+# fixture is present so a future refactor can't silently drop the teardown.
+assert callable(_clean_orphaned_lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_session_advisory_lock_persists_across_pgbouncer_client_disconnect():
+    """A client disconnect through PgBouncer does NOT release its advisory lock.
+
+    The pgbouncer client is gone by the time we check, but Postgres still
+    shows the lock as held by the (now orphaned) server-side session.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    held = _count_advisory_locks_held(LOCK_ID)
+
+    assert held == 1, (
+        "Expected the advisory lock to still be held on Postgres after the "
+        "pgbouncer client disconnected (this is the orphaning that makes "
+        "bootstrap_db hang). Found %d held locks for id=%d." % (held, LOCK_ID)
+    )
+
+
+@pytest.mark.integration
+def test_orphaned_lock_blocks_a_fresh_postgres_session():
+    """A fresh Postgres session cannot acquire the orphaned lock.
+
+    This is the assertion that maps directly to the bug symptom: the N-th
+    gateway replica's Alembic bootstrap sees ``pg_try_advisory_lock`` return
+    FALSE and spins in its retry loop until it times out.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    # Fresh direct-to-postgres connection = guaranteed distinct session.
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        row = conn.execute("SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)).fetchone()
+        assert row is not None
+        acquired = bool(row[0])
+
+    assert not acquired, (
+        "Expected pg_try_advisory_lock to return FALSE from a fresh session "
+        "because the lock is held by the orphaned backend. Got TRUE — either "
+        "pgbouncer is not configured with pool_mode=transaction, or "
+        "server_reset_query is clearing advisory locks between clients. "
+        "Check tests/integration/fixtures/transaction_pool/docker-compose.yml."
+    )
+
+
+@pytest.mark.integration
+def test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example():
+    """Same-session reentrance explains the 'sometimes it works' confusion.
+
+    When a subsequent pgbouncer client happens to land on the *same* server
+    backend that still holds the lock, ``pg_try_advisory_lock`` returns TRUE
+    because Postgres advisory locks are reentrant within a session.
+
+    This is not contradictory evidence: it's why the bug is intermittent
+    under load, and why our repro had to pin pool sizing to force a handoff.
+    This test exists so a future reader who reruns ``pg_try_advisory_lock``
+    via pgbouncer and sees TRUE does not conclude "no bug". With
+    ``DEFAULT_POOL_SIZE=2`` (our repro config) and only one client active,
+    the second pgbouncer connection will reuse the same backend.
+    """
+    _acquire_lock_via_pgbouncer_and_disconnect(LOCK_ID)
+
+    with psycopg.connect(PGBOUNCER_URL, autocommit=True) as conn:
+        row = conn.execute("SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)).fetchone()
+        assert row is not None
+        acquired_via_bouncer = bool(row[0])
+
+        # The pgbouncer client's view (reentrant) differs from a fresh
+        # direct session's view (blocked) — that divergence is what makes
+        # the bug hard to debug.
+        with psycopg.connect(POSTGRES_URL, autocommit=True) as direct:
+            row = direct.execute("SELECT pg_try_advisory_lock(%s)", (LOCK_ID,)).fetchone()
+            assert row is not None
+            acquired_direct = bool(row[0])
+
+    assert acquired_via_bouncer, (
+        "Expected same-backend reentrance via pgbouncer to succeed. If this "
+        "fails, pgbouncer may not be reusing the same server backend for a "
+        "sequential client — check DEFAULT_POOL_SIZE in "
+        "tests/integration/fixtures/transaction_pool/docker-compose.yml."
+    )
+    assert not acquired_direct, "A fresh direct session must still be blocked — otherwise the " "orphaning invariant from the previous test no longer holds."
+
+
+# ---------------------------------------------------------------------------
+# Invariant test — the regression gate for the multi-replica advisory-lock
+# hang. Red without the fast-path probe (bootstrap_db always takes the
+# advisory-lock path, blocks on the orphan, exhausts retries). Green once
+# the "schema already at head" fast-path skip is in place.
+# ---------------------------------------------------------------------------
+
+
+def _drop_public_schema() -> None:
+    """Reset the test database to an empty state."""
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        conn.execute("DROP SCHEMA IF EXISTS public CASCADE")
+        conn.execute("CREATE SCHEMA public")
+
+
+def _hold_advisory_lock_in_separate_session(lock_id: int):
+    """Open a direct (non-pgbouncer) Postgres session, take ``lock_id``, and
+    return the connection so the caller can close it when done.
+
+    Using a direct connection — rather than taking the lock through pgbouncer
+    and disconnecting — guarantees the holder's Postgres session is distinct
+    from whatever backend pgbouncer hands to a subsequent client. Without
+    that guarantee, pgbouncer may assign the same backend twice and
+    pg_try_advisory_lock succeeds via PostgreSQL's reentrant-within-session
+    semantics (see test_reentrant_acquire_through_same_pgbouncer_is_not_a_
+    counter_example), masking the hang this test is trying to catch.
+    """
+    holder = psycopg.connect(POSTGRES_URL, autocommit=True)
+    holder.execute("SELECT pg_advisory_lock(%s)", (lock_id,))
+    return holder
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(240)
+def test_bootstrap_db_skips_lock_when_schema_already_at_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bootstrap_db.main()`` must complete quickly when the schema is at
+    head, even if the migration advisory lock is held by another session.
+
+    In production the "other session" is an orphaned server backend whose
+    pgbouncer client disconnected without DISCARD ALL clearing the lock.
+    We synthesize the same condition more reliably by
+    holding the lock in a distinct, still-alive Postgres session — that
+    way pg_try_advisory_lock from bootstrap's pgbouncer-facing session
+    must return FALSE regardless of which server backend pgbouncer hands
+    us.
+
+    Pre-fix: bootstrap_db always enters the advisory-lock retry loop; it
+    sees the lock as held, spins for ~10 minutes, then raises TimeoutError.
+    (pytest.mark.timeout cuts us off at 240s.)
+
+    Post-fix: the fast-path short-circuits on ``alembic_version == head``
+    before any lock is attempted; the second bootstrap completes in under
+    a second.
+    """
+    # Standard
+    import asyncio
+    import time
+
+    # First-Party (deferred so import-time failures inside mcpgateway don't
+    # break collection for this module).
+    from mcpgateway import config as mcp_config  # pylint: disable=import-outside-toplevel
+    from mcpgateway.bootstrap_db import main as bootstrap_db  # pylint: disable=import-outside-toplevel
+
+    # --- Preconditions ----------------------------------------------------
+    _drop_public_schema()
+
+    # Point the gateway's ORM at pgbouncer (transaction pool). tests/conftest.py
+    # normally forces DATABASE_URL to in-memory SQLite; overriding the live
+    # settings object is enough — bootstrap_db reads settings.database_url at
+    # call time. SQLAlchemy needs the +psycopg driver hint so it doesn't try
+    # to import psycopg2 (not installed in this project).
+    monkeypatch.setattr(
+        mcp_config.settings,
+        "database_url",
+        _as_sqlalchemy_url(PGBOUNCER_URL),
+    )
+    monkeypatch.setattr(mcp_config.settings, "email_auth_enabled", False)
+
+    # First bootstrap seeds the schema and stamps alembic_version to head.
+    # This is the "replica 1 wins the race" moment in production.
+    asyncio.run(bootstrap_db())
+
+    # --- Synthesize the held-lock precondition ---------------------------
+    # Reuse the module-level LOCK_ID — same sentinel ``advisory_lock()`` in
+    # bootstrap_db uses, so the orphan we synthesise here is the one
+    # production would actually contend on.
+    holder = _hold_advisory_lock_in_separate_session(LOCK_ID)
+    try:
+        assert _count_advisory_locks_held(LOCK_ID) == 1, "Test setup failed: expected the advisory lock to be held by the " "holder session before running the second bootstrap."
+
+        # --- The invariant -----------------------------------------------
+        # Post-fix: fast-path skips the lock entirely; completes in ms.
+        # Pre-fix: advisory_lock retry loop sees FALSE, spins for minutes.
+        start = time.monotonic()
+        asyncio.run(bootstrap_db())
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 10.0, (
+            f"bootstrap_db.main() took {elapsed:.1f}s with the schema at head "
+            f"and the migration advisory lock held by another session. "
+            f"Expected < 10s via the fast-path skip. This is the regression "
+            f"gate for the advisory-lock hang on multi-replica startup behind "
+            f"transaction-pool PgBouncer."
+        )
+    finally:
+        holder.close()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(60)
+def test_bootstrap_db_is_idempotent_once_schema_is_at_head(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second ``bootstrap_db.main()`` call must not touch ``advisory_lock``.
+
+    The first invocation populates the schema and stamps ``alembic_version``.
+    The second should recognise the DB is at head and take the fast-path
+    exclusively — never entering the ``advisory_lock`` context manager at
+    all. Pins the fast-path wiring against regressions that would re-route
+    bootstrap through the lock even when no schema work is needed.
+    """
+    # Standard
+    import asyncio
+    import time
+    from contextlib import contextmanager
+
+    # First-Party
+    from mcpgateway import bootstrap_db as bootstrap_module  # pylint: disable=import-outside-toplevel
+    from mcpgateway import config as mcp_config  # pylint: disable=import-outside-toplevel
+
+    _drop_public_schema()
+
+    monkeypatch.setattr(
+        mcp_config.settings,
+        "database_url",
+        _as_sqlalchemy_url(PGBOUNCER_URL),
+    )
+    monkeypatch.setattr(mcp_config.settings, "email_auth_enabled", False)
+
+    # First call: real advisory_lock (slow path on empty DB is expected).
+    asyncio.run(bootstrap_module.main())
+
+    # Install a spy that wraps the real advisory_lock so we can assert
+    # whether the second call entered it. We keep the wrapped behavior
+    # (rather than replacing with a no-op) so that if the spy IS hit, the
+    # test can still tear down cleanly.
+    advisory_lock_entries: list[object] = []
+    original_advisory_lock = bootstrap_module.advisory_lock
+
+    @contextmanager
+    def spy_advisory_lock(conn: object):
+        advisory_lock_entries.append(conn)
+        with original_advisory_lock(conn):  # type: ignore[arg-type]
+            yield
+
+    monkeypatch.setattr(bootstrap_module, "advisory_lock", spy_advisory_lock)
+
+    # Second call: schema is at head, fast-path should fire exclusively.
+    start = time.monotonic()
+    asyncio.run(bootstrap_module.main())
+    elapsed = time.monotonic() - start
+
+    assert advisory_lock_entries == [], (
+        f"bootstrap_db.main() entered advisory_lock {len(advisory_lock_entries)} "
+        f"time(s) on the second invocation, when the schema was already at head. "
+        f"Expected zero entries via the fast-path. A regression here would "
+        f"reintroduce the multi-replica hang behind transaction-pool poolers."
+    )
+
+    assert elapsed < 3.0, (
+        f"Second bootstrap_db.main() took {elapsed:.1f}s; expected < 3s via the "
+        f"fast-path. Either the probe connection or the post-migration bootstrap "
+        f"has acquired hidden cost — investigate before relaxing this threshold."
+    )
+
+    assert _count_advisory_locks_held(LOCK_ID) == 0, "Fast-path must not leave any advisory locks held after bootstrap_db " "completes."
+
+
+# ---------------------------------------------------------------------------
+# End-to-end compose smoke — the closest re-runnable proxy for an OpenShift
+# cluster smoke (3 gateway replicas through CrunchyData PGO + transaction-
+# pool PgBouncer). Drives the fixture compose stack at the container level
+# rather than calling bootstrap_db.main() in-process.
+#
+# Destructive: drops the fixture's `public` schema. Gated behind an explicit
+# env-var opt-in (MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1) so a contributor
+# who happens to have an unrelated Postgres on localhost cannot trip it
+# accidentally.
+# ---------------------------------------------------------------------------
+
+
+_FIXTURE_COMPOSE = "tests/integration/fixtures/transaction_pool/docker-compose.yml"
+_GATEWAY_IMAGE = "mcpgateway/mcpgateway:latest"
+
+
+def _docker_compose_args() -> list[str]:
+    """Absolute-path compose invocation that works regardless of cwd."""
+    # Standard
+    from pathlib import Path  # pylint: disable=import-outside-toplevel
+
+    repo_root = Path(__file__).resolve().parents[2]
+    return ["docker", "compose", "-f", str(repo_root / _FIXTURE_COMPOSE)]
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(240)
+def test_compose_three_replicas_complete_bootstrap_e2e():
+    """End-to-end: scale fixture's gateway service to 3 replicas; assert all
+    reach bootstrap completion within 60s.
+
+    This drives the FULL pod-startup path (gunicorn + lifespan +
+    bootstrap_db.main() inside real containers) against the same
+    transaction-pool PgBouncer the rest of this module uses. It is the
+    closest re-runnable analog of an OpenShift cluster smoke (3 gateway
+    replicas through CrunchyData PGO + transaction-pool PgBouncer).
+
+    Pre-fix (no fast-path probe): replica gunicorn workers race for the
+    advisory lock, get orphaned by PgBouncer's backend handoffs, and
+    spin in their retry loop. ``pytest.mark.timeout(240)`` fires before
+    the 60s polling deadline can complete.
+
+    Post-fix: one worker wins the seed race (slow path), the rest see
+    ``alembic_version`` at head and fast-path past the lock. All 3
+    replicas emit a bootstrap-completion log line within ~15-30s.
+
+    Destructive — drops the fixture's ``public`` schema. Skipped unless
+    ``MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1`` is set.
+    """
+    # Standard
+    import re  # pylint: disable=import-outside-toplevel
+    import shutil  # pylint: disable=import-outside-toplevel
+    import subprocess  # pylint: disable=import-outside-toplevel
+    import time  # pylint: disable=import-outside-toplevel
+
+    # --- Skip-checks -----------------------------------------------------
+
+    if os.environ.get("MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E") != "1":
+        pytest.skip(
+            "[regression-gate] End-to-end multi-replica bootstrap test for "
+            "issue #4051 — exercises the full pod-startup path (gunicorn "
+            "lifespan + bootstrap_db.main() inside real containers) against "
+            "transaction-pool PgBouncer. NOT run in CI (cost: image build + "
+            "3-replica compose + ~60s polling). Run locally before signing "
+            "off on changes to bootstrap_db or chart probe wiring:\n"
+            "  1. make docker          # builds mcpgateway/mcpgateway:latest\n"
+            "  2. MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1 uv run pytest "
+            "tests/integration/test_migrations_under_transaction_pool.py "
+            "--with-integration\n"
+            "Destructive: drops the fixture stack's `public` schema."
+        )
+
+    if shutil.which("docker") is None:
+        pytest.skip("docker not on PATH; cannot run compose-driven e2e test")
+
+    image_check = subprocess.run(
+        ["docker", "image", "inspect", _GATEWAY_IMAGE],
+        capture_output=True,
+        check=False,
+    )
+    if image_check.returncode != 0:
+        pytest.skip(f"Local gateway image {_GATEWAY_IMAGE!r} not present — run " "`make docker` first to enable this test.")
+
+    compose = _docker_compose_args()
+
+    # Probe the fixture's postgres+pgbouncer health. If the user hasn't
+    # brought the stack up yet, fail soft with the exact command to fix it.
+    pgcheck = subprocess.run(
+        compose + ["ps", "--services", "--filter", "status=running"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+    )
+    running_services = set(pgcheck.stdout.split())
+    if not {"postgres", "pgbouncer"}.issubset(running_services):
+        pytest.skip("Fixture stack not running. Bring it up first with:\n" "  docker compose -f tests/integration/fixtures/transaction_pool/" "docker-compose.yml up -d postgres pgbouncer")
+
+    # --- Paranoia check: confirm we're talking to the FIXTURE's postgres,
+    # not someone's prod DB that happens to be on the same port. ----------
+    with psycopg.connect(POSTGRES_URL, autocommit=True) as conn:
+        row = conn.execute("SELECT current_database()").fetchone()
+        assert row is not None and row[0] == "mcp", (
+            f"Refusing to run destructive e2e test: connected database is " f"{row[0]!r}, expected 'mcp' (the fixture's database name). " f"POSTGRES_URL appears to be pointing at the wrong server."
+        )
+
+    # --- Reset state -----------------------------------------------------
+
+    _drop_public_schema()
+
+    # Scale the gateway service to 0 first so we get clean container names
+    # and timing. --no-recreate keeps postgres/pgbouncer running for any
+    # subsequent tests.
+    subprocess.run(
+        compose + ["up", "-d", "--scale", "gateway=0", "--no-recreate", "gateway"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    try:
+        # --- Trigger the race ------------------------------------------------
+
+        subprocess.run(
+            compose + ["up", "-d", "--scale", "gateway=3", "--no-recreate", "gateway"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        # --- Poll for completion --------------------------------------------
+        # Match either log line that signals a worker finished bootstrap:
+        #   · "Database ready"                       (slow-path winner)
+        #   · "Schema already at Alembic head"       (L1 fast-path skip)
+        # Either way, count UNIQUE container hostnames so we measure
+        # pod-level coverage, not per-worker noise.
+        completion_pattern = re.compile(r'"name":\s*"mcpgateway\.bootstrap_db".*' r'"message":\s*"(?:Database ready|Schema already at Alembic head)')
+        hostname_pattern = re.compile(r'"hostname":\s*"([^"]+)"')
+
+        deadline = time.monotonic() + 60.0
+        successful_hostnames: set[str] = set()
+        while time.monotonic() < deadline:
+            logs = subprocess.run(
+                compose + ["logs", "--no-log-prefix", "gateway"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            )
+            for line in logs.stdout.splitlines():
+                if completion_pattern.search(line):
+                    match = hostname_pattern.search(line)
+                    if match:
+                        successful_hostnames.add(match.group(1))
+            if len(successful_hostnames) >= 3:
+                break
+            time.sleep(2.0)
+
+        if len(successful_hostnames) < 3:
+            tail = subprocess.run(
+                compose + ["logs", "--tail=80", "gateway"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=15,
+            ).stdout
+            pytest.fail(
+                f"Only {len(successful_hostnames)}/3 gateway replicas reached "
+                f"bootstrap completion within 60s. Distinct hostnames seen: "
+                f"{sorted(successful_hostnames)!r}.\n\nRecent logs:\n{tail}"
+            )
+    finally:
+        # --- Always: scale gateway back to 0 (leave pg+pgbouncer up) ----
+        subprocess.run(
+            compose + ["up", "-d", "--scale", "gateway=0", "--no-recreate", "gateway"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )

--- a/tests/unit/charts/test_deployment_mcpgateway.py
+++ b/tests/unit/charts/test_deployment_mcpgateway.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Helm chart render tests — gateway Deployment env wiring.
+
+Pins the migration-Job / gateway-Deployment contract:
+
+    "When the chart enables the migration Job, the gateway Deployment must
+     set MCPGATEWAY_SKIP_MIGRATIONS=true so app pods don't redundantly
+     bootstrap the schema. When the Job is disabled, the gateway must
+     either omit the env var or set it to false so pods bootstrap
+     themselves via the in-process fast-path."
+
+Tests are skipped automatically when ``helm`` is not on PATH; they don't
+require a Kubernetes cluster — only chart rendering.
+"""
+
+# Standard
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+# Third-Party
+import pytest
+import yaml
+
+CHART_DIR = Path(__file__).resolve().parents[3] / "charts" / "mcp-stack"
+GATEWAY_DEPLOYMENT_NAME_SUFFIX = "mcp-stack-mcpgateway"
+
+# Helm refuses to render without these, so populate with throwaway values.
+# Values must be strings — the chart's schema is strict about types.
+REQUIRED_SECRETS = {
+    "mcpContextForge.secret.JWT_SECRET_KEY": "x" * 32,
+    "mcpContextForge.secret.AUTH_ENCRYPTION_SECRET": "y" * 32,
+    "mcpContextForge.secret.BASIC_AUTH_PASSWORD": "throwaway-pass-1234567",  # pragma: allowlist secret
+    "mcpContextForge.secret.PLATFORM_ADMIN_PASSWORD": "throwaway-pass-1234567",  # pragma: allowlist secret
+    "mcpContextForge.secret.REQUIRE_STRONG_SECRETS": '"false"',  # quoted: schema demands string
+}
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed; chart-render tests cannot run",
+)
+
+
+def _helm_template(*set_overrides: str) -> list[dict[str, Any]]:
+    """Render the chart with the given --set overrides, return parsed manifests."""
+    sets: list[str] = []
+    for k, v in REQUIRED_SECRETS.items():
+        sets.extend(["--set", f"{k}={v}"])
+    for override in set_overrides:
+        sets.extend(["--set", override])
+
+    result = subprocess.run(
+        ["helm", "template", "release-test", str(CHART_DIR), *sets],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _gateway_deployment(manifests: list[dict[str, Any]]) -> dict[str, Any]:
+    for m in manifests:
+        if m.get("kind") == "Deployment" and m.get("metadata", {}).get("name", "").endswith(GATEWAY_DEPLOYMENT_NAME_SUFFIX):
+            return m
+    raise AssertionError("gateway Deployment not found in rendered chart — selector may have drifted")
+
+
+def _gateway_env(manifests: list[dict[str, Any]]) -> dict[str, str]:
+    """Return the gateway container's ``env`` list as a dict for easy assertions."""
+    deploy = _gateway_deployment(manifests)
+    containers = deploy["spec"]["template"]["spec"]["containers"]
+    gateway_container = next(c for c in containers if c["name"] in ("mcp-context-forge", "mcpgateway", "gateway"))
+    out: dict[str, str] = {}
+    for entry in gateway_container.get("env", []) or []:
+        # Plain string values only — env entries with valueFrom are skipped.
+        if "value" in entry:
+            out[entry["name"]] = str(entry["value"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_skip_migrations_set_to_true_when_migration_job_enabled():
+    """When the chart's migration Job is enabled, app pods must skip
+    in-pod bootstrap so they don't race the Job's schema work."""
+    env = _gateway_env(_helm_template("migration.enabled=true"))
+    assert env.get("MCPGATEWAY_SKIP_MIGRATIONS") == "true", (
+        "Expected MCPGATEWAY_SKIP_MIGRATIONS=true on the gateway Deployment "
+        "when migration.enabled=true — the chart-level contract that ties "
+        "the migration Job to the in-pod bootstrap skip. "
+        f"Got: {env.get('MCPGATEWAY_SKIP_MIGRATIONS')!r}. Full env keys: {sorted(env)}"
+    )
+
+
+def test_skip_migrations_off_when_migration_job_disabled():
+    """When the chart's migration Job is disabled, gateway pods are the
+    sole bootstrap path. The L1 fast-path makes the in-pod path safe."""
+    env = _gateway_env(_helm_template("migration.enabled=false"))
+    value = env.get("MCPGATEWAY_SKIP_MIGRATIONS", "false")
+    assert value == "false", (
+        "Expected MCPGATEWAY_SKIP_MIGRATIONS to be absent or false when " "migration.enabled=false (the gateway is the only bootstrap path " f"in this configuration). Got: {value!r}"
+    )
+
+
+def test_skip_migrations_default_matches_migration_enabled_default():
+    """The chart's default for migration.enabled is True (see values.yaml).
+    Default render therefore must set SKIP=true."""
+    env = _gateway_env(_helm_template())
+    assert env.get("MCPGATEWAY_SKIP_MIGRATIONS") == "true", (
+        "Default chart values render to migration.enabled=true, so " "MCPGATEWAY_SKIP_MIGRATIONS must default to 'true'. Got: " f"{env.get('MCPGATEWAY_SKIP_MIGRATIONS')!r}"
+    )

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -19,7 +19,7 @@ import pytest
 
 # First-Party
 from mcpgateway.bootstrap_db import (
-    _is_at_alembic_head,
+    alembic_at_head,
     advisory_lock,
     bootstrap_admin_user,
     bootstrap_default_roles,
@@ -1458,7 +1458,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_with_normalization(self, mock_settings):
         """Test main function with team normalization."""
-        mock_settings.skip_migration = False
+        mock_settings.mcpgateway_skip_migrations = False
         mock_engine = Mock()
         mock_conn = Mock()
         mock_conn.commit = Mock()
@@ -1492,7 +1492,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_complete_flow(self, mock_settings):
         """Test complete main flow: skip_migration=True with schema already at head."""
-        # mock_settings.skip_migration is a truthy Mock attribute — tests skip_migration=True path
+        # mock_settings.mcpgateway_skip_migrations is a truthy Mock attribute — tests skip_migration=True path
         mock_engine = Mock()
         mock_conn = Mock()
         mock_conn.commit = Mock()
@@ -1512,7 +1512,7 @@ class TestMain:
 
                 with patch("mcpgateway.bootstrap_db.Config", return_value=mock_config):
                     with patch("mcpgateway.bootstrap_db.command") as mock_command:
-                        with patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True):
+                        with patch("mcpgateway.bootstrap_db.alembic_at_head", return_value=True):
                             with patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0):
                                 with patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin:
                                     with patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles:
@@ -1545,7 +1545,7 @@ class TestMain:
         with patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine), \
              patch("importlib.resources.files") as mock_files, \
              patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})), \
-             patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=False), \
+             patch("mcpgateway.bootstrap_db.alembic_at_head", return_value=False), \
              patch("mcpgateway.bootstrap_db.settings", mock_settings):
             mock_files.return_value.joinpath.return_value = "alembic.ini"
             with pytest.raises(RuntimeError, match="Schema not at head; migrations required before startup"):
@@ -1554,7 +1554,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_exception_handling(self, mock_settings):
         """Test main function exception handling and re-raise."""
-        mock_settings.skip_migration = False
+        mock_settings.mcpgateway_skip_migrations = False
         mock_engine = Mock()
 
         # Mock engine.connect() to raise an exception
@@ -1567,6 +1567,98 @@ class TestMain:
                         await main()
 
                     mock_logger.error.assert_called_with("Database migration failed: Connection failed")
+
+
+class TestAlembicAtHead:
+    """Unit tests for the ``alembic_at_head`` fast-path probe.
+
+    ``alembic_at_head`` decides whether ``main()`` skips the migration
+    advisory lock — the fast-path that prevents multi-replica startup from
+    serializing on a session-scoped lock that a transaction-pooling
+    connection pooler can orphan. Its truth-table needs pinning independently
+    of the integration test so a future refactor cannot silently widen or
+    narrow the fast-path's trigger.
+    """
+
+    def test_returns_true_when_db_heads_match_script_heads(self):
+        """At-head DB → fast-path fires."""
+        # First-Party
+        from mcpgateway.bootstrap_db import alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_conn = Mock()
+        mock_cfg = Mock()
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("abc123",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ("abc123",)
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert alembic_at_head(mock_conn, mock_cfg) is True
+
+        mock_sd.from_config.assert_called_once_with(mock_cfg)
+        mock_mc.configure.assert_called_once_with(mock_conn)
+
+    def test_returns_false_when_db_has_no_alembic_version(self):
+        """Empty DB or missing ``alembic_version`` row → must take slow path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("abc123",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ()  # no version rows
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert alembic_at_head(Mock(), Mock()) is False
+
+    def test_returns_false_when_db_head_does_not_match_script_head(self):
+        """Out-of-date DB → must take slow path so migrations actually run."""
+        # First-Party
+        from mcpgateway.bootstrap_db import alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ("newhead",)
+        mock_context = Mock()
+        mock_context.get_current_heads.return_value = ("oldhead",)
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                mock_mc.configure.return_value = mock_context
+                assert alembic_at_head(Mock(), Mock()) is False
+
+    def test_returns_false_when_script_directory_has_no_heads(self):
+        """Defensive: a zero-revision script dir must not fast-path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        mock_script_dir = Mock()
+        mock_script_dir.get_heads.return_value = ()
+
+        with patch("mcpgateway.bootstrap_db.ScriptDirectory") as mock_sd:
+            mock_sd.from_config.return_value = mock_script_dir
+            # MigrationContext must never be consulted in this case.
+            with patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc:
+                assert alembic_at_head(Mock(), Mock()) is False
+                mock_mc.configure.assert_not_called()
+
+    def test_returns_false_on_probe_exception(self):
+        """Any error while probing falls through to the slow path."""
+        # First-Party
+        from mcpgateway.bootstrap_db import alembic_at_head  # pylint: disable=import-outside-toplevel
+
+        with patch(
+            "mcpgateway.bootstrap_db.ScriptDirectory.from_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert alembic_at_head(Mock(), Mock()) is False
 
 
 class TestModuleLevel:
@@ -1591,63 +1683,6 @@ class TestModuleLevel:
         assert asyncio.iscoroutinefunction(main)
 
 
-class TestIsAtAlembicHead:
-    """Test _is_at_alembic_head internal branches."""
-
-    def test_returns_false_when_empty_current_heads(self):
-        """alembic_version table exists but no current heads → False (lines 126-129)."""
-        mock_conn = Mock()
-        mock_cfg = Mock()
-        with patch("sqlalchemy.inspect") as mock_inspect, patch("alembic.runtime.migration.MigrationContext") as mock_mc:
-            mock_inspector = Mock()
-            mock_inspector.get_table_names.return_value = ["alembic_version"]
-            mock_inspect.return_value = mock_inspector
-            mock_ctx = Mock()
-            mock_ctx.get_current_heads.return_value = ()
-            mock_mc.configure.return_value = mock_ctx
-            assert _is_at_alembic_head(mock_conn, mock_cfg) is False
-
-    def test_returns_true_when_heads_match(self):
-        """Current heads equal target heads → True (lines 131-133)."""
-        mock_conn = Mock()
-        mock_cfg = Mock()
-        with (
-            patch("sqlalchemy.inspect") as mock_inspect,
-            patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc,
-            patch("alembic.script.ScriptDirectory") as mock_sd,
-        ):
-            mock_inspector = Mock()
-            mock_inspector.get_table_names.return_value = ["alembic_version"]
-            mock_inspect.return_value = mock_inspector
-            mock_ctx = Mock()
-            mock_ctx.get_current_heads.return_value = ("abc123",)
-            mock_mc.configure.return_value = mock_ctx
-            mock_script = Mock()
-            mock_script.get_heads.return_value = ["abc123"]
-            mock_sd.from_config.return_value = mock_script
-            assert _is_at_alembic_head(mock_conn, mock_cfg) is True
-
-    def test_returns_false_when_heads_differ(self):
-        """Current heads differ from target → False (lines 131-133)."""
-        mock_conn = Mock()
-        mock_cfg = Mock()
-        with (
-            patch("sqlalchemy.inspect") as mock_inspect,
-            patch("alembic.runtime.migration.MigrationContext") as mock_mc,
-            patch("alembic.script.ScriptDirectory") as mock_sd,
-        ):
-            mock_inspector = Mock()
-            mock_inspector.get_table_names.return_value = ["alembic_version"]
-            mock_inspect.return_value = mock_inspector
-            mock_ctx = Mock()
-            mock_ctx.get_current_heads.return_value = ("old_rev",)
-            mock_mc.configure.return_value = mock_ctx
-            mock_script = Mock()
-            mock_script.get_heads.return_value = ["new_rev"]
-            mock_sd.from_config.return_value = mock_script
-            assert _is_at_alembic_head(mock_conn, mock_cfg) is False
-
-
 class TestMainAdditionalBranches:
     """Cover bootstrap_db.main() branches not exercised by TestMain."""
 
@@ -1664,14 +1699,14 @@ class TestMainAdditionalBranches:
     @pytest.mark.asyncio
     async def test_main_skip_migration_at_head_with_normalization(self, mock_settings):
         """skip_migration=True, at head, normalize_team_visibility > 0 logs info (line 798)."""
-        mock_settings.skip_migration = True
+        mock_settings.mcpgateway_skip_migrations = True
         mock_engine, _ = self._make_engine_cm()
 
         with (
             patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
             patch("importlib.resources.files") as mock_files,
             patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
-            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.alembic_at_head", return_value=True),
             patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=3),
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),
@@ -1686,14 +1721,14 @@ class TestMainAdditionalBranches:
     @pytest.mark.asyncio
     async def test_main_skip_migration_exception_reraises(self, mock_settings):
         """skip_migration=True, exception inside try: logged and re-raised (lines 803-805)."""
-        mock_settings.skip_migration = True
+        mock_settings.mcpgateway_skip_migrations = True
         mock_engine, _ = self._make_engine_cm()
 
         with (
             patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
             patch("importlib.resources.files") as mock_files,
             patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
-            patch("mcpgateway.bootstrap_db._is_at_alembic_head", side_effect=RuntimeError("alembic check failed")),
+            patch("mcpgateway.bootstrap_db.alembic_at_head", side_effect=RuntimeError("alembic check failed")),
             patch("mcpgateway.bootstrap_db.settings", mock_settings),
             patch("mcpgateway.bootstrap_db.logger") as mock_logger,
         ):
@@ -1705,14 +1740,14 @@ class TestMainAdditionalBranches:
     @pytest.mark.asyncio
     async def test_main_fast_path_already_at_head(self, mock_settings):
         """skip_migration=False, already at head: skips advisory lock, commits (lines 820, 827)."""
-        mock_settings.skip_migration = False
+        mock_settings.mcpgateway_skip_migrations = False
         mock_engine, mock_conn = self._make_engine_cm()
 
         with (
             patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
             patch("importlib.resources.files") as mock_files,
             patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
-            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.alembic_at_head", return_value=True),
             patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0),
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin,
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles,
@@ -1722,7 +1757,7 @@ class TestMainAdditionalBranches:
         ):
             mock_files.return_value.joinpath.return_value = "alembic.ini"
             await main()
-            mock_logger.info.assert_any_call("Schema already at migration head — skipping advisory lock and alembic upgrade")
+            mock_logger.info.assert_any_call("Schema already at Alembic head; skipping migration lock")
             mock_conn.commit.assert_called()
             mock_admin.assert_called_once()
             mock_roles.assert_called_once()
@@ -1731,7 +1766,7 @@ class TestMainAdditionalBranches:
     @pytest.mark.asyncio
     async def test_main_sqlite_multi_replica_warning(self, mock_settings):
         """SQLite + GATEWAY_REPLICAS > 1 emits warning (line 768)."""
-        mock_settings.skip_migration = False
+        mock_settings.mcpgateway_skip_migrations = False
         mock_settings.database_url = "sqlite:///./mcp.db"
         mock_engine, _ = self._make_engine_cm()
 
@@ -1740,7 +1775,7 @@ class TestMainAdditionalBranches:
             patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
             patch("importlib.resources.files") as mock_files,
             patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
-            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.alembic_at_head", return_value=True),
             patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0),
             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -282,6 +282,48 @@ def test_api_key_property():
     assert settings.api_key == "u:p"
 
 
+# --------------------------------------------------------------------------- #
+#                MCPGATEWAY_SKIP_MIGRATIONS — settings field & env override    #
+# --------------------------------------------------------------------------- #
+def test_skip_migrations_defaults_to_false():
+    """Library default keeps the in-pod bootstrap path on so users running
+    the gateway image directly (no migration runner in front) still get a
+    populated schema. Helm chart and compose overlays ship with the env
+    set to True when they pair with a dedicated migration step.
+    """
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is False
+
+
+def test_skip_migrations_env_true_flips_flag():
+    """MCPGATEWAY_SKIP_MIGRATIONS=true → in-pod bootstrap is suppressed."""
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+        "MCPGATEWAY_SKIP_MIGRATIONS": "true",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is True
+
+
+def test_skip_migrations_env_false_keeps_flag_off():
+    """Explicit MCPGATEWAY_SKIP_MIGRATIONS=false matches the default."""
+    dummy_env = {
+        "JWT_SECRET_KEY": "x" * 32,
+        "AUTH_ENCRYPTION_SECRET": "dummy-secret",
+        "MCPGATEWAY_SKIP_MIGRATIONS": "false",
+    }
+    with patch.dict(os.environ, dummy_env, clear=True):
+        settings = Settings(_env_file=None)
+        assert settings.mcpgateway_skip_migrations is False
+
+
 def test_supports_transport_properties():
     s_all = Settings(transport_type="all")
     assert (s_all.supports_http, s_all.supports_websocket, s_all.supports_sse) == (True, True, True)

--- a/tests/unit/mcpgateway/utils/test_check_schema_at_head.py
+++ b/tests/unit/mcpgateway/utils/test_check_schema_at_head.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for ``mcpgateway.utils.check_schema_at_head``.
+
+The module is the gateway pod's K8s startup-probe entrypoint — it runs
+every five seconds and its exit code determines whether a pod is allowed
+to serve traffic. The contract this module exists to pin:
+
+  * exit 0  ⇔  ``alembic_at_head`` returned True
+  * exit 1  ⇔  ``alembic_at_head`` returned False
+  * exit 1  ⇔  any exception inside the try/except is swallowed and
+                logged at WARNING (operator-visible at the project's
+                default log level)
+  * ``engine.dispose()`` is called on every code path
+
+A regression here either fails open (probe returns 0 with no schema —
+gateway pods reach Ready against an empty DB and 500 on the first
+request) or fails closed forever (an exception propagates with a non-1
+exit code that K8s might re-classify). Neither is acceptable; both are
+silent. These tests are the truth-table that catches such regressions
+at PR time rather than in production pod logs.
+"""
+
+# Standard
+import logging
+from unittest.mock import MagicMock, Mock, patch
+
+# First-Party
+import mcpgateway.utils.check_schema_at_head as check_schema_at_head
+
+
+def _build_mock_engine_with_connect():
+    """Return a MagicMock engine whose ``connect()`` works as a context manager.
+
+    The probe's ``with engine.connect() as conn:`` pattern requires
+    ``__enter__``/``__exit__`` on whatever ``engine.connect()`` returns.
+    MagicMock supplies both by default; this helper just wires the
+    yielded connection to a plain Mock so tests can assert on it if they
+    want to.
+    """
+    mock_engine = MagicMock()
+    mock_conn = Mock()
+    mock_engine.connect.return_value.__enter__.return_value = mock_conn
+    mock_engine.connect.return_value.__exit__.return_value = False
+    return mock_engine
+
+
+class TestMain:
+    """Truth-table for ``check_schema_at_head.main()``.
+
+    Each test patches the three symbols ``main()`` reaches for
+    (``create_engine``, ``make_alembic_cfg``, ``alembic_at_head``) at the
+    point they're imported into ``check_schema_at_head`` — that way we
+    never touch a real database, the tests run in milliseconds, and they
+    pin the wrapper's contract without coupling to any specific engine
+    or Alembic implementation detail.
+    """
+
+    def test_returns_0_when_schema_at_head(self):
+        """Happy path: alembic_at_head True → exit 0; engine disposed once."""
+        mock_engine = _build_mock_engine_with_connect()
+
+        with patch.object(check_schema_at_head, "create_engine", return_value=mock_engine):
+            with patch.object(check_schema_at_head, "make_alembic_cfg", return_value=Mock()):
+                with patch.object(check_schema_at_head, "alembic_at_head", return_value=True):
+                    assert check_schema_at_head.main() == 0
+
+        mock_engine.dispose.assert_called_once()
+
+    def test_returns_1_when_schema_not_at_head(self):
+        """Probe says no → exit 1 (K8s holds the pod 0/1 until next tick)."""
+        mock_engine = _build_mock_engine_with_connect()
+
+        with patch.object(check_schema_at_head, "create_engine", return_value=mock_engine):
+            with patch.object(check_schema_at_head, "make_alembic_cfg", return_value=Mock()):
+                with patch.object(check_schema_at_head, "alembic_at_head", return_value=False):
+                    assert check_schema_at_head.main() == 1
+
+        mock_engine.dispose.assert_called_once()
+
+    def test_returns_1_on_engine_connect_error(self):
+        """``engine.connect()`` raising (DB unreachable, bad URL, network
+        partition) must be caught and exit 1, not propagate. K8s relies on
+        the probe being deterministic on the failure path."""
+        mock_engine = MagicMock()
+        mock_engine.connect.side_effect = OSError("connection refused")
+
+        with patch.object(check_schema_at_head, "create_engine", return_value=mock_engine):
+            with patch.object(check_schema_at_head, "make_alembic_cfg", return_value=Mock()):
+                assert check_schema_at_head.main() == 1
+
+        mock_engine.dispose.assert_called_once()
+
+    def test_returns_1_on_probe_exception(self):
+        """``alembic_at_head`` itself raising (e.g., corrupt alembic_version
+        row) must be caught and exit 1. The helper's own ``except`` returns
+        False, but a defensive test pins ``main()``'s outer ``except`` too —
+        a future refactor that drops the helper's broad-except would otherwise
+        pass through unnoticed."""
+        mock_engine = _build_mock_engine_with_connect()
+
+        with patch.object(check_schema_at_head, "create_engine", return_value=mock_engine):
+            with patch.object(check_schema_at_head, "make_alembic_cfg", return_value=Mock()):
+                with patch.object(
+                    check_schema_at_head,
+                    "alembic_at_head",
+                    side_effect=RuntimeError("boom"),
+                ):
+                    assert check_schema_at_head.main() == 1
+
+        mock_engine.dispose.assert_called_once()
+
+    def test_logs_warning_on_exception(self, caplog):
+        """Probe-failure path must emit at WARNING so it's visible at the
+        project's default ``LOG_LEVEL=INFO`` (most chart deployments).
+        DEBUG would render the failure invisible to operators — the same
+        observability concern H1 fixed in ``alembic_at_head``."""
+        mock_engine = MagicMock()
+        mock_engine.connect.side_effect = OSError("connection refused")
+
+        with patch.object(check_schema_at_head, "create_engine", return_value=mock_engine):
+            with patch.object(check_schema_at_head, "make_alembic_cfg", return_value=Mock()):
+                with caplog.at_level(logging.WARNING, logger="mcpgateway.check_schema_at_head"):
+                    check_schema_at_head.main()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("schema-at-head probe failed" in r.message for r in warnings), f"Expected WARNING containing 'schema-at-head probe failed' from check_schema_at_head; got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## Summary

Fixes issue #4051 — Alembic migration advisory lock hangs when multiple gateway replicas start through PgBouncer in transaction-pooling mode. The session-scoped `pg_advisory_lock` is orphaned across PgBouncer's backend handoffs; the N-th gateway pod sees the lock held by an effectively-dead session and spins in its retry loop until the ~10-minute timeout fires.

This PR closes the bug along three pieces and ships them together so the chart is safe under both deployment patterns:

- **Layer 1 (correctness)** — `bootstrap_db.main()` now probes `alembic_version` *before* attempting the advisory lock. When the schema is at the script directory's head, the lock acquisition is skipped entirely. Replicas 2..N never participate in the race.
- **Layer 2 (operator ergonomics)** — `MCPGATEWAY_SKIP_MIGRATIONS=true` tells `bootstrap_db.main()` to skip the Alembic upgrade and the advisory lock, while still running the idempotent post-migration helpers (admin user, default RBAC roles, orphaned-resource assignment) so single-pod first-startup contracts still hold. The path **fails fast** with `RuntimeError("Schema not at head; migrations required before startup")` if the flag is set but the schema isn't actually at head — operators see the deployment error immediately rather than serving traffic against a half-migrated DB. The `mcp-stack` Helm chart wires the flag from `migration.enabled` so the contract "the pre-install Job owns migrations, app pods skip" is enforced at the chart layer rather than left to operators to coordinate.
- **Schema-at-head startup probe (chart-level Ready gate)** — gateway pod's startup probe now runs `python -m mcpgateway.utils.check_schema_at_head` instead of `db_isready`. Pods refuse Ready until `alembic_version` matches the script-directory head, regardless of which entity (pre-install Job, post-install Job, init container, external CD pipeline) ran the migration. Defense in depth: even if L2 mis-fires, no pod ever serves traffic against a half-migrated DB.

Library defaults preserve backward compatibility: a direct `docker run mcpgateway:latest` continues to bootstrap its own schema. Only the chart and (future) compose overlays opt into `MCPGATEWAY_SKIP_MIGRATIONS=true`.

Built on top of [#4784](https://github.com/IBM/mcp-context-forge/pull/4784) (Lang-Akshay), which landed independently with the same fast-path technique and the `MCPGATEWAY_SKIP_MIGRATIONS` plumbing inside `bootstrap_db.main()`. This PR adds the Helm chart wiring, the K8s schema-at-head startup probe, the integration test fixture, and the regression-suite coverage on top of that baseline.

Related: existing `migration.hostKey: host` / `portKey: port` knobs in `charts/mcp-stack/profiles/ocp/values-pgo.yaml` already let the migration Job bypass PgBouncer; that workaround stays in place but is no longer load-bearing.

### Approach

The fix was built **reproduction-first**: rather than implement against the issue text alone, the bug was first reproduced deterministically in a throwaway docker-compose harness (inlined in the Test results section below) and then again on a real OpenShift cluster against CrunchyData PGO + transaction-pool PgBouncer. Both reproductions are documented in `todo/issue-4051-ocp-reproduction.md`, and the compose-side stack lives permanently in the repo as a test fixture at `tests/integration/fixtures/transaction_pool/`.

For each layer (L1 fast-path, L2 chart-wired skip), the cycle was:

```
   1. write a failing test that captures the invariant ──────► RED
   2. implement just enough to make it pass ─────────────────► GREEN
   3. verify on the OCP cluster against pre-fix and post-fix
      images, side-by-side, on the same stack ──────────────► EVIDENCE
   4. commit
```

The regression test for the bug — `test_bootstrap_db_skips_lock_when_schema_already_at_head` — is **reliably RED** pre-fix (240s timeout, 29/60 retry attempts visible in logs) and **reliably GREEN** post-fix (~1.4s). It's not a flaky timing-based test: it synthesizes the held-lock condition deterministically by holding the advisory lock in a distinct, still-alive Postgres session for the duration of the second `bootstrap_db.main()` call. That guarantees the bootstrap's PgBouncer-side session sees `pg_try_advisory_lock` return FALSE regardless of PgBouncer's internal backend assignment — without that guarantee, PgBouncer can hand the bootstrap the *same* server backend that the holder used, and `pg_try_advisory_lock` succeeds via PostgreSQL's reentrant-within-session semantics, masking the bug. (We landed on this design after observing a passing test that should have failed; the false-positive is documented as `test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example` so a future reader who hits the same gotcha understands what they're seeing.)

---

## Gaps closed

### HIGH — Bug correctness

**Gap 1 (HIGH)** — Advisory lock orphan via PgBouncer transaction-pool handoffs: `bootstrap_db.advisory_lock` always called `pg_try_advisory_lock` and retried up to 60 times with exponential backoff. When PgBouncer reused a backend whose previous client took the lock, new clients saw it held by an unreachable session and spun until timeout. Fixed with the public `alembic_at_head()` probe that runs before the lock — when the DB is at the script-directory head, the lock is never attempted. The probe uses Alembic's `MigrationContext.get_current_heads()` and `ScriptDirectory.from_config(cfg).get_heads()` for the canonical source of truth; any error during probing falls through to the existing slow path so empty / partial / out-of-date databases still go through the explicit handling. Two adjacent helpers ship alongside it: `make_alembic_cfg(database_url, configure_logger=False)` centralises the `alembic.ini` discovery + URL `%`-escaping so the same Config can be built identically by both `bootstrap_db.main()` and the K8s startup-probe entry-point; `_run_post_migration_bootstrap(conn)` extracts the team-visibility normalisation + admin-user / RBAC-role / orphaned-resource bootstrap calls into one place so the fast-path, slow-path, and skip-migrations branches all run the same idempotent steps.

**Gap 2 (HIGH)** — Worker-level fan-out under-stated in the issue text: each gateway pod runs N gunicorn workers (default 8 in the OCP profile), and each worker calls `bootstrap_db.main()` in its own lifespan. So a 3-replica deployment produces 24 racing acquirers, not 3. Reproduction on OpenShift confirmed the fan-out: pre-fix, the same pod's logs show interleaved `Acquired lock on attempt N` and `Lock held by another instance, attempt N/60` at the same timestamps — different workers in the same gunicorn process. The L1 fast-path eliminates the race for replicas 2..N entirely; for replica 1 the within-pod race is bounded to a sub-second seed window.

**Gap 3 (HIGH)** — Chart safety today depends on the OCP-only workaround: `migration.hostKey: host` / `portKey: port` route the pre-install Job direct to Postgres (bypassing PgBouncer), masking the bug whenever the Job is enabled. A community user setting `migration.enabled=false` (because they manage migrations externally, or run the chart in compose-flavoured contexts) loses that protection. Layer 1 makes `migration.enabled=false` safe.

### HIGH — Operator ergonomics

**Gap 4 (HIGH)** — In-pod bootstrap runs even when a dedicated migration runner has already populated the schema: redundant probe activity per worker, plus the within-pod race for replica 1's seed window. Fixed with `MCPGATEWAY_SKIP_MIGRATIONS=true`: inside `bootstrap_db.main()` the skip branch verifies the schema is at head, raises `RuntimeError("Schema not at head; migrations required before startup")` if not (fail-closed — the deployment error is visible immediately rather than silently degraded), then runs only the idempotent post-migration helpers (admin user, default RBAC roles, orphaned-resource assignment) so single-pod bootstrap contracts still hold regardless of which entity ran the schema migration. The advisory lock and the Alembic upgrade are skipped entirely. An audit-log line — `"MCPGATEWAY_SKIP_MIGRATIONS=true — schema already at head, skipping migration"` — is emitted on the success path so operators can see the choice in pod logs.

**Gap 5 (HIGH)** — No chart wiring for the SKIP/Job pairing: even if the env var existed, expecting operators to set both `migration.enabled=true` AND `MCPGATEWAY_SKIP_MIGRATIONS=true` is a foot-gun (forgetting one means redundant in-pod bootstrap; forgetting the other means schema never populated). Fixed in `charts/mcp-stack/templates/deployment-mcpgateway.yaml`: the env var is rendered as `{{ ternary "true" "false" .Values.migration.enabled }}` and placed *after* `extraEnv` so a user override cannot accidentally undo the contract.

### MEDIUM — Test infrastructure

**Gap 6 (MEDIUM)** — No regression test for the advisory-lock invariant: no existing test exercised concurrent `bootstrap_db.main()` callers through PgBouncer. Fixed with `tests/integration/test_migrations_under_transaction_pool.py` containing six `@pytest.mark.integration` tests: three pinning the PgBouncer mechanism (so the substrate behavior is captured for posterity even if PgBouncer changes), one regression gate (synthesizes the orphaned-lock condition and asserts `bootstrap_db.main()` returns within 10s — fails in 240s pre-fix), one idempotency invariant (asserts a second call after schema is at head never enters the `advisory_lock` context manager), and one full 3-replica docker-compose end-to-end (`test_compose_three_replicas_complete_bootstrap_e2e`, gated by `MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1`) that scales the fixture's gateway service to 3 replicas and asserts all reach bootstrap completion within 60s. Tests skip cleanly without `--with-integration`; the E2E skips additionally without the env-var opt-in and without a local `mcpgateway/mcpgateway:latest` image (`make docker`).

**Gap 7 (MEDIUM)** — No reproduction artifact in the repo: future debuggers had nothing to anchor on. Fixed by promoting the reproduction's compose stack to a permanent test fixture at `tests/integration/fixtures/transaction_pool/docker-compose.yml` (driven by the integration suite). A throwaway shell harness (`demonstrate_orphan.sh` proving the PgBouncer mechanism in 3 psql calls; `reproduce.sh` scaling gateway replicas) lived on the branch during development and was removed in the squashed commit; the script contents are inlined verbatim in the Test results section below so a future reader can rebuild the reproduction without checking out an old commit.

### LOW — Documentation and observability

**Gap 8 (LOW)** — Two readiness markers, one log-line: the L1 fast-path returns without emitting `"Database ready"` (only the slow-path return logs it). Operators reading pod logs see *either* the slow-path marker or the fast-path skip line, not a single canonical "bootstrap finished" line. **Tracked as a tiny follow-up; not blocking.**

---

## Architecture

### Before — every replica × every worker races for the lock

```text
                        DB schema starts populated (alembic_version at head)
                                                │
                                                ▼
   ┌────────── pod 1 (8 gunicorn workers) ──────────┐
   │  W1 → SELECT pg_try_advisory_lock(42…42) → t   │ ─┐
   │  W2 → SELECT pg_try_advisory_lock(42…42) → f   │ ─┤
   │  W3 → SELECT pg_try_advisory_lock(42…42) → f   │ ─┤
   │  …                                              │  │
   └─────────────────────────────────────────────────┘  │
                                                        │ all 24 workers
   ┌────────── pod 2 (8 gunicorn workers) ──────────┐  │ converge through
   │  W1..W8 → all 'f', spin in retry loop          │ ─┤ the same pgbouncer
   └─────────────────────────────────────────────────┘  │ pool
                                                        │
   ┌────────── pod 3 (8 gunicorn workers) ──────────┐  │
   │  W1..W8 → all 'f', spin in retry loop          │ ─┘
   └─────────────────────────────────────────────────┘
                                                        │
                                                        ▼
                        ┌──────────────────────────────────────────┐
                        │ PgBouncer (transaction pool)             │
                        │   each transaction commit → backend      │
                        │   handed to next client                  │
                        │   advisory lock outlives client session  │
                        └──────────────────────────────────────────┘
                                                        │
                                                        ▼
                        ┌──────────────────────────────────────────┐
                        │ Postgres                                  │
                        │   1 backend granted advisory lock         │
                        │   N–1 backends "idle in transaction" on   │
                        │   pg_try_advisory_lock(42424242424242)    │
                        └──────────────────────────────────────────┘

   Observable on OCP (issue reporter + our reproduction):
     · pods cycle 0/1 Running → CrashLoopBackOff → … → Ready over ~13 min
     · 7 restarts per pod (×3 = 21 restart events)
     · 60+ visible "Lock held by another instance" retries per restart
     · helm release status: failed
```

### After Layer 1 — fast-path before the lock

```text
   ┌────────── pod 1 worker ─────────────────────────────────────┐
   │  bootstrap_db.main()                                         │
   │    ┌─ probe (read-only) ─────────────────────────────────┐  │
   │    │  alembic_version == script_dir.get_heads() ?        │  │
   │    │       │                                              │  │
   │    │       ├── YES → return early, no lock involved      │  │
   │    │       │                                              │  │
   │    │       └── NO → fall through to advisory_lock path   │  │
   │    │              (existing slow path, unchanged)         │  │
   │    └─────────────────────────────────────────────────────┘  │
   └──────────────────────────────────────────────────────────────┘

   On a fresh deploy (empty DB), only the FIRST worker that wins the
   lock runs the slow path; replicas 2..N probe AFTER the seed and
   skip the lock entirely.

   Observed on OCP (verified end-to-end on <your-cluster>):
     · pod 1 (seed):    0 retries → completes in ~1s
     · pods 2 & 3:      0 retries, 8 fast-path firings each
     · all 3 pods 1/1 Ready in 56 seconds, 0 restarts
     · helm release status: deployed
```

### After Layer 2 — skip the lock, keep the helpers, fail-fast if schema isn't ready

```text
                                                       Helm pre-install Job
                                                       ─────────────────────
                                                       direct to postgres :5432
                                                       runs bootstrap_db,
                                                       exits 0
                                                              │
                                                              ▼
                                              alembic_version at head
                                                              │
                                                              ▼
   ┌────────── gateway Deployment (chart-rendered) ─────────────────┐
   │  env:                                                           │
   │    - MCPGATEWAY_SKIP_MIGRATIONS: "true"   ← from                │
   │                                              .Values.           │
   │                                              migration.         │
   │                                              enabled            │
   │                                                                 │
   │  lifespan:                                                      │
   │    wait_for_db_ready()                                          │
   │    await bootstrap_db.main()                                    │
   │             │                                                   │
   │             ▼                                                   │
   │  ┌─ bootstrap_db.main() ──────────────────────────────────┐     │
   │  │  if settings.mcpgateway_skip_migrations:               │     │
   │  │      │                                                 │     │
   │  │      ├── alembic_at_head(conn, cfg) ──► no             │     │
   │  │      │     raise RuntimeError                          │     │
   │  │      │       ("Schema not at head;                     │     │
   │  │      │        migrations required                      │     │
   │  │      │        before startup")                         │     │
   │  │      │                                                 │     │
   │  │      └── alembic_at_head(conn, cfg) ──► yes            │     │
   │  │          logger.info("MCPGATEWAY_SKIP_MIGRATIONS=true  │     │
   │  │                       — schema already at head,        │     │
   │  │                       skipping migration")             │     │
   │  │          await _run_post_migration_bootstrap(conn)     │     │
   │  │          return                                        │     │
   │  │                                                        │     │
   │  │  # otherwise: fast-path / advisory-lock slow path      │     │
   │  └────────────────────────────────────────────────────────┘     │
   └─────────────────────────────────────────────────────────────────┘

   No advisory lock acquired. No Alembic upgrade attempted.
   Idempotent helpers still run (admin user, default RBAC roles,
   orphaned-resource assignment), so first-startup contracts hold
   regardless of which entity ran the schema migration. Single
   audit-log line per pod so operators can see the choice.

   Fail-closed safety: if MCPGATEWAY_SKIP_MIGRATIONS=true but the
   schema is NOT at head (init container failed, wrong DB targeted,
   chart misconfigured), the pod raises immediately rather than
   serve traffic against a half-migrated DB.
```

### After: schema-at-head startup probe (chart-level Ready gate)

```text
   ┌── gateway pod (chart-rendered when migration.enabled=true) ──┐
   │  spec.containers[0].startupProbe.exec:                       │
   │    python -m mcpgateway.utils.check_schema_at_head           │
   │      ├── db_heads == script_dir.get_heads() ─► exit 0  Ready │
   │      ├── any mismatch                       ─► exit 1  0/1   │
   │      │                                          probe runs   │
   │      │                                          every 5s     │
   │      └── unhandled exception (bad URL, etc.) ─► exit 1  0/1  │
   │                                                  fail closed │
   └──────────────────────────────────────────────────────────────┘

   Defence in depth complementing L1 + L2: ensures no pod serves
   traffic against a half-migrated DB regardless of which entity
   (pre/post-install Job, init container, external CD pipeline)
   actually ran the migration. The chart-level Ready gate is
   independent of the migration runner's identity.
```

---

## Test results

The change ships with three layers of verification, each addressing a different failure mode:

```
   ┌──────────────────────────────────────────────────────────────────────┐
   │ Layer            │ Catches                                            │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Unit             │ Fast-path predicate logic; settings field          │
   │                  │ defaults; lifespan helper gate; chart render       │
   │                  │ outputs the right env var; schema-at-head probe    │
   │                  │ entry-point exit-code contract.                    │
   │                  │                                                    │
   │                  │ A future refactor that breaks ANY of these gets a  │
   │                  │ red unit test in seconds.                          │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Integration      │ The actual bug surface: bootstrap_db running       │
   │ (6 tests)        │ against a real Postgres + PgBouncer stack with     │
   │                  │ the held-lock precondition synthesized — plus a    │
   │                  │ full 3-replica docker-compose end-to-end gated     │
   │                  │ by MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1.        │
   │                  │                                                    │
   │                  │ Reliably RED on main (240s timeout). Reliably      │
   │                  │ GREEN with the L1 fast-path. Plus 3 mechanism      │
   │                  │ tests pinning PgBouncer's transaction-pool         │
   │                  │ semantics for documentation-as-code.               │
   ├──────────────────┼────────────────────────────────────────────────────┤
   │ Cluster smoke    │ End-to-end on OpenShift with CrunchyData PGO +     │
   │ (manual)         │ transaction-pool PgBouncer. Same image, same       │
   │                  │ stack, only the gateway code differs between       │
   │                  │ pre- and post-fix runs. Concrete numbers below.    │
   └──────────────────────────────────────────────────────────────────────┘
```

The integration tests sit behind `--with-integration`; the unit tests run on every CI pass. The cluster smoke is documented evidence, not automated, and lives as `todo/issue-4051-ocp-reproduction.md` for the PR record.

<details>
<summary>Reproduction harness — files, steps, and observed results</summary>

A throwaway harness lived on the branch during development at
`tests/reproduction/issue-4051/`, then was removed before merge. Its three
files are inlined below so a future reader can rebuild the reproduction
without checking out an old commit.

The compose stack the scripts drove was promoted to
`tests/integration/fixtures/transaction_pool/docker-compose.yml` so the
integration test owns the same infrastructure long-term. The shell harness
is a separate, optional layer on top of that for ad-hoc runs.

```
   demonstrate_orphan.sh   ── deterministic mechanism proof (3 psql calls)
                              always passes; documents PgBouncer behavior

   reproduce.sh            ── replica-scaling symptom reproduction
                              fails on pre-fix images, succeeds on post-fix
```

Why two harnesses for one bug? `demonstrate_orphan.sh` proves the *PgBouncer
mechanism* exists (orphaned advisory locks); `reproduce.sh` proves the
*operational symptom* exists (replicas hang). Together they answer two
questions any reviewer might ask: "is this a real PgBouncer property?" and
"does it actually cause user-visible breakage?" — without making us guess
timing.

PgBouncer's `default_pool_size` is deliberately small (`2`) in the fixture so
total client connections comfortably exceed it, forcing backend multiplexing
— without that pressure, the bug is hard to trigger locally because bootstrap
can finish before any backend handoff happens.

#### Step 1 — `demonstrate_orphan.sh` (mechanism proof)

```bash
cd <repo-root>
./tests/reproduction/issue-4051/demonstrate_orphan.sh
```

Three steps:

1. Through PgBouncer, take advisory lock `42424242424242`, disconnect.
2. Query `pg_locks` directly on Postgres → lock is **still held** by the
   now-orphaned backend.
3. From a fresh direct-to-Postgres session,
   `pg_try_advisory_lock(42424242424242)` returns `f`.

Step 3 returning `f` is the exact condition that makes
`bootstrap_db.main()` hang: a new gateway pod spins on a lock no live
client owns. Always reproducible; runs in ~10 s.

#### Step 2 — `reproduce.sh` (symptom reproduction at replica scale)

```bash
./tests/reproduction/issue-4051/reproduce.sh
```

Scales gateway to N replicas (default 3) against the same PgBouncer-fronted
Postgres, watches each pod's logs for the bootstrap-completion line,
then dumps `pg_locks` and `pg_stat_activity` if any pod is still hung.

Pre-fix expected output:

- Exits `1`.
- One container logs `"Database ready"`; the others end at
  `INFO  [alembic.runtime.migration] Will assume transactional DDL.`
- `pg_locks` shows one granted advisory row plus several backends
  `idle in transaction` on `SELECT pg_try_advisory_lock(...)`.

Post-fix expected output: all replicas log `Database ready` within the
timeout, no stuck backends, exits `0`.

#### Inlined file contents

<details>
<summary><code>demonstrate_orphan.sh</code></summary>

```bash
#!/usr/bin/env bash
# Direct demonstration of the mechanism behind issue #4051.
#
# Three steps against the same stack that reproduce.sh uses:
#
#   1. Through PgBouncer (transaction pool, POOL_SIZE=2), take a Postgres
#      session-scoped advisory lock, then close the connection. PgBouncer
#      returns the backend to its pool.
#   2. Query pg_locks on Postgres directly. The lock is STILL HELD — the
#      pgbouncer "session" is gone but the server session on the backend
#      is still alive.
#   3. Open a fresh connection through PgBouncer and try to acquire the
#      SAME lock. Returns FALSE because the backend PgBouncer hands us is
#      the same one that still holds it.
#
# That "FALSE in step 3 even though no-one is actually doing anything" is
# what makes bootstrap_db.main() hang: the advisory-lock retry loop spins
# forever because the lock is orphaned on a backend no client owns.
#
# Requires:
#   - docker compose with the stack defined in
#     tests/integration/fixtures/transaction_pool/docker-compose.yml
#     (postgres + pgbouncer only; no gateway needed).

set -u

REPO_ROOT=$(git rev-parse --show-toplevel)
COMPOSE_FILE="${REPO_ROOT}/tests/integration/fixtures/transaction_pool/docker-compose.yml"
COMPOSE=(docker compose -f "${COMPOSE_FILE}")
LOCK_ID="${LOCK_ID:-42424242424242}"

log() { printf '[demo] %s\n' "$*"; }

PSQL_PGBOUNCER=("${COMPOSE[@]}" exec -T -e PGPASSWORD=reprosecret postgres
                psql -h pgbouncer -p 6432 -U postgres -d mcp -t -A)
PSQL_DIRECT=("${COMPOSE[@]}" exec -T -e PGPASSWORD=reprosecret postgres
             psql -h postgres -p 5432 -U postgres -d mcp -t -A)

log "clean slate"
"${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true

log "start postgres + pgbouncer"
"${COMPOSE[@]}" up -d --wait postgres pgbouncer

# Sanity: confirm both are reachable.
"${PSQL_DIRECT[@]}" -c "SELECT 1;" >/dev/null
"${PSQL_PGBOUNCER[@]}" -c "SELECT 1;" >/dev/null

echo
log "=== STEP 1: through PgBouncer, acquire advisory lock ${LOCK_ID}, then disconnect"
"${PSQL_PGBOUNCER[@]}" -c "SELECT pg_advisory_lock(${LOCK_ID});" >/dev/null
log "    done (pgbouncer-facing connection closed)"

echo
log "=== STEP 2: direct to Postgres, check pg_locks for any advisory lock"
direct_locks=$("${PSQL_DIRECT[@]}" -c \
    "SELECT pid::text||'|'||locktype||'|'||classid::text||'|'||objid::text||'|'||granted::text FROM pg_locks WHERE locktype='advisory';")
if [ -z "$direct_locks" ]; then
    log "    NO advisory lock found on Postgres — backend was fully reset."
    exit 1
fi
log "    lock still held at server level (classid<<32 | objid == ${LOCK_ID}):"
printf '      %s\n' "$direct_locks" | awk -F'|' '{printf "pid=%s type=%s classid=%s objid=%s granted=%s\n", $1,$2,$3,$4,$5}'

echo
log "=== STEP 3: from a DIFFERENT Postgres session (direct, bypass PgBouncer),"
log "           try to take the same advisory lock"
result=$("${PSQL_DIRECT[@]}" -c "SELECT pg_try_advisory_lock(${LOCK_ID});" | tr -d '[:space:]')
log "    pg_try_advisory_lock (from fresh session) -> ${result}"

result_via_bouncer=$("${PSQL_PGBOUNCER[@]}" -c "SELECT pg_try_advisory_lock(${LOCK_ID});" | tr -d '[:space:]')
log "    pg_try_advisory_lock (via pgbouncer, may reuse same backend) -> ${result_via_bouncer}"

echo
case "$result" in
    f)
        log "RESULT: ORPHANED. The lock set in step 1 is held by a backend"
        log "        that no pgbouncer client still owns, and a different"
        log "        postgres session cannot acquire it. A new gateway pod"
        log "        taking this path would spin on pg_try_advisory_lock"
        log "        until the advisory_lock retry timeout fires — exactly"
        log "        the symptom described in issue #4051."
        exit 0 ;;
    t)
        log "RESULT: lock was NOT orphaned. PgBouncer cleared it between"
        log "        clients (likely via DISCARD ALL on server_reset_query)."
        exit 1 ;;
    *)
        log "RESULT: unexpected psql output: '${result}'"
        exit 2 ;;
esac
```

</details>

<details>
<summary><code>reproduce.sh</code></summary>

```bash
#!/usr/bin/env bash
# Reproduces issue #4051.
#
# Brings up postgres + pgbouncer (transaction pool) + N gateway replicas and
# reports how many of them reached "Database ready" within TIMEOUT_SECONDS.
# When the bug is present the first replica finishes bootstrap; the rest hang
# at Alembic's advisory-lock acquisition.

set -u

REPO_ROOT=$(git rev-parse --show-toplevel)
COMPOSE_FILE="${REPO_ROOT}/tests/integration/fixtures/transaction_pool/docker-compose.yml"
COMPOSE=(docker compose -f "${COMPOSE_FILE}")
REPLICAS="${REPLICAS:-3}"
TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-600}"
POLL_INTERVAL="${POLL_INTERVAL:-10}"

READY_PATTERN='"name": "mcpgateway.bootstrap_db".*"message": "Database ready"'

log() { printf '[repro] %s\n' "$*"; }

count_ready() {
    "${COMPOSE[@]}" logs --no-log-prefix gateway 2>/dev/null \
        | grep -cE "${READY_PATTERN}" || true
}

log "clean slate"
"${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true

log "start postgres + pgbouncer"
"${COMPOSE[@]}" up -d postgres pgbouncer

log "scale gateway to ${REPLICAS}"
"${COMPOSE[@]}" up -d --scale gateway="${REPLICAS}" --no-recreate gateway

log "waiting up to ${TIMEOUT_SECONDS}s for all replicas to log 'Database ready'..."
elapsed=0
ready=0
while (( elapsed < TIMEOUT_SECONDS )); do
    ready=$(count_ready)
    running=$("${COMPOSE[@]}" ps -q gateway | wc -l | tr -d ' ')
    printf '  t=%4ds  ready=%s/%s  running=%s/%s\n' "$elapsed" "$ready" "$REPLICAS" "$running" "$REPLICAS"
    if (( ready >= REPLICAS )); then break; fi
    sleep "$POLL_INTERVAL"
    elapsed=$((elapsed + POLL_INTERVAL))
done

echo "=============== gateway replica status ==============="
"${COMPOSE[@]}" ps gateway
echo "=============== advisory locks on postgres ==============="
"${COMPOSE[@]}" exec -T postgres psql -U postgres -d mcp -c \
    "SELECT locktype, mode, pid, granted, objid, classid FROM pg_locks WHERE locktype='advisory';" || true
echo "=============== active backends on postgres ==============="
"${COMPOSE[@]}" exec -T postgres psql -U postgres -d mcp -c \
    "SELECT pid, application_name, state, wait_event_type, wait_event, left(query, 80) AS query FROM pg_stat_activity WHERE datname='mcp';" || true

if (( ready >= REPLICAS )); then
    log "RESULT: all ${REPLICAS} replicas reached 'Database ready' (BUG NOT REPRODUCED)"
    exit 0
else
    log "RESULT: only ${ready}/${REPLICAS} replicas reached 'Database ready' (BUG REPRODUCED)"
    exit 1
fi
```

</details>

<details>
<summary><code>README.md</code></summary>

````markdown
# Reproduction — Issue #4051

Alembic migration advisory lock hangs when multiple gateway replicas start
concurrently through PgBouncer in transaction-pooling mode.

Issue: https://github.com/IBM/mcp-context-forge/issues/4051

## What's here

Three ways to observe / prove the bug, in increasing order of abstraction:

| Artifact | Scope | When to use |
|---|---|---|
| `demonstrate_orphan.sh` | Mechanism proof | Fastest, deterministic. Proves the PgBouncer session-advisory-lock orphan exists. Runs in ~10s against just postgres + pgbouncer. |
| `reproduce.sh` | End-to-end symptom | Scales gateway to N replicas through PgBouncer and watches for the hang. Matches the issue reporter's OCP symptoms. |
| `tests/integration/test_migrations_under_transaction_pool.py` | Pinned regression | The mechanism as three pytest assertions. Keeps the invariants enforceable as the stack evolves. |

All three drive the same `tests/integration/fixtures/transaction_pool/docker-compose.yml` stack:

- `postgres:17`
- `edoburu/pgbouncer:latest` with `POOL_MODE=transaction` and a deliberately small `DEFAULT_POOL_SIZE=2` to force backend multiplexing
- N gateway replicas (default 3) pointed at `pgbouncer:6432` (only used by `reproduce.sh`)

## Prerequisites

- Docker and Docker Compose v2.
- For `reproduce.sh` only: a local gateway image tagged `mcpgateway/mcpgateway:latest`. Build from the repo root with `make docker` (or `make docker-prod`); override the tag via `IMAGE_LOCAL` if needed.
- For the pytest regression test: the `postgres` optional extra — `uv sync --extra postgres`.

## Tear down

```bash
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml down -v
```

## Host-exposed ports

| Service   | Host port | In-network port |
|-----------|-----------|-----------------|
| postgres  | `54320`   | `5432`          |
| pgbouncer | `64320`   | `6432`          |

```bash
PGPASSWORD=reprosecret psql -h localhost -p 54320 -U postgres -d mcp   # direct to postgres
PGPASSWORD=reprosecret psql -h localhost -p 64320 -U postgres -d mcp   # through pgbouncer
PGPASSWORD=reprosecret psql -h localhost -p 64320 -U postgres -d pgbouncer -c 'SHOW pools;'   # pgbouncer admin
```

## Notes

- The stack deliberately omits Redis, the admin UI, plugins, federation, and A2A — they're not required to trigger the bug.
- `PgBouncer`'s `DEFAULT_POOL_SIZE` is set low (`2`) so total client connections comfortably exceed it; without multiplexing pressure the bug is hard to trigger locally because bootstrap can finish before any backend handoff happens.
- Production OCP/Helm deployments hit this reliably because real migrations take seconds to tens of seconds (plenty of handoff opportunities) and pool sizes are often sized for steady-state, not for migration bursts.
````

</details>

</details>

<details>
<summary>Why the regression test is deterministic (not flaky)</summary>

Three ideas had to land before `test_bootstrap_db_skips_lock_when_schema_already_at_head` was reliably RED on main:

```
   ❌ First attempt — race the bootstrap calls
       Open 3 concurrent gateway processes, hope one wins the lock and
       the others spin. Worked sometimes (lucky timing) → fragile.

   ❌ Second attempt — synthesize an orphan via PgBouncer
       Take the lock through PgBouncer, disconnect, then call
       bootstrap_db.main() through PgBouncer. PgBouncer reused the same
       server backend for the bootstrap → pg_try_advisory_lock returned
       TRUE (reentrant within the same Postgres session) → FALSE
       POSITIVE (test passed when bug was present).

   ✅ Final design — hold the lock in a distinct postgres session
       Open a direct postgres connection (NOT through PgBouncer), take
       the advisory lock, KEEP the connection alive. Now run
       bootstrap_db.main() through PgBouncer. The bootstrap's session
       is guaranteed different from the holder's session, so
       pg_try_advisory_lock MUST return FALSE → bootstrap retries →
       240s pytest.mark.timeout fires. RED, every time.
```

The middle attempt's false-positive is captured as a permanent test (`test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example`) so future readers who see "but I called pg_try_advisory_lock through PgBouncer and it returned TRUE!" understand the reentrant-session gotcha.

The same logic underpins the `_clean_orphaned_lock` autouse fixture: it runs `pg_terminate_backend` on any session still holding the test lock id between tests, so a single failed test cannot wedge the next one behind a leaked orphan.

</details>

<details>
<summary>Unit — `alembic_at_head` truth table (5 tests)</summary>

```
tests/unit/mcpgateway/test_bootstrap_db.py::TestAlembicAtHead

  test_returns_true_when_db_heads_match_script_heads          PASSED
  test_returns_false_when_db_has_no_alembic_version           PASSED
  test_returns_false_when_db_head_does_not_match_script_head  PASSED
  test_returns_false_when_script_directory_has_no_heads       PASSED
  test_returns_false_on_probe_exception                       PASSED

5 passed
```

Pins each branch of the fast-path predicate independently of the integration test, so a future refactor that widens or narrows the trigger condition is caught locally.

</details>

<details>
<summary>Unit — `MCPGATEWAY_SKIP_MIGRATIONS` settings field (3 tests)</summary>

```
tests/unit/mcpgateway/test_config.py

  test_skip_migrations_defaults_to_false        PASSED
  test_skip_migrations_env_true_flips_flag      PASSED
  test_skip_migrations_env_false_keeps_flag_off PASSED

3 passed
```

Library default stays False (the `docker run mcpgateway` happy path), env var override flips True, explicit False matches the default. No accidental coercion.

</details>

<details>
<summary>Unit — `MCPGATEWAY_SKIP_MIGRATIONS` branch inside `bootstrap_db.main()` (4 tests)</summary>

```
tests/unit/mcpgateway/test_bootstrap_db.py::TestMainAdditionalBranches

  test_main_skip_migration_at_head_with_normalization  PASSED
  test_main_skip_migration_exception_reraises          PASSED
  test_main_fast_path_already_at_head                  PASSED
  test_main_sqlite_multi_replica_warning               PASSED

4 passed
```

The skip-case tests exercise both the success path (flag set + schema at head → run helpers, emit audit-log line, return) and the fail-closed path (flag set + schema not at head → raise `RuntimeError`). The fast-path-at-head test pins the L1 behaviour separately from the integration suite. The SQLite-multi-replica warning test covers the operator-misconfiguration guard that Akshay's #4784 added.

</details>

<details>
<summary>Unit — Helm chart render (3 tests)</summary>

```
tests/unit/charts/test_deployment_mcpgateway.py

  test_skip_migrations_set_to_true_when_migration_job_enabled        PASSED
  test_skip_migrations_off_when_migration_job_disabled               PASSED
  test_skip_migrations_default_matches_migration_enabled_default     PASSED

3 passed
```

Tests run `helm template` as a subprocess, parse the rendered manifests, and assert on the gateway Deployment's env block. Skipped automatically when `helm` is not on PATH; no cluster needed.

</details>

<details>
<summary>Integration — PgBouncer mechanism + bootstrap regression + compose E2E (6 tests, gated by `--with-integration`)</summary>

```
tests/integration/test_migrations_under_transaction_pool.py

  test_session_advisory_lock_persists_across_pgbouncer_client_disconnect  PASSED
  test_orphaned_lock_blocks_a_fresh_postgres_session                       PASSED
  test_reentrant_acquire_through_same_pgbouncer_is_not_a_counter_example  PASSED
  test_bootstrap_db_skips_lock_when_schema_already_at_head                 PASSED
  test_bootstrap_db_is_idempotent_once_schema_is_at_head                   PASSED
  test_compose_three_replicas_complete_bootstrap_e2e                       PASSED  (gated)

6 passed in 18.98s   (post-fix, with destructive E2E enabled, fixture up)
1 fails in 240.34s   (pre-fix, hits pytest.mark.timeout — confirmed RED on main)
```

The mechanism tests document what PgBouncer does (lock orphaning is a real, named property of transaction-pool handoffs) so a future reader who sees "but pg_try_advisory_lock returned TRUE through PgBouncer!" understands the reentrance gotcha. The regression tests gate the actual fix.

`test_compose_three_replicas_complete_bootstrap_e2e` is the heaviest of the six: it scales the fixture's `gateway` service to 3 replicas through transaction-pool PgBouncer and asserts all three emit either `"Database ready"` or `"Schema already at Alembic head"` within a 60s window (one replica wins the slow-path seed, the other two fast-path past the lock). Gated by `MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1` because it drops and recreates the fixture's `public` schema; additionally skips if a local `mcpgateway/mcpgateway:latest` image isn't present. Locally observed runtime: ~13s in isolation against a pre-warmed image.

Run with the docker-compose stack from `tests/integration/fixtures/transaction_pool/docker-compose.yml`:

```
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml up -d postgres pgbouncer
make docker                                                    # rebuilds mcpgateway/mcpgateway:latest
MCPGATEWAY_TEST_ALLOW_DESTRUCTIVE_E2E=1 uv run pytest \
  tests/integration/test_migrations_under_transaction_pool.py \
  --with-integration
```

</details>

<details>
<summary>Manual — 3-replica docker-compose walkthrough (optional, for demos and ad-hoc verification)</summary>

Same fixture as the integration test, driven by hand instead of by pytest. Use this when you want to *watch* replicas come up — for a team demo, a post-merge sanity check, or when investigating a suspected regression on the bootstrap path. Pytest's one-dot pass output is fine for CI but not very theatrical.

#### Phase 0 — Prerequisites

```bash
# Fixture (postgres + pgbouncer in transaction-pool mode) is up
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \
  up -d postgres pgbouncer

# Local gateway image reflects the branch being tested
make docker
```

#### Phase 1 — Wipe schema (forces a fresh-deploy substrate)

```bash
docker exec transaction-pool-fixture-postgres-1 \
  psql -U postgres -d mcp -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
```

#### Phase 2 — Scale to 3 replicas (the moment)

```bash
# Make sure no leftover gateway replicas exist.
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \
  up -d --scale gateway=0 --no-recreate gateway

# Scale to 3 replicas concurrently — this is the moment the lock race would
# fire pre-fix.
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \
  up -d --scale gateway=3 --no-recreate gateway
```

#### Phase 3 — Verify the fix fired

```bash
# Per-replica per-worker bootstrap log signature.
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \
  logs gateway 2>&1 | \
  grep -E "Database ready|Schema already at Alembic head|Acquired migration lock|Lock held by another"

# Confirm Postgres has no orphaned advisory locks afterwards.
docker exec transaction-pool-fixture-postgres-1 \
  psql -U postgres -d mcp -c \
  "SELECT pid, granted, classid, objid FROM pg_locks WHERE locktype='advisory';"
```

#### What to look for (illustrative trace)

A typical post-fix run with a fresh schema produces something like the timeline below — wall-clock ~3–15 seconds end-to-end for all 3 replicas (varies with disk + image cache state):

```
t0           gateway-N  Acquired Postgres advisory lock on attempt 1      ← seed-winner
t0+~1ms      gateway-M  Lock held by another instance, retrying in 1.0s   ← brief contention
t0+~200ms    gateway-N  Acquired lock (2nd worker, same pod)              ← within-pod race
t0+~1s       gateway-K  Acquired lock (schema already at head — quick)
t0+~1s       gateway-N  "Database ready"
t0+~1s       gateway-*  Schema already at Alembic head; skipping lock     ← FAST-PATH
t0+~1s       gateway-*  Schema already at Alembic head; skipping lock     ← (one per
t0+~1s       gateway-*  Schema already at Alembic head; skipping lock        gunicorn
t0+~1s       gateway-*  Schema already at Alembic head; skipping lock        worker per
t0+~2s       gateway-M  Acquired lock on attempt 3                           replica)
t0+~2s       gateway-M  "Database ready"
```

Three things to point at:

1. The advisory lock still works — one replica wins, others retry briefly, but the whole storm is bounded to a few seconds rather than ~13 minutes pre-fix.
2. `"Lock held by another instance"` appears only a handful of times total. Pre-fix this line would appear 60+ times per replica before timeout.
3. `"Schema already at Alembic head; skipping migration lock"` is the fast-path firing for every worker after the seed. Most of the post-startup log lines should be this.

#### Outcome — success criteria

| Marker | Expected | Pre-fix would show |
|---|---|---|
| Wall-clock from scale-up to all 3 settled | ≤ 15s | ~13 min, then crash loop |
| `"Lock held by another instance"` lines | a small handful (≤ ~5 total) | 60+ per replica per restart |
| `"Schema already at Alembic head; skipping migration lock"` lines | many (one per worker per pod after seed) | does not exist on pre-fix code |
| `"Database ready"` lines | one per replica | one (from the lock-winner) and the rest hang |
| `pg_locks` advisory rows after stabilise | 0 | 1 granted + several `idle in transaction` waiters |

#### Cleanup

```bash
# Scale gateway back to 0; leaves postgres + pgbouncer running for subsequent runs.
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml \
  up -d --scale gateway=0 --no-recreate gateway

# Stop everything if you're done with the fixture.
docker compose -f tests/integration/fixtures/transaction_pool/docker-compose.yml down -v
```

#### Optional — before/after comparison

To demonstrate the bug as well as the fix on the same stack, swap in a pre-fix image before the scale-up step:

```bash
docker pull ghcr.io/ibm/mcp-context-forge:1.0.0
docker tag ghcr.io/ibm/mcp-context-forge:1.0.0 mcpgateway/mcpgateway:latest
# ... run Phase 2 and Phase 3 above ...
# Expect: one replica logs "Database ready", others spin on "Lock held by another instance"
# Let it run for ~60 seconds to make the point, then restore the post-fix image:
docker rmi mcpgateway/mcpgateway:latest
make docker
```

</details>

<details>
<summary>Manual — OCP deployment runbook (optional, after-test, end-to-end)</summary>

Full sequence of commands to verify the fix on an OCP cluster with CrunchyData PGO + transaction-pool PgBouncer, starting from a built/pushed image. Use this as a copy-paste recipe for hands-on verification.

Two chart/code drifts surfaced during this verification and have to be worked around; both are unrelated to this PR and are tracked separately (see "Workarounds" at the end of this block).

#### Phase 0 — Prerequisites

```bash
# Log in to the target OCP cluster
oc login -u <cluster-admin-user> --server=<https://api.your-cluster:6443>
export OCP_NS=<namespace>

# Confirm CrunchyData PGO has Postgres + PgBouncer running in this namespace
oc get pods -n ${OCP_NS} -l postgres-operator.crunchydata.com/cluster

# Confirm the local secrets override file exists (gitignored — see
# docs/docs/deployment/openshift-pgo.md "Prepare secrets")
ls charts/mcp-stack/profiles/ocp/values-pgo-secrets.yaml

# Workaround for chart drift #1 (see "Workarounds" below). Required because
# charts/mcp-stack/templates/job-migration.yaml hardcodes runAsUser/fsGroup 10001
# while the deployment template uses values-driven security context. nonroot-v2
# is the minimum SCC that allows non-root UIDs without granting root.
oc adm policy add-scc-to-user nonroot-v2 -z default -n ${OCP_NS}

# Workaround for chart drift #2 (see "Workarounds" below): add a TOKEN_EXPIRY
# override to your local values-pgo-secrets.yaml under mcpContextForge.secret,
# e.g. TOKEN_EXPIRY: "1440"   (24h, the maximum the code validator accepts).
```

#### Phase 1 — Build the test image (x86 host required)

The image must be built on an x86_64 host so it runs on the OCP worker nodes (most dev machines are arm64 — cross-builds work but native is simpler). Any x86 Linux VM with docker installed and access to the branch will do.

```bash
# On the x86 build host
cd <path-to-mcp-context-forge>
git fetch origin <branch> && git reset --hard FETCH_HEAD
make docker

# Tag and push to a registry the OCP cluster can pull from
TAG="<your-tag>"
docker tag mcpgateway/mcpgateway:latest <your-registry>/<your-image-name>:${TAG}
docker push <your-registry>/<your-image-name>:${TAG}
```

#### Phase 2 — Tear down any existing release

```bash
make ocp-uninstall OCP_NS=${OCP_NS}
# Helm release removed; the PostgresCluster CR and PgBouncer remain (PGO-managed,
# not helm-managed) so we don't have to wait for Postgres to come back up.
```

#### Phase 3 — Wipe the schema (forces a fresh-deploy substrate)

This is what makes the test exercise the fix — without a fresh schema, the migration is a no-op and the lock race never fires.

```bash
POSTGRES_POD=$(oc get pods -n ${OCP_NS} \
  -l postgres-operator.crunchydata.com/role=master \
  -o jsonpath='{.items[0].metadata.name}')

# Check the actual database name from the PGO-managed secret
DB_NAME=$(oc get secret <pgo-cluster-name>-pguser-admin -n ${OCP_NS} \
  -o jsonpath='{.data.dbname}' | base64 -d)

# ALTER SCHEMA OWNER is required: PGO assigns schema ownership to a service user,
# so a plain CREATE SCHEMA defaults to postgres ownership and the application
# user cannot create tables. See todo/issue-4051-ocp-reproduction.md.
oc exec -n ${OCP_NS} ${POSTGRES_POD} -c database -- \
  psql -U postgres -d ${DB_NAME} -c \
  "DROP SCHEMA public CASCADE;
   CREATE SCHEMA public;
   ALTER SCHEMA public OWNER TO admin;
   GRANT ALL ON SCHEMA public TO admin;
   GRANT ALL ON SCHEMA public TO public;"
```

#### Phase 4 — Point the chart at the test image, then deploy

Edit `charts/mcp-stack/profiles/ocp/values-pgo.yaml` to override three image blocks so the migration Job, the gateway pods, and the post-install registration hook all run from the same test image:

- `mcpContextForge.image` (gateway pods)
- `migration.image`        (migration Job — not in `values-pgo.yaml` by default; add it)
- `testing.registration.image` (post-install registration hook)

Each block should point at `<your-registry>/<your-image-name>` with `tag: <your-tag>`.

```bash
make ocp-deploy OCP_NS=${OCP_NS}
# Migration pre-install Job runs against Postgres directly (bypassing PgBouncer
# per values-pgo.yaml's hostKey/portKey config), then helm proceeds with
# gateway/nginx/redis/fast-time pods.
```

#### Phase 5 — Verify the fix fired

```bash
# Helm release status
helm status ${OCP_NS} -n ${OCP_NS} | grep STATUS
# Expect: STATUS: deployed

# Gateway pods up cleanly
oc get pods -n ${OCP_NS} -l app.kubernetes.io/name=mcpgateway
# Expect: 3/3 Ready, 0 restarts

# Per-worker per-pod skip-migration log line — the L2 contract firing inside
# bootstrap_db.main()
oc logs -n ${OCP_NS} deploy/${OCP_NS}-mcp-stack-mcpgateway --all-containers --prefix=false \
  | grep "MCPGATEWAY_SKIP_MIGRATIONS=true — schema already at head, skipping migration"
# Expect: one line per gunicorn worker per pod

# Postgres advisory locks: must be empty after stabilise
oc exec -n ${OCP_NS} ${POSTGRES_POD} -c database -- \
  psql -U postgres -d ${DB_NAME} -c \
  "SELECT pid, granted, classid, objid FROM pg_locks WHERE locktype='advisory';"
# Expect: 0 rows

# Schema state
oc exec -n ${OCP_NS} ${POSTGRES_POD} -c database -- \
  psql -U postgres -d ${DB_NAME} -tAc "SELECT version_num FROM alembic_version;"
# Expect: a hex revision id (the current Alembic head)
```

#### Outcome — what "the fix fired" looks like

| Metric | Expected |
|---|---|
| `helm status` | `deployed` |
| Gateway pods Ready | 3/3, 0 restarts |
| Wall-clock to all 3 Ready | ≤ 90s |
| `MCPGATEWAY_SKIP_MIGRATIONS=true …` log line | one per gunicorn worker per pod |
| `pg_locks` (advisory) | 0 rows |
| `alembic_version` | a hex head revision |

#### Cleanup

```bash
git checkout charts/mcp-stack/profiles/ocp/values-pgo.yaml   # revert the temporary image edits
# Optional: remove the SCC binding once the chart drift is fixed upstream
# oc adm policy remove-scc-from-user nonroot-v2 -z default -n ${OCP_NS}
# Optional: tear down the release
# make ocp-uninstall OCP_NS=${OCP_NS}
```

#### Workarounds applied above (not caused by this PR)

The `nonroot-v2` SCC binding and the `TOKEN_EXPIRY: "1440"` override are workarounds for two chart-vs-code drifts that landed independently of this PR. Both are tracked in issue **[#4856](https://github.com/IBM/mcp-context-forge/issues/4856)** for a proper chart-side fix; the workarounds are recorded here so the runbook is reproducible until that issue is resolved.

</details>

<details>
<summary>OCP verification — L1 fix on real OpenShift + CrunchyData PGO (cluster: <your-cluster-api-host>)</summary>

```
Image:    docker.io/<your-docker-namespace>/mcp-context-forge:<your-l1-image-tag>
Stack:    mcp-stack chart, default values + migration.enabled=false
Initial:  empty DB (DROP SCHEMA public CASCADE; CREATE SCHEMA public; …)

                                       PRE-FIX            POST-L1
                                       ───────            ───────
   Helm release status                 failed             deployed
   Pod restarts before Ready           7 each (21 total)  0
   Wall-clock to 3/3 Ready             ~13 min            56 sec
   Pods using fast-path                n/a                2 of 3, every worker
   Total visible retry messages        64+                28 (all confined to one pod's
                                                              worker-race during a
                                                              sub-second seed window)
   Advisory locks held at sample time  0 (after storm)    0 (no storm)

Per-pod log signature — post-L1
─────────────────────────────────
Pod 9jvtd  (won the seed race — slow path expected here):
  Acquired migration lock:     8
  Lock held by another:       28   ← within-pod race during ~1s seed window
  Schema already at head:      0
  Database ready:              8

Pods 2p9ls and jvb4t  (replicas 2 & 3):
  Acquired migration lock:     0   ← skipped the lock entirely
  Lock held by another:        0   ← no retries
  Schema already at head:      8   ← fast-path fired for every worker
  Database ready:              0
```

> Note: the "Empty DB detected" log line, previously emitted from `bootstrap_db.main()` when a fresh database was seen, no longer exists in the current codebase — fresh-DB schema creation was moved into Alembic itself by [#4690](https://github.com/IBM/mcp-context-forge/pull/4690). The Ready-time and restart-count outcomes above are unchanged; only that one log line is no longer produced.

Full reproduction-vs-fix evidence in `todo/issue-4051-ocp-reproduction.md`.

</details>

<details>
<summary>OCP verification — L2 (chart-wired SKIP_MIGRATIONS) on real OpenShift</summary>

```
Image:    docker.io/<your-docker-namespace>/mcp-context-forge:<your-l1-l2-image-tag>
Stack:    mcp-stack chart, DEFAULT values (migration.enabled=true), so the
          chart's pre-install Job runs the migration and the gateway
          Deployment is rendered with MCPGATEWAY_SKIP_MIGRATIONS=true.
Initial:  empty DB (DROP SCHEMA public CASCADE; CREATE SCHEMA public; …)

                                       PRE-FIX            POST-L1            POST-L2
                                       ───────            ───────            ───────
   Helm release status                 failed             deployed           deployed*
   Pod restarts before Ready           7 each (21 total)  0                  0
   Wall-clock to 3/3 Ready             ~13 min            56 sec             91 sec
   bootstrap_db activity in pods       very high          slow-path on 1     ZERO
   Advisory lock acquisitions in pods  many               8 (1 pod's race)   0
   Workers using fast-path             n/a                16 of 24           n/a (skipped)
   Workers using SKIP path             n/a                n/a                24 of 24
   Migration Job runs                  no (disabled)      no (disabled)      yes (Complete)

   * register-fast-time post-install Job failed; it's unrelated to the
     migration/skip story (registers the test fast-time-server via gateway
     API call). Doesn't affect L2 contract verification. Tracked separately.

Per-pod log signature — post-L2 (all 3 pods identical)
──────────────────────────────────────────────────────
  MCPGATEWAY_SKIP_MIGRATIONS=true — schema
    already at head, skipping migration:    8   ← one per gunicorn worker
  Acquired migration lock:                  0
  Schema already at Alembic head:           0
  Lock held by another instance:            0
  Database ready:                           0

DB state after pods Ready:
  Tables in public schema:               61
  alembic_version:                       d3e4f5a6b7c8 (at head)
  Advisory locks held:                   0
```

The 3-way pre-fix / post-L1 / post-L2 comparison is the headline win. The chart's contract — migration Job runs → app pods skip — is honored automatically; operators don't have to remember to set both `migration.enabled` AND `MCPGATEWAY_SKIP_MIGRATIONS` because the chart wires them together.

Full reproduction-vs-fix evidence in `todo/issue-4051-ocp-reproduction.md`.

</details>

<details>
<summary>OCP verification — L2 on minimal profile (no PGO operator, chart-managed Postgres + PgBouncer)</summary>

The OCP-PGO smoke above proves the fix on the operator-managed path. This second smoke proves it on the **community Helm path** — the chart's base `values.yaml` with the chart's own standalone `postgres` + `pgbouncer` Deployments (no CrunchyData operator). That's the configuration most community users will hit and the one a downstream pipeline using `DEPLOYMENT_PROFILE=minimal` lands on.

```
Cluster:   same OpenShift cluster as the PGO smoke
Namespace: issue-4051-minimal-test                  (fresh project)
Image:     docker.io/<your-docker-namespace>/mcp-context-forge:<your-l1-l2-image-tag>
Profile:   MINIMAL — chart's base values.yaml only,
           NO profiles/ocp/values-pgo.yaml, NO PGO operator
Override:  storageClassName=nfs-client (PVCs)
           REQUIRE_STRONG_SECRETS=false (test secrets)
```

```
Result
──────
  Helm release status                  deployed
  Wall-clock to all gateway pods Ready ~58 s
  Pod restarts before Ready            0
  Migration Job (pre-install hook)     ran to completion (cleaned up
                                        by hook-succeeded policy)
  Schema in postgresdb                  61 tables, alembic_version at head
  Advisory locks held after stabilise   0

Per-pod log signature (each gateway pod, identical)
───────────────────────────────────────────────────
  MCPGATEWAY_SKIP_MIGRATIONS=true — schema
    already at head, skipping migration:  1   ← per gunicorn worker
  Acquired migration lock:                0
  Lock held by another instance:          0
  Schema already at Alembic head:         0
  Database ready:                         0
```

Stack components running in the namespace:

```
NAME                                              READY   STATUS    RESTARTS
mcp-stack-mcp-fast-time-server-7bb594568b-d5ctj   1/1     Running   0
mcp-stack-mcp-fast-time-server-7bb594568b-zgp5b   1/1     Running   0
mcp-stack-mcpgateway-b8f4776bf-44cpz              1/1     Running   0
mcp-stack-mcpgateway-b8f4776bf-x44m5              1/1     Running   0
mcp-stack-postgres-7499dfc6c8-krdbc               1/1     Running   0
mcp-stack-redis-7c5fc464c4-6xfb5                  1/1     Running   0
```

What this confirms beyond the PGO smoke:

- The chart's `migration.enabled` → `MCPGATEWAY_SKIP_MIGRATIONS` wiring is profile-agnostic — works on both operator-managed and chart-managed Postgres.
- Community users on vanilla K8s with the chart's defaults get the L2 contract automatically; no special profile or extra knob needed.
- A downstream CD pipeline using `DEPLOYMENT_PROFILE=minimal` (without PGO) is unblocked by this PR with no additional configuration changes — they only need to bump their image tag to one with this fix.

</details>

---

## Additional improvements

- **Idempotent post-migration bootstrap extracted to `_run_post_migration_bootstrap()`** — admin-user creation, default-role seeding, and orphaned-resource assignment are now called from both the fast-path and slow-path branches. Previously these were only inside the `advisory_lock` block, so a fast-path skip would have missed them on a partial-startup edge case (replica 1 stamps head then crashes before bootstrapping the admin user → replica 2 fast-paths and runs the bootstrap steps to fill the gap).

- **Reproduction harness inlined in this description** — the development-time harness directory has been removed in the squashed commit; the compose stack it drove was promoted to `tests/integration/fixtures/transaction_pool/docker-compose.yml` so the integration suite owns the same infrastructure long-term. The two shell scripts (`reproduce.sh`, `demonstrate_orphan.sh`) are inlined in the Test results section above so a future reader can rebuild the harness from the PR alone.

- **Module docstrings reference the issue number** — both the helper functions and the integration test module carry an inline reference to issue #4051 so a future reader greps once and lands in the right context.

---

## Limitations

1. **Fast-path returns without emitting `"Database ready"`** — the canonical readiness marker only fires on the slow-path return. Operators reading pod logs see *either* `Database ready` *or* `Schema already at Alembic head; skipping migration lock`. Both signal "bootstrap finished," but inconsistently. Captured as Gap 8 above; trivial follow-up.

2. **Table-based mutex fallback not included** — the original plan considered a Postgres table-based mutex for environments where `migration_database_url` (direct-Postgres bypass) isn't available AND the chart's pre-install Job is disabled. With L1 + L2 + the schema-at-head probe in place, that combination is well-covered: L1 makes the in-pod path safe, L2 lets the chart guarantee the in-pod path is skipped when the Job runs, and the probe holds Ready until the schema is correct regardless. Reopening if a real-world report justifies it.

3. **DROP SCHEMA in PGO setups requires ownership restoration** — observed during the OCP reproduction. CrunchyData PGO assigns schema ownership to a service user; a manual `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` re-creates the schema owned by `postgres`, so the service user can't create tables in it until ownership is restored:

   ```sql
   ALTER SCHEMA public OWNER TO admin;
   GRANT ALL ON SCHEMA public TO admin;
   GRANT ALL ON SCHEMA public TO public;
   ```

   Documented in the OCP reproduction notes; not a code fix.

4. **Pod readiness can be misleading during pre-fix cycling** — observed pods show `1/1 Ready` even while several gunicorn workers are still in their retry loop. One worker's lifespan completing seems sufficient to satisfy the readiness probe. With L1+L2 the storm window is gone; this is captured here for operator awareness when reading historical pre-fix logs.

5. **Fast-path makes the post-migration role/user-role seeders non-serialised** — `bootstrap_default_roles()` and the platform_admin user-role assignment now run outside the migration advisory lock on every replica that takes the fast path. Chart-default deployments (`migration.enabled=true` + `MCPGATEWAY_SKIP_MIGRATIONS=true` on gateway pods) are unaffected — the migration Job is the sole writer. Configurations where gateway pods bootstrap themselves (e.g., `migration.enabled=false`, multi-worker single-pod gunicorn) carry a small first-startup race window that can produce duplicate active rows in `roles` / `user_roles`. Fully closed by the follow-up linked below.

---

## Future work

### RBAC seeder race fix — PR #4480 / issue #4482

Inline review on this PR identified two related races (HIGH on `roles`, MEDIUM on `user_roles`) that the L1 fast-path exposes by running the post-migration seeders without holding the advisory lock. The fix is staged in **PR #4480** with **issue #4482** as the tracking record. Approach: partial unique indexes on `(name, scope)` / `(user_email, role_id, scope[, scope_id])` `WHERE is_active = true`, an idempotent dedupe-then-constrain Alembic migration, plus savepoint-and-refetch in `RoleService.create_role` / `assign_role_to_user`.

The race fix is **strictly additive**; the hang fix in this PR does not depend on it. Split out to keep this PR narrowly scoped to the original bug, and to keep the diff in front of the chart-and-bootstrap reviewers separate from the diff in front of the RBAC reviewers.

### Compose-side L2 (deferred)

The root `docker-compose.yml` was left unchanged. It's currently safe thanks to L1 alone (the fast-path makes in-pod bootstrap pgbouncer-safe). Adding a dedicated `migrate` service in compose plus `MCPGATEWAY_SKIP_MIGRATIONS=true` on the gateway would mirror the chart's contract one-to-one — useful for users who want production-shaped semantics in dev. Tracked as a separate issue if there's appetite; deliberately out-of-scope here to keep `docker-compose.yml` touch-free for existing users.

### Unify the readiness log line

Per Gap 8 above. Either:

- emit `"Database ready"` from both paths (fast and slow), or
- replace it with a single richer line carrying the path taken (`"Database ready (fast-path)"` / `"Database ready (slow-path)"`).

Either change is a one-line edit; deferred so this PR stays scoped to the bug fix.

### `MIGRATION_DATABASE_URL` (only if requested)

The Helm chart already exposes `migration.hostKey` / `portKey` to point the pre-install Job direct to Postgres (bypassing PgBouncer). A code-level `MIGRATION_DATABASE_URL` setting would let docker-compose users do the same without two `DATABASE_URL` definitions. Not necessary for the bug fix; deferred unless someone explicitly asks for it.

---

Closes #4051. Built on top of #4784 (Lang-Akshay), which contributed the in-`bootstrap_db.main()` skip-migration plumbing and the SQLite-multi-replica warning that this PR layers chart wiring, the K8s schema-at-head startup probe, and the integration test coverage on top of.
