### PR TITLE
fix(mcp): prevent 307 redirects for Streamable HTTP /mcp probes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -5118,7 +5118,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2809,8 +2809,9 @@ class MCPPathRewriteMiddleware:
     """
     Middleware that rewrites paths ending with '/mcp' to '/mcp/', after performing authentication.
 
+    - Rewrites exact '/mcp' to '/mcp/' so Starlette's mount does not emit a 307 redirect.
     - Rewrites paths like '/servers/<server_id>/mcp' to '/mcp/'.
-    - Only paths ending with '/mcp' or '/mcp/' (but not exactly '/mcp' or '/mcp/') are rewritten.
+    - Only exact '/mcp' and server-scoped MCP transport paths are rewritten.
     - Authentication is performed before any path rewriting.
     - If authentication fails, the request is not processed further.
     - All other requests are passed through without change.
@@ -2950,6 +2951,10 @@ class MCPPathRewriteMiddleware:
         # Skip rewriting for well-known URIs (RFC 9728 OAuth metadata, etc.)
         # These paths may end with /mcp but should not be rewritten to the MCP transport
         if not app_path.startswith("/.well-known/"):
+            if app_path == "/mcp":
+                scope["path"] = f"{root_path}/mcp/" if root_path else "/mcp/"
+                await self.application(scope, receive, send)
+                return
             if (app_path.endswith("/mcp") and app_path != "/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
                 # SECURITY: Only rewrite recognised MCP paths — /servers/{id}/mcp.
                 # Arbitrary prefixes (e.g. /foo/mcp) must NOT be rewritten to

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2811,6 +2811,7 @@ class MCPPathRewriteMiddleware:
 
     - Rewrites exact '/mcp' to '/mcp/' so Starlette's mount does not emit a 307 redirect.
     - Rewrites paths like '/servers/<server_id>/mcp' to '/mcp/'.
+    - Keeps ASGI ``raw_path`` aligned with rewritten paths when present.
     - Only exact '/mcp' and server-scoped MCP transport paths are rewritten.
     - Authentication is performed before any path rewriting.
     - If authentication fails, the request is not processed further.
@@ -2952,7 +2953,10 @@ class MCPPathRewriteMiddleware:
         # These paths may end with /mcp but should not be rewritten to the MCP transport
         if not app_path.startswith("/.well-known/"):
             if app_path == "/mcp":
-                scope["path"] = f"{root_path}/mcp/" if root_path else "/mcp/"
+                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
+                scope["path"] = new_path
+                if "raw_path" in scope:
+                    scope["raw_path"] = new_path.encode("latin-1")
                 await self.application(scope, receive, send)
                 return
             if (app_path.endswith("/mcp") and app_path != "/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
@@ -2976,7 +2980,10 @@ class MCPPathRewriteMiddleware:
                     return
                 # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
                 # Preserve root_path prefix when rewriting
-                scope["path"] = f"{root_path}/mcp/" if root_path else "/mcp/"
+                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
+                scope["path"] = new_path
+                if "raw_path" in scope:
+                    scope["raw_path"] = new_path.encode("latin-1")
                 await self.application(scope, receive, send)
                 return
         await self.application(scope, receive, send)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2929,6 +2929,13 @@ class MCPPathRewriteMiddleware:
             >>> with patch('mcpgateway.main.streamable_http_auth', return_value=True):
             ...     asyncio.run(middleware._call_streamable_http(scope, receive, send))
             >>> app_mock.assert_called_once_with(scope, receive, send)
+
+            >>> # Exact /mcp is normalized to avoid Starlette's mount redirect.
+            >>> scope = {"type": "http", "path": "/mcp"}
+            >>> with patch('mcpgateway.main.streamable_http_auth', return_value=True):
+            ...     asyncio.run(middleware._call_streamable_http(scope, receive, send))
+            >>> scope["path"]
+            '/mcp/'
         """
         # Auth check first
         auth_ok = await streamable_http_auth(scope, receive, send)
@@ -2953,13 +2960,10 @@ class MCPPathRewriteMiddleware:
         # These paths may end with /mcp but should not be rewritten to the MCP transport
         if not app_path.startswith("/.well-known/"):
             if app_path == "/mcp":
-                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
-                scope["path"] = new_path
-                if "raw_path" in scope:
-                    scope["raw_path"] = new_path.encode("latin-1")
+                self._apply_mcp_rewrite(scope, root_path)
                 await self.application(scope, receive, send)
                 return
