### PR TITLE
fix: add rust coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8539,7 +8539,8 @@ upgrade-validate:                         ## Validate fresh + upgrade DB startup
 # help: rust-doc                              - Build Rust documentation
 # help: rust-vet                              - Run cargo vet (strict supply-chain auditing)
 # help: rust-licenses                         - Run cargo-deny license check
-# help: rust-coverage                         - Run coverage (cargo-llvm-cov)
+# help: rust-coverage                         - Run coverage (terminal, HTML, Cobertura XML)
+# help: rust-diff-cover                       - Run changed-line coverage for Rust
 # help: rust-clean                            - Clean Rust build artifacts and uninstall maturin crates
 # help: rust-bench-check                      - Verify benchmarks build (no run; for CI)
 # help:
@@ -8559,7 +8560,7 @@ upgrade-validate:                         ## Validate fresh + upgrade DB startup
 # help: rust-mcp-runtime-run                  - Run the experimental Rust MCP runtime against local gateway /rpc
 # help: -----------------------------------------------------------------------------
 
-.PHONY: rust-build rust-build-check rust-dev rust-test rust-format rust-fmt-check rust-lint rust-check rust-doc rust-clean rust-verify rust-verify-stubs rust-stub-gen rust-licenses rust-vet rust-deny rust-coverage rust-bench-check
+.PHONY: rust-build rust-build-check rust-dev rust-test rust-format rust-fmt-check rust-lint rust-check rust-doc rust-clean rust-verify rust-verify-stubs rust-stub-gen rust-licenses rust-vet rust-deny rust-coverage rust-diff-cover rust-bench-check
 .PHONY: rust-ensure-deps rust-install-deps rust-install-targets rust-install rust-build-wheels rust-uninstall-plugins rust-clean-stubs rust-verify-python-crates
 .PHONY: rust-mcp-runtime-build rust-mcp-runtime-test rust-mcp-runtime-run
 
@@ -8688,8 +8689,20 @@ rust-coverage: rust-ensure-deps         ## Run coverage for Rust workspace
 	@echo "🦀 Running coverage (workspace)..."
 	@command -v cargo-llvm-cov >/dev/null 2>&1 || { echo "Install cargo-llvm-cov: cargo install cargo-llvm-cov"; exit 1; }
 	@mkdir -p coverage
-	@cargo llvm-cov --workspace --cobertura --output-path coverage/cobertura.xml
-	@echo "✅ Coverage written to coverage/cobertura.xml"
+	@cargo llvm-cov --workspace --html --output-dir coverage/rust
+	@cargo llvm-cov report --cobertura --output-path coverage/cobertura.xml
+	@cargo llvm-cov report
+	@echo "✅ Coverage artefacts: HTML in coverage/rust/html/index.html & XML in coverage/cobertura.xml ✔"
+
+rust-diff-cover:                       ## Run changed-line coverage for Rust
+	@echo "📊  Running Rust diff-cover against main branch..."
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@if [ ! -f coverage/cobertura.xml ]; then \
+		echo "ℹ️  No coverage/cobertura.xml found - running rust-coverage first..."; \
+		$(MAKE) --no-print-directory rust-coverage; \
+	fi
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
+		diff-cover coverage/cobertura.xml --compare-branch=main --fail-under=90"
 
 rust-bench-check: rust-ensure-deps      ## Verify benchmarks build (no run; for CI)
 	@echo "🦀 Verifying Rust benchmarks build (no run)..."

--- a/crates/mcp_runtime/DEVELOPING.md
+++ b/crates/mcp_runtime/DEVELOPING.md
@@ -331,7 +331,8 @@ make diff-cover
 For Rust coverage:
 
 ```bash
-make -C crates/mcp_runtime coverage
+make rust-coverage
+make rust-diff-cover
 ```
 
 Coverage guidance:
@@ -340,8 +341,12 @@ Coverage guidance:
 - use `make coverage` when you need to regenerate the full Python coverage set
 - use `make diff-cover` when you need changed-line coverage against the main
   branch
-- use runtime-local `coverage` when you are explicitly improving Rust crate
-  coverage
+- use `make rust-coverage` when you need workspace Rust coverage with terminal,
+  HTML, and Cobertura XML reports
+- use `make rust-diff-cover` when you need Rust changed-line coverage against
+  the main branch
+- use runtime-local `make -C crates/mcp_runtime coverage` only when you are
+  explicitly improving that crate in isolation
 
 ## Benchmarking
 

--- a/tests/unit/test_makefile_rust_targets.py
+++ b/tests/unit/test_makefile_rust_targets.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+MAKEFILE = Path(__file__).resolve().parents[2] / "Makefile"
+RUST_RUNTIME_DEVELOPING = Path(__file__).resolve().parents[2] / "crates" / "mcp_runtime" / "DEVELOPING.md"
+
+
+def _target_body(target: str) -> str:
+    lines = MAKEFILE.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"{target}:"))
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith("\t") and not line.startswith(" "):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _target_commands(target: str) -> list[str]:
+    return [line.strip().removeprefix("@") for line in _target_body(target).splitlines()]
+
+
+def test_rust_coverage_generates_html_xml_and_terminal_report() -> None:
+    body = _target_body("rust-coverage")
+    commands = _target_commands("rust-coverage")
+
+    assert "--html" in body
+    assert "--output-dir coverage/rust" in body
+    assert "--cobertura --output-path coverage/cobertura.xml" in body
+    assert "cargo llvm-cov report" in commands
+    assert "coverage/rust/html/index.html" in body
+
+
+def test_rust_diff_cover_uses_rust_cobertura_xml() -> None:
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+    body = _target_body("rust-diff-cover")
+
+    assert "rust-diff-cover" in makefile
+    assert "rust-diff-cover: rust-ensure-deps" not in makefile
+    assert "coverage/cobertura.xml" in body
+    assert "No coverage/cobertura.xml found - running rust-coverage first" in body
+    assert "$(MAKE) --no-print-directory rust-coverage" in body
+    assert "diff-cover coverage/cobertura.xml --compare-branch=main --fail-under=90" in body
+
+
+def test_rust_runtime_developing_doc_mentions_root_coverage_targets() -> None:
+    docs = RUST_RUNTIME_DEVELOPING.read_text(encoding="utf-8")
+
+    assert "make rust-coverage" in docs
+    assert "make rust-diff-cover" in docs


### PR DESCRIPTION
## Summary

- Update `make rust-coverage` to generate HTML, Cobertura XML, and the terminal coverage table.
- Print the generated Rust coverage report locations in the target output.
- Add `make rust-diff-cover` for changed-line Rust coverage using `coverage/cobertura.xml`.
- Add a small Makefile regression test for the Rust coverage targets.
