### PR TITLE
[BUG]: fix OAuth audience-learning regressions introduced by #4404

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-27T15:55:30Z",
+  "generated_at": "2026-04-27T19:52:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5000,7 +5000,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 643,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7290,7 +7290,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 275,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8550,7 +8550,7 @@
         "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 441,
+        "line_number": 539,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -93,7 +93,9 @@ async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, An
     API (which does enforce ``gateways.update``).
 
     This is a best-effort operation: opaque tokens, missing ``aud`` claims, and
-    already-set resources are silently skipped.
+    already-set (truthy) resources are silently skipped.  Empty strings and
+    empty lists count as unset, so an admin can clear the field to trigger
+    re-learning on the next callback.
 
     Args:
         gateway: The gateway ORM object (will be mutated and flushed).
@@ -105,10 +107,13 @@ async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, An
     if token_aud is None:
         return
 
-    # First-write-only: do not overwrite an existing learned or admin-configured
-    # resource value.  See docstring for the authorization rationale.
-    current_resource = (gateway.oauth_config or {}).get("resource")
-    if current_resource is not None:
+    # First-write-only: do not overwrite an existing usable resource.  Empty
+    # strings and empty lists are treated as unset (Python truthiness) so an
+    # admin can clear the field via the gateway update API to trigger
+    # re-learning on the next callback.  See docstring for the authorization
+    # rationale.
+    oauth_config = gateway.oauth_config or {}
+    if oauth_config.get("resource"):
         return
 
     # Store aud as-is (string or list) -- RFC 7519 allows both forms.

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -83,8 +83,17 @@ async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, An
     ensure that subsequent token validation in ``_validate_audience`` succeeds
     and that future OAuth requests use the IdP's preferred audience identifier.
 
-    This is a best-effort operation: opaque tokens and missing aud claims are
-    silently ignored.
+    Persistence is **first-write-only**: the learned audience is written only
+    when ``oauth_config["resource"]`` is currently unset.  The OAuth callback
+    path enforces gateway access (read-equivalent) but not ``gateways.update``,
+    so allowing every authenticated callback to overwrite shared gateway
+    configuration would let any user with gateway access mutate global state on
+    behalf of all other users.  To re-learn a stale audience after an IdP
+    change, an admin must clear the ``resource`` field via the gateway update
+    API (which does enforce ``gateways.update``).
+
+    This is a best-effort operation: opaque tokens, missing ``aud`` claims, and
+    already-set resources are silently skipped.
 
     Args:
         gateway: The gateway ORM object (will be mutated and flushed).