-            if (app_path.endswith("/mcp") and app_path != "/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
+            if app_path.endswith("/mcp") or (app_path.endswith("/mcp/") and app_path != "/mcp/"):
                 # SECURITY: Only rewrite recognised MCP paths — /servers/{id}/mcp.
                 # Arbitrary prefixes (e.g. /foo/mcp) must NOT be rewritten to
                 # /mcp/ as that would expose the global MCP transport under
@@ -2980,13 +2984,27 @@ class MCPPathRewriteMiddleware:
                     return
                 # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
                 # Preserve root_path prefix when rewriting
-                new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
-                scope["path"] = new_path
-                if "raw_path" in scope:
-                    scope["raw_path"] = new_path.encode("latin-1")
+                self._apply_mcp_rewrite(scope, root_path)
                 await self.application(scope, receive, send)
                 return
         await self.application(scope, receive, send)
+
+    @staticmethod
+    def _apply_mcp_rewrite(scope, root_path: str) -> str:
+        """Rewrite a validated MCP transport path to the mounted /mcp/ app path."""
+        original_path = scope.get("path", "")
+        new_path = f"{root_path}/mcp/" if root_path else "/mcp/"
+        scope["path"] = new_path
+
+        if "raw_path" in scope:
+            try:
+                # ASGI raw_path stores raw octets; latin-1 preserves a 1:1 byte mapping for valid values.
+                scope["raw_path"] = new_path.encode("latin-1")
+            except (UnicodeEncodeError, ValueError):
+                logger.warning("MCPPathRewriteMiddleware: non-latin-1 raw_path skipped for %s", new_path)
+
+        logger.debug("MCPPathRewriteMiddleware: %s -> %s", original_path, new_path)
+        return new_path
 
 
 # Configure CORS with environment-aware origins

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -2996,6 +2996,22 @@ class TestMCPPathRewriteMiddleware:
         assert response.status_code == 200
         assert response.headers.get("location") is None
 
+    def test_rewrite_exact_mcp_post_avoids_starlette_mount_redirect(self):
+        """POST /mcp is normalized the same way as GET for Streamable HTTP."""
+
+        async def mounted_app(scope, receive, send):
+            response = StarletteResponse("ok")
+            await response(scope, receive, send)
+
+        app_with_mount = Starlette(routes=[Mount("/mcp", app=mounted_app)])
+        middleware = MCPPathRewriteMiddleware(app_with_mount)
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            response = TestClient(middleware).post("/mcp", content=b"{}", follow_redirects=False)
+
+        assert response.status_code == 200
+        assert response.headers.get("location") is None
+
     @pytest.mark.asyncio
     async def test_rewrite_exact_mcp_path_updates_raw_path(self):
         """Exact /mcp normalization keeps raw_path aligned with path."""
@@ -3010,6 +3026,30 @@ class TestMCPPathRewriteMiddleware:
 
         assert scope["path"] == "/mcp/"
         assert scope["raw_path"] == b"/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_rewrite_exact_mcp_path_skips_non_latin_raw_path(self, caplog):
+        """Malformed proxy prefixes must not crash raw_path byte alignment."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/gateway/中/mcp",
+            "root_path": "/gateway/中",
+            "raw_path": b"/gateway/%E4%B8%AD/mcp",
+            "headers": [],
+        }
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        caplog.set_level("WARNING")
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/gateway/中/mcp/"
+        assert scope["raw_path"] == b"/gateway/%E4%B8%AD/mcp"
+        assert any("non-latin-1 raw_path skipped" in rec.message for rec in caplog.records)
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio
@@ -3078,6 +3118,27 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio
+    async def test_well_known_mcp_suffix_with_root_path_is_not_rewritten(self):
+        """Root-path-stripped well-known metadata URLs must not hit the MCP transport."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {
+            "type": "http",
+            "path": "/gateway/.well-known/oauth-protected-resource/servers/123/mcp",
+            "root_path": "/gateway",
+            "headers": [],
+        }
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/.well-known/oauth-protected-resource/servers/123/mcp"
+        assert scope["path"] == "/gateway/.well-known/oauth-protected-resource/servers/123/mcp"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
     async def test_rewrite_mcp_path(self):
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
@@ -3118,6 +3179,22 @@ class TestMCPPathRewriteMiddleware:
         with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=False)):
             await middleware._call_streamable_http(scope, receive, send)
 
