### PR TITLE
Correct failing tests on main

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T14:14:15Z",
+  "generated_at": "2026-04-27T15:49:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T15:49:27Z",
+  "generated_at": "2026-04-27T15:55:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/tests/unit/mcpgateway/test_admin_logout_token_revocation.py
+++ b/tests/unit/mcpgateway/test_admin_logout_token_revocation.py
@@ -15,10 +15,12 @@ regressions are caught.
 """
 
 # Standard
+from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import FastAPI
 from unittest.mock import AsyncMock, MagicMock, patch
-import importlib
-import os
 import uuid
 
 # Third-Party
@@ -29,50 +31,11 @@ from fastapi.testclient import TestClient
 # First-Party
 from mcpgateway.admin import enforce_admin_csrf
 from mcpgateway.config import settings
-from mcpgateway.main import app
 
 
-@pytest.fixture(scope="module", autouse=True)
-def enable_admin_api():
-    """Enable admin API for logout tests.
-
-    The admin router is only registered when MCPGATEWAY_ADMIN_API_ENABLED=True.
-    This fixture sets the environment variable before the app is initialized,
-    clears the settings cache, and forces a reload of the main module to pick
-    up the setting.
-    """
-    # Store original value
-    original_value = os.environ.get("MCPGATEWAY_ADMIN_API_ENABLED")
-
-    # Set environment variable
-    os.environ["MCPGATEWAY_ADMIN_API_ENABLED"] = "true"
-
-    # Clear the settings cache so get_settings() will create a new instance
-    from mcpgateway.config import get_settings
-
-    get_settings.cache_clear()
-
-    # Force reload of config and main modules to pick up the setting
-    import mcpgateway.config
-    import mcpgateway.main
-
-    importlib.reload(mcpgateway.config)
-    importlib.reload(mcpgateway.main)
-
-    # Update the app reference in this module to use the reloaded app
-    global app
-    app = mcpgateway.main.app
-
-    yield
-
-    # Cleanup
-    if original_value is None:
-        os.environ.pop("MCPGATEWAY_ADMIN_API_ENABLED", None)
-    else:
-        os.environ["MCPGATEWAY_ADMIN_API_ENABLED"] = original_value
-
-    # Clear cache again for other tests
-    get_settings.cache_clear()
+@pytest.fixture
+def client(main_app_with_admin_api: FastAPI) -> TestClient:
+    return TestClient(main_app_with_admin_api, follow_redirects=False)
 
 
 def _jwt_secret() -> str:
@@ -80,14 +43,14 @@ def _jwt_secret() -> str:
     return secret.get_secret_value() if hasattr(secret, "get_secret_value") else secret
 
 
-def _build_admin_jwt(*, include_jti: bool = True, expires_in_minutes: int = 20) -> tuple[str, dict]:
+def _build_admin_jwt(*, include_jti: bool = True, expires_in_minutes: int = 20) -> tuple[str, dict[str, Any]]:
     """Build a signed admin JWT and return (token, payload).
 
     Returns:
         Tuple of (encoded JWT string, payload dict).
     """
     now = datetime.now(timezone.utc)
-    payload: dict = {
+    payload: dict[str, Any] = {
         "email": "admin@example.com",
         "exp": int((now + timedelta(minutes=expires_in_minutes)).timestamp()),
         "iat": int(now.timestamp()),
@@ -100,7 +63,7 @@ def _build_admin_jwt(*, include_jti: bool = True, expires_in_minutes: int = 20) 
 
 
 @pytest.fixture
-def disable_admin_csrf():
+def disable_admin_csrf(main_app_with_admin_api: FastAPI) -> Generator[None, None, None]:
     """Bypass admin CSRF for happy-path tests via dependency override.
 
     A separate test (``test_admin_logout_post_rejects_missing_csrf_token``)
@@ -110,17 +73,17 @@ def disable_admin_csrf():
     async def _noop():
         return None
 
-    app.dependency_overrides[enforce_admin_csrf] = _noop
+    main_app_with_admin_api.dependency_overrides[enforce_admin_csrf] = _noop
     try:
         yield
     finally:
-        app.dependency_overrides.pop(enforce_admin_csrf, None)
+        main_app_with_admin_api.dependency_overrides.pop(enforce_admin_csrf, None)
 
 
 class TestAdminLogoutTokenRevocation:
     """Happy-path: ``/admin/logout`` revokes the caller's token in the blocklist."""
 
