### PR TITLE
fix: serialize delete_tool with row lock and propagate ToolNotFoundError

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
+    "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-24T12:36:31Z",
+  "generated_at": "2026-07-24T15:33:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12380,6 +12380,9 @@ async def admin_delete_tool(tool_id: str, request: Request, db: Session = Depend
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} deleting tool {tool_id}: {e}")
         error_message = str(e)
+    except ToolLockConflictError as e:
+        LOGGER.warning(f"Lock conflict for user {user_email} deleting tool {tool_id}: {e}")
+        error_message = "Tool is being modified by another request. Please try again."
     except Exception as e:
         LOGGER.error(f"Error deleting tool: {e}")
         error_message = "Failed to delete tool. Please try again."

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -6030,6 +6030,8 @@ async def delete_tool(
         raise HTTPException(status_code=403, detail=str(e))
     except ToolNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except ToolLockConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3358,24 +3358,34 @@ class ToolService(BaseService):
 
         Raises:
             ToolNotFoundError: If the tool is not found.
+            ToolLockConflictError: If the tool row is locked by another transaction.
             PermissionError: If user doesn't own the tool.
             ToolError: For other deletion errors.
 
         Examples:
             >>> from mcpgateway.services.tool_service import ToolService
-            >>> from unittest.mock import MagicMock, AsyncMock
+            >>> from unittest.mock import MagicMock, AsyncMock, patch
             >>> service = ToolService()
             >>> db = MagicMock()
             >>> tool = MagicMock()
-            >>> db.get.return_value = tool
-            >>> db.delete = MagicMock()
             >>> db.commit = MagicMock()
             >>> service._notify_tool_deleted = AsyncMock()
             >>> import asyncio
-            >>> asyncio.run(service.delete_tool(db, 'tool_id'))
+            >>> with patch("mcpgateway.services.tool_service.get_for_update", return_value=tool):
+            ...     asyncio.run(service.delete_tool(db, 'tool_id'))
         """
         try:
-            tool = db.get(DbTool, tool_id)
+            # Use nowait=True to fail fast if row is locked, mirroring set_tool_state.
+            # This serializes concurrent associate/delete operations on the same tool
+            # so callers see a 409 rather than an opaque 500 from a downstream FK
+            # violation when an INSERT into server_tool_association races with the
+            # association cleanup below.
+            try:
+                tool = get_for_update(db, DbTool, tool_id, nowait=True)
+            except OperationalError as lock_err:
+                # Row is locked by another transaction - fail fast with 409
+                db.rollback()
+                raise ToolLockConflictError(f"Tool {tool_id} is currently being modified by another request") from lock_err
             if not tool:
                 raise ToolNotFoundError(f"Tool not found: {tool_id}")
 
@@ -3473,6 +3483,14 @@ class ToolService(BaseService):
                 resource_id=tool_id,
                 error=pe,
             )
+            raise
+        except ToolLockConflictError:
+            # Re-raise lock conflicts without wrapping - allows 409 response.
+            # Rollback already performed in the inner OperationalError handler.
+            raise
+        except ToolNotFoundError:
+            # Re-raise not found without wrapping - allows 404 response
+            db.rollback()
             raise
         except Exception as e:
             db.rollback()

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -49,6 +49,7 @@ from mcpgateway.services.tool_service import (
     TextContent,
     ToolError,
     ToolInvocationError,
+    ToolLockConflictError,
     ToolNameConflictError,
     ToolNotFoundError,
     ToolResult,
@@ -1657,15 +1658,31 @@ class TestToolService:
 
     @pytest.mark.asyncio
     async def test_delete_tool_not_found(self, tool_service, test_db):
-        """Test deleting a non-existent tool."""
-        # Mock DB get to return None
+        """Missing tool surfaces ToolNotFoundError, not a generic ToolError wrap."""
         test_db.get = Mock(return_value=None)
+        test_db.rollback = Mock()
 
-        # The service wraps the exception in ToolError
-        with pytest.raises(ToolError) as exc_info:
+        with pytest.raises(ToolNotFoundError) as exc_info:
             await tool_service.delete_tool(test_db, 999)
 
         assert "Tool not found: 999" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_delete_tool_lock_conflict(self, tool_service, test_db):
+        """Concurrent locker on the tool row surfaces as ToolLockConflictError (409)."""
+        from sqlalchemy.exc import OperationalError
+
+        test_db.rollback = Mock()
+
+        with patch(
+            "mcpgateway.services.tool_service.get_for_update",
+            side_effect=OperationalError("locked", {}, Exception("locked")),
+        ):
+            with pytest.raises(ToolLockConflictError) as exc_info:
+                await tool_service.delete_tool(test_db, "tool-id")
+
+        assert "currently being modified" in str(exc_info.value)
+        test_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_set_tool_state(self, tool_service, mock_tool, test_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -16924,6 +16924,28 @@ async def test_admin_delete_tool_generic_exception_error_redirect(mock_delete, m
 
 
 @pytest.mark.asyncio
+@patch.object(ToolService, "delete_tool")
+async def test_admin_delete_tool_lock_conflict_error_redirect(mock_delete, mock_db):
+    """ToolLockConflictError surfaces the concurrent-modification message in the redirect."""
+    # Standard
+    from urllib.parse import unquote
+
+    # First-Party
+    from mcpgateway.services.tool_service import ToolLockConflictError
+
+    mock_delete.side_effect = ToolLockConflictError("locked")
+    request = MagicMock(spec=Request)
+    request.form = AsyncMock(return_value=FakeForm({"is_inactive_checked": "false"}))
+    request.scope = {"root_path": "/root"}
+
+    response = await admin_delete_tool("550e8400e29b41d4a7164466554400b1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
+    assert isinstance(response, RedirectResponse)
+    assert response.status_code == 303
+    location = unquote(response.headers["location"])
+    assert "Tool is being modified by another request" in location
+
+
+@pytest.mark.asyncio
 @patch.object(GatewayService, "delete_gateway")
 async def test_admin_delete_gateway_success(mock_delete, mock_db):
     request = MagicMock(spec=Request)

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -12646,6 +12646,17 @@ class TestRemainingCoverageGaps:
             await main_mod.delete_tool.__wrapped__("t1", purge_metrics=False, db=MagicMock(), user={"email": "u"})
         assert excinfo.value.status_code == 404
 
+    async def test_delete_tool_lock_conflict_maps_to_409(self, monkeypatch):
+        # First-Party
+        import mcpgateway.main as main_mod
+        from mcpgateway.services.tool_service import ToolLockConflictError
+
+        monkeypatch.setattr(main_mod.tool_service, "delete_tool", AsyncMock(side_effect=ToolLockConflictError("locked")))
+        with pytest.raises(HTTPException) as excinfo:
+            await main_mod.delete_tool.__wrapped__("t1", purge_metrics=False, db=MagicMock(), user={"email": "u"})
+        assert excinfo.value.status_code == 409
+        assert "locked" in str(excinfo.value.detail)
+
     async def test_create_resource_resource_error_maps_to_400(self, monkeypatch):
         # First-Party
         import mcpgateway.main as main_mod


### PR DESCRIPTION
## Summary

- Add `get_for_update(db, DbTool, tool_id, nowait=True)` to `delete_tool()`, mirroring the existing pattern in `set_tool_state()`. This serializes concurrent associate/delete operations on the same tool — callers see a 409 `ToolLockConflictError` instead of an opaque 500 from a downstream FK violation when an INSERT into `server_tool_association` races with the association cleanup from #4263.
- Fix a pre-existing exception-propagation bug: `delete_tool()`'s catch-all `except Exception` was wrapping `ToolNotFoundError` into `ToolError`, preventing `main.py` from returning 404 (always fell through to the 400 catch-all). Add explicit re-raises for `ToolNotFoundError` and `ToolLockConflictError`.
- Wire `ToolLockConflictError` through the two `delete_tool` callers: `admin.py` (redirect with friendly message, matching `admin_set_tool_state`) and `main.py` (`HTTPException(409)`, matching `set_tool_state`).

## Context

Split out from #4263 during review — these are behavioral changes beyond the scope of the contributor's FK-constraint fix and belong in their own PR with their own review cycle.

Discovered during the #4263 review:
- `delete_tool()` was the only tool-mutation method that didn't use `get_for_update()` (compare `set_tool_state` at L3388, register/upsert paths at L6016/6026/6037/6106)
- The `ToolNotFoundError` → `ToolError` wrapping bug was pre-existing but only noticeable once the exception-handler block was being edited

## Changes

| File | Change |
|---|---|
| `mcpgateway/services/tool_service.py` | `db.get()` → `get_for_update(nowait=True)` in `delete_tool()`; add `except ToolLockConflictError` and `except ToolNotFoundError` re-raises; update doctest to use `patch("...get_for_update")` |
| `mcpgateway/admin.py` | `admin_delete_tool` catches `ToolLockConflictError` with a friendly retry message (mirrors `admin_set_tool_state`) |
| `mcpgateway/main.py` | `delete_tool` route maps `ToolLockConflictError` → `HTTPException(409)` (mirrors `set_tool_state`) |
| `tests/unit/.../test_tool_service.py` | `test_delete_tool_not_found` tightened to assert `ToolNotFoundError` (was `ToolError`); new `test_delete_tool_lock_conflict` |

## Testing

- 32 delete-related unit tests pass (including the new `test_delete_tool_lock_conflict`)
- `delete_tool` doctest passes
- Existing PG-only integration test `test_concurrent_tool_delete_operations` will exercise the new `nowait=True` path under real row locking

Closes #4261 (residual concurrency UX gap from the original bug report path)