### PR TITLE
perf: speed up content pattern scans

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-10T07:43:43Z",
+  "generated_at": "2026-05-10T08:30:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4988,7 +4988,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2891,
+        "line_number": 2897,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -550,9 +550,9 @@ content = "Data: {{ config.secret_key }}"  # Potential server-side template inje
 
 **Performance Optimization:**
 
-- **Pattern Caching**: Compiled regex patterns are cached for 10x performance improvement
-- **Cache Size**: Default 1000 patterns, configurable via `CONTENT_PATTERN_MAX_CACHE_SIZE`
-- **Lazy Compilation**: Patterns compiled on first use
+- **Pattern Caching**: Compiled regex patterns are reused and successful clean validation results are cached for repeated content
+- **Cache Size**: Default 1000 clean validation results, configurable via `CONTENT_PATTERN_MAX_CACHE_SIZE`
+- **Startup Compilation**: Patterns compile once when the content security service initializes
 - **Thread-Safe**: Cache uses threading locks for concurrent access
 
 **Security Checklist:**

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -442,41 +442,18 @@ CONTENT_MAX_PROMPT_SIZE=10240     # 10KB for prompt templates (range: 512B–1MB
 - [ ] Review default size limits for your use case
 - [ ] Monitor 413 responses in logs for legitimate content being blocked
 
-#### Layer 2: PII Detection
+#### Layer 2: PII-Safe Logging
 
-Automatically detect and block Personally Identifiable Information (PII) in resource and prompt content:
+User identifiers are automatically sanitized before being written to audit logs:
 
-```bash
-# Enable PII detection (enabled by default)
-CONTENT_PII_DETECTION_ENABLED=true
+- **Email addresses**: Hashed to an 8-character SHA-256 prefix
+- **IP addresses**: Last octet masked (e.g., `192.168.1.xxx`)
 
-# Configure PII validation mode
-CONTENT_PII_VALIDATION_MODE=strict  # Options: strict, moderate, lenient
-
-# PII detection patterns (default patterns cover common PII types)
-# CONTENT_PII_PATTERNS='["email", "ssn", "credit_card", "phone", "ip_address"]'
-```
-
-**PII Detection Features:**
-
-- **Email addresses**: RFC 5322 compliant pattern
-- **Social Security Numbers**: US SSN format (XXX-XX-XXXX)
-- **Credit card numbers**: Luhn algorithm validation for major card types
-- **Phone numbers**: International formats (E.164)
-- **IP addresses**: IPv4 and IPv6 formats
-- **Custom patterns**: Extensible via configuration
-
-**Validation Modes:**
-
-| Mode | Behavior | Use Case |
-|------|----------|----------|
-| `strict` | Block all PII, no exceptions | Production, high-security environments |
-| `moderate` | Context-aware validation, allow some formats | Development, testing |
-| `lenient` | Log only, don't block | Monitoring, gradual rollout |
+This ensures that security event logs contain enough information for debugging and correlation without exposing raw PII. No additional configuration is required.
 
 #### Layer 3: Malicious Pattern Detection
 
-Detect and block common attack patterns including XSS, template injection, command injection, and SQL injection with **context-aware validation**:
+Detect and block common attack patterns including XSS, template injection, command injection, and SQL injection:
 
 ```bash
 # Enable pattern detection (enabled by default)
@@ -493,60 +470,67 @@ CONTENT_PATTERN_MAX_CACHE_SIZE=1000
 # CONTENT_BLOCKED_PATTERNS='["custom_pattern_1", "custom_pattern_2"]'
 ```
 
-**Context-Aware Validation:**
+**Pattern Detection Behavior:**
 
-The system intelligently distinguishes between legitimate and malicious use of template syntax:
+The system scans all content for malicious patterns. Specific high-risk template patterns
+(such as `{{ config }}` and `${...}`) are blocked globally, while generic template
+variables (such as `{{ user.name }}`) are not blocked. Prompt templates are additionally
+validated for balanced braces and Jinja2 syntax safety.
 
-| Pattern Type | Prompts | Resources | Rationale |
-|--------------|---------|-----------|-----------|
-| Template syntax (`{{ }}`, `{% %}`, `${ }`) | ✅ **ALLOWED** | ❌ **BLOCKED** | Prompts legitimately use template variables; resources could enable SSTI attacks |
-| XSS (`<script>`, `javascript:`) | ❌ **BLOCKED** | ❌ **BLOCKED** | Always dangerous |
-| Command injection (`;`, `&&`, `` ` ``) | ❌ **BLOCKED** | ❌ **BLOCKED** | Always dangerous |
-| SQL injection (`union`, `--`) | ❌ **BLOCKED** | ❌ **BLOCKED** | Always dangerous |
+| Pattern Type | Blocked Globally | Notes |
+|--------------|-----------------|-------|
+| XSS (`<script>`, `javascript:`) | ❌ **BLOCKED** | Always dangerous |
+| Command injection (`&&`, `` ` ``) | ❌ **BLOCKED** | Always dangerous |
+| SQL injection (`union`, `--`) | ❌ **BLOCKED** | Always dangerous |
+| High-risk template (`{{ config }}`, `${...}`) | ❌ **BLOCKED** | Blocks config access and expression evaluation |
+| Generic template variables (`{{ var }}`) | ✅ **ALLOWED** | Legitimate in prompts and resources |
 
 **Example - Legitimate Prompt Template:**
 ```python
-# ✅ This is ALLOWED in prompts
+# ✅ This is ALLOWED
 template = "Hello {{ user.name }}, welcome to {{ company }}!"
 ```
 
-**Example - Potential SSTI Attack in Resource:**
+**Example - Potential SSTI Attack:**
 ```python
-# ❌ This is BLOCKED in resources
+# ❌ This is BLOCKED
 content = "Data: {{ config.secret_key }}"  # Potential server-side template injection
 ```
 
-**Default Attack Patterns (12 patterns):**
+**Default Attack Patterns:**
 
-1. **XSS Attacks** (3 patterns) - **Always blocked**:
+1. **XSS Attacks** (4 patterns) - **Always blocked**:
    - Script tag injection: `<script[^>]*>.*?</script>`
    - Event handler injection: `on\w+\s*=`
    - JavaScript protocol: `javascript:`
+   - Iframe injection: `<iframe[^>]*>`
 