@@ -96,17 +105,18 @@ async def _persist_learned_audience(gateway: Gateway, oauth_result: Dict[str, An
     if token_aud is None:
         return
 
-    # Store aud as-is (string or list) -- RFC 7519 allows both forms.
+    # First-write-only: do not overwrite an existing learned or admin-configured
+    # resource value.  See docstring for the authorization rationale.
     current_resource = (gateway.oauth_config or {}).get("resource")
-    if current_resource == token_aud:
-        return  # Already correct
+    if current_resource is not None:
+        return
 
-    # Persist the learned audience as resource
+    # Store aud as-is (string or list) -- RFC 7519 allows both forms.
     updated_config = dict(gateway.oauth_config) if gateway.oauth_config else {}
     updated_config["resource"] = token_aud
     gateway.oauth_config = updated_config
     db.flush()
-    logger.debug("Learned OAuth audience from IdP token for gateway %s; persisted as resource", gateway.name)
+    logger.info("Learned OAuth audience from IdP token for gateway %s; persisted as resource", gateway.name)
 
 
 oauth_router = APIRouter(prefix="/oauth", tags=["oauth"])

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -299,23 +299,31 @@ class TokenStorageService:
             from urllib.parse import urlparse, urlunparse  # pylint: disable=import-outside-toplevel
 
             def normalize_resource(url: str, *, preserve_query: bool = False) -> str | None:
-                """Normalize resource URL per RFC 8707.
+                """Normalize a resource value per RFC 8707, or pass through opaque identifiers.
+
+                URL-shaped inputs are canonicalized (fragment stripped; query stripped
+                or preserved per ``preserve_query``).  Non-URL inputs are returned
+                verbatim so that opaque audience identifiers learned from IdPs that do
+                not honor RFC 8707 (e.g. ServiceNow / Authentik returning ``aud=client_id``)
+                round-trip correctly through token refresh.  RFC 8707 §2 explicitly
+                permits the AS to map ``resource`` to an abstract identifier; the
+                resource server therefore must accept either form.
 
                 Args:
-                    url: Resource URL to normalize
+                    url: Resource URL or opaque audience identifier to normalize.
                     preserve_query: If True, preserve query (for explicit config). If False, strip query.
 
                 Returns:
-                    Normalized URL string, or None if invalid.
+                    Normalized URL string, the original opaque value, or None if input is empty.
                 """
                 if not url:
                     return None
                 parsed = urlparse(url)
-                # RFC 8707: resource MUST be absolute URI (requires scheme)
-                # Support both hierarchical URIs and URNs
+                # If the value lacks a scheme it is not a URL; treat as an opaque
+                # audience identifier and pass through verbatim so a learned
+                # client_id-style audience survives refresh.
                 if not parsed.scheme:
-                    logger.warning(f"Invalid resource URL (must be absolute URI with scheme): {url}")
-                    return None
+                    return url
                 # Remove fragment (MUST NOT); query: preserve for explicit, strip for auto-derived
                 query = parsed.query if preserve_query else ""
                 return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, query, ""))
@@ -328,17 +336,17 @@ class TokenStorageService:
                     normalized = [normalize_resource(r, preserve_query=True) for r in existing_resource]
                     oauth_config["resource"] = [r for r in normalized if r]
                     if not oauth_config["resource"] and original_count > 0:
-                        logger.warning(f"All {original_count} configured resource values were invalid and removed during refresh")
+                        logger.warning(f"All {original_count} configured resource values were empty and removed during refresh")
                 else:
                     normalized = normalize_resource(existing_resource, preserve_query=True)
                     if not normalized and existing_resource:
-                        logger.warning(f"Configured resource was invalid and removed during refresh: {existing_resource}")
+                        logger.warning(f"Configured resource was empty and removed during refresh: {existing_resource}")
                     oauth_config["resource"] = normalized
             elif gateway.url:
                 # Derive from gateway.url if not explicitly configured (strip query)
                 oauth_config["resource"] = normalize_resource(gateway.url)
                 if not oauth_config.get("resource"):
-                    logger.warning(f"Gateway URL is not a valid absolute URI, skipping resource parameter: {gateway.url}")
+                    logger.warning(f"Gateway URL is empty, skipping resource parameter: {gateway.url}")
 
             # Use OAuthManager to refresh the token
             # First-Party

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -215,6 +215,29 @@ class TestPersistLearnedAudience:
 
         db.flush.assert_not_called()
 
+    @pytest.mark.parametrize("falsy_resource", ["", []])
+    @pytest.mark.asyncio
+    async def test_persists_when_existing_resource_is_falsy(self, falsy_resource):
+        """Empty string / empty list persisted resource counts as unset; re-learning proceeds.
+
+        This lets an admin clear the field via the gateway update API to trigger
+        re-learning on the next callback (recovery path after stale config).
+        """
+        oauth_result = {"token_aud": "fresh-client-id"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "cid", "resource": falsy_resource}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        db.flush.assert_called_once()
+        assert gateway.oauth_config["resource"] == "fresh-client-id"
+
 
 class TestOAuthRouter:
     """Test cases for OAuth router endpoints."""

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -142,8 +142,8 @@ class TestPersistLearnedAudience:
         db.flush.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_skips_when_resource_already_matches(self):
-        """Does not flush if the persisted resource already matches aud."""
+    async def test_skips_when_resource_already_set_to_same_value(self):
+        """First-write-only: does not flush when resource is already set, even if it matches."""
         oauth_result = {"token_aud": "my-client-id", "user_id": "u1"}
 
         gateway = Mock(spec=Gateway)
@@ -157,6 +157,29 @@ class TestPersistLearnedAudience:
         await _persist_learned_audience(gateway, oauth_result, db)
 
         db.flush.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_resource_already_set_to_different_value(self):
+        """First-write-only: never overwrites a previously learned/configured resource.
+
+        The OAuth callback path only enforces gateway access, not gateways.update.
+        Allowing a non-admin user to overwrite a shared resource value would let
+        any authenticated user mutate global config on behalf of all other users.
+        """
+        oauth_result = {"token_aud": "new-client-id", "user_id": "u1"}
+
+        gateway = Mock(spec=Gateway)
+        gateway.name = "Test GW"
+        gateway.oauth_config = {"client_id": "my-client-id", "resource": "previously-learned-id"}
+
+        db = Mock(spec=Session)
+
+        from mcpgateway.routers.oauth_router import _persist_learned_audience
+
+        await _persist_learned_audience(gateway, oauth_result, db)
+
+        db.flush.assert_not_called()
+        assert gateway.oauth_config["resource"] == "previously-learned-id"
 
     @pytest.mark.asyncio
     async def test_skips_opaque_token(self):

--- a/tests/unit/mcpgateway/services/test_token_storage_service.py
+++ b/tests/unit/mcpgateway/services/test_token_storage_service.py
@@ -449,6 +449,92 @@ async def test_refresh_preserves_opaque_single_resource(service, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_refresh_resource_list_all_empty_logs_warning(service, mock_db, caplog):
+    """Line 339: when every entry in the resource list normalizes to empty, log a warning.
+
+    Empty strings inside the list short-circuit ``normalize_resource`` to ``None`` via
+    its ``if not url`` guard, leaving the filtered list empty.  The gateway warns
+    operators that a misconfiguration silently dropped every audience identifier.
+    """
+    gw = MagicMock(
+        oauth_config={"token_url": "https://token", "client_id": "cid", "resource": ["", ""]},
+        url="https://gw.com",
+    )
+    mock_db.query.return_value.filter.return_value.first.return_value = gw
+    mock_oauth_manager = MagicMock()
+    mock_oauth_manager.refresh_token = AsyncMock(return_value={"access_token": "new_access", "expires_in": 3600})
+
+    # Standard
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with patch("mcpgateway.services.oauth_manager.OAuthManager", return_value=mock_oauth_manager):
+            result = await service._refresh_access_token(_make_token_record())
+
+    assert result == "new_access"
+    assert any("All 2 configured resource values were empty and removed during refresh" in msg for msg in caplog.messages)
+    refresh_call_oauth_config = mock_oauth_manager.refresh_token.call_args[0][1]
+    assert refresh_call_oauth_config["resource"] == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_resource_string_normalizes_to_empty_logs_warning(service, mock_db, caplog):
+    """Line 343: when a non-list resource normalizes to empty, log a warning.
+
+    Defensive code path: ``normalize_resource`` does not return falsy for truthy
+    URL inputs in the natural flow.  Patching ``urllib.parse.urlunparse`` to return
+    an empty string forces the defensive branch so the warning is exercised.
+    """
+    gw = MagicMock(
+        oauth_config={"token_url": "https://token", "client_id": "cid", "resource": "https://api.example.com"},
+        url="https://gw.com",
+    )
+    mock_db.query.return_value.filter.return_value.first.return_value = gw
+    mock_oauth_manager = MagicMock()
+    mock_oauth_manager.refresh_token = AsyncMock(return_value={"access_token": "new_access", "expires_in": 3600})
+
+    # Standard
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with patch("urllib.parse.urlunparse", return_value=""):
+            with patch("mcpgateway.services.oauth_manager.OAuthManager", return_value=mock_oauth_manager):
+                result = await service._refresh_access_token(_make_token_record())
+
+    assert result == "new_access"
+    assert any("Configured resource was empty and removed during refresh: https://api.example.com" in msg for msg in caplog.messages)
+
+
+@pytest.mark.asyncio
+async def test_refresh_derived_gateway_url_normalizes_to_empty_logs_warning(service, mock_db, caplog):
+    """Line 349: when the auto-derived ``gateway.url`` normalizes to empty, log a warning.
+
+    Defensive code path: with no explicit ``resource`` configured, the gateway falls
+    back to ``gateway.url``.  ``normalize_resource`` does not return falsy for truthy
+    URL inputs in the natural flow, so we patch ``urllib.parse.urlunparse`` to return
+    an empty string and trip the defensive warning.
+    """
+    gw = MagicMock(
+        oauth_config={"token_url": "https://token", "client_id": "cid"},
+        url="https://gw.example.com/api",
+    )
+    mock_db.query.return_value.filter.return_value.first.return_value = gw
+    mock_oauth_manager = MagicMock()
+    mock_oauth_manager.refresh_token = AsyncMock(return_value={"access_token": "new_access", "expires_in": 3600})
+
+    # Standard
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with patch("urllib.parse.urlunparse", return_value=""):
+            with patch("mcpgateway.services.oauth_manager.OAuthManager", return_value=mock_oauth_manager):
+                result = await service._refresh_access_token(_make_token_record())
+
+    assert result == "new_access"
+    assert any("Gateway URL is empty, skipping resource parameter: https://gw.example.com/api" in msg for msg in caplog.messages)
+
+
+@pytest.mark.asyncio
 async def test_refresh_client_secret_decrypt_fails_uses_plaintext(service, mock_db):
     gw = MagicMock(oauth_config={"token_url": "https://token", "client_id": "cid", "client_secret": "maybe_plain"}, url="https://gw.com")
     mock_db.query.return_value.filter.return_value.first.return_value = gw

--- a/tests/unit/mcpgateway/services/test_token_storage_service.py
+++ b/tests/unit/mcpgateway/services/test_token_storage_service.py
@@ -415,25 +415,37 @@ async def test_refresh_derives_resource_from_gateway_url(service, mock_db):
 
 
 @pytest.mark.asyncio
-async def test_refresh_invalid_resource_list_filtered(service, mock_db):
-    gw = MagicMock(oauth_config={"token_url": "https://token", "client_id": "cid", "resource": ["no-scheme", "also-bad"]}, url="https://gw.com")
+async def test_refresh_preserves_opaque_resource_list(service, mock_db):
+    """Opaque audience identifiers (non-URL) survive token refresh as-is.
+
+    This is the round-trip scenario for IdPs that don't honor RFC 8707 and
+    return aud=client_id (e.g. ServiceNow, Authentik).  The learned audience
+    must not be stripped during refresh, otherwise validation regresses to
+    the unfixed-bug state on the first refresh after callback.
+    """
+    gw = MagicMock(oauth_config={"token_url": "https://token", "client_id": "cid", "resource": ["client-id-1", "client-id-2"]}, url="https://gw.com")
     mock_db.query.return_value.filter.return_value.first.return_value = gw
     mock_oauth_manager = MagicMock()
     mock_oauth_manager.refresh_token = AsyncMock(return_value={"access_token": "new_access", "expires_in": 3600})
     with patch("mcpgateway.services.oauth_manager.OAuthManager", return_value=mock_oauth_manager):
         result = await service._refresh_access_token(_make_token_record())
     assert result == "new_access"
+    refresh_call_oauth_config = mock_oauth_manager.refresh_token.call_args[0][1]
+    assert refresh_call_oauth_config["resource"] == ["client-id-1", "client-id-2"]
 
 
 @pytest.mark.asyncio
-async def test_refresh_invalid_single_resource(service, mock_db):
-    gw = MagicMock(oauth_config={"token_url": "https://token", "client_id": "cid", "resource": "no-scheme-url"}, url="https://gw.com")
+async def test_refresh_preserves_opaque_single_resource(service, mock_db):
+    """Opaque single-string audience identifier survives refresh as-is."""
+    gw = MagicMock(oauth_config={"token_url": "https://token", "client_id": "cid", "resource": "my-client-id"}, url="https://gw.com")
     mock_db.query.return_value.filter.return_value.first.return_value = gw
     mock_oauth_manager = MagicMock()
     mock_oauth_manager.refresh_token = AsyncMock(return_value={"access_token": "new_access", "expires_in": 3600})
     with patch("mcpgateway.services.oauth_manager.OAuthManager", return_value=mock_oauth_manager):
         result = await service._refresh_access_token(_make_token_record())
     assert result == "new_access"
+    refresh_call_oauth_config = mock_oauth_manager.refresh_token.call_args[0][1]
+    assert refresh_call_oauth_config["resource"] == "my-client-id"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three correctness fixes for the OAuth auto-learn audience flow merged in #4404 (issue #4384).  Without these, the merged code has a real production regression and a security gap.

**Note**: PR #4404 was merged today (2026-04-27).  This PR addresses gaps identified in a post-merge review of the implementation.  Issue #4384 was auto-closed by the merge but most of its acceptance criteria remain open; those are addressed in follow-up PRs (see "Stack" below).

## Fixes (in dependency order)

### 1. B1 — Refresh path strips opaque audience identifiers (regression — urgent)

`mcpgateway/services/token_storage_service.py:normalize_resource()` previously dropped any non-URL `resource` value as "invalid".  After #4404 auto-learns an opaque audience (e.g. ServiceNow / Authentik return ``aud=client_id``), the refresh path silently nukes it on the first refresh, regressing validation back to the unfixed-bug state.

**Fix**: treat scheme-less values as opaque audience identifiers and pass them through verbatim during normalization.  RFC 8707 §2 explicitly permits the AS to map ``resource`` to an abstract identifier.

### 2. B2 — First-write-only persistence (security correctness)

`_persist_learned_audience` originally overwrote ``oauth_config["resource"]`` on every callback.  The OAuth callback path enforces gateway access (read-equivalent) but **not** ``gateways.update``, so on a public/shared gateway any authenticated user with gateway access could mutate global config on behalf of all other users (last-user-wins).

**Fix**: write only when ``oauth_config["resource"]`` is currently unset.  An admin must clear the field via the gateway update API (which does enforce ``gateways.update``) to trigger re-learning.  Persistence log promoted INFO so the privileged mutation is visible.

### 3. B2 follow-up — falsy resource counts as unset

The first-write-only check used ``is not None`` and treated empty strings, empty lists, etc. as "already set", blocking re-learning forever.

**Fix**: use Python truthiness so an admin clearing the field to ``""`` or ``[]`` triggers re-learning naturally.

## Stack

This is the first of a 3-PR follow-up to the original (#4404):

1. **This PR** — bugfix corrections (3 commits, 5 files, +160/-79).
2. **#4476** (`feat/oauth-aud-resource-hybrid`) — implements the maintainer's recommended Option-2 hybrid: UI Resource (Audience) field, origin-extraction fallback, softened validation for auto-derived audience, plus issuer pinning, shape validation, and diagnostic logs.
3. **#4477** (`docs/oauth-audience-handling`) — documentation completing #4384's acceptance criteria.

## Verification

- 443 affected unit tests pass
- 17 doctests pass
- ``ruff check`` clean on changed files
- Manual trace of refresh, validation, and authorize/callback paths against current ``main``

## Authors

- @madhav165 contributed the original PR #4404 (auto-learn).  His work is already in main via the squash merge.  This stack builds on top of it.
- Hardening corrections in this PR are by me.
