### PR TITLE
feat(tokens): add admin bypass for POST /tokens/teams/{team_id} to support service account workflows

### DIFF
--- a/docs/docs/manage/rbac.md
+++ b/docs/docs/manage/rbac.md
@@ -643,10 +643,21 @@ When `AUTH_REQUIRED=false`:
 | Use Case | Recommended Token Scope |
 |----------|------------------------|
 | Admin UI access | Session token (admin bypass is DB-derived; no `teams` claim needed) |
-| CI/CD pipeline | `teams: []` (public-only) |
+| Public-only CI/CD pipeline | `teams: []` (public resources only) |
+| Team-scoped CI/CD pipeline | Team-scoped token provisioned by an un-narrowed platform admin |
 | Service integration | Specific team(s) |
 | Developer access | Personal team + project teams |
 | Monitoring/alerting | `teams: []` with read permissions |
+| Service account provisioning | Un-narrowed platform admin (`is_admin: true`, `teams: null`) can create and list team tokens without joining the team |
+
+**Service Account Provisioning**: Un-narrowed platform admins (tokens with `is_admin: true` and `teams: null`) can create and list team-scoped tokens without being active team members. This enables:
+
+- Centralized token provisioning for CI/CD pipelines
+- Emergency access scenarios without joining teams
+- Automated service account management across teams
+- Cross-team token auditing and lifecycle management
+
+Narrowed admin sessions and regular users still require active team membership to create or list team tokens.
 
 ---
 