-2. **Template Injection** (3 patterns) - **Context-aware**:
-   - Jinja2/Django: `\{\{.*?\}\}|\{%.*?%\}`
-   - Mustache/Handlebars: `\{\{.*?\}\}`
-   - Expression evaluation: `\$\{.*?\}`
+2. **Command Injection** (4 patterns) - **Always blocked**:
+   - Dangerous rm command: `;\s*rm\s+-rf`
+   - Command chaining: `&&|\|\|`
+   - Backtick execution: `` `[^`]+` ``
+   - Command substitution: `\$\([^)]+\)`
 
-3. **Command Injection** (3 patterns) - **Always blocked**:
-   - Shell metacharacters: `[;&|`$()]`
-   - Command chaining: `&&|\|\||;`
-   - Backtick execution: `` `.*?` ``
+3. **SQL Injection** (3 patterns) - **Always blocked**:
+   - SQL keywords: `(?i)(union|select|insert|update|delete|drop)\s+`
+   - Comment injection: `--\s*$`
+   - Classic injection: `'\s*or\s*'1'\s*=\s*'1`
 
-4. **SQL Injection** (3 patterns) - **Always blocked**:
-   - SQL keywords: `(union|select|insert|update|delete|drop|create|alter)\s`
-   - Comment injection: `--|\#|/\*|\*/`
-   - String concatenation: `'\s*(or|and)\s*'`
+4. **Template Injection** (4 patterns) - **High-risk patterns only**:
+   - Jinja2 config object access: `\{\{\s*config\s*\}\}`
+   - Jinja2 config attribute access: `\{\{\s*config\.`
+   - Jinja2 config loops: `\{%\s*for\s+\w+\s+in\s+config`
+   - Expression evaluation: `\$\{.*\}`
 
 **Validation Modes:**
 
 | Mode | Behavior | Use Case |
 |------|----------|----------|
-| `strict` | Block patterns with context-awareness | Production (recommended) |
-| `moderate` | Same as strict (context-aware) | Production |
+| `strict` | Block high-risk patterns | Production (recommended) |
+| `moderate` | Same as strict | Production |
 | `lenient` | Log only, don't block | Monitoring, testing |
 
-**Note**: Both `strict` and `moderate` modes use context-aware validation. The distinction is maintained for future enhancements.
+**Note**: Both `strict` and `moderate` modes block the same set of high-risk patterns. The distinction is maintained for future enhancements.
 
 **Performance Optimization:**
 
@@ -594,7 +578,7 @@ Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' c
 The 6-layer approach ensures that even if one layer is bypassed, other layers provide protection. For example:
 
 1. Size limits prevent DoS before content is processed
-2. PII detection blocks sensitive data leakage
+2. PII-safe logging prevents sensitive data exposure in audit trails
 3. Pattern detection catches attack attempts
 4. Sanitization removes dangerous elements
 5. Output encoding prevents injection
@@ -604,8 +588,8 @@ The 6-layer approach ensures that even if one layer is bypassed, other layers pr
 
 All content security violations are logged with:
 
-- Violation type (size, PII, pattern, etc.)
-- Sanitized user identifier (email masked)
+- Violation type (size, pattern, etc.)
+- Sanitized user identifier (email hashed, IP masked)
 - Timestamp and correlation ID
 - Attack classification (XSS, SQLi, etc.)
 - Validation mode and action taken
@@ -617,7 +601,7 @@ All content security violations are logged with:
   "timestamp": "2026-03-27T12:00:00Z",
   "level": "WARNING",
   "message": "Content pattern violation detected",
-  "user": "user@*****.com",
+  "user_hash": "a1b2c3d4",
   "violation_type": "xss_script_tag",
   "validation_mode": "strict",
   "action": "blocked",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2260,7 +2260,7 @@ class Settings(BaseSettings):
     )
     content_pattern_validation_mode: str = Field(
         default="strict",
-        description="Validation mode for pattern detection (US-3): 'strict' (block), 'moderate' (warn+block), 'lenient' (warn only).",
+        description="Validation mode for pattern detection (US-3): 'strict' (warn+block), 'moderate' (same as strict), 'lenient' (warn only).",
     )
     content_blocked_patterns: List[str] = Field(
         default_factory=lambda: [

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2288,7 +2288,13 @@ class Settings(BaseSettings):
     )
     content_pattern_cache_enabled: bool = Field(
         default=True,
-        description="Enable caching of pattern validation results (US-3). Improves performance by caching validation outcomes.",
+        description="Enable caching of successful clean pattern validation results (US-3). Improves performance for repeated clean content without caching malicious detections.",
+    )
+    content_pattern_max_cache_size: int = Field(
+        default=1000,
+        ge=0,
+        le=100000,
+        description="Maximum number of successful clean pattern validation results to cache in memory. Set 0 to disable clean-result caching.",
     )
     content_pattern_max_scan_size: int = Field(
         default=200_000,
@@ -2298,7 +2304,7 @@ class Settings(BaseSettings):
     content_pattern_regex_timeout: float = Field(
         default=1.0,
         gt=0.0,
-        description="Per-pattern regex execution timeout in seconds (US-3). Used natively on Python 3.13+ via re.search(..., timeout=) and as a soft thread-join timeout on older Pythons. Primary ReDoS defense is content_pattern_max_scan_size; this is defense-in-depth.",
+        description="Per-pattern regex execution timeout in seconds (US-3) for custom configured patterns via a soft thread-join timeout. Default built-in patterns use direct search; primary ReDoS defense is content_pattern_max_scan_size.",
     )
 
     # Timeout for SSE task group cleanup (seconds).

--- a/mcpgateway/services/content_security.py
+++ b/mcpgateway/services/content_security.py
@@ -20,7 +20,7 @@ import threading
 from typing import List, Optional, Union
 
 # First-Party
-from mcpgateway.config import settings
+from mcpgateway.config import settings, Settings
 
 # Import metrics with error handling for test environments
 try:
@@ -48,22 +48,6 @@ except ImportError:
     content_size_violations_counter = NoOpCounter()
     content_type_violations_counter = NoOpCounter()
 
-
-# Some Python builds may expose a native ``timeout`` keyword for regex search,
-# but support is a runtime capability, not something we can safely infer from
-# ``sys.version_info``.  Python 3.13.11, for example, still raises TypeError for
-# ``re.Pattern.search(..., timeout=...)``.  Probe the actual stdlib regex engine
-# once at import time and fall back to the soft thread-join timeout when absent.
-def _supports_native_regex_timeout() -> bool:
-    """Return whether stdlib regex search accepts the ``timeout`` keyword."""
-    try:
-        re.compile("x").search("x", timeout=0.001)  # type: ignore[call-arg]  # pylint: disable=unexpected-keyword-arg
-    except TypeError:
-        return False
-    return True
-
-
-_HAS_NATIVE_REGEX_TIMEOUT: bool = _supports_native_regex_timeout()
 
 logger = logging.getLogger(__name__)
 
@@ -322,6 +306,12 @@ class ContentSecurityService:
             settings.content_blocked_template_patterns,
             pattern_kind="content_blocked_template_patterns",
         )
+        self._clean_pattern_cache: dict[str, None] = {}
+        self._clean_pattern_cache_lock = threading.Lock()
+        self._clean_pattern_cache_max_entries = settings.content_pattern_max_cache_size
+        self._blocked_patterns_signature = self._patterns_signature(settings.content_blocked_patterns)
+        self._use_blocked_pattern_timeout = settings.content_blocked_patterns != self._default_settings_list("content_blocked_patterns")
+        self._use_template_pattern_timeout = settings.content_blocked_template_patterns != self._default_settings_list("content_blocked_template_patterns")
         logger.info(
             "ContentSecurityService initialized",
             extra={
@@ -332,8 +322,22 @@ class ContentSecurityService:
                 "compiled_blocked_patterns": len(self._compiled_blocked_patterns),
                 "compiled_template_patterns": len(self._compiled_template_patterns),
                 "pattern_max_scan_size": settings.content_pattern_max_scan_size,
+                "pattern_cache_max_entries": self._clean_pattern_cache_max_entries,
             },
         )
+
+    @staticmethod
+    def _default_settings_list(field_name: str) -> List[str]:
+        """Return the configured Settings default list for a field."""
+        field = Settings.model_fields[field_name]
+        if field.default_factory is None:
+            return list(field.default or [])
+        return list(field.default_factory())
+
+    @staticmethod
+    def _patterns_signature(raw_patterns: List[str]) -> str:
+        """Return a stable signature for the active pattern list."""
+        return hashlib.sha256("\n".join(raw_patterns).encode("utf-8")).hexdigest()
 
     @staticmethod
     def _compile_patterns(raw_patterns: List[str], pattern_kind: str) -> List[tuple[str, re.Pattern]]:
@@ -418,6 +422,17 @@ class ContentSecurityService:
             raise captured_exception
 
         return result[0]
+
+    def _search_compiled_pattern(self, pattern, content: str, timeout: float = 1.0, enforce_timeout: bool = False):
+        """Search a compiled regex, optionally using the legacy soft timeout wrapper.
+
+        Default project patterns use direct search for the hot path. Custom
+        operator-provided patterns retain the pre-existing thread-join timeout
+        behavior because they may have unknown ReDoS characteristics.
+        """
+        if enforce_timeout:
+            return self._regex_search_with_timeout(pattern, content, timeout=timeout)
+        return pattern.search(content)
 
     def _normalize_input(self, content: str) -> str:
         """Normalize input to prevent encoding bypass attacks (CWE-116).
@@ -704,14 +719,27 @@ class ContentSecurityService:
                 violation_type="content_too_large_to_scan",
             )
 
+        cache_key = None
+        if settings.content_pattern_cache_enabled and self._clean_pattern_cache_max_entries > 0:
+            cache_key = ":".join(
+                [
+                    validation_mode,
+                    str(max_scan_size),
+                    self._blocked_patterns_signature,
+                    hashlib.sha256(normalized_content.encode("utf-8")).hexdigest(),
+                ]
+            )
+            with self._clean_pattern_cache_lock:
+                if cache_key in self._clean_pattern_cache:
+                    return
+
+        found_violation = False
         for raw_pattern, compiled in self._compiled_blocked_patterns:
             try:
-                if _HAS_NATIVE_REGEX_TIMEOUT:
-                    match = compiled.search(normalized_content, timeout=regex_timeout)  # pylint: disable=unexpected-keyword-arg
-                else:
-                    match = self._regex_search_with_timeout(compiled, normalized_content, timeout=regex_timeout)
+                match = self._search_compiled_pattern(compiled, normalized_content, timeout=regex_timeout, enforce_timeout=self._use_blocked_pattern_timeout)
 
                 if match:
+                    found_violation = True
                     # Determine violation type from pattern
                     violation_type = self._classify_violation(raw_pattern, match.group(0))
 
@@ -758,6 +786,12 @@ class ContentSecurityService:
                     content_type=content_type,
                     violation_type="redos_timeout",
                 )
+
+        if cache_key is not None and not found_violation:
+            with self._clean_pattern_cache_lock:
+                if len(self._clean_pattern_cache) >= self._clean_pattern_cache_max_entries:
+                    self._clean_pattern_cache.pop(next(iter(self._clean_pattern_cache)))
+                self._clean_pattern_cache[cache_key] = None
 
     def _classify_violation(self, pattern: str, matched_text: str) -> str:
         """Classify violation type based on pattern and matched text.
@@ -854,10 +888,7 @@ class ContentSecurityService:
         regex_timeout = settings.content_pattern_regex_timeout
         for raw_pattern, compiled in self._compiled_template_patterns:
             try:
-                if _HAS_NATIVE_REGEX_TIMEOUT:
-                    match = compiled.search(template, timeout=regex_timeout)  # pylint: disable=unexpected-keyword-arg
-                else:
-                    match = self._regex_search_with_timeout(compiled, template, timeout=regex_timeout)
+                match = self._search_compiled_pattern(compiled, template, timeout=regex_timeout, enforce_timeout=self._use_template_pattern_timeout)
             except TimeoutError:
                 sanitized = _sanitize_pii_for_logging(user_email, ip_address)
                 logger.error("Template pattern matching timeout - possible ReDoS", extra={"template_name": template_name, "pattern_length": len(raw_pattern), **sanitized})

--- a/mcpgateway/services/content_security.py
+++ b/mcpgateway/services/content_security.py
@@ -337,7 +337,8 @@ class ContentSecurityService:
     @staticmethod
     def _patterns_signature(raw_patterns: List[str]) -> str:
         """Return a stable signature for the active pattern list."""
-        return hashlib.sha256("\n".join(raw_patterns).encode("utf-8")).hexdigest()
+        # Use null delimiter to avoid ambiguity when patterns contain newlines
+        return hashlib.sha256("\0".join(raw_patterns).encode("utf-8")).hexdigest()
 
     @staticmethod
     def _compile_patterns(raw_patterns: List[str], pattern_kind: str) -> List[tuple[str, re.Pattern]]:
@@ -361,10 +362,11 @@ class ContentSecurityService:
         return compiled
 
     def _regex_search_with_timeout(self, pattern, content: str, timeout: float = 1.0):
-        """Execute regex search with timeout protection for Python < 3.13.
+        """Execute regex search with best-effort timeout detection.
 
-        Uses threading to implement timeout for regex operations that don't
-        natively support it. This prevents ReDoS attacks on Python 3.11/3.12.
+        Uses threading to implement a soft timeout for regex operations. Because
+        CPython's re engine holds the GIL during backtracking, this is a
+        best-effort defense and may not abort pathological regex promptly.
 
         Args:
             pattern: Regex pattern to search for. Accepts either a raw source
@@ -429,6 +431,10 @@ class ContentSecurityService:
         Default project patterns use direct search for the hot path. Custom
         operator-provided patterns retain the pre-existing thread-join timeout
         behavior because they may have unknown ReDoS characteristics.
+
+        Note: CPython's re engine holds the GIL during backtracking, so the
+        thread-join timeout is a *soft* timeout. Custom patterns should be
+        authored to avoid catastrophic backtracking.
         """
         if enforce_timeout:
             return self._regex_search_with_timeout(pattern, content, timeout=timeout)
@@ -663,8 +669,8 @@ class ContentSecurityService:
 
         Scans content for XSS, command injection, SQL injection, and template injection patterns.
         Behavior depends on content_pattern_validation_mode:
-        - strict: Raises ContentPatternError on detection
-        - moderate: Logs warning and raises ContentPatternError
+        - strict: Logs warning and raises ContentPatternError on detection
+        - moderate: Same as strict (maintained for future enhancements)
         - lenient: Logs warning only, allows content
 
         Args:
@@ -789,9 +795,10 @@ class ContentSecurityService:
 
         if cache_key is not None and not found_violation:
             with self._clean_pattern_cache_lock:
-                if len(self._clean_pattern_cache) >= self._clean_pattern_cache_max_entries:
-                    self._clean_pattern_cache.pop(next(iter(self._clean_pattern_cache)))
-                self._clean_pattern_cache[cache_key] = None
+                if cache_key not in self._clean_pattern_cache:
+                    if len(self._clean_pattern_cache) >= self._clean_pattern_cache_max_entries:
+                        self._clean_pattern_cache.pop(next(iter(self._clean_pattern_cache)))
+                    self._clean_pattern_cache[cache_key] = None
 
     def _classify_violation(self, pattern: str, matched_text: str) -> str:
         """Classify violation type based on pattern and matched text.

--- a/tests/performance/test_content_security_benchmark.py
+++ b/tests/performance/test_content_security_benchmark.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Benchmark content security pattern scanning.
+
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Usage:
+    uv run python scripts/benchmark_content_security.py --mode latency
+    uv run python scripts/benchmark_content_security.py --mode service-rps
+    uv run python scripts/benchmark_content_security.py --mode http-e2e
+    uv run python scripts/benchmark_content_security.py --mode all
+"""
+
+# Standard
+import argparse
+import http.client
+import json
+import os
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable
+
+SMALL_CONTENT = "clean end to end prompt content"
+TEN_KB_CONTENT = ("clean end to end prompt content without blocked patterns\n" * 190)[:10_000]
+HUNDRED_KB_CONTENT = ("clean resource line with ordinary text and no blocked patterns\n" * 1800)[:100_000]
+JWT_SECRET = "e2e-benchmark-secret-key-with-minimum-32-bytes"  # pragma: allowlist secret  # nosec B105 - benchmark-only local secret
+AUTH_SECRET = "e2e-benchmark-encryption-secret-32-bytes"  # pragma: allowlist secret  # nosec B105 - benchmark-only local secret
+
+
+def _content_cases() -> list[tuple[str, str, int]]:
+    """Return shared content benchmark cases."""
+    return [
+        ("small", SMALL_CONTENT, 3_000),
+        ("10kb", TEN_KB_CONTENT, 1_000),
+        ("100kb", HUNDRED_KB_CONTENT, 200),
+    ]
+
+
+def _set_cache(enabled: bool) -> None:
+    """Toggle the clean-result cache when the setting exists."""
+    # First-Party
+    from mcpgateway.config import settings
+
+    if hasattr(settings, "content_pattern_cache_enabled"):
+        settings.content_pattern_cache_enabled = enabled
+
+
+def _service() -> object:
+    """Create a fresh content security service."""
+    # First-Party
+    from mcpgateway.services.content_security import ContentSecurityService
+
+    return ContentSecurityService()
+
+
+def _time_one_call(service: object, content: str, label: str) -> float:
+    """Return one validation call duration in milliseconds."""
+    start = time.perf_counter()
+    service.detect_malicious_patterns(content, content_type=label)
+    return (time.perf_counter() - start) * 1000
+
+
+def run_latency() -> dict[str, dict[str, float]]:
+    """Measure validator latency for first scans and repeated clean scans."""
+    results: dict[str, dict[str, float]] = {}
+    for label, content, _iterations in _content_cases():
+        _set_cache(True)
+        service = _service()
+        first_ms = _time_one_call(service, content, label)
+        samples = [_time_one_call(service, content, label) for _ in range(500)]
+        results[label] = {
+            "first_ms": first_ms,
+            "mean_repeated_ms": statistics.mean(samples),
+            "median_repeated_ms": statistics.median(samples),
+            "min_repeated_ms": min(samples),
+            "max_repeated_ms": max(samples),
+        }
+    return results
+
+
+def _bench_service_rps(label: str, content: str, iterations: int, cache: bool) -> dict[str, float]:
+    """Measure validator operations per second."""
+    _set_cache(cache)
+    service = _service()
+    if cache:
+        service.detect_malicious_patterns(content, content_type=label)
+
+    samples = []
+    for _ in range(5):
+        start = time.perf_counter()
+        for _i in range(iterations):
+            service.detect_malicious_patterns(content, content_type=label)
+        elapsed = time.perf_counter() - start
+        samples.append(iterations / elapsed)
+
+    return {
+        "iterations_per_round": iterations,
+        "median_rps": statistics.median(samples),
+        "min_rps": min(samples),
+        "max_rps": max(samples),
+    }
+
+
+def run_service_rps() -> dict[str, dict[str, float]]:
+    """Measure validator throughput with and without clean cache hits."""
+    results: dict[str, dict[str, float]] = {}
+    for label, content, iterations in _content_cases():
+        results[f"{label}_uncached"] = _bench_service_rps(label, content, iterations, cache=False)
+        results[f"{label}_repeated"] = _bench_service_rps(label, content, iterations, cache=True)
+    return results
+
+
+class GatewayProcess:
+    """Temporary local gateway used for the HTTP end-to-end benchmark."""
+
+    def __init__(self) -> None:
+        """Create temp resources for a live benchmark gateway."""
+        self.db_file = tempfile.NamedTemporaryFile(prefix="mcfg-e2e-bench-", suffix=".db", delete=False)
+        self.db_file.close()
+        self.log_file = tempfile.NamedTemporaryFile(prefix="mcfg-e2e-bench-", suffix=".log", delete=False)
+        self.log_file.close()
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        self.port = sock.getsockname()[1]
+        sock.close()
+        self.proc: subprocess.Popen | None = None
+        self.token = ""
+
+    def _env(self) -> dict[str, str]:
+        """Return gateway benchmark environment."""
+        env = os.environ.copy()
+        env.update(
+            {
+                "AUTH_REQUIRED": "true",
+                "MCP_REQUIRE_AUTH": "true",
+                "MCPGATEWAY_UI_ENABLED": "false",
+                "MCPGATEWAY_ADMIN_API_ENABLED": "false",
+                "DATABASE_URL": f"sqlite:///{self.db_file.name}",
+                "JWT_SECRET_KEY": JWT_SECRET,
+                "BASIC_AUTH_PASSWORD": "StrongPass123!",  # pragma: allowlist secret
+                "AUTH_ENCRYPTION_SECRET": AUTH_SECRET,
+                "LOG_LEVEL": "ERROR",
+            }
+        )
+        return env
+
+    def start(self) -> None:
+        """Start uvicorn and create a benchmark JWT."""
+        self.proc = subprocess.Popen(
+            [sys.executable, "-m", "uvicorn", "mcpgateway.main:app", "--host", "127.0.0.1", "--port", str(self.port), "--log-level", "warning"],
+            stdout=open(self.log_file.name, "w", encoding="utf-8"),
+            stderr=subprocess.STDOUT,
+            env=self._env(),
+        )
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            try:
+                status, _data = self.request("GET", "/health", auth=False)
+                if status == 200:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.25)
+        else:
+            raise RuntimeError(f"Gateway did not become healthy; log={Path(self.log_file.name).read_text(encoding='utf-8')[-2000:]}")
+
+        token_proc = subprocess.run(
+            [sys.executable, "-m", "mcpgateway.utils.create_jwt_token", "--username", "admin@example.com", "--exp", "60", "--secret", JWT_SECRET],
+            env=self._env(),
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        self.token = token_proc.stdout.strip().splitlines()[-1]
+
+    def request(self, method: str, path: str, body: dict | None = None, auth: bool = True) -> tuple[int, bytes]:
+        """Send one HTTP request to the benchmark gateway."""
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=20)
+        payload = None if body is None else json.dumps(body).encode()
+        headers = {}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        if auth:
+            headers["Authorization"] = f"Bearer {self.token}"
+        conn.request(method, path, payload, headers)
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp.status, data
+
+    def close(self) -> None:
+        """Stop gateway and remove temp files."""
+        if self.proc is not None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+        Path(self.db_file.name).unlink(missing_ok=True)
+        Path(self.log_file.name).unlink(missing_ok=True)
+
+
+def _prompt_payload(name: str, template: str) -> dict:
+    """Return a prompt create payload."""
+    return {
+        "prompt": {
+            "name": name,
+            "description": "content security benchmark",
+            "template": template,
+            "arguments": [],
+        },
+        "team_id": None,
+        "visibility": "public",
+    }
+
+
+def _bench_http_case(gateway: GatewayProcess, case: str, template_fn: Callable[[int], str], warmup: int, iterations: int) -> dict[str, float]:
+    """Measure POST /prompts throughput for one HTTP case."""
+    for i in range(warmup):
+        status, data = gateway.request("POST", "/prompts", _prompt_payload(f"warm_{case}_{i}_{time.time_ns()}", template_fn(i)))
+        if status != 200:
+            raise RuntimeError(f"Warmup {case} failed with {status}: {data[:300]!r}")
+
+    samples = []
+    for round_idx in range(5):
+        start = time.perf_counter()
+        for i in range(iterations):
+            status, data = gateway.request("POST", "/prompts", _prompt_payload(f"bench_{case}_{round_idx}_{i}_{time.time_ns()}", template_fn(i + round_idx * iterations)))
+            if status != 200:
+                raise RuntimeError(f"{case} failed with {status}: {data[:300]!r}")
+        elapsed = time.perf_counter() - start
+        samples.append(iterations / elapsed)
+
+    return {
+        "iterations_per_round": iterations,
+        "median_rps": statistics.median(samples),
+        "min_rps": min(samples),
+        "max_rps": max(samples),
+    }
+
+
+def run_http_e2e() -> dict[str, dict[str, float]]:
+    """Measure real HTTP POST /prompts throughput."""
+    gateway = GatewayProcess()
+    try:
+        gateway.start()
+        return {
+            "small_repeated_post_prompts": _bench_http_case(gateway, "small_repeated", lambda _i: SMALL_CONTENT, warmup=10, iterations=80),
+            "10kb_repeated_post_prompts": _bench_http_case(gateway, "10kb_repeated", lambda _i: TEN_KB_CONTENT, warmup=10, iterations=60),
+            "10kb_unique_post_prompts": _bench_http_case(gateway, "10kb_unique", lambda i: f"{TEN_KB_CONTENT}\nunique {i}", warmup=10, iterations=60),
+        }
+    finally:
+        gateway.close()
+
+
+def main() -> None:
+    """Run selected benchmark mode."""
+    parser = argparse.ArgumentParser(description="Benchmark content security validation")
+    parser.add_argument("--mode", choices=["latency", "service-rps", "http-e2e", "all"], default="all")
+    args = parser.parse_args()
+
+    results = {}
+    if args.mode in {"latency", "all"}:
+        results["latency"] = run_latency()
+    if args.mode in {"service-rps", "all"}:
+        results["service_rps"] = run_service_rps()
+    if args.mode in {"http-e2e", "all"}:
+        results["http_e2e"] = run_http_e2e()
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/test_content_security_benchmark.py
+++ b/tests/performance/test_content_security_benchmark.py
@@ -6,10 +6,10 @@ Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 
 Usage:
-    uv run python scripts/benchmark_content_security.py --mode latency
-    uv run python scripts/benchmark_content_security.py --mode service-rps
-    uv run python scripts/benchmark_content_security.py --mode http-e2e
-    uv run python scripts/benchmark_content_security.py --mode all
+    uv run python tests/performance/test_content_security_benchmark.py --mode latency
+    uv run python tests/performance/test_content_security_benchmark.py --mode service-rps
+    uv run python tests/performance/test_content_security_benchmark.py --mode http-e2e
+    uv run python tests/performance/test_content_security_benchmark.py --mode all
 """
 
 # Standard

--- a/tests/unit/mcpgateway/services/test_content_pattern_detection.py
+++ b/tests/unit/mcpgateway/services/test_content_pattern_detection.py
@@ -253,7 +253,8 @@ class TestTimeoutAndEdgeCases:
             pattern = "clean"
             search_calls = 0
 
-            def search(self, content):
+            def search(self, _content):
+                """Count search call."""
                 self.search_calls += 1
 
         pattern = CountingPattern()
@@ -302,6 +303,7 @@ class TestTimeoutAndEdgeCases:
                 self._pattern = pattern
 
             def search(self, content):
+                """Count search call and delegate to wrapped pattern."""
                 nonlocal search_calls
                 search_calls += 1
                 return self._pattern.search(content)
@@ -348,7 +350,7 @@ class TestTimeoutAndEdgeCases:
 
         service.detect_malicious_patterns(content="clean content", content_type="Prompt template")
 
-        assert service._clean_pattern_cache == {}
+        assert not service._clean_pattern_cache
 
     def test_malicious_content_is_not_cached(self, monkeypatch):
         """Repeated malicious scans still evaluate patterns and raise."""
@@ -365,7 +367,7 @@ class TestTimeoutAndEdgeCases:
             with pytest.raises(ContentPatternError):
                 service.detect_malicious_patterns(content="<script>alert(1)</script>", content_type="Resource content")
 
-        assert service._clean_pattern_cache == {}
+        assert not service._clean_pattern_cache
 
     def test_timeout_error_handling(self, monkeypatch):
         """Test TimeoutError is caught and converted to ContentPatternError."""
@@ -381,6 +383,7 @@ class TestTimeoutAndEdgeCases:
             pattern = "timeout"
 
             def search(self, content):
+                """Simulate regex timeout."""
                 raise TimeoutError("Pattern timeout")
 
         with (
@@ -436,13 +439,30 @@ class TestTimeoutAndEdgeCases:
     def test_search_helper_never_passes_timeout_keyword_to_stdlib_re(self):
         """The stdlib re API has no timeout keyword on supported Python versions."""
         # Standard
-        from unittest.mock import MagicMock
+        import re
 
         service = ContentSecurityService()
-        mock_compiled = MagicMock()
-        mock_compiled.search.return_value = None
 
-        with patch.object(service, "_compiled_blocked_patterns", [("test_pattern", mock_compiled)]), patch.object(service, "_regex_search_with_timeout") as mock_fallback:
+        # Wrap a real compiled pattern to record calls and assert no timeout kwarg
+        class SearchRecorder:
+            """Proxy that records search calls and rejects unexpected kwargs."""
+
+            def __init__(self, pattern: re.Pattern):
+                self._pattern = pattern
+                self.search_calls: list[tuple[tuple, dict]] = []
+
+            def search(self, content: str, **kwargs):
+                """Record call and proxy to real pattern, rejecting unexpected kwargs."""
+                if kwargs:
+                    raise TypeError(f"Unexpected keyword arguments: {kwargs}")
+                self.search_calls.append(((content,), kwargs))
+                return self._pattern.search(content)
+
+        real_pattern = re.compile(r"clean")
+        recorder = SearchRecorder(real_pattern)
+
+        with patch.object(service, "_compiled_blocked_patterns", [("test_pattern", recorder)]), patch.object(service, "_regex_search_with_timeout") as mock_fallback:
             service.detect_malicious_patterns(content="Clean content", content_type="Test")
-            assert not mock_fallback.called, "Py3.13+ path incorrectly fell back to thread-based timeout"
-            mock_compiled.search.assert_called_once_with("Clean content")
+            assert not mock_fallback.called, "Default pattern path incorrectly fell back to thread-based timeout"
+            assert len(recorder.search_calls) == 1
+            assert recorder.search_calls[0][0] == ("Clean content",)

--- a/tests/unit/mcpgateway/services/test_content_pattern_detection.py
+++ b/tests/unit/mcpgateway/services/test_content_pattern_detection.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 
 # First-Party
-from mcpgateway.services.content_security import ContentPatternError, ContentSecurityService
+from mcpgateway.services.content_security import ContentPatternError, ContentSecurityService, TemplateValidationError
 
 
 class TestMaliciousPatternDetection:
@@ -129,6 +129,7 @@ class TestMaliciousPatternDetection:
             mock_settings.content_blocked_patterns = [r"<script[^>]*>.*?</script>"]
             mock_settings.content_blocked_template_patterns = []
             mock_settings.content_pattern_max_scan_size = 1_000_000
+            mock_settings.content_pattern_max_cache_size = 1000
             mock_settings.content_pattern_regex_timeout = 1.0
 
             service = ContentSecurityService()
@@ -151,6 +152,7 @@ class TestMaliciousPatternDetection:
             ]
             mock_settings.content_blocked_template_patterns = []
             mock_settings.content_pattern_max_scan_size = 1_000_000
+            mock_settings.content_pattern_max_cache_size = 1000
             mock_settings.content_pattern_regex_timeout = 1.0
 
             service = ContentSecurityService()
@@ -241,18 +243,170 @@ class TestClassifyViolation:
 class TestTimeoutAndEdgeCases:
     """Test timeout handling and edge cases for coverage."""
 
-    def test_timeout_error_handling(self):
-        """Test TimeoutError is caught and converted to ContentPatternError."""
+    def test_python312_clean_scan_uses_direct_compiled_regex(self):
+        """Clean scans with default patterns avoid the thread-per-pattern timeout wrapper."""
         service = ContentSecurityService()
 
-        # Force the thread-based fallback path (Py<3.13 semantics) regardless of
-        # the interpreter the tests are running on, then make that helper raise.
-        with patch("mcpgateway.services.content_security._HAS_NATIVE_REGEX_TIMEOUT", False), patch.object(service, "_regex_search_with_timeout", side_effect=TimeoutError("Pattern timeout")):
+        class CountingPattern:
+            """Pattern wrapper that counts direct search calls."""
+
+            pattern = "clean"
+            search_calls = 0
+
+            def search(self, content):
+                self.search_calls += 1
+
+        pattern = CountingPattern()
+        service._compiled_blocked_patterns = [("clean", pattern)]
+
+        with patch.object(service, "_regex_search_with_timeout") as mock_fallback:
+            mock_fallback.return_value = None
+            service.detect_malicious_patterns(content="Hello world, this is clean content", content_type="Test")
+
+        mock_fallback.assert_not_called()
+        assert pattern.search_calls == 1
+
+    def test_custom_pattern_timeout_wrapper_is_preserved(self, monkeypatch):
+        """Custom operator patterns still use timeout wrapper for ReDoS safety."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_blocked_patterns", [r"(a+)+$"])
+        service = ContentSecurityService()
+
+        with patch.object(service, "_regex_search_with_timeout", side_effect=TimeoutError("Pattern timeout")) as mock_timeout:
+            with pytest.raises(ContentPatternError) as exc_info:
+                service.detect_malicious_patterns(content="a" * 20 + "!", content_type="Test content")
+
+        mock_timeout.assert_called_once()
+        assert exc_info.value.violation_type == "redos_timeout"
+
+    def test_clean_scan_cache_skips_repeated_regex_work(self, monkeypatch):
+        """Repeated clean scans use the advertised content pattern cache."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_pattern_cache_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_detection_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_validation_mode", "strict")
+
+        service = ContentSecurityService()
+        search_calls = 0
+        original_patterns = service._compiled_blocked_patterns
+
+        class CountingPattern:
+            """Pattern wrapper that counts search calls."""
+
+            def __init__(self, pattern):
+                self.pattern = pattern.pattern
+                self._pattern = pattern
+
+            def search(self, content):
+                nonlocal search_calls
+                search_calls += 1
+                return self._pattern.search(content)
+
+        service._compiled_blocked_patterns = [(raw, CountingPattern(compiled)) for raw, compiled in original_patterns]
+
+        content = "This clean prompt is submitted repeatedly"
+        service.detect_malicious_patterns(content=content, content_type="Prompt template")
+        first_call_count = search_calls
+        service.detect_malicious_patterns(content=content, content_type="Prompt template")
+
+        assert first_call_count > 0
+        assert search_calls == first_call_count
+
+    def test_clean_scan_cache_is_bounded(self, monkeypatch):
+        """Clean-result cache evicts old entries at its configured bound."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_pattern_cache_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_detection_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_max_cache_size", 2)
+
+        service = ContentSecurityService()
+        assert service._clean_pattern_cache_max_entries == 2
+
+        service.detect_malicious_patterns(content="clean content 1", content_type="Prompt template")
+        service.detect_malicious_patterns(content="clean content 2", content_type="Prompt template")
+        service.detect_malicious_patterns(content="clean content 3", content_type="Prompt template")
+
+        assert len(service._clean_pattern_cache) == 2
+
+    def test_zero_cache_size_disables_clean_scan_cache(self, monkeypatch):
+        """Cache size 0 disables clean-result cache insertion."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_pattern_cache_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_detection_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_max_cache_size", 0)
+
+        service = ContentSecurityService()
+        assert service._clean_pattern_cache_max_entries == 0
+
+        service.detect_malicious_patterns(content="clean content", content_type="Prompt template")
+
+        assert service._clean_pattern_cache == {}
+
+    def test_malicious_content_is_not_cached(self, monkeypatch):
+        """Repeated malicious scans still evaluate patterns and raise."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_pattern_cache_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_detection_enabled", True)
+        monkeypatch.setattr(settings, "content_pattern_validation_mode", "strict")
+
+        service = ContentSecurityService()
+
+        for _ in range(2):
+            with pytest.raises(ContentPatternError):
+                service.detect_malicious_patterns(content="<script>alert(1)</script>", content_type="Resource content")
+
+        assert service._clean_pattern_cache == {}
+
+    def test_timeout_error_handling(self, monkeypatch):
+        """Test TimeoutError is caught and converted to ContentPatternError."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_blocked_patterns", [r"timeout"])
+        service = ContentSecurityService()
+
+        class TimeoutPattern:
+            """Pattern stub that simulates regex timeout handling."""
+
+            pattern = "timeout"
+
+            def search(self, content):
+                raise TimeoutError("Pattern timeout")
+
+        with (
+            patch.object(service, "_compiled_blocked_patterns", [("timeout", TimeoutPattern())]),
+            patch.object(service, "_regex_search_with_timeout", side_effect=TimeoutError("Pattern timeout")),
+        ):
             with pytest.raises(ContentPatternError) as exc_info:
                 service.detect_malicious_patterns(content="test content", content_type="Test content")
 
             assert exc_info.value.violation_type == "redos_timeout"
             assert exc_info.value.pattern_matched == "[timeout]"
