### PR TITLE
fix(admin): add missing URL field in server edit modal

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -11141,6 +11141,20 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                       />
                       <p data-error-message-for="name" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">Name is required.</p>
                     </div>
+                    <div class="relative">
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >URL</label
+                      >
+                      <input
+                        type="url"
+                        name="url"
+                        required
+                        id="edit-server-url"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                      <p data-error-message-for="url" class="absolute top-full left-0 mt-1 text-xs text-red-500 invisible">URL is required.</p>
+                    </div>
                     <div>
                       <label
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300"


### PR DESCRIPTION
# 🐛 Bug-fix PR

Fixes #4492

## 📌 Summary

The server edit modal is missing the URL input field that `servers.js` references via `safeGetElement('edit-server-url')`. The create server modal has the URL field, but the edit modal does not — making it impossible to view or modify a server's URL after creation.

Likely a regression from PR #337 (July 2025) which restructured the server modals.

## 🔁 Reproduction Steps

1. Navigate to Virtual MCP Servers in admin UI
2. Click edit on any server
3. Edit modal opens without a URL field
4. No way to view or change the URL

See issue #4492 for details.

## 🐞 Root Cause

The `<input id="edit-server-url">` element was never added to the `server-edit-modal` form in `admin.html`. The JavaScript populates it via `safeGetElement('edit-server-url')` which silently returns null, so the URL is lost on save.

## 💡 Fix Description

Add the URL input field (`type="url"`, `id="edit-server-url"`) to the server edit modal, between the Name and Description fields, matching the create modal pattern:

```html
<div class="relative">
  <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">URL</label>
  <input type="url" name="url" required id="edit-server-url"
    class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-600 shadow-sm ..." />
  <p data-error-message-for="url" class="...">URL is required.</p>
</div>
```

Single file change: `mcpgateway/templates/admin.html` (+14 lines).

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | ✅     |
| Unit tests                            | `make test`          | ✅     |
| Manual regression no longer fails     | Verified in browser  | ✅     |

## 📐 MCP Compliance
- [x] No impact on MCP protocol
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted
- [x] No secrets/credentials committed
- [x] Signed-off-by included in commit