+        app_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exact_mcp_auth_failure_blocks_rewrite(self):
+        """Exact /mcp auth failures return before normalization mutates the scope."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=False)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope.get("path") == "/mcp"
+        assert "modified_path" not in scope
         app_mock.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -2963,6 +2963,87 @@ class TestMCPPathRewriteMiddleware:
     """Cover MCPPathRewriteMiddleware branches."""
 
     @pytest.mark.asyncio
+    async def test_rewrite_exact_mcp_path_prevents_mount_redirect(self):
+        """Exact /mcp is internally normalized so Starlette Mount cannot emit 307."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/mcp"
+        assert scope["path"] == "/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_exact_mcp_path_with_root_path_preserves_prefix(self):
+        """Exact /mcp normalization preserves reverse-proxy root_path prefixes."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/gateway/mcp", "root_path": "/gateway", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/mcp"
+        assert scope["path"] == "/gateway/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_exact_mcp_path_with_app_root_path_preserves_prefix(self):
+        """Exact /mcp normalization also works when APP_ROOT_PATH supplies the prefix."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/gateway/mcp", "root_path": "", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.config.settings.app_root_path", "/gateway"):
+            with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+                await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/mcp"
+        assert scope["path"] == "/gateway/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_exact_mcp_with_trailing_slash_passes_through(self):
+        """Exact /mcp/ is already canonical and should not be rewritten again."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/mcp/", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/mcp/"
+        assert scope["path"] == "/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_well_known_mcp_suffix_is_not_rewritten(self):
+        """RFC 9728 well-known resource URLs ending in /mcp must not hit the MCP transport."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/.well-known/oauth-protected-resource/servers/123/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["modified_path"] == "/.well-known/oauth-protected-resource/servers/123/mcp"
+        assert scope["path"] == "/.well-known/oauth-protected-resource/servers/123/mcp"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
     async def test_rewrite_mcp_path(self):
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -29,7 +29,9 @@ from fastapi.testclient import TestClient
 import orjson
 import pytest
 import sqlalchemy as sa
+from starlette.applications import Starlette
 from starlette.responses import Response as StarletteResponse
+from starlette.routing import Mount
 
 # First-Party
 from mcpgateway.common.models import LogLevel
@@ -2978,6 +2980,38 @@ class TestMCPPathRewriteMiddleware:
         assert scope["path"] == "/mcp/"
         app_mock.assert_called_once_with(scope, receive, send)
 
+    def test_rewrite_exact_mcp_path_avoids_starlette_mount_redirect(self):
+        """Exact /mcp reaches the mounted app without Starlette returning 307."""
+
+        async def mounted_app(scope, receive, send):
+            response = StarletteResponse("ok")
+            await response(scope, receive, send)
+
+        app_with_mount = Starlette(routes=[Mount("/mcp", app=mounted_app)])
+        middleware = MCPPathRewriteMiddleware(app_with_mount)
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            response = TestClient(middleware).get("/mcp", follow_redirects=False)
+
+        assert response.status_code == 200
+        assert response.headers.get("location") is None
+
+    @pytest.mark.asyncio
+    async def test_rewrite_exact_mcp_path_updates_raw_path(self):
+        """Exact /mcp normalization keeps raw_path aligned with path."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/mcp", "raw_path": b"/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/mcp/"
+        assert scope["raw_path"] == b"/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
     @pytest.mark.asyncio
     async def test_exact_mcp_path_with_root_path_preserves_prefix(self):
         """Exact /mcp normalization preserves reverse-proxy root_path prefixes."""
@@ -3055,6 +3089,22 @@ class TestMCPPathRewriteMiddleware:
             await middleware._call_streamable_http(scope, receive, send)
 
         assert scope["path"] == "/mcp/"
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_rewrite_server_mcp_path_updates_raw_path(self):
+        """Server-scoped MCP rewrites keep raw_path aligned with path."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/servers/123/mcp", "raw_path": b"/servers/123/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("mcpgateway.main.streamable_http_auth", new=AsyncMock(return_value=True)):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert scope["path"] == "/mcp/"
+        assert scope["raw_path"] == b"/mcp/"
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Normalize MCP mount rewrites before Starlette can emit a trailing-slash `307` redirect, and keep ASGI `raw_path` aligned when the middleware rewrites MCP transport paths.