+
+    def test_custom_template_pattern_timeout_wrapper_is_preserved(self, monkeypatch):
+        """Custom template patterns still use timeout wrapper for ReDoS safety."""
+        # First-Party
+        from mcpgateway.config import settings
+
+        monkeypatch.setattr(settings, "content_blocked_template_patterns", [r"(a+)+$"])
+        service = ContentSecurityService()
+
+        with patch.object(service, "_regex_search_with_timeout", side_effect=TimeoutError("Pattern timeout")) as mock_timeout:
+            with pytest.raises(TemplateValidationError) as exc_info:
+                service.validate_prompt_template(template="hello", name="timeout-test")
+
+        mock_timeout.assert_called_once()
+        assert "exceeded timeout" in str(exc_info.value)
 
     def test_fallback_path_no_match(self):
         """Test fallback path when no patterns match (covers line 514 fallback)."""
@@ -270,6 +424,7 @@ class TestTimeoutAndEdgeCases:
             mock_settings.content_blocked_patterns = [r"<script"]
             mock_settings.content_blocked_template_patterns = []
             mock_settings.content_pattern_max_scan_size = 1_000_000
+            mock_settings.content_pattern_max_cache_size = 1000
             mock_settings.content_pattern_regex_timeout = 1.0
 
             service = ContentSecurityService()
