### PR TITLE
fix(gateways): resources not fetched from gateway

### DIFF
--- a/mcpgateway/admin_ui/gateways.js
+++ b/mcpgateway/admin_ui/gateways.js
@@ -1805,8 +1805,13 @@ export const refreshGatewayTools = async function (gatewayId, gatewayName, butto
   }
 
   try {
+    const params = new URLSearchParams({
+      include_resources: "true",
+      include_prompts: "true",
+    });
+
     const response = await fetch(
-      `${window.ROOT_PATH}/gateways/${gatewayId}/tools/refresh`,
+      `${window.ROOT_PATH}/gateways/${gatewayId}/tools/refresh?${params.toString()}`,
       {
         method: "POST",
         credentials: "include", // pragma: allowlist secret
@@ -1893,8 +1898,13 @@ export const refreshToolsForSelectedGateways = async function(buttonEl) {
   await Promise.allSettled(
     realGwIds.map(async (gid) => {
       try {
+        const params = new URLSearchParams({
+          include_resources: "true",
+          include_prompts: "true",
+        });
+
         const res = await fetch(
-          `${window.ROOT_PATH}/gateways/${gid}/tools/refresh`,
+          `${window.ROOT_PATH}/gateways/${gid}/tools/refresh?${params.toString()}`,
           {
             method: "POST",
             credentials: "include", // pragma: allowlist secret

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -7156,8 +7156,8 @@ async def delete_gateway(gateway_id: str, request: Request, db: Session = Depend
 async def refresh_gateway_tools(
     gateway_id: str,
     request: Request,
-    include_resources: bool = Query(False, description="Include resources in refresh"),
-    include_prompts: bool = Query(False, description="Include prompts in refresh"),
+    include_resources: bool = Query(True, description="Include resources in refresh"),
+    include_prompts: bool = Query(True, description="Include prompts in refresh"),
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
 ) -> GatewayRefreshResponse:


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4288

---

## 📝 Summary
Fixes a regression where refreshing an MCP Gateway from the admin UI only refreshed tools and could silently skip MCP resources and prompts.

This change updates the admin UI refresh calls in [`refreshGatewayTools()`](mcpgateway/admin_ui/gateways.js:1800) and [`refreshToolsForSelectedGateways()`](mcpgateway/admin_ui/gateways.js:1877) to explicitly request resource and prompt refreshes. It also makes the backend refresh route in [`refresh_gateway_tools()`](mcpgateway/main.py:6719) default to refreshing resources and prompts so future callers do not accidentally trigger a tools-only refresh.

As a result, MCP resources exposed by a gateway are fetched again during UI-driven refresh flows and should appear correctly in the ContextForge UI.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
- Updated [`mcpgateway/admin_ui/gateways.js`](mcpgateway/admin_ui/gateways.js) so refresh requests include `include_resources=true` and `include_prompts=true`.
- Updated [`mcpgateway/main.py`](mcpgateway/main.py:6722) so the refresh endpoint defaults to including resources and prompts.