This prevents exact `GET /mcp` probes from being converted into a framework-level redirect before they reach the MCP transport.

## Motivation

Fixes #4441.

The MCP Streamable HTTP transport allows `GET /mcp` to either:

- return `200` with `Content-Type: text/event-stream`, or
- return `405 Method Not Allowed` when the server does not offer an SSE stream at that endpoint.

A `307` redirect is not a valid transport response for that probe. The issue points to the Python/Starlette gateway layer as the source of the redirect, not the Rust MCP runtime.

The root cause is Starlette mount behavior: an exact `/mcp` request against `app.mount("/mcp", ...)` is redirected to `/mcp/`. ContextForge already has `MCPPathRewriteMiddleware` in front of the mounted transport, so this patch normalizes the exact `/mcp` path there after authentication.

I also noticed #4282, which addresses the same redirect class. This PR follows the same fix direction and adds extra coverage for the actual Starlette mount behavior, `APP_ROOT_PATH`, canonical `/mcp/` pass-through, RFC 9728 well-known path exclusion, and `raw_path` alignment.

## Changes

- Normalize exact `/mcp` to `/mcp/` in `MCPPathRewriteMiddleware`.
- Preserve reverse-proxy prefixes when `root_path` or `APP_ROOT_PATH` is set.
- Keep ASGI `raw_path` aligned with rewritten `/mcp/` paths when present.
- Leave already-canonical `/mcp/` unchanged.
- Keep RFC 9728 well-known URLs ending in `/mcp` out of the MCP transport rewrite path.
- Add a regression test that wires the middleware in front of a real Starlette `Mount("/mcp", ...)` and verifies `/mcp` no longer returns a `Location` redirect.
- Add unit coverage for exact `/mcp`, `root_path`, `APP_ROOT_PATH`, canonical `/mcp/`, well-known URI boundaries, and `raw_path` synchronization.

## Test Plan

- `uv run --group dev pytest tests/unit/mcpgateway/test_main_extended.py::TestMCPPathRewriteMiddleware -q`
  - Result: `22 passed`
- `uv run --group dev pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_streamable_http_auth_requires_auth_for_trailing_slash_variants tests/unit/mcpgateway/transports/test_streamablehttp_transport.py::test_streamable_http_auth_skips_well_known_rfc9728_even_when_strict -q`
  - Result: `5 passed`
- `uv run --group dev pytest tests/unit/mcpgateway/test_main_extended.py -q`
  - Result: passed
- `uv run python -m py_compile mcpgateway/main.py tests/unit/mcpgateway/test_main_extended.py`
  - Result: passed
- `uv run ruff check mcpgateway/main.py`
  - Result: passed
- `git diff --check`
  - Result: passed
- ASGI smoke test with Edge-mode environment variables and no Rust sidecar:
  - Before this patch: `/mcp -> 307 Location: /mcp/`
  - After this patch: `/mcp -> 502` and `/mcp/ -> 502`, both without `Location`
  - The `502` is expected in this local smoke test because the Rust MCP sidecar is not running; the relevant regression check is that `/mcp` no longer returns `307`.

I also ran:

- `uv run --group dev pytest tests/protocol_compliance/test_transport_semantics.py::test_get_mcp_returns_sse_stream_or_405 -q`
  - Result: skipped because no live gateway is running at `http://127.0.0.1:8080`.

Running Ruff on the full `tests/unit/mcpgateway/test_main_extended.py` file still reports existing findings outside this diff, so this patch avoids mixing unrelated cleanup into the bug fix.

## Risk

Low. The change is scoped to MCP transport paths after MCP authentication has already succeeded.

It does not broaden arbitrary path rewrites. Non-server paths such as `/foo/mcp` still pass through unchanged, and well-known OAuth metadata paths remain excluded from MCP transport rewriting.

The `raw_path` update mirrors the rewritten `path` value so downstream ASGI consumers do not see inconsistent path metadata after middleware normalization.

## Related Issue

Fixes #4441.

Related: #4282.

## Maintainer Context

This keeps the fix in the existing MCP path normalization layer instead of changing the MCP transport, Rust runtime proxy, or Nginx configuration.

The patch is intentionally small and includes boundary tests for reverse-proxy prefixes, ASGI raw path metadata, already-canonical MCP paths, and non-MCP metadata paths so the redirect fix does not expand the public route surface.

If maintainers prefer the implementation in #4282, the additional regression and boundary tests in this PR can be reused directly.