@@ -278,14 +433,8 @@ class TestTimeoutAndEdgeCases:
             service.detect_malicious_patterns(content="<script>alert(1)</script>", content_type="Test")
             # If we get here without exception, lenient mode worked
 
-    def test_python313_native_timeout_path_coverage(self):
-        """Cover the Python 3.13+ native `compiled.search(..., timeout=)` branch.
-
-        Stubs the compiled pattern list with a mock whose ``.search`` accepts the
-        timeout kwarg (real re.Pattern.search rejects it on Py<3.13), forces the
-        module-level ``_HAS_NATIVE_REGEX_TIMEOUT`` constant True, and asserts the
-        thread-based fallback helper is not invoked.
-        """
+    def test_search_helper_never_passes_timeout_keyword_to_stdlib_re(self):
+        """The stdlib re API has no timeout keyword on supported Python versions."""
         # Standard
         from unittest.mock import MagicMock
 
@@ -293,11 +442,7 @@ class TestTimeoutAndEdgeCases:
         mock_compiled = MagicMock()
         mock_compiled.search.return_value = None
 
-        with (
-            patch("mcpgateway.services.content_security._HAS_NATIVE_REGEX_TIMEOUT", True),
-            patch.object(service, "_compiled_blocked_patterns", [("test_pattern", mock_compiled)]),
-            patch.object(service, "_regex_search_with_timeout") as mock_fallback,
-        ):
+        with patch.object(service, "_compiled_blocked_patterns", [("test_pattern", mock_compiled)]), patch.object(service, "_regex_search_with_timeout") as mock_fallback:
             service.detect_malicious_patterns(content="Clean content", content_type="Test")
             assert not mock_fallback.called, "Py3.13+ path incorrectly fell back to thread-based timeout"