--- a/mcpgateway/routers/tokens.py
+++ b/mcpgateway/routers/tokens.py
@@ -147,10 +147,12 @@ async def create_token(
 
     service = TokenCatalogService(db)
 
-    # Get caller permissions for scope containment (if custom scope requested)
-    caller_permissions = None
-    if request.scope and request.scope.permissions:
-        caller_permissions = await _get_caller_permissions(db, current_user, effective_team_id)
+    # CRITICAL: Always fetch caller_permissions for admin bypass check.
+    # The service needs this to determine if the caller is an un-narrowed admin
+    # who can bypass team membership requirements, regardless of whether a custom
+    # scope is provided.
+    caller_permissions = await _get_caller_permissions(db, current_user, effective_team_id)
+    is_admin = current_user.get("is_admin", False)
 
     # Convert request to TokenScope if provided
     scope = None
@@ -173,6 +175,9 @@ async def create_token(
             tags=request.tags,
             team_id=effective_team_id,
             caller_permissions=caller_permissions,
+            is_admin=is_admin,
+            caller_token_teams=caller_token_teams,
+            caller_token_teams_provided=True,
             is_active=request.is_active,
         )
 
@@ -679,28 +684,35 @@ async def create_team_token(
     current_user=Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> TokenCreateResponse:
-    """Create a new API token for a team (only team owners can do this).
+    """Create a new API token for a team.
+
+    Team members and un-narrowed platform admins (is_admin=True with wildcard
+    permissions) can create tokens. Narrowed admins and regular non-members
+    still require active team membership.
 
     Args:
         team_id: Team ID to create token for
         request: Token creation request with name, description, scoping, etc.
-        current_user: Authenticated user (must be team owner)
+        current_user: Authenticated user (must be active team member, or un-narrowed platform admin)
         db: Database session
 
     Returns:
         TokenCreateResponse: Created token details with raw token
 
     Raises:
-        HTTPException: If user is not team owner or validation fails
+        HTTPException: If user is not a team member (and admin bypass does not apply) or validation fails
     """
     _require_authenticated_session(current_user)
 
     service = TokenCatalogService(db)
 
-    # Use team_id from path for permission context
-    caller_permissions = None
-    if request.scope and request.scope.permissions:
-        caller_permissions = await _get_caller_permissions(db, current_user, team_id)
+    # CRITICAL: Always fetch caller_permissions for admin bypass check.
+    # The service needs this to determine if the caller is an un-narrowed admin
+    # who can bypass team membership requirements, regardless of whether a custom
+    # scope is provided.
+    caller_permissions = await _get_caller_permissions(db, current_user, team_id)
+    is_admin = current_user.get("is_admin", False)
+    caller_token_teams = current_user.get("token_teams")
 
     # Convert request to TokenScope if provided
     scope = None
@@ -721,8 +733,11 @@ async def create_team_token(
             scope=scope,
             expires_in_days=request.expires_in_days,
             tags=request.tags,
-            team_id=team_id,  # This will validate team ownership
+            team_id=team_id,
             caller_permissions=caller_permissions,
+            is_admin=is_admin,
+            caller_token_teams=caller_token_teams,
+            caller_token_teams_provided=True,
             is_active=request.is_active,
         )
 
@@ -781,33 +796,46 @@ async def list_team_tokens(
     current_user=Depends(get_current_user_with_permissions),
     db: Session = Depends(get_db),
 ) -> TokenListResponse:
-    """List API tokens for a team (requires active team membership).
+    """List API tokens for a team.
+
+    Team members and un-narrowed platform admins (is_admin=True with wildcard
+    permissions) can list tokens. Narrowed admins and regular non-members
+    still require active team membership.
 
     Args:
         team_id: Team ID to list tokens for
         include_inactive: Include inactive/expired tokens
         limit: Maximum number of tokens to return (default 50)
         offset: Number of tokens to skip for pagination
-        current_user: Authenticated user (must be an active member of the team)
+        current_user: Authenticated user (must be active team member, or un-narrowed platform admin)
         db: Database session
 
     Returns:
         TokenListResponse: List of team's API tokens
 
     Raises:
-        HTTPException: If user is not an active member of the team
+        HTTPException: If user is not a team member (and admin bypass does not apply)
     """
     _require_authenticated_session(current_user)
 
     service = TokenCatalogService(db)
 
+    # Fetch caller permissions and admin status for potential admin bypass
+    caller_permissions = await _get_caller_permissions(db, current_user, team_id)
+    is_admin = current_user.get("is_admin", False)
+    caller_token_teams = current_user.get("token_teams")
+
     try:
         tokens = await service.list_team_tokens(
             team_id=team_id,
-            user_email=current_user["email"],  # This will validate team ownership
+            user_email=current_user["email"],
             include_inactive=include_inactive,
             limit=limit,
             offset=offset,
+            caller_permissions=caller_permissions,
+            is_admin=is_admin,
+            caller_token_teams=caller_token_teams,
+            caller_token_teams_provided=True,
         )
 
         total_count = await service.count_team_tokens(

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -383,6 +383,9 @@ class TokenCatalogService:
         tags: Optional[List[str]] = None,
         team_id: Optional[str] = None,
         caller_permissions: Optional[List[str]] = None,
+        is_admin: bool = False,
+        caller_token_teams: Optional[List[str]] = None,
+        caller_token_teams_provided: bool = False,
         is_active: bool = True,
     ) -> tuple[EmailApiToken, str]:
         """
@@ -394,7 +397,7 @@ class TokenCatalogService:
 
         The function will:
         - Validate the existence of the user.
-        - Ensure the user is an active member of the specified team.
+        - Ensure the user is an active member of the specified team (unless admin bypass applies).
         - Verify that the token name is unique for the user+team combination.
         - Generate a JWT with the specified scoping parameters (e.g., permissions, IP, etc.).
         - Store the token in the database with the relevant details and return the token and raw JWT string.
@@ -410,6 +413,18 @@ class TokenCatalogService:
             team_id (Optional[str]): The team ID to which the token should be scoped. This is required for team-level scoping.
             caller_permissions (Optional[List[str]]): The permissions of the caller creating the token. Used for
                 scope containment validation to ensure the new token cannot have broader permissions than the caller.
+                Also used with is_admin and caller_token_teams to determine admin bypass eligibility.
+            is_admin (bool): Whether the caller is a platform admin. Used with caller_permissions and
+                caller_token_teams for defense-in-depth validation of admin bypass (default is False).
+            caller_token_teams (Optional[List[str]]): The caller's token narrowing scope (from JWT ``teams`` claim
+                via ``current_user["token_teams"]``). Required for admin bypass evaluation: only un-narrowed
+                sessions (``caller_token_teams_provided=True`` and ``caller_token_teams is None``) may bypass
+                team-membership checks. Narrowed (``["team-a"]``) and public-only (``[]``) sessions never bypass,
+                even if their effective permissions include ``"*"`` via a global ``platform_admin`` role.
+            caller_token_teams_provided (bool): Whether the caller resolved ``caller_token_teams`` from the
+                authenticated session. Defaults to ``False``: callers that did not opt in cannot satisfy the
+                admin bypass, even if they pass ``is_admin=True`` and ``caller_permissions=["*"]``. Routers
+                that intend to allow the bypass must set this to ``True`` (default is False).
             is_active (bool): Whether the token should be created as active (default is True).
 
         Returns:
@@ -455,13 +470,33 @@ class TokenCatalogService:
             if not team:
                 raise ValueError(f"Team not found: {team_id}")
 
-            # Verify user is an active member of the team
-            membership = self.db.execute(
-                select(EmailTeamMember).where(and_(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email, EmailTeamMember.is_active.is_(True)))
-            ).scalar_one_or_none()
+            # Admin bypass: Only un-narrowed platform admins may create team tokens
+            # without being active team members. This supports service account
+            # workflows and centralized token management.
+            #
+            # Triple-gated defense-in-depth — ALL must hold for bypass:
+            #   1. is_admin=True               — caller flagged as platform admin by router
+            #   2. caller_token_teams_provided — router opted into bypass evaluation and
+            #      caller_token_teams is None  — session is un-narrowed (no JWT `teams` claim)
+            #   3. caller_permissions == ["*"] — effective permissions are wildcard
+            #
+            # Why all three: a narrowed admin (is_admin=True, token_teams=["other"]) can still
+            # have caller_permissions=["*"] from the global `platform_admin` role, because
+            # `_get_caller_permissions` falls through to PermissionService for narrowed
+            # sessions. Without the token_teams gate, narrowed admins would silently bypass
+            # membership for teams they were never granted access to. Defaulting
+            # caller_token_teams_provided=False also keeps callers that haven't been audited
+            # for this contract from accidentally satisfying the bypass.
+            is_unrestricted_admin = is_admin and caller_token_teams_provided and caller_token_teams is None and caller_permissions is not None and caller_permissions == ["*"]
 
-            if not membership:
-                raise ValueError(f"User {user_email} is not an active member of team {team_id}. Only team members can create tokens for the team.")
+            if not is_unrestricted_admin:
+                # Verify user is an active member of the team
+                membership = self.db.execute(
+                    select(EmailTeamMember).where(and_(EmailTeamMember.team_id == team_id, EmailTeamMember.user_email == user_email, EmailTeamMember.is_active.is_(True)))
+                ).scalar_one_or_none()
+
+                if not membership:
+                    raise ValueError(f"User {user_email} is not an active member of team {team_id}. Only team members can create tokens for the team.")
 
         # Check for duplicate active token name for this user within the same team scope,
         # matching DB constraint uq_email_api_tokens_user_name_team (user_email, name, team_id).
@@ -639,26 +674,50 @@ class TokenCatalogService:
         result = self.db.execute(query)
         return result.scalars().all()
 
-    async def list_team_tokens(self, team_id: str, user_email: str, include_inactive: bool = False, limit: int = 100, offset: int = 0) -> List[EmailApiToken]:
-        """List API tokens for a team (accessible by any active team member).
+    async def list_team_tokens(
+        self,
+        team_id: str,
+        user_email: str,
+        include_inactive: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+        caller_permissions: Optional[List[str]] = None,
+        is_admin: bool = False,
+        caller_token_teams: Optional[List[str]] = None,
+        caller_token_teams_provided: bool = False,
+    ) -> List[EmailApiToken]:
+        """List API tokens for a team (accessible by any active team member or un-narrowed admin).
 
         Args:
             team_id: Team ID to list tokens for
-            user_email: User's email (must be an active member of the team)
+            user_email: User's email (must be an active member of the team unless admin bypass applies)
             include_inactive: Include inactive/expired tokens
             limit: Maximum tokens to return
             offset: Number of tokens to skip
+            caller_permissions: Caller's effective permissions (for admin bypass check)
+            is_admin: Whether the caller is a platform admin (for admin bypass check)
+            caller_token_teams: Caller's token narrowing scope from JWT ``teams`` claim. Must be ``None``
+                (un-narrowed) for admin bypass to apply. Narrowed (``["team-a"]``) and public-only (``[]``)
+                sessions never bypass membership, even when ``caller_permissions == ["*"]`` from a global
+                ``platform_admin`` role.
+            caller_token_teams_provided: Whether the caller resolved ``caller_token_teams`` from the
+                authenticated session. Defaults to ``False``: callers that did not opt in cannot satisfy
+                the admin bypass. Routers that intend to allow the bypass must set this to ``True``.
 
         Returns:
             List[EmailApiToken]: Team's API tokens
 
         Raises:
-            ValueError: If user is not an active member of the team
+            ValueError: If user is not an active member of the team (unless admin bypass applies)
         """
-        team_ids = await self.get_user_team_ids(user_email)
+        # Triple-gated admin bypass — see create_token() for the security rationale.
+        is_unrestricted_admin = is_admin and caller_token_teams_provided and caller_token_teams is None and caller_permissions is not None and caller_permissions == ["*"]
 
-        if team_id not in team_ids:
-            raise ValueError(f"User {user_email} is not an active member of team {team_id}")
+        if not is_unrestricted_admin:
+            team_ids = await self.get_user_team_ids(user_email)
+
+            if team_id not in team_ids:
+                raise ValueError(f"User {user_email} is not an active member of team {team_id}")
 
         # Validate parameters
         if limit <= 0 or limit > 1000:

--- a/tests/unit/mcpgateway/routers/test_tokens.py
+++ b/tests/unit/mcpgateway/routers/test_tokens.py
@@ -75,10 +75,11 @@ def mock_current_user(mock_db):
 
 @pytest.fixture
 def mock_admin_user(mock_db):
-    """Create a mock admin user with db context."""
+    """Create a mock un-narrowed platform admin (token_teams=None)."""
     return {
         "email": "admin@example.com",
         "is_admin": True,
+        "token_teams": None,  # Un-narrowed: required to satisfy admin bypass
         "permissions": ["*"],
         "db": mock_db,  # Include db in user context for RBAC decorator
         "auth_method": "jwt",  # Required for interactive session check
@@ -1105,6 +1106,178 @@ class TestEdgeCases:
 
             call_args = mock_service.create_token.call_args
             assert call_args[1]["team_id"] == "team-auto"
+
+
+class TestAdminBypassRouterLevel:
+    """Router-level tests for admin bypass feature (PR review findings)."""
+
+    @pytest.mark.asyncio
+    async def test_create_team_token_admin_bypass_no_scope(self, mock_db, mock_admin_user, mock_token_record):
+        """Un-narrowed admin can create team token without scope (primary use case).
+
+        This is the critical test that would have caught the router bug where
+        caller_permissions was only fetched when request.scope was provided.
+        """
+        request = TokenCreateRequest(name="Admin Service Token", description="For automation")
+
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                mock_get_perms.return_value = ["*"]  # Un-narrowed admin
+                mock_service = mock_service_class.return_value
+                mock_service.create_token = AsyncMock(return_value=(mock_token_record, "admin-bypass-token"))
+
+                result = await create_team_token(team_id="team-123", request=request, current_user=mock_admin_user, db=mock_db)
+
+                # Verify _get_caller_permissions was called even without scope
+                mock_get_perms.assert_called_once()
+
+                # Verify service.create_token received the full bypass-gate context
+                call_kwargs = mock_service.create_token.call_args[1]
+                assert call_kwargs["caller_permissions"] == ["*"]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_token_teams"] is None
+                assert call_kwargs["caller_token_teams_provided"] is True
+                assert call_kwargs["team_id"] == "team-123"
+                assert result.access_token == "admin-bypass-token"
+
+    @pytest.mark.asyncio
+    async def test_create_team_token_admin_bypass_with_scope(self, mock_db, mock_admin_user, mock_token_record):
+        """Un-narrowed admin can create team token with custom scope."""
+        from mcpgateway.schemas import TokenScopeRequest
+
+        request = TokenCreateRequest(name="Scoped Admin Token", description="With permissions", scope=TokenScopeRequest(permissions=["tools.read"]))
+
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                mock_get_perms.return_value = ["*"]
+                mock_service = mock_service_class.return_value
+                mock_service.create_token = AsyncMock(return_value=(mock_token_record, "scoped-admin-token"))
+
+                result = await create_team_token(team_id="team-456", request=request, current_user=mock_admin_user, db=mock_db)
+
+                # Verify the full bypass-gate context propagates
+                call_kwargs = mock_service.create_token.call_args[1]
+                assert call_kwargs["caller_permissions"] == ["*"]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_token_teams"] is None
+                assert call_kwargs["caller_token_teams_provided"] is True
+                assert result.access_token == "scoped-admin-token"
+
+    @pytest.mark.asyncio
+    async def test_create_token_base_endpoint_admin_bypass(self, mock_db, mock_admin_user, mock_token_record):
+        """Base POST /tokens endpoint also gets admin bypass for team tokens."""
+        request = TokenCreateRequest(name="Base Endpoint Token", description="Via base endpoint", team_id="team-789")
+
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                mock_get_perms.return_value = ["*"]
+                mock_service = mock_service_class.return_value
+                mock_service.create_token = AsyncMock(return_value=(mock_token_record, "base-endpoint-token"))
+
+                result = await create_token(request=request, current_user=mock_admin_user, db=mock_db)
+
+                # Verify admin parameters propagate from base endpoint
+                call_kwargs = mock_service.create_token.call_args[1]
+                assert call_kwargs["caller_permissions"] == ["*"]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_token_teams"] is None
+                assert call_kwargs["caller_token_teams_provided"] is True
+                assert call_kwargs["team_id"] == "team-789"
+                assert result.access_token == "base-endpoint-token"
+
+    @pytest.mark.asyncio
+    async def test_list_team_tokens_admin_bypass(self, mock_db, mock_admin_user, mock_token_record):
+        """Un-narrowed admin can list team tokens without membership."""
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                mock_get_perms.return_value = ["*"]
+                mock_service = mock_service_class.return_value
+                mock_service.list_team_tokens = AsyncMock(return_value=[mock_token_record])
+                mock_service.count_team_tokens = AsyncMock(return_value=1)
+                mock_service.get_token_revocations_batch = AsyncMock(return_value={})
+
+                result = await list_team_tokens(team_id="team-999", current_user=mock_admin_user, db=mock_db)
+
+                # Verify admin parameters and the un-narrowed token scope propagate
+                call_kwargs = mock_service.list_team_tokens.call_args[1]
+                assert call_kwargs["caller_permissions"] == ["*"]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_token_teams"] is None
+                assert call_kwargs["caller_token_teams_provided"] is True
+                assert len(result.tokens) == 1
+
+    @pytest.mark.asyncio
+    async def test_narrowed_admin_requires_membership(self, mock_db, mock_token_record):
+        """Narrowed admin (token_teams set) still requires team membership."""
+        narrowed_admin = {
+            "email": "narrowed@example.com",
+            "is_admin": True,
+            "token_teams": ["other-team"],  # Narrowed to different team
+            "permissions": ["tools.read"],
+            "db": mock_db,
+            "auth_method": "jwt",
+        }
+
+        request = TokenCreateRequest(name="Should Fail", description="Narrowed admin")
+
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                mock_get_perms.return_value = ["tools.read"]  # NOT ["*"]
+                mock_service = mock_service_class.return_value
+                # Service will raise ValueError for non-member
+                mock_service.create_token = AsyncMock(side_effect=ValueError("User narrowed@example.com is not an active member of team team-blocked"))
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await create_team_token(team_id="team-blocked", request=request, current_user=narrowed_admin, db=mock_db)
+
+                assert exc_info.value.status_code == 400
+                # Verify the router forwarded the narrowed scope so the service can deny bypass
+                call_kwargs = mock_service.create_token.call_args[1]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_permissions"] != ["*"]
+                assert call_kwargs["caller_token_teams"] == ["other-team"]
+                assert call_kwargs["caller_token_teams_provided"] is True
+
+    @pytest.mark.asyncio
+    async def test_narrowed_admin_with_global_wildcard_does_not_bypass(self, mock_db, mock_token_record):
+        """Narrowed admin holding the global ``platform_admin`` role still requires membership.
+
+        This regression covers the case where ``_get_caller_permissions`` falls
+        through to ``PermissionService`` for narrowed sessions and the service
+        returns ``{"*"}`` because the user has the seeded ``platform_admin``
+        role globally. The router must forward ``caller_token_teams`` so the
+        service can refuse the bypass even when ``caller_permissions == ["*"]``.
+        """
+        narrowed_admin = {
+            "email": "narrowed-admin@example.com",
+            "is_admin": True,
+            "token_teams": ["other-team"],
+            "permissions": ["*"],
+            "db": mock_db,
+            "auth_method": "jwt",
+        }
+
+        request = TokenCreateRequest(name="Should Fail", description="Narrowed admin with platform_admin role")
+
+        with patch("mcpgateway.routers.tokens.TokenCatalogService") as mock_service_class:
+            with patch("mcpgateway.routers.tokens._get_caller_permissions") as mock_get_perms:
+                # Simulates PermissionService returning {"*"} for a narrowed admin
+                # who holds the global platform_admin role.
+                mock_get_perms.return_value = ["*"]
+                mock_service = mock_service_class.return_value
+                mock_service.create_token = AsyncMock(side_effect=ValueError("User narrowed-admin@example.com is not an active member of team team-blocked"))
+
+                with pytest.raises(HTTPException) as exc_info:
+                    await create_team_token(team_id="team-blocked", request=request, current_user=narrowed_admin, db=mock_db)
+
+                assert exc_info.value.status_code == 400
+                # The router must forward the narrowed token scope so the service refuses bypass
+                # even though caller_permissions == ["*"] from the global platform_admin role.
+                call_kwargs = mock_service.create_token.call_args[1]
+                assert call_kwargs["caller_permissions"] == ["*"]
+                assert call_kwargs["is_admin"] is True
+                assert call_kwargs["caller_token_teams"] == ["other-team"]
+                assert call_kwargs["caller_token_teams_provided"] is True
 
 
 # ---------- Codex Review Findings: Regression Tests ----------

--- a/tests/unit/mcpgateway/services/test_token_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_token_catalog_service.py
@@ -523,6 +523,211 @@ class TestTokenCatalogService:
             await token_service.create_token(user_email="test@example.com", name="Token", team_id="team-123")
 
     @pytest.mark.asyncio
+    async def test_create_token_admin_bypass_with_unrestricted_permissions(self, token_service, mock_db, mock_user, mock_team):
+        """Test admin bypass: un-narrowed platform admin can create team tokens without membership.
+
+        Security invariant: Requires caller_permissions=["*"] (un-narrowed admin).
+        This supports service account workflows and centralized token management.
+        """
+        # Setup mock responses for specific queries
+        # Note: Uses call_count to sequence responses (user lookup, team lookup, token name check)
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+
+        def scalar_one_or_none_side_effect():
+            call_count = mock_db.execute.call_count
+            if call_count == 1:
+                return mock_user  # User exists
+            elif call_count == 2:
+                return mock_team  # Team exists
+            # All other queries (membership check skipped, token name check) return None
+            return None
+
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = scalar_one_or_none_side_effect
+
+        with patch.object(token_service, "_generate_token", new_callable=AsyncMock) as mock_gen_token:
+            mock_gen_token.return_value = "jwt_token_admin_bypass"
+
+            # Un-narrowed admin with wildcard permissions can bypass team membership
+            token, raw_token = await token_service.create_token(
+                user_email="admin@example.com",
+                name="Admin Service Token",
+                team_id="team-123",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=None,
+                caller_token_teams_provided=True,
+                expires_in_days=30,
+            )
+
+            assert raw_token == "jwt_token_admin_bypass"
+            added_token = mock_db.add.call_args[0][0]
+            assert added_token.team_id == "team-123"
+            assert added_token.user_email == "admin@example.com"
+
+            # Verify membership check was skipped by inspecting actual queries
+            # Should have: user lookup, team lookup, token name check
+            # Should NOT have: membership query (EmailTeamMember)
+            executed_queries = [str(call[0][0]) for call in mock_db.execute.call_args_list]
+            membership_query_executed = any("EmailTeamMember" in query or "email_team_members" in query.lower() for query in executed_queries)
+            assert not membership_query_executed, "Admin bypass should skip membership check"
+
+    @pytest.mark.asyncio
+    async def test_create_token_narrowed_admin_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Test security invariant: narrowed admin sessions still require team membership.
+
+        Even if user has is_admin=True, if caller_permissions is not ["*"],
+        they must be an active team member.
+        """
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,  # User exists
+            mock_team,  # Team exists
+            None,  # User is NOT a team member
+        ]
+
+        # Narrowed admin (has specific permissions, not wildcard) must be team member
+        with pytest.raises(ValueError, match="User test@example.com is not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=["tools.read", "resources.read"],  # Narrowed permissions
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_no_caller_permissions_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Test security invariant: without caller_permissions, team membership is required.
+
+        If caller_permissions is None or empty, the user must be an active team member.
+        """
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,  # User exists
+            mock_team,  # Team exists
+            None,  # User is NOT a team member
+        ]
+
+        # No caller_permissions means no admin bypass
+        with pytest.raises(ValueError, match="User test@example.com is not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=None,  # No permissions provided
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_empty_caller_permissions_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Test security invariant: empty caller_permissions list requires team membership."""
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,  # User exists
+            mock_team,  # Team exists
+            None,  # User is NOT a team member
+        ]
+
+        # Empty permissions list means no admin bypass
+        with pytest.raises(ValueError, match="User test@example.com is not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=[],  # Empty permissions
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_admin_bypass_still_validates_team_exists(self, token_service, mock_db, mock_user):
+        """Test security invariant: admin bypass still requires team to exist.
+
+        Even un-narrowed admins cannot create tokens for non-existent teams.
+        """
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,  # User exists
+            None,  # Team does NOT exist
+        ]
+
+        # Admin bypass doesn't skip team existence validation
+        with pytest.raises(ValueError, match="Team not found: nonexistent-team"):
+            await token_service.create_token(
+                user_email="admin@example.com",
+                name="Token",
+                team_id="nonexistent-team",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=None,
+                caller_token_teams_provided=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_narrowed_admin_with_wildcard_still_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Narrowed admin with wildcard permissions still requires team membership.
+
+        Regression for the case where a narrowed admin (is_admin=True,
+        token_teams=["other-team"]) inherits caller_permissions=["*"] from a
+        global ``platform_admin`` role. The bypass must NOT fire because the
+        session is narrowed, so PermissionService can return wildcard
+        permissions while the token has no claim on the target team.
+        """
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,  # User exists
+            mock_team,  # Team exists
+            None,  # User is NOT a member of the target team
+        ]
+
+        with pytest.raises(ValueError, match="not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=["other-team"],
+                caller_token_teams_provided=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_public_only_admin_with_wildcard_still_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Public-only admin (token_teams=[]) with wildcard permissions still requires membership."""
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,
+            mock_team,
+            None,
+        ]
+
+        with pytest.raises(ValueError, match="not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=[],
+                caller_token_teams_provided=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_token_admin_without_provided_flag_requires_membership(self, token_service, mock_db, mock_user, mock_team):
+        """Callers that don't opt in via caller_token_teams_provided cannot satisfy the bypass.
+
+        Defense-in-depth: even if is_admin=True, caller_token_teams=None, and
+        caller_permissions=["*"] are all passed, the bypass must NOT fire when
+        caller_token_teams_provided is False (the safe default).
+        """
+        mock_db.execute.return_value.scalar_one_or_none.side_effect = [
+            mock_user,
+            mock_team,
+            None,
+        ]
+
+        with pytest.raises(ValueError, match="not an active member of team team-123"):
+            await token_service.create_token(
+                user_email="test@example.com",
+                name="Token",
+                team_id="team-123",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=None,
+                # caller_token_teams_provided defaults to False — bypass must not fire
+            )
+
+    @pytest.mark.asyncio
     async def test_create_token_with_scope(self, token_service, mock_db, mock_user, token_scope):
         """Test create_token method with TokenScope."""
         mock_db.execute.return_value.scalar_one_or_none.side_effect = [
@@ -633,6 +838,56 @@ class TestTokenCatalogService:
         with patch.object(token_service, "get_user_team_ids", new_callable=AsyncMock, return_value=[]):
             with pytest.raises(ValueError, match="is not an active member of team"):
                 await token_service.list_team_tokens("team-123", "notmember@example.com")
+
+    @pytest.mark.asyncio
+    async def test_list_team_tokens_admin_bypass(self, token_service, mock_db, mock_api_token):
+        """Un-narrowed admin can list team tokens without membership."""
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_api_token]
+        mock_db.execute.return_value = mock_result
+
+        with patch.object(token_service, "get_user_team_ids", new_callable=AsyncMock) as mock_team_ids:
+            tokens = await token_service.list_team_tokens(
+                "team-123",
+                "admin@example.com",
+                caller_permissions=["*"],
+                is_admin=True,
+                caller_token_teams=None,
+                caller_token_teams_provided=True,
+            )
+            mock_team_ids.assert_not_called()  # Admin bypass skips membership check
+
+        assert tokens == [mock_api_token]
+
+    @pytest.mark.asyncio
+    async def test_list_team_tokens_narrowed_admin_with_wildcard_requires_membership(self, token_service, mock_db):
+        """Narrowed admin with wildcard permissions still requires membership for list."""
+        with patch.object(token_service, "get_user_team_ids", new_callable=AsyncMock, return_value=["other-team"]) as mock_team_ids:
+            with pytest.raises(ValueError, match="is not an active member of team"):
+                await token_service.list_team_tokens(
+                    "team-123",
+                    "narrowed-admin@example.com",
+                    caller_permissions=["*"],
+                    is_admin=True,
+                    caller_token_teams=["other-team"],
+                    caller_token_teams_provided=True,
+                )
+            mock_team_ids.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_list_team_tokens_admin_without_provided_flag_requires_membership(self, token_service, mock_db):
+        """Callers that don't opt in via caller_token_teams_provided cannot bypass list membership."""
+        with patch.object(token_service, "get_user_team_ids", new_callable=AsyncMock, return_value=[]) as mock_team_ids:
+            with pytest.raises(ValueError, match="is not an active member of team"):
+                await token_service.list_team_tokens(
+                    "team-123",
+                    "admin@example.com",
+                    caller_permissions=["*"],
+                    is_admin=True,
+                    caller_token_teams=None,
+                    # caller_token_teams_provided defaults to False — bypass must not fire
+                )
+            mock_team_ids.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_list_user_and_team_tokens_basic(self, token_service, mock_db, mock_api_token):


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4390

---

## 📝 Summary

Adds admin bypass capability to `POST /tokens/teams/{team_id}` endpoint to support service account workflows and centralized token management.

**Problem:**
- Platform admins and service accounts were blocked from creating team tokens when not active members of the target team
- This prevented centralized token provisioning and emergency access scenarios
- Inconsistent with other admin endpoints that allow un-narrowed admins to bypass team restrictions

**Solution:**
- Modified [`token_catalog_service.py`](mcpgateway/services/token_catalog_service.py:458-471) to check for un-narrowed platform admin status (`caller_permissions=["*"]`) before enforcing team membership
- Un-narrowed platform admins can now create team tokens without being active team members
- Narrowed admin sessions and regular users still require team membership (security invariant maintained)

**Use Cases Enabled:**
- Service account management across teams
- Centralized token provisioning by platform admins
- Emergency access without joining teams
- Automated CI/CD workflows

---

## 🏷️ Type of Change
- [x] Feature / Enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |


**New Tests Added:**
- `test_create_token_admin_bypass_with_unrestricted_permissions` - Verifies admin bypass works correctly
- `test_create_token_narrowed_admin_requires_membership` - Ensures narrowed admins still need membership
- `test_create_token_no_caller_permissions_requires_membership` - Validates None permissions require membership
- `test_create_token_empty_caller_permissions_requires_membership` - Validates empty list requires membership
- `test_create_token_admin_bypass_still_validates_team_exists` - Ensures team existence check remains enforced

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (5 new comprehensive tests)
- [x] Documentation updated (inline comments explaining security model)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Security Invariants Maintained:**
1. ✅ Requires un-narrowed platform admin (`is_admin=true` AND `caller_permissions=["*"]`)
2. ✅ Narrowed admin sessions still require team membership
3. ✅ Regular users still require team membership
4. ✅ Team existence validation enforced for all users
5. ✅ Management Plane isolation preserved
6. ✅ Audit trail maintained (token creation logs include user email)

**Implementation Details:**
- Admin bypass check: `is_unrestricted_admin = caller_permissions is not None and caller_permissions == ["*"]`
- Only skips membership validation when condition is true
- Team existence check always runs before membership check
- Consistent with existing admin bypass patterns in the codebase

**Testing Coverage:**
- Positive case: Admin with `["*"]` permissions can create team tokens
- Negative cases: Narrowed admins, users with `None` permissions, users with `[]` permissions all require membership
- Edge case: Admin bypass still validates team exists (cannot create tokens for non-existent teams)