### PR TITLE
fix: increase SSO authorization code max_length from 512 to 4096 (Entra ID regression)

### DIFF
--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -306,7 +306,7 @@ async def handle_sso_callback(
     # '!*%', and our own session-bound state uses '.' as a separator
     # (sso_service._STATE_BINDING_SEPARATOR). Bound length only; downstream token
     # exchange and HMAC verification validate integrity.
-    code: Optional[str] = Query(None, max_length=512, description="Authorization code from SSO provider"),
+    code: Optional[str] = Query(None, max_length=4096, description="Authorization code from SSO provider"),
     state: Optional[str] = Query(None, max_length=128, description="CSRF state parameter"),
     # error values are RFC 6749 Section 4.1.2.1 / 5.2 enum-like snake_case tokens
     # (invalid_request, unauthorized_client, access_denied, ...).


### PR DESCRIPTION
# 🐛 Bug-fix PR

Fixes #4490

## 📌 Summary

The SSO callback endpoint rejects valid Microsoft Entra ID authorization codes with HTTP 422 because the `code` query parameter is limited to `max_length=512`. Entra ID v2 authorization codes routinely exceed 1500 characters, **completely breaking SSO login** for all Azure AD / Entra ID users.

This is a **regression** introduced when input validation constraints were added to SSO parameters.

## 🔁 Reproduction Steps

1. Configure SSO with Microsoft Entra ID authorization server
2. Attempt SSO login via admin UI
3. Entra ID redirects to `/api/v1/sso/callback?code=<1500+ char code>&state=...`
4. HTTP 422: `string_too_long` on `code` parameter

See issue #4490 for full details and error payload.

## 🐞 Root Cause

In `mcpgateway/routers/sso.py`, the `code` parameter has `max_length=512`:

```python
code: Optional[str] = Query(None, max_length=512, description="Authorization code from SSO provider"),
```

Microsoft Entra ID v2 authorization codes are 1200–2000+ characters. The 512 limit triggers a Pydantic validation error before token exchange.

## 💡 Fix Description

Increase `max_length` from **512** to **4096** for the `code` query parameter.

- RFC 6749 does not define a maximum authorization code length
- Google: ~70 chars, Microsoft Entra ID: 1200–2000+ chars
- 4096 provides safe headroom for all known providers
- Security is enforced by token exchange + HMAC state verification, not code length

### Change

```diff
-    code: Optional[str] = Query(None, max_length=512, description="Authorization code from SSO provider"),
+    code: Optional[str] = Query(None, max_length=4096, description="Authorization code from SSO provider"),
```

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Manual regression no longer fails     | Tested with Entra ID | ✅     |

## 📐 MCP Compliance
- [x] No impact on MCP protocol
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted
- [x] No secrets/credentials committed
- [x] Signed-off-by included in commit