-            mock_compiled.search.assert_called_once_with("Clean content", timeout=1.0)
+            mock_compiled.search.assert_called_once_with("Clean content")


### PR DESCRIPTION
## 🔗 Related Issue
None

---

## 📝 Summary
Speeds up content security pattern validation by using direct compiled-regex searches for the built-in safe pattern set while preserving the soft timeout wrapper for custom configured regexes.

Adds a bounded cache for successful clean pattern validations, makes the cache size configurable, and updates docs to describe the clean-result cache behavior.

The repeated clean-content gains apply when identical normalized clean content is submitted within the same process. Unique clean-content gains come from avoiding the thread-per-regex timeout wrapper on the built-in pattern set. Custom configured pattern lists still use the existing soft timeout wrapper for ReDoS protection, so they do not take the direct-scan fast path.

---

## 📊 Benchmarks

Three benchmark types were run locally with Python 3.12 using `tests/performance/test_content_security_benchmark.py`.

### 1. Service latency microbenchmark

Directly times `ContentSecurityService.detect_malicious_patterns()` for clean content. This isolates the validator itself and excludes HTTP, auth, DB, and serialization overhead.

| Clean content case | `origin/main` | This branch first scan | First-scan diff | This branch repeated clean cache hit | Cache-hit diff |
|--------------------|---------------|------------------------|-----------------|--------------------------------------|----------------|
| Small text | mean `0.608ms` | first `0.036ms` | `16.9x` faster | mean `0.004ms` | `152.0x` faster |
| 10KB prompt | mean `1.331ms` | first `0.632ms` | `2.1x` faster | mean `0.032ms` | `41.6x` faster |
| 100KB resource | mean `6.54ms` | first `5.94ms` | `1.1x` faster | mean `0.277ms` | `23.6x` faster |