-    def test_post_revokes_token_in_blocklist(self, disable_admin_csrf):
+    def test_post_revokes_token_in_blocklist(self, client: TestClient, disable_admin_csrf: None) -> None:
         token, payload = _build_admin_jwt()
 
         with (
@@ -132,7 +95,6 @@ class TestAdminLogoutTokenRevocation:
             mock_blocklist.revoke_token.return_value = True
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout", cookies={"jwt_token": token})
 
             assert response.status_code in (302, 303, 307, 200)
@@ -144,18 +106,17 @@ class TestAdminLogoutTokenRevocation:
             assert kwargs["token_expiry"] is not None
             assert kwargs["last_activity"] is not None
 
-    def test_post_without_jwt_cookie_does_not_call_blocklist(self, disable_admin_csrf):
+    def test_post_without_jwt_cookie_does_not_call_blocklist(self, client: TestClient, disable_admin_csrf: None) -> None:
         with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_get_service:
             mock_blocklist = MagicMock()
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout")
 
             assert response.status_code in (302, 303, 307, 200)
             mock_blocklist.revoke_token.assert_not_called()
 
-    def test_post_with_invalid_jwt_cookie_does_not_block_logout(self, disable_admin_csrf):
+    def test_post_with_invalid_jwt_cookie_does_not_block_logout(self, client: TestClient, disable_admin_csrf: None) -> None:
         with (
             patch("mcpgateway.admin.verify_jwt_token_cached", new_callable=AsyncMock) as mock_verify,
             patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_get_service,
@@ -164,13 +125,12 @@ class TestAdminLogoutTokenRevocation:
             mock_blocklist = MagicMock()
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout", cookies={"jwt_token": "not.a.valid.jwt"})
 
             assert response.status_code in (302, 303, 307, 200)
             mock_blocklist.revoke_token.assert_not_called()
 
-    def test_post_payload_without_jti_does_not_revoke(self, disable_admin_csrf):
+    def test_post_payload_without_jti_does_not_revoke(self, client: TestClient, disable_admin_csrf: None) -> None:
         token, payload = _build_admin_jwt(include_jti=False)
         assert "jti" not in payload
 
@@ -182,13 +142,12 @@ class TestAdminLogoutTokenRevocation:
             mock_blocklist = MagicMock()
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout", cookies={"jwt_token": token})
 
             assert response.status_code in (302, 303, 307, 200)
             mock_blocklist.revoke_token.assert_not_called()
 
-    def test_post_blocklist_failure_does_not_block_logout(self, disable_admin_csrf):
+    def test_post_blocklist_failure_does_not_block_logout(self, client: TestClient, disable_admin_csrf: None) -> None:
         token, payload = _build_admin_jwt()
 
         with (
@@ -200,7 +159,6 @@ class TestAdminLogoutTokenRevocation:
             mock_blocklist.revoke_token.side_effect = Exception("Database unavailable")
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout", cookies={"jwt_token": token})
 
             assert response.status_code in (302, 303, 307, 200)
@@ -210,7 +168,7 @@ class TestAdminLogoutTokenRevocation:
 class TestAdminLogoutDenyPaths:
     """Deny-path regression tests required by AGENTS.md for security-sensitive changes."""
 
-    def test_post_with_jwt_cookie_but_no_csrf_token_is_rejected(self):
+    def test_post_with_jwt_cookie_but_no_csrf_token_is_rejected(self, client: TestClient) -> None:
         """Cookie auth + state-changing POST without a CSRF token must return 403.
 
         This protects against cross-site-forced-logout attacks. No
@@ -223,14 +181,13 @@ class TestAdminLogoutDenyPaths:
             mock_blocklist = MagicMock()
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.post("/admin/logout", cookies={"jwt_token": token})
 
             assert response.status_code == 403
             assert "csrf" in response.json().get("detail", "").lower()
             mock_blocklist.revoke_token.assert_not_called()
 
-    def test_get_logout_is_exempt_from_csrf(self):
+    def test_get_logout_is_exempt_from_csrf(self, client: TestClient) -> None:
         """GET /admin/logout supports OIDC front-channel logout and is exempt from CSRF.
 
         Per the OIDC Front-Channel Logout 1.0 spec the IdP issues a GET; we
@@ -247,7 +204,6 @@ class TestAdminLogoutDenyPaths:
             mock_blocklist.revoke_token.return_value = True
             mock_get_service.return_value = mock_blocklist
 
-            client = TestClient(app, follow_redirects=False)
             response = client.get(
                 "/admin/logout",
                 cookies={"jwt_token": token},

--- a/tests/unit/mcpgateway/test_admin_logout_token_revocation.py
+++ b/tests/unit/mcpgateway/test_admin_logout_token_revocation.py
@@ -17,6 +17,8 @@ regressions are caught.
 # Standard
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
+import importlib
+import os
 import uuid
 
 # Third-Party
@@ -28,6 +30,49 @@ from fastapi.testclient import TestClient
 from mcpgateway.admin import enforce_admin_csrf
 from mcpgateway.config import settings
 from mcpgateway.main import app
+
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_admin_api():
+    """Enable admin API for logout tests.
+
+    The admin router is only registered when MCPGATEWAY_ADMIN_API_ENABLED=True.
+    This fixture sets the environment variable before the app is initialized,
+    clears the settings cache, and forces a reload of the main module to pick
+    up the setting.
+    """
+    # Store original value
+    original_value = os.environ.get("MCPGATEWAY_ADMIN_API_ENABLED")
+
+    # Set environment variable
+    os.environ["MCPGATEWAY_ADMIN_API_ENABLED"] = "true"
+
+    # Clear the settings cache so get_settings() will create a new instance
+    from mcpgateway.config import get_settings
+
+    get_settings.cache_clear()
+
+    # Force reload of config and main modules to pick up the setting
+    import mcpgateway.config
+    import mcpgateway.main
+
+    importlib.reload(mcpgateway.config)
+    importlib.reload(mcpgateway.main)
+
+    # Update the app reference in this module to use the reloaded app
+    global app
+    app = mcpgateway.main.app
+
+    yield
+
+    # Cleanup
+    if original_value is None:
+        os.environ.pop("MCPGATEWAY_ADMIN_API_ENABLED", None)
+    else:
+        os.environ["MCPGATEWAY_ADMIN_API_ENABLED"] = original_value
+
+    # Clear cache again for other tests
+    get_settings.cache_clear()
 
 
 def _jwt_secret() -> str:


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #4471

---

## 📝 Summary
Corrects the failing test cases by correcting an omission in the set up to allow the test to access the admin endpoints via the fixture.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |
---

Run `pytest tests/unit/mcpgateway/test_admin_logout_token_revocation.py`
Get results:
.......                                                                                                                                                                              [100%]
===================================================================================== warnings summary =====================================================================================
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_revokes_token_in_blocklist
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_payload_without_jti_does_not_revoke
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_blocklist_failure_does_not_block_logout
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_post_with_jwt_cookie_but_no_csrf_token_is_rejected
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_get_logout_is_exempt_from_csrf
  /Users/brian/dev/github.com/IBM/proj_mcp-context-forge/feat_work/failing_tests/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:147: InsecureKeyLengthWarning: The HMAC key is 11 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
    return self._jws.encode(

tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_revokes_token_in_blocklist
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_with_invalid_jwt_cookie_does_not_block_logout
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_payload_without_jti_does_not_revoke
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_blocklist_failure_does_not_block_logout
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_post_with_jwt_cookie_but_no_csrf_token_is_rejected
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_get_logout_is_exempt_from_csrf
  /Users/brian/dev/github.com/IBM/proj_mcp-context-forge/feat_work/failing_tests/.venv/lib/python3.12/site-packages/starlette/testclient.py:445: DeprecationWarning: Setting per-request cookies=<...> is being deprecated, because the expected behaviour on cookie persistence is ambiguous. Set cookies directly on the client instance instead.
    return super().request(

tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_revokes_token_in_blocklist
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_payload_without_jti_does_not_revoke
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutTokenRevocation::test_post_blocklist_failure_does_not_block_logout
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_post_with_jwt_cookie_but_no_csrf_token_is_rejected
tests/unit/mcpgateway/test_admin_logout_token_revocation.py::TestAdminLogoutDenyPaths::test_get_logout_is_exempt_from_csrf
  /Users/brian/dev/github.com/IBM/proj_mcp-context-forge/feat_work/failing_tests/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:365: InsecureKeyLengthWarning: The HMAC key is 11 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
    decoded = self.decode_complete(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
7 passed, 16 warnings in 2.00s```

```

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