How to run from the PR branch:

```bash
uv run python tests/performance/test_content_security_benchmark.py --mode latency
```

The harness imports `ContentSecurityService`, scans small/10KB/100KB clean strings, records first-scan time, then repeats the same clean input to measure cache-hit latency. To compare against main, run the same command from an `origin/main` checkout.

### 2. Service RPS microbenchmark

Directly measures validator operations/sec for clean content. This isolates validation throughput and excludes HTTP, auth, DB, and serialization overhead.

| Clean content case | `origin/main` | This branch | Diff |
|--------------------|---------------|-------------|------|
| Small text, uncached | `2,354 rps` | `227,599 rps` | `96.7x` |
| Small text, repeated | `2,348 rps` | `506,350 rps` | `215.7x` |
| 10KB prompt, uncached | `780 rps` | `1,361 rps` | `1.7x` |
| 10KB prompt, repeated | `783 rps` | `88,252 rps` | `112.8x` |
| 100KB resource, uncached | `132 rps` | `145 rps` | `1.1x` |
| 100KB resource, repeated | `123 rps` | `10,965 rps` | `89.0x` |

How to run from the PR branch:

```bash
uv run python tests/performance/test_content_security_benchmark.py --mode service-rps
```

The harness imports `ContentSecurityService`, disables the clean-result cache for uncached cases, enables it for repeated cases, and reports median ops/sec over five runs. To compare against main, run the same command from an `origin/main` checkout.

### 3. HTTP end-to-end RPS benchmark

Measured on 2026-04-28 against current `origin/main` (`6ec1992be`). This uses a live uvicorn server, admin JWT authentication, temporary SQLite database, and `POST /prompts` with unique prompt names. FastAPI routing, auth/RBAC middleware, DB write, prompt service, template validation, content security scan, and response serialization are all in path.

| HTTP benchmark case | `origin/main` | This branch | Diff |
|---------------------|---------------|-------------|------|
| Small repeated clean prompt | `162.2 rps` | `194.2 rps` | `1.20x` / `+19.8%` |
| 10KB repeated clean prompt | `64.1 rps` | `70.7 rps` | `1.10x` / `+10.4%` |
| 10KB unique clean prompt | `60.3 rps` | `64.0 rps` | `1.06x` / `+6.0%` |

How to run from the PR branch:

```bash
uv run python tests/performance/test_content_security_benchmark.py --mode http-e2e
```

To compare against main, run the same command from an `origin/main` checkout. The HTTP harness starts uvicorn with:

```bash
AUTH_REQUIRED=true \
MCP_REQUIRE_AUTH=true \
MCPGATEWAY_UI_ENABLED=false \
MCPGATEWAY_ADMIN_API_ENABLED=false \
DATABASE_URL=sqlite:////tmp/<temp-db>.db \
JWT_SECRET_KEY=e2e-benchmark-secret-key-with-minimum-32-bytes \
BASIC_AUTH_PASSWORD=StrongPass123! \
AUTH_ENCRYPTION_SECRET=e2e-benchmark-encryption-secret-32-bytes \
LOG_LEVEL=ERROR
```

It generates an admin JWT with `python -m mcpgateway.utils.create_jwt_token`, warms up each case, then reports median RPS over five measured rounds.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| E2E suite                 | `uv run pytest tests/e2e -q` | Passed; environment-dependent tests skipped |
| HTTP RPS benchmark        | `uv run python tests/performance/test_content_security_benchmark.py --mode http-e2e` against `origin/main` and this branch | Passed |
| Lint suite                | `uv run ruff check docs/docs/manage/securing.md mcpgateway/services/content_security.py mcpgateway/config.py tests/unit/mcpgateway/services/test_content_pattern_detection.py` | Passed |
| Unit tests                | `uv run pytest tests/unit/mcpgateway/services/test_content_security.py tests/unit/mcpgateway/services/test_content_pattern_detection.py tests/unit/mcpgateway/test_config.py -q` | Passed |
| Secrets scan              | `make detect-secrets-scan` | Passed |
| Coverage ≥ 80%            | Not run | Not checked |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
The cache stores only successful clean validation results. Malicious matches are still evaluated on every request and are not cached.
