### PR TITLE
feat(auth): add configurable JWT authentication header support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -280,6 +280,13 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Security / auth (see also "Security Defaults" section above)
 # AUTH_REQUIRED=true
 # MCP_CLIENT_AUTH_ENABLED=true
+
+# HTTP header name for JWT authentication (default: Authorization)
+# Use alternative header (e.g., X-MCP-Gateway-Auth) to avoid collision with
+# downstream server authentication. When using custom header, the standard
+# Authorization header is preserved and passed through to backend servers.
+# AUTH_HEADER_NAME=Authorization
+# AUTH_HEADER_NAME=X-MCP-Gateway-Auth
 # TRUST_PROXY_AUTH=false
 # TRUST_PROXY_AUTH_DANGEROUSLY=false  # DANGER: Only set true behind a strictly trusted auth proxy
 # ALLOW_UNAUTHENTICATED_ADMIN=false   # DANGER: Only for local dev — grants admin to unauthenticated requests

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-28T10:13:19Z",
+  "generated_at": "2026-04-28T10:32:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-06T19:42:21Z",
+  "generated_at": "2026-04-28T10:13:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 578,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 766,
+        "line_number": 773,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1039,
+        "line_number": 1046,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1065,
+        "line_number": 1072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1073,
+        "line_number": 1080,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 1159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1157,
+        "line_number": 1164,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1162,
+        "line_number": 1169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1168,
+        "line_number": 1175,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1180,
+        "line_number": 1187,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1198,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1266,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -250,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1064,
+        "line_number": 859,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1502,
+        "line_number": 1297,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2868,
+        "line_number": 2663,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2959,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3002,
+        "line_number": 2797,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3007,
+        "line_number": 2802,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3012,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -334,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 959,
+        "line_number": 951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 961,
+        "line_number": 953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6231,
+        "line_number": 6263,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6728,
+        "line_number": 6760,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6740,
+        "line_number": 6772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6812,
+        "line_number": 6844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7893,
+        "line_number": 7923,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1300,7 +1300,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1308,7 +1308,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2145,6 +2145,16 @@
         "verified_result": null
       }
     ],
+    "docs/docs/development/release-management.md": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 902,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2174,7 +2184,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2182,7 +2192,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2250,7 +2260,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 584,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2333,12 +2343,38 @@
         "verified_result": null
       }
     ],
+    "docs/docs/manage/configurable-auth-header.md": [
+      {
+        "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 194,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 221,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/docs/manage/configuration.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 195,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2346,7 +2382,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 426,
+        "line_number": 476,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2354,7 +2390,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 792,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2362,7 +2398,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1209,
+        "line_number": 1259,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2370,7 +2406,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1213,
+        "line_number": 1263,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3052,7 +3088,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3060,7 +3096,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3068,7 +3104,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3076,7 +3112,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3084,7 +3120,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3092,7 +3128,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3100,7 +3136,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3108,7 +3144,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3136,7 +3172,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 152,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4178,7 +4214,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4205,
+        "line_number": 4190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4186,7 +4222,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4840,
+        "line_number": 4825,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4194,7 +4230,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4842,
+        "line_number": 4827,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4202,7 +4238,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15211,
+        "line_number": 15206,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4222,7 +4258,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4232,7 +4268,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4242,7 +4278,7 @@
         "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4252,7 +4288,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 17,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4260,7 +4296,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4290,7 +4326,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4298,7 +4334,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4318,7 +4354,7 @@
         "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4328,17 +4364,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/4842b831d24e_add_on_error_to_tool_plugin_bindings.py": [
-      {
-        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4348,7 +4374,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4358,7 +4384,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4368,7 +4394,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4378,7 +4404,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4386,7 +4412,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4406,7 +4432,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4416,7 +4442,7 @@
         "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4426,43 +4452,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py": [
-      {
-        "hashed_secret": "6fc2a8a23c7db93d6624d3e40d9db9f3157c715e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9c45d2e63bc0_merge_plugin_bindings_and_token_.py": [
-      {
-        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 13,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "37aeb741aa6f0a22a08c218234b31ee891f64400",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4472,7 +4462,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4482,7 +4472,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4492,7 +4482,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4502,7 +4492,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4510,7 +4500,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4520,7 +4510,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 17,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4528,7 +4518,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4538,22 +4528,12 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
       {
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/aa1b2c3d4e5f_add_token_revocation_idle_timeout_fields.py": [
-      {
-        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
         "is_secret": false,
         "is_verified": false,
         "line_number": 20,
@@ -4566,7 +4546,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 14,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4576,7 +4556,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4596,7 +4576,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4604,7 +4584,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4614,7 +4594,17 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 14,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
+      {
+        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4624,7 +4614,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4634,7 +4624,7 @@
         "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4642,7 +4632,7 @@
         "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4662,7 +4652,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4670,7 +4660,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4698,7 +4688,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4706,7 +4696,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4716,7 +4706,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4724,7 +4714,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4752,7 +4742,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 21,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4762,7 +4752,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4772,7 +4762,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4780,7 +4770,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4800,7 +4790,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4820,7 +4810,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4830,7 +4820,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 16,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4840,7 +4830,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4850,7 +4840,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 39,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4860,7 +4850,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 16,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4890,7 +4880,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 224,
+        "line_number": 221,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4898,7 +4888,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2423,
+        "line_number": 2424,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4962,6 +4952,36 @@
         "is_verified": false,
         "line_number": 269,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/hooks/policies.py": [
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5086,7 +5106,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 672,
+        "line_number": 573,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5182,7 +5202,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 357,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5190,7 +5210,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3526,
+        "line_number": 3517,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5322,7 +5342,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5330,7 +5350,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 261,
+        "line_number": 262,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5338,7 +5358,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5462,7 +5482,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 687,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5482,6 +5502,16 @@
         "is_verified": false,
         "line_number": 913,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5774,7 +5804,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 639,
+        "line_number": 448,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5782,7 +5812,7 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 646,
+        "line_number": 455,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5965,12 +5995,56 @@
         "verified_result": null
       }
     ],
+    "tests/e2e/test_mcp_rbac_transport.py": [
+      {
+        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 851,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/e2e/test_oauth_protected_resource.py": [
       {
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_translate_dynamic_env_e2e.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 201,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 338,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5990,7 +6064,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6010,7 +6084,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6056,7 +6130,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3780,
+        "line_number": 3783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6064,7 +6138,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6623,
+        "line_number": 6626,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6072,7 +6146,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6979,
+        "line_number": 6982,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6080,7 +6154,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7003,
+        "line_number": 7006,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6090,7 +6164,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 96,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6100,7 +6174,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 103,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6380,7 +6454,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 59,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6390,7 +6464,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 70,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6400,7 +6474,7 @@
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6408,7 +6482,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6416,7 +6490,7 @@
         "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6426,7 +6500,7 @@
         "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 528,
+        "line_number": 520,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6434,7 +6508,7 @@
         "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 593,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6442,7 +6516,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 629,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6452,7 +6526,7 @@
         "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6472,7 +6546,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 37,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6482,7 +6556,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 24,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6492,7 +6566,7 @@
         "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 238,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6502,7 +6576,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6510,7 +6584,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 587,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6520,7 +6594,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 36,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6530,7 +6604,7 @@
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6540,7 +6614,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 26,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6550,7 +6624,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 45,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6580,7 +6654,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 42,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6590,7 +6664,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 14,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6600,7 +6674,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6628,7 +6702,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6636,7 +6710,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6656,7 +6730,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 27,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6684,7 +6758,7 @@
         "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 52,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6760,7 +6834,7 @@
         "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6768,7 +6842,7 @@
         "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 464,
+        "line_number": 472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6776,7 +6850,7 @@
         "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6784,7 +6858,7 @@
         "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 674,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6794,7 +6868,7 @@
         "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1396,
+        "line_number": 1387,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6802,7 +6876,7 @@
         "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1483,
+        "line_number": 1474,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6812,7 +6886,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 116,
+        "line_number": 115,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6820,7 +6894,7 @@
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6828,8 +6902,174 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 214,
+        "line_number": 213,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 225,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
+      {
+        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 247,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 311,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 233,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 238,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
+      {
+        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 616,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 801,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 815,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -6846,7 +7086,7 @@
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 247,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6856,7 +7096,7 @@
         "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 260,
+        "line_number": 301,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6864,7 +7104,7 @@
         "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 323,
+        "line_number": 381,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6892,7 +7132,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 62,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6900,7 +7140,7 @@
         "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 143,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6930,7 +7170,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6938,7 +7178,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 210,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6966,7 +7206,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6974,7 +7214,7 @@
         "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 522,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6982,7 +7222,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 657,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6990,7 +7230,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1421,
+        "line_number": 1422,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6998,7 +7238,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1490,
+        "line_number": 1491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7006,7 +7246,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1594,
+        "line_number": 1595,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7014,7 +7254,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1625,
+        "line_number": 1626,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7022,7 +7262,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1642,
+        "line_number": 1643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7030,7 +7270,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1676,
+        "line_number": 1677,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7038,7 +7278,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2135,
+        "line_number": 2136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7048,7 +7288,7 @@
         "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 532,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7056,7 +7296,7 @@
         "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 558,
+        "line_number": 538,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7066,7 +7306,7 @@
         "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 126,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7106,7 +7346,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 279,
+        "line_number": 278,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7114,7 +7354,7 @@
         "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 343,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7122,7 +7362,7 @@
         "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7130,7 +7370,7 @@
         "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 432,
+        "line_number": 431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7138,7 +7378,7 @@
         "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 563,
+        "line_number": 562,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7346,7 +7586,7 @@
         "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 578,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7356,7 +7596,7 @@
         "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 129,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -7364,7 +7604,7 @@
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 130,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7374,7 +7614,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 404,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7382,7 +7622,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7390,7 +7630,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 790,
+        "line_number": 785,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7464,7 +7704,7 @@
         "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1505,
+        "line_number": 1504,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7472,7 +7712,7 @@
         "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1517,
+        "line_number": 1516,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7480,7 +7720,7 @@
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1580,
+        "line_number": 1579,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7488,7 +7728,7 @@
         "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1602,
+        "line_number": 1601,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7496,7 +7736,7 @@
         "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7504,7 +7744,7 @@
         "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1661,
+        "line_number": 1660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7512,7 +7752,7 @@
         "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2177,
+        "line_number": 2176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7520,7 +7760,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2262,
+        "line_number": 2261,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7530,7 +7770,7 @@
         "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 389,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7566,7 +7806,7 @@
         "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 154,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7576,7 +7816,7 @@
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 376,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7584,7 +7824,7 @@
         "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 380,
+        "line_number": 378,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7592,7 +7832,7 @@
         "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 416,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7600,7 +7840,7 @@
         "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 419,
+        "line_number": 417,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7608,7 +7848,7 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 420,
+        "line_number": 418,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -7616,7 +7856,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 734,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7624,7 +7864,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 735,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7632,7 +7872,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 797,
+        "line_number": 781,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7640,7 +7880,7 @@
         "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 782,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7648,7 +7888,7 @@
         "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 819,
+        "line_number": 803,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7676,7 +7916,7 @@
         "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 203,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7684,7 +7924,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 227,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7822,7 +8062,7 @@
         "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 288,
+        "line_number": 308,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7830,7 +8070,7 @@
         "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 517,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7838,7 +8078,7 @@
         "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1390,
+        "line_number": 1449,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7846,7 +8086,7 @@
         "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1543,
+        "line_number": 1602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7854,7 +8094,7 @@
         "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1613,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7862,7 +8102,7 @@
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2384,
+        "line_number": 2504,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7870,7 +8110,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2401,
+        "line_number": 2521,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7878,7 +8118,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2550,
+        "line_number": 2670,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7888,7 +8128,7 @@
         "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7896,7 +8136,7 @@
         "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 275,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7904,7 +8144,7 @@
         "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7912,7 +8152,7 @@
         "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 555,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7920,7 +8160,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 773,
+        "line_number": 769,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7928,7 +8168,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 779,
+        "line_number": 775,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7938,7 +8178,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 440,
+        "line_number": 434,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7946,7 +8186,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 447,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7954,7 +8194,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 466,
+        "line_number": 460,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7972,7 +8212,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7980,7 +8220,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 123,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7988,7 +8228,7 @@
         "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 148,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7996,7 +8236,7 @@
         "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8004,7 +8244,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8014,7 +8254,7 @@
         "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 266,
+        "line_number": 256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8022,7 +8262,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 346,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8030,7 +8270,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 821,
+        "line_number": 807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8038,7 +8278,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8046,7 +8286,7 @@
         "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1229,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8054,7 +8294,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1335,
+        "line_number": 1289,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8062,7 +8302,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8072,7 +8312,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 164,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -8082,7 +8322,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 421,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8090,7 +8330,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 446,
+        "line_number": 440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8098,7 +8338,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 695,
+        "line_number": 689,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8106,7 +8346,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 771,
+        "line_number": 765,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8114,7 +8354,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 774,
+        "line_number": 768,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8124,7 +8364,7 @@
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 62,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8132,7 +8372,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 366,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8140,7 +8380,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 489,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8150,7 +8390,7 @@
         "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 410,
+        "line_number": 405,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8158,7 +8398,7 @@
         "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 406,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8168,7 +8408,7 @@
         "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4118,
+        "line_number": 4117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8176,7 +8416,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4133,
+        "line_number": 4132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8184,7 +8424,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4831,
+        "line_number": 4830,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8252,7 +8492,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8260,7 +8500,7 @@
         "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 198,
+        "line_number": 197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8268,7 +8508,7 @@
         "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 335,
+        "line_number": 334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8278,15 +8518,23 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 83,
+        "line_number": 82,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 106,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -8294,7 +8542,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 196,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -8302,16 +8550,8 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 210,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 254,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -8320,7 +8560,7 @@
         "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 25,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8328,7 +8568,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8336,7 +8576,7 @@
         "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 545,
+        "line_number": 539,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8346,7 +8586,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 549,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8354,7 +8594,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8362,7 +8602,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 566,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8370,7 +8610,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 1985,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8378,7 +8618,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3570,
+        "line_number": 3571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8386,7 +8626,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4203,
+        "line_number": 4204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8394,7 +8634,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7559,
+        "line_number": 7560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8402,7 +8642,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8051,
+        "line_number": 8052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8410,7 +8650,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9398,
+        "line_number": 9399,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8418,7 +8658,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9540,
+        "line_number": 9541,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8426,7 +8666,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10022,
+        "line_number": 10023,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8436,7 +8676,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2985,
+        "line_number": 2980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8444,7 +8684,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3671,
+        "line_number": 3666,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8452,7 +8692,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3680,
+        "line_number": 3675,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8460,7 +8700,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4130,
+        "line_number": 4125,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8468,7 +8708,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7057,
+        "line_number": 7052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8476,7 +8716,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7075,
+        "line_number": 7070,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8484,7 +8724,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7099,
+        "line_number": 7094,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8492,7 +8732,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7163,
+        "line_number": 7158,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8500,7 +8740,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7174,
+        "line_number": 7169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8508,7 +8748,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7215,
+        "line_number": 7210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8516,7 +8756,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7221,
+        "line_number": 7216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8524,7 +8764,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8415,
+        "line_number": 8410,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8658,7 +8898,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 459,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8666,7 +8906,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1112,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9002,7 +9242,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 68,
+        "line_number": 67,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9012,7 +9252,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 44,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9020,7 +9260,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 140,
+        "line_number": 128,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9028,7 +9268,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 141,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9128,7 +9368,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 171,
+        "line_number": 167,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9156,7 +9396,7 @@
         "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 333,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9164,7 +9404,7 @@
         "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 352,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9172,7 +9412,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 377,
+        "line_number": 371,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9180,7 +9420,7 @@
         "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 382,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9190,7 +9430,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 781,
+        "line_number": 775,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9198,7 +9438,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 956,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9206,7 +9446,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 967,
+        "line_number": 961,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9214,7 +9454,7 @@
         "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 993,
+        "line_number": 987,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9222,7 +9462,7 @@
         "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1011,
+        "line_number": 1005,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9230,7 +9470,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1224,
+        "line_number": 1218,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9238,7 +9478,7 @@
         "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1340,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9258,7 +9498,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 135,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9268,7 +9508,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 276,
+        "line_number": 277,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9306,7 +9546,7 @@
         "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 201,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9344,7 +9584,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 75,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9354,7 +9594,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 32,
         "type": "Private Key",
         "verified_result": null
       }
@@ -9392,7 +9632,7 @@
         "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 50,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9402,7 +9642,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 41,
+        "line_number": 40,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9410,7 +9650,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9418,7 +9658,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 57,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9426,7 +9666,7 @@
         "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 66,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9434,7 +9674,7 @@
         "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 80,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9442,7 +9682,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 153,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9450,7 +9690,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 155,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9458,7 +9698,7 @@
         "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 215,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9484,7 +9724,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1045,
+        "line_number": 1042,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9492,7 +9732,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1194,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9512,7 +9752,7 @@
         "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 136,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9520,7 +9760,7 @@
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 451,
+        "line_number": 504,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9528,7 +9768,7 @@
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 495,
+        "line_number": 548,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9536,7 +9776,7 @@
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 508,
+        "line_number": 561,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9544,7 +9784,7 @@
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 877,
+        "line_number": 930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9552,7 +9792,7 @@
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1179,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9567,22 +9807,12 @@
         "verified_result": null
       }
     ],
-    "tests/unit/plugins/test_secrets_detection.py": [
-      {
-        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 141,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
     "tests/unit/test_conc_01_helpers.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 160,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-28T10:37:46Z",
+  "generated_at": "2026-05-06T20:00:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -250,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 859,
+        "line_number": 1064,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 947,
+        "line_number": 1152,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1297,
+        "line_number": 1502,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2868,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2754,
+        "line_number": 2959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2797,
+        "line_number": 3002,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2802,
+        "line_number": 3007,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 3012,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -334,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 951,
+        "line_number": 959,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 953,
+        "line_number": 961,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1613,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1857,
+        "line_number": 1826,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6263,
+        "line_number": 6231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6760,
+        "line_number": 6728,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6772,
+        "line_number": 6740,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6844,
+        "line_number": 6812,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7923,
+        "line_number": 7893,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1300,7 +1300,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1308,7 +1308,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2145,16 +2145,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/development/release-management.md": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 902,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2184,7 +2174,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 319,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2192,7 +2182,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2260,7 +2250,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 584,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2346,7 +2336,6 @@
     "docs/docs/manage/configurable-auth-header.md": [
       {
         "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 143,
         "type": "Secret Keyword",
@@ -2354,7 +2343,6 @@
       },
       {
         "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 194,
         "type": "Secret Keyword",
@@ -2362,7 +2350,6 @@
       },
       {
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 221,
         "type": "Secret Keyword",
@@ -2374,7 +2361,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 145,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2382,7 +2369,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 476,
+        "line_number": 426,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2390,7 +2377,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 792,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2398,7 +2385,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1209,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2406,7 +2393,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1263,
+        "line_number": 1213,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3088,7 +3075,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3096,7 +3083,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3104,7 +3091,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3112,7 +3099,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3120,7 +3107,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 414,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3128,7 +3115,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3136,7 +3123,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 633,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3144,7 +3131,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 844,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3172,7 +3159,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 149,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4214,7 +4201,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4190,
+        "line_number": 4205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4222,7 +4209,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4825,
+        "line_number": 4840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4230,7 +4217,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4827,
+        "line_number": 4842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4238,7 +4225,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15206,
+        "line_number": 15211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4258,7 +4245,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4268,7 +4255,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4278,7 +4265,7 @@
         "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4288,7 +4275,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4296,7 +4283,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4326,7 +4313,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4334,7 +4321,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4354,7 +4341,7 @@
         "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4364,7 +4351,17 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/4842b831d24e_add_on_error_to_tool_plugin_bindings.py": [
+      {
+        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4374,7 +4371,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4384,7 +4381,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4394,7 +4391,7 @@
         "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4404,7 +4401,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4412,7 +4409,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4432,7 +4429,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4442,7 +4439,7 @@
         "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4452,7 +4449,43 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py": [
+      {
+        "hashed_secret": "6fc2a8a23c7db93d6624d3e40d9db9f3157c715e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/9c45d2e63bc0_merge_plugin_bindings_and_token_.py": [
+      {
+        "hashed_secret": "f538aed8b4f3c292a140aca68c67439bbe2d066a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37aeb741aa6f0a22a08c218234b31ee891f64400",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4462,7 +4495,7 @@
         "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4472,7 +4505,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4482,7 +4515,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4492,7 +4525,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 36,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4500,7 +4533,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 37,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4510,7 +4543,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4518,7 +4551,7 @@
         "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4528,12 +4561,22 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
       {
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/aa1b2c3d4e5f_add_token_revocation_idle_timeout_fields.py": [
+      {
+        "hashed_secret": "9d3ff55a4142c729a413d7362c0aaa57e3fc0789",
         "is_secret": false,
         "is_verified": false,
         "line_number": 20,
@@ -4546,7 +4589,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 18,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4556,7 +4599,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 37,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4576,7 +4619,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 30,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4584,7 +4627,7 @@
         "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 31,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4594,17 +4637,7 @@
         "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
-      {
-        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 39,
+        "line_number": 19,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4614,7 +4647,7 @@
         "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 34,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4624,7 +4657,7 @@
         "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 33,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4632,7 +4665,7 @@
         "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 34,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4652,7 +4685,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 35,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4660,7 +4693,7 @@
         "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 36,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4688,7 +4721,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4696,7 +4729,7 @@
         "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 23,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4706,7 +4739,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4714,7 +4747,7 @@
         "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4742,7 +4775,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 26,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4752,7 +4785,7 @@
         "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 25,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4762,7 +4795,7 @@
         "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4770,7 +4803,7 @@
         "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 24,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4790,7 +4823,7 @@
         "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4810,7 +4843,7 @@
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 22,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4820,7 +4853,7 @@
         "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4830,7 +4863,7 @@
         "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4840,7 +4873,7 @@
         "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4850,7 +4883,7 @@
         "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 16,
+        "line_number": 20,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4870,7 +4903,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 751,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4880,7 +4913,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 224,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4888,7 +4921,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2424,
+        "line_number": 2427,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4952,36 +4985,6 @@
         "is_verified": false,
         "line_number": 269,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/hooks/policies.py": [
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5106,7 +5109,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 672,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5202,7 +5205,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 357,
+        "line_number": 366,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5210,7 +5213,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3517,
+        "line_number": 3526,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5342,7 +5345,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5350,7 +5353,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 262,
+        "line_number": 261,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5358,7 +5361,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5502,16 +5505,6 @@
         "is_verified": false,
         "line_number": 913,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 118,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5804,7 +5797,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5812,7 +5805,7 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 455,
+        "line_number": 646,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5995,56 +5988,12 @@
         "verified_result": null
       }
     ],
-    "tests/e2e/test_mcp_rbac_transport.py": [
-      {
-        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 851,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/e2e/test_oauth_protected_resource.py": [
       {
         "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_translate_dynamic_env_e2e.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 201,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 290,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 554,
+        "line_number": 59,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6064,7 +6013,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 149,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6084,7 +6033,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 210,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6130,7 +6079,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3783,
+        "line_number": 3780,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6138,7 +6087,7 @@
         "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6626,
+        "line_number": 6623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6146,7 +6095,7 @@
         "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6982,
+        "line_number": 6979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6154,7 +6103,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7006,
+        "line_number": 7003,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6164,7 +6113,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 87,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6174,7 +6123,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 100,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6454,7 +6403,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 59,
+        "line_number": 63,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6464,7 +6413,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 74,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -6474,7 +6423,7 @@
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6482,7 +6431,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6490,7 +6439,7 @@
         "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 150,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6500,7 +6449,7 @@
         "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 520,
+        "line_number": 528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6508,7 +6457,7 @@
         "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 593,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6516,7 +6465,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 629,
+        "line_number": 637,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6526,7 +6475,7 @@
         "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6546,7 +6495,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 31,
+        "line_number": 37,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6556,7 +6505,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 30,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6566,7 +6515,7 @@
         "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 243,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6576,7 +6525,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6584,7 +6533,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 587,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6594,7 +6543,7 @@
         "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6604,7 +6553,7 @@
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 283,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6614,7 +6563,7 @@
         "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 32,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6624,7 +6573,7 @@
         "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 46,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6654,7 +6603,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 47,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6664,7 +6613,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 20,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6674,7 +6623,7 @@
         "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 125,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6702,7 +6651,7 @@
         "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 28,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -6710,7 +6659,7 @@
         "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6730,7 +6679,7 @@
         "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 27,
+        "line_number": 32,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -6758,7 +6707,7 @@
         "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6834,7 +6783,7 @@
         "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6842,7 +6791,7 @@
         "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 472,
+        "line_number": 464,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6850,7 +6799,7 @@
         "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 512,
+        "line_number": 502,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6858,7 +6807,7 @@
         "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 674,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6868,7 +6817,7 @@
         "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1387,
+        "line_number": 1396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6876,7 +6825,7 @@
         "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1474,
+        "line_number": 1483,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6886,7 +6835,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 115,
+        "line_number": 116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6894,7 +6843,7 @@
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 116,
+        "line_number": 117,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6902,174 +6851,8 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 213,
+        "line_number": 214,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 225,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 104,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 230,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
-      {
-        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 247,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 265,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 311,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 233,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
-      {
-        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 121,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 616,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 801,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 815,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 85,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -7086,7 +6869,7 @@
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 247,
+        "line_number": 199,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7096,7 +6879,7 @@
         "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7104,7 +6887,7 @@
         "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 381,
+        "line_number": 323,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7132,7 +6915,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 63,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7140,7 +6923,7 @@
         "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 144,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7170,7 +6953,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7178,7 +6961,7 @@
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 186,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7206,7 +6989,7 @@
         "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7214,7 +6997,7 @@
         "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 522,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7222,7 +7005,7 @@
         "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 657,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7230,7 +7013,7 @@
         "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1422,
+        "line_number": 1421,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7238,7 +7021,7 @@
         "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1491,
+        "line_number": 1490,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7246,7 +7029,7 @@
         "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1595,
+        "line_number": 1594,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7254,7 +7037,7 @@
         "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1626,
+        "line_number": 1625,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7262,7 +7045,7 @@
         "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1642,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7270,7 +7053,7 @@
         "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1677,
+        "line_number": 1676,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7278,7 +7061,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2136,
+        "line_number": 2135,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7288,7 +7071,7 @@
         "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 532,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7296,7 +7079,7 @@
         "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 538,
+        "line_number": 558,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7306,7 +7089,7 @@
         "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7346,7 +7129,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 278,
+        "line_number": 279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7354,7 +7137,7 @@
         "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 343,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7362,7 +7145,7 @@
         "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7370,7 +7153,7 @@
         "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 431,
+        "line_number": 432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7378,7 +7161,7 @@
         "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 562,
+        "line_number": 563,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7586,7 +7369,7 @@
         "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 563,
+        "line_number": 578,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7596,7 +7379,7 @@
         "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 135,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -7604,7 +7387,7 @@
         "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 136,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -7614,7 +7397,7 @@
         "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 404,
+        "line_number": 409,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7622,7 +7405,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 655,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7630,7 +7413,7 @@
         "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 785,
+        "line_number": 790,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7704,7 +7487,7 @@
         "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1504,
+        "line_number": 1505,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7712,7 +7495,7 @@
         "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1516,
+        "line_number": 1517,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7720,7 +7503,7 @@
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1579,
+        "line_number": 1580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7728,7 +7511,7 @@
         "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7736,7 +7519,7 @@
         "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7744,7 +7527,7 @@
         "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1660,
+        "line_number": 1661,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7752,7 +7535,7 @@
         "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7760,7 +7543,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2261,
+        "line_number": 2262,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7770,7 +7553,7 @@
         "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 389,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7806,7 +7589,7 @@
         "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 155,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7816,7 +7599,7 @@
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 376,
+        "line_number": 378,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7824,7 +7607,7 @@
         "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 378,
+        "line_number": 380,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -7832,7 +7615,7 @@
         "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 418,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7840,7 +7623,7 @@
         "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 417,
+        "line_number": 419,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -7848,7 +7631,7 @@
         "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 418,
+        "line_number": 420,
         "type": "AWS Access Key",
         "verified_result": null
       },
@@ -7856,7 +7639,7 @@
         "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 734,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7864,7 +7647,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 719,
+        "line_number": 735,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7872,7 +7655,7 @@
         "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 781,
+        "line_number": 797,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7880,7 +7663,7 @@
         "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 782,
+        "line_number": 798,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7888,7 +7671,7 @@
         "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 803,
+        "line_number": 819,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7916,7 +7699,7 @@
         "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 203,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7924,7 +7707,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 229,
+        "line_number": 227,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8062,7 +7845,7 @@
         "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 308,
+        "line_number": 288,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8070,7 +7853,7 @@
         "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 517,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8078,7 +7861,7 @@
         "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1449,
+        "line_number": 1390,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8086,7 +7869,7 @@
         "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1602,
+        "line_number": 1543,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8094,7 +7877,7 @@
         "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1613,
+        "line_number": 1554,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8102,7 +7885,7 @@
         "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2504,
+        "line_number": 2384,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8110,7 +7893,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2521,
+        "line_number": 2401,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8118,7 +7901,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2670,
+        "line_number": 2550,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8128,7 +7911,7 @@
         "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8136,7 +7919,7 @@
         "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 275,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8144,7 +7927,7 @@
         "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 540,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8152,7 +7935,7 @@
         "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 555,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8160,7 +7943,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 769,
+        "line_number": 773,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8168,7 +7951,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 779,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8178,7 +7961,7 @@
         "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8186,7 +7969,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 447,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8194,7 +7977,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 460,
+        "line_number": 466,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8212,7 +7995,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 99,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8220,7 +8003,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 123,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8228,7 +8011,7 @@
         "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8236,7 +8019,7 @@
         "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8244,7 +8027,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 187,
+        "line_number": 185,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8254,7 +8037,7 @@
         "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 256,
+        "line_number": 266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8262,7 +8045,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8270,7 +8053,7 @@
         "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 807,
+        "line_number": 821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8278,7 +8061,7 @@
         "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8286,7 +8069,7 @@
         "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1229,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8294,7 +8077,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1289,
+        "line_number": 1335,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8302,7 +8085,7 @@
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8312,7 +8095,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 169,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -8322,7 +8105,7 @@
         "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 421,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8330,7 +8113,7 @@
         "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 440,
+        "line_number": 446,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8338,7 +8121,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 689,
+        "line_number": 695,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8346,7 +8129,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 765,
+        "line_number": 771,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8354,7 +8137,7 @@
         "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 768,
+        "line_number": 774,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8364,7 +8147,7 @@
         "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
+        "line_number": 67,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8372,7 +8155,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 371,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8380,7 +8163,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 489,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8390,7 +8173,7 @@
         "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 410,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8398,7 +8181,7 @@
         "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 406,
+        "line_number": 411,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8408,7 +8191,7 @@
         "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4117,
+        "line_number": 4118,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8416,7 +8199,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4132,
+        "line_number": 4133,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8424,7 +8207,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4830,
+        "line_number": 4831,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -8492,7 +8275,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8500,7 +8283,7 @@
         "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 197,
+        "line_number": 198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8508,7 +8291,7 @@
         "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
+        "line_number": 335,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8518,23 +8301,15 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 82,
+        "line_number": 83,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 107,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -8542,7 +8317,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 196,
+        "line_number": 197,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -8550,8 +8325,16 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 210,
+        "line_number": 211,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 254,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -8560,7 +8343,7 @@
         "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8568,7 +8351,7 @@
         "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 331,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8576,7 +8359,7 @@
         "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8586,7 +8369,7 @@
         "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 548,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8594,7 +8377,7 @@
         "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8602,7 +8385,7 @@
         "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 566,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8610,7 +8393,7 @@
         "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1985,
+        "line_number": 1984,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -8618,7 +8401,7 @@
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3571,
+        "line_number": 3570,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8626,7 +8409,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4204,
+        "line_number": 4203,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8634,7 +8417,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7560,
+        "line_number": 7559,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8642,7 +8425,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8052,
+        "line_number": 8051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8650,7 +8433,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9399,
+        "line_number": 9398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8658,7 +8441,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9541,
+        "line_number": 9540,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8666,7 +8449,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10023,
+        "line_number": 10022,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8676,7 +8459,7 @@
         "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2980,
+        "line_number": 2985,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8684,7 +8467,7 @@
         "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3666,
+        "line_number": 3671,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8692,7 +8475,7 @@
         "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3675,
+        "line_number": 3680,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8700,7 +8483,7 @@
         "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4125,
+        "line_number": 4130,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -8708,7 +8491,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7052,
+        "line_number": 7057,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8716,7 +8499,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7070,
+        "line_number": 7075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8724,7 +8507,7 @@
         "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7094,
+        "line_number": 7099,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8732,7 +8515,7 @@
         "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7158,
+        "line_number": 7163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8740,7 +8523,7 @@
         "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7169,
+        "line_number": 7174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8748,7 +8531,7 @@
         "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7210,
+        "line_number": 7215,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8756,7 +8539,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7216,
+        "line_number": 7221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8764,7 +8547,7 @@
         "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8410,
+        "line_number": 8415,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -8898,7 +8681,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 459,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8906,7 +8689,7 @@
         "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1112,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9242,7 +9025,7 @@
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 67,
+        "line_number": 68,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9252,7 +9035,7 @@
         "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 44,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9260,7 +9043,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 128,
+        "line_number": 140,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -9268,7 +9051,7 @@
         "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 153,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -9368,7 +9151,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 171,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9396,7 +9179,7 @@
         "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 333,
+        "line_number": 339,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9404,7 +9187,7 @@
         "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 352,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9412,7 +9195,7 @@
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 371,
+        "line_number": 377,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9420,7 +9203,7 @@
         "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9430,7 +9213,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 775,
+        "line_number": 781,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9438,7 +9221,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 956,
+        "line_number": 962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9446,7 +9229,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 961,
+        "line_number": 967,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9454,7 +9237,7 @@
         "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 987,
+        "line_number": 993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9462,7 +9245,7 @@
         "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1005,
+        "line_number": 1011,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9470,7 +9253,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1224,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9478,7 +9261,7 @@
         "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1340,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9498,7 +9281,7 @@
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 141,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9508,7 +9291,7 @@
         "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 277,
+        "line_number": 276,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9546,7 +9329,7 @@
         "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9584,7 +9367,7 @@
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 81,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -9594,7 +9377,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 38,
         "type": "Private Key",
         "verified_result": null
       }
@@ -9632,7 +9415,7 @@
         "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9642,7 +9425,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9650,7 +9433,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 48,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9658,7 +9441,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9666,7 +9449,7 @@
         "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 66,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9674,7 +9457,7 @@
         "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 81,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9682,7 +9465,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 154,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9690,7 +9473,7 @@
         "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 156,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -9698,7 +9481,7 @@
         "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 215,
+        "line_number": 216,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9724,7 +9507,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1042,
+        "line_number": 1045,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9732,7 +9515,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1194,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9752,7 +9535,7 @@
         "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 138,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9760,7 +9543,7 @@
         "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 504,
+        "line_number": 451,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9768,7 +9551,7 @@
         "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 548,
+        "line_number": 495,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9776,7 +9559,7 @@
         "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 561,
+        "line_number": 508,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -9784,7 +9567,7 @@
         "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 930,
+        "line_number": 877,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9792,7 +9575,7 @@
         "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1179,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9807,12 +9590,22 @@
         "verified_result": null
       }
     ],
+    "tests/unit/plugins/test_secrets_detection.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 141,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
     "tests/unit/test_conc_01_helpers.py": [
       {
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 167,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-06T20:00:52Z",
+  "generated_at": "2026-05-06T21:23:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -2336,22 +2336,25 @@
     "docs/docs/manage/configurable-auth-header.md": [
       {
         "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 194,
+        "line_number": 215,
         "type": "Secret Keyword",
         "verified_result": null
       },
       {
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 255,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4893,7 +4896,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 153,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4921,7 +4924,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2427,
+        "line_number": 2461,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4967,7 +4970,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4975,7 +4978,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4983,7 +4986,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 270,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4993,7 +4996,7 @@
         "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 152,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5485,7 +5488,7 @@
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 687,
+        "line_number": 810,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-28T10:32:14Z",
+  "generated_at": "2026-04-28T10:37:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4870,7 +4870,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 753,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/docs/manage/configurable-auth-header.md
+++ b/docs/docs/manage/configurable-auth-header.md
@@ -1,12 +1,22 @@
 # Configurable JWT Authentication Header
 
-ContextForge supports configurable HTTP headers for JWT authentication, allowing you to avoid header collisions with downstream MCP servers.
+ContextForge supports configurable HTTP headers for JWT authentication, allowing you to free up the standard `Authorization` header for downstream MCP servers.
 
 ## Overview
 
-By default, ContextForge uses the standard `Authorization` header for JWT authentication. However, when client applications need to pass their own JWT tokens to downstream MCP servers, this creates a header collision where ContextForge's authentication overwrites the client's token.
+By default, ContextForge uses the standard `Authorization` header for JWT authentication. When a client wants to send a *different* token to a downstream MCP server (for example, the user's own bearer token), the gateway-bound `Authorization` value collides with the downstream-bound one.
 
-The `AUTH_HEADER_NAME` configuration option solves this problem by allowing you to specify an alternative header for ContextForge authentication, preserving the original `Authorization` header for passthrough to backend servers.
+The `AUTH_HEADER_NAME` configuration option lets ContextForge read its own JWT from a different header (for example `X-MCP-Gateway-Auth`), so the standard `Authorization` header is left untouched on the inbound request and remains available for downstream forwarding.
+
+!!! warning "Authorization is not auto-forwarded to every downstream server"
+    Setting `AUTH_HEADER_NAME` only changes which header the *gateway* reads on the inbound request. Whether `Authorization` reaches a particular downstream MCP server depends on **how that gateway is registered**:
+
+    * `auth_type=none` registered gateways forward the inbound `Authorization` header as-is.
+    * `auth_type=basic`, `auth_type=bearer`, or `auth_type=oauth` registered gateways **replace** `Authorization` with the configured server credentials. The client's `Authorization` is not forwarded.
+    * For all gateway auth types, clients can opt into explicit downstream passthrough by sending `X-Upstream-Authorization: Bearer <token>`. ContextForge renames it to `Authorization` on the upstream request. This is the recommended mechanism when the registered gateway already uses its own auth.
+    * Internal gateway-to-gateway loopback never forwards `Authorization` (loop-prevention).
+
+    Use `AUTH_HEADER_NAME` together with `X-Upstream-Authorization` (or `auth_type=none` registrations) when you need a downstream-bound `Authorization` header.
 
 ## Configuration
 
@@ -35,16 +45,25 @@ While you can use any header name, these are commonly used alternatives:
 
 ### Scenario 1: JWT Passthrough to Downstream Servers
 
-**Problem**: Your client application has existing JWT-based authentication and needs to pass tokens to downstream MCP servers, but ContextForge's authentication overwrites the `Authorization` header.
+**Problem**: Your client has its own JWT for a downstream MCP server, but ContextForge's authentication uses the same `Authorization` header.
 
-**Solution**: Configure ContextForge to use an alternative authentication header:
+**Solution**: Configure ContextForge to read its JWT from a different header. Pair it with the appropriate forwarding mechanism for your registered gateway:
 
 ```bash
 # .env configuration
 AUTH_HEADER_NAME=X-MCP-Gateway-Auth
 ```
 
-**Client Request**:
+**Client Request (recommended — works regardless of gateway auth_type)**:
+```http
+POST /mcp HTTP/1.1
+Host: contextforge.example.com
+X-MCP-Gateway-Auth: Bearer <contextforge-jwt>
+X-Upstream-Authorization: Bearer <downstream-server-jwt>
+Content-Type: application/json
+```
+
+**Client Request (alternative — only when the registered gateway has `auth_type=none`)**:
 ```http
 POST /mcp HTTP/1.1
 Host: contextforge.example.com
@@ -54,9 +73,9 @@ Content-Type: application/json
 ```
 
 **Result**:
-- ContextForge authenticates using `X-MCP-Gateway-Auth` header
-- Original `Authorization` header is preserved and passed to downstream MCP servers
-- Backend servers receive the client's original JWT for their authentication
+- ContextForge authenticates using `X-MCP-Gateway-Auth`.
+- With `X-Upstream-Authorization`: the gateway renames it to `Authorization` on the upstream request, regardless of how the gateway is registered.
+- With raw `Authorization` and `auth_type=none`: the gateway forwards it as-is. With other auth types, the gateway will replace it with the registered credentials.
 
 ### Scenario 2: Multi-Tenant Deployments
 
@@ -93,24 +112,26 @@ X-Mcp-Gateway-Auth: Bearer token
 
 ### Header Passthrough
 
-When using a custom authentication header (not `Authorization`), the standard `Authorization` header is automatically preserved and passed through to downstream servers:
+`AUTH_HEADER_NAME` only changes how the gateway reads its own JWT on the inbound request. Downstream forwarding is governed by the gateway registration and the existing passthrough machinery:
 
-1. **Custom Auth Header**: ContextForge extracts JWT from configured header
-2. **Authorization Header**: Preserved in request and forwarded to backend
-3. **Other Headers**: All other headers pass through unchanged
+1. **Custom Auth Header (inbound)**: ContextForge extracts its JWT from `AUTH_HEADER_NAME`. The configured header and the standard `Authorization` header are both protected from plugin overrides on the inbound request.
+2. **Authorization to a downstream server**: forwarded only when the gateway is registered with `auth_type=none`, or when the client explicitly opts in via `X-Upstream-Authorization` (recommended).
+3. **Loopback (internal gateway-to-gateway)**: `Authorization` is never forwarded, regardless of `AUTH_HEADER_NAME`.
+4. **Other Headers**: subject to the standard passthrough allowlist (`enable_header_passthrough`, per-gateway overrides).
 
 ### Security Considerations
 
 #### Protected Headers
 
-When using a custom authentication header, ContextForge protects the configured header from plugin modification while allowing the standard `Authorization` header to pass through:
+When `PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=false` (the default), ContextForge prevents plugin pre-request hooks from replacing client-supplied auth-sensitive headers. Both the gateway-bound and the downstream-bound auth headers are protected, so a plugin cannot silently swap a client's downstream token:
 
 **With `AUTH_HEADER_NAME=Authorization` (default)**:
-- Protected: `Authorization`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
+- Protected from override: `Authorization`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
 
 **With `AUTH_HEADER_NAME=X-MCP-Gateway-Auth`**:
-- Protected: `X-MCP-Gateway-Auth`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
-- **Not Protected**: `Authorization` (allows passthrough)
+- Protected from override: `X-MCP-Gateway-Auth`, `Authorization`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
+
+In both modes, plugins **may still create** `Authorization` (or the configured custom header) when the client did not send one — only existing client-supplied values are protected.
 
 #### Plugin Override Control
 
@@ -223,17 +244,24 @@ curl -v -H "X-MCP-Gateway-Auth: Bearer token" ...
 
 ### Authorization Header Not Passed Through
 
-**Symptom**: Downstream servers don't receive the `Authorization` header
+**Symptom**: Downstream servers don't receive the `Authorization` header even though `AUTH_HEADER_NAME` is set.
 
-**Solution**: Ensure you're using a custom authentication header (not `Authorization`):
+**Likely cause**: The registered gateway's `auth_type` is `basic`, `bearer`, or `oauth`. ContextForge replaces the inbound `Authorization` with those configured credentials. `AUTH_HEADER_NAME` only frees up the inbound side — it does not override gateway-credential injection.
 
-```bash
-# This enables passthrough
-AUTH_HEADER_NAME=X-MCP-Gateway-Auth
+**Solutions** (pick the one that matches your deployment):
 
-# This does NOT enable passthrough (default behavior)
-AUTH_HEADER_NAME=Authorization
+```http
+# Send the downstream-bound token via X-Upstream-Authorization (recommended)
+X-MCP-Gateway-Auth: Bearer <gateway-jwt>
+X-Upstream-Authorization: Bearer <downstream-jwt>
 ```
+
+```text
+# Or register the upstream gateway with auth_type=none, in which case the
+# client's inbound Authorization header is forwarded as-is.
+```
+
+If the request is going through internal loopback (gateway-to-gateway) the `Authorization` header is intentionally dropped to prevent loops; use `X-Upstream-Authorization` instead.
 
 ### Plugin Conflicts
 

--- a/docs/docs/manage/configurable-auth-header.md
+++ b/docs/docs/manage/configurable-auth-header.md
@@ -1,0 +1,260 @@
+# Configurable JWT Authentication Header
+
+ContextForge supports configurable HTTP headers for JWT authentication, allowing you to avoid header collisions with downstream MCP servers.
+
+## Overview
+
+By default, ContextForge uses the standard `Authorization` header for JWT authentication. However, when client applications need to pass their own JWT tokens to downstream MCP servers, this creates a header collision where ContextForge's authentication overwrites the client's token.
+
+The `AUTH_HEADER_NAME` configuration option solves this problem by allowing you to specify an alternative header for ContextForge authentication, preserving the original `Authorization` header for passthrough to backend servers.
+
+## Configuration
+
+### Environment Variable
+
+Set the `AUTH_HEADER_NAME` environment variable to specify which HTTP header ContextForge should use for JWT authentication:
+
+```bash
+# Default behavior (uses Authorization header)
+AUTH_HEADER_NAME=Authorization
+
+# Alternative header to avoid collision
+AUTH_HEADER_NAME=X-MCP-Gateway-Auth
+```
+
+### Common Alternative Headers
+
+While you can use any header name, these are commonly used alternatives:
+
+- `X-MCP-Gateway-Auth` - Recommended for MCP-specific deployments
+- `X-Gateway-Authorization` - Generic gateway authentication
+- `X-CF-Auth` - Short form for ContextForge authentication
+- `X-API-Gateway-Auth` - For API gateway deployments
+
+## Use Cases
+
+### Scenario 1: JWT Passthrough to Downstream Servers
+
+**Problem**: Your client application has existing JWT-based authentication and needs to pass tokens to downstream MCP servers, but ContextForge's authentication overwrites the `Authorization` header.
+
+**Solution**: Configure ContextForge to use an alternative authentication header:
+
+```bash
+# .env configuration
+AUTH_HEADER_NAME=X-MCP-Gateway-Auth
+```
+
+**Client Request**:
+```http
+POST /mcp HTTP/1.1
+Host: contextforge.example.com
+X-MCP-Gateway-Auth: Bearer <contextforge-jwt>
+Authorization: Bearer <downstream-server-jwt>
+Content-Type: application/json
+```
+
+**Result**:
+- ContextForge authenticates using `X-MCP-Gateway-Auth` header
+- Original `Authorization` header is preserved and passed to downstream MCP servers
+- Backend servers receive the client's original JWT for their authentication
+
+### Scenario 2: Multi-Tenant Deployments
+
+**Problem**: Different tenants have different authentication requirements, and some need to preserve the `Authorization` header for their backend services.
+
+**Solution**: Use a custom authentication header for ContextForge while allowing tenants to use standard `Authorization` for their services:
+
+```bash
+AUTH_HEADER_NAME=X-Tenant-Gateway-Auth
+```
+
+### Scenario 3: Legacy System Integration
+
+**Problem**: Integrating with legacy systems that expect specific authentication headers.
+
+**Solution**: Configure ContextForge to use a non-conflicting header:
+
+```bash
+AUTH_HEADER_NAME=X-Modern-Auth
+```
+
+## Implementation Details
+
+### Header Lookup
+
+The authentication header lookup is **case-insensitive**:
+
+```http
+# All of these work when AUTH_HEADER_NAME=X-MCP-Gateway-Auth
+X-MCP-Gateway-Auth: Bearer token
+x-mcp-gateway-auth: Bearer token
+X-Mcp-Gateway-Auth: Bearer token
+```
+
+### Header Passthrough
+
+When using a custom authentication header (not `Authorization`), the standard `Authorization` header is automatically preserved and passed through to downstream servers:
+
+1. **Custom Auth Header**: ContextForge extracts JWT from configured header
+2. **Authorization Header**: Preserved in request and forwarded to backend
+3. **Other Headers**: All other headers pass through unchanged
+
+### Security Considerations
+
+#### Protected Headers
+
+When using a custom authentication header, ContextForge protects the configured header from plugin modification while allowing the standard `Authorization` header to pass through:
+
+**With `AUTH_HEADER_NAME=Authorization` (default)**:
+- Protected: `Authorization`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
+
+**With `AUTH_HEADER_NAME=X-MCP-Gateway-Auth`**:
+- Protected: `X-MCP-Gateway-Auth`, `Cookie`, `X-API-Key`, `Proxy-Authorization`
+- **Not Protected**: `Authorization` (allows passthrough)
+
+#### Plugin Override Control
+
+The `PLUGINS_CAN_OVERRIDE_AUTH_HEADERS` setting controls whether plugins can modify authentication headers:
+
+```bash
+# Default: plugins cannot override auth headers (secure)
+PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=false
+
+# Allow plugins to transform auth headers (use with caution)
+PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=true
+```
+
+## API Examples
+
+### Python Client
+
+```python
+import requests
+
+# ContextForge authentication token
+gateway_token = "eyJhbGc..."
+
+# Downstream server authentication token
+downstream_token = "eyJhbGc..."
+
+response = requests.post(
+    "https://contextforge.example.com/mcp",
+    headers={
+        "X-MCP-Gateway-Auth": f"Bearer {gateway_token}",
+        "Authorization": f"Bearer {downstream_token}",
+        "Content-Type": "application/json"
+    },
+    json={
+        "jsonrpc": "2.0",
+        "method": "tools/list",
+        "id": 1
+    }
+)
+```
+
+### JavaScript/TypeScript Client
+
+```typescript
+const response = await fetch('https://contextforge.example.com/mcp', {
+  method: 'POST',
+  headers: {
+    'X-MCP-Gateway-Auth': `Bearer ${gatewayToken}`,
+    'Authorization': `Bearer ${downstreamToken}`,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    jsonrpc: '2.0',
+    method: 'tools/list',
+    id: 1
+  })
+});
+```
+
+### cURL
+
+```bash
+curl -X POST https://contextforge.example.com/mcp \
+  -H "X-MCP-Gateway-Auth: Bearer ${GATEWAY_TOKEN}" \
+  -H "Authorization: Bearer ${DOWNSTREAM_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/list",
+    "id": 1
+  }'
+```
+
+## WebSocket Support
+
+The configurable authentication header also works with WebSocket connections:
+
+```javascript
+const ws = new WebSocket('wss://contextforge.example.com/mcp', {
+  headers: {
+    'X-MCP-Gateway-Auth': `Bearer ${gatewayToken}`,
+    'Authorization': `Bearer ${downstreamToken}`
+  }
+});
+```
+
+## Backward Compatibility
+
+The feature is fully backward compatible:
+
+- **Default Value**: `Authorization` (standard behavior)
+- **Existing Deployments**: No changes required unless you want to use the feature
+- **Existing Clients**: Continue to work without modification
+
+## Troubleshooting
+
+### Authentication Fails with Custom Header
+
+**Symptom**: 401 Unauthorized when using custom header
+
+**Solution**: Verify the header name matches your configuration:
+
+```bash
+# Check your configuration
+echo $AUTH_HEADER_NAME
+
+# Ensure client sends matching header (case-insensitive)
+curl -v -H "X-MCP-Gateway-Auth: Bearer token" ...
+```
+
+### Authorization Header Not Passed Through
+
+**Symptom**: Downstream servers don't receive the `Authorization` header
+
+**Solution**: Ensure you're using a custom authentication header (not `Authorization`):
+
+```bash
+# This enables passthrough
+AUTH_HEADER_NAME=X-MCP-Gateway-Auth
+
+# This does NOT enable passthrough (default behavior)
+AUTH_HEADER_NAME=Authorization
+```
+
+### Plugin Conflicts
+
+**Symptom**: Plugins modify authentication headers unexpectedly
+
+**Solution**: Check plugin override settings:
+
+```bash
+# Disable plugin auth header override (recommended)
+PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=false
+```
+
+## Related Configuration
+
+- [`AUTH_REQUIRED`](./rbac.md#authentication-requirements) - Enable/disable authentication
+- [`JWT_SECRET_KEY`](./rbac.md#jwt-configuration) - JWT signing key
+- [`PLUGINS_CAN_OVERRIDE_AUTH_HEADERS`](../using/plugins/overview.md) - Plugin header modification
+
+## See Also
+
+- [RBAC Documentation](./rbac.md)
+- [Multi-tenancy Architecture](../architecture/multitenancy.md)
+- [OAuth Token Delegation](../architecture/oauth-design.md)
+- [Plugin Framework](../using/plugins/overview.md)

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -73,7 +73,7 @@ import uuid
 # Third-Party
 from cpex.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, HttpHookType, PluginViolationError
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 
@@ -92,75 +92,20 @@ from mcpgateway.utils.trace_context import (
     set_trace_user_email,
     set_trace_user_is_admin,
 )
-from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
+from mcpgateway.utils.verify_credentials import (
+    ConfigurableHTTPBearer,
+    security,
+    verify_jwt_token_cached,
+)
 
-
-class ConfigurableHTTPBearer(HTTPBearer):
-    """HTTPBearer with configurable header name.
-
-    This class extends HTTPBearer to support custom authentication header names,
-    allowing ContextForge to use alternative headers like X-MCP-Gateway-Auth
-    instead of the standard Authorization header to avoid collisions with
-    downstream server authentication.
-
-    Inherits from HTTPBearer to maintain compatibility with FastAPI's OpenAPI
-    schema generation and security dependencies.
-    """
-
-    def __init__(self, *, scheme_name: Optional[str] = None, auto_error: bool = True):
-        """Initialize the configurable bearer authentication scheme.
-
-        Args:
-            scheme_name: Optional scheme name for OpenAPI docs
-            auto_error: Whether to automatically raise 403 on missing credentials
-        """
-        # Initialize parent HTTPBearer for OpenAPI compatibility
-        super().__init__(scheme_name=scheme_name, auto_error=auto_error)
-
-    async def __call__(self, request: Request) -> Optional[HTTPAuthorizationCredentials]:
-        """Extract bearer token from configured authentication header.
-
-        Args:
-            request: The incoming request
-
-        Returns:
-            HTTPAuthorizationCredentials if token found, None otherwise
-
-        Raises:
-            HTTPException: If auto_error is True and credentials are missing
-        """
-        # Use configured header name (default: Authorization)
-        # Get the header name and ensure it's a string (handle mocks in tests)
-        auth_header_name = getattr(settings, "auth_header_name", "Authorization")
-        if not isinstance(auth_header_name, str):
-            auth_header_name = "Authorization"  # Fallback for mocked settings
-
-        # Starlette normalizes headers to lowercase, so we need to search case-insensitively
-        auth_header_name_lower = auth_header_name.lower()
-
-        # Search through all headers case-insensitively
-        authorization = None
-        for header_name, header_value in request.headers.items():
-            if header_name.lower() == auth_header_name_lower:
-                authorization = header_value
-                break
-
-        if not authorization:
-            if self.auto_error:
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authenticated")
-            return None
-
-        scheme, _, credentials = authorization.partition(" ")
-        if scheme.lower() != "bearer":
-            if self.auto_error:
-                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid authentication credentials")
-            return None
-
-        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
-
-
-# Security scheme with configurable header
-security = ConfigurableHTTPBearer(auto_error=False)
+__all__ = [
+    "ConfigurableHTTPBearer",
+    "security",
+    "get_current_user",
+    "get_user_team_roles",
+    "normalize_token_teams",
+    "resolve_session_teams",
+]
 
 # Module-level sync Redis client for rate-limiting (lazy-initialized)
 _SYNC_REDIS_CLIENT = None  # pylint: disable=invalid-name

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -74,6 +74,7 @@ import uuid
 from cpex.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, HttpHookType, PluginViolationError
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security.http import HTTPBase
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 
@@ -94,8 +95,79 @@ from mcpgateway.utils.trace_context import (
 )
 from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
 
-# Security scheme
-security = HTTPBearer(auto_error=False)
+
+class ConfigurableHTTPBearer(HTTPBearer):
+    """HTTPBearer with configurable header name.
+
+    This class extends HTTPBearer to support custom authentication header names,
+    allowing ContextForge to use alternative headers like X-MCP-Gateway-Auth
+    instead of the standard Authorization header to avoid collisions with
+    downstream server authentication.
+
+    Inherits from HTTPBearer to maintain compatibility with FastAPI's OpenAPI
+    schema generation and security dependencies.
+    """
+
+    def __init__(self, *, scheme_name: Optional[str] = None, auto_error: bool = True):
+        """Initialize the configurable bearer authentication scheme.
+
+        Args:
+            scheme_name: Optional scheme name for OpenAPI docs
+            auto_error: Whether to automatically raise 403 on missing credentials
+        """
+        # Initialize parent HTTPBearer for OpenAPI compatibility
+        super().__init__(scheme_name=scheme_name, auto_error=auto_error)
+
+    async def __call__(self, request: Request) -> Optional[HTTPAuthorizationCredentials]:
+        """Extract bearer token from configured authentication header.
+
+        Args:
+            request: The incoming request
+
+        Returns:
+            HTTPAuthorizationCredentials if token found, None otherwise
+
+        Raises:
+            HTTPException: If auto_error is True and credentials are missing
+        """
+        # Use configured header name (default: Authorization)
+        # Get the header name and ensure it's a string (handle mocks in tests)
+        auth_header_name = getattr(settings, "auth_header_name", "Authorization")
+        if not isinstance(auth_header_name, str):
+            auth_header_name = "Authorization"  # Fallback for mocked settings
+
+        # Starlette normalizes headers to lowercase, so we need to search case-insensitively
+        auth_header_name_lower = auth_header_name.lower()
+
+        # Search through all headers case-insensitively
+        authorization = None
+        for header_name, header_value in request.headers.items():
+            if header_name.lower() == auth_header_name_lower:
+                authorization = header_value
+                break
+
+        if not authorization:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not authenticated"
+                )
+            return None
+
+        scheme, _, credentials = authorization.partition(" ")
+        if scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Invalid authentication credentials"
+                )
+            return None
+
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
+
+
+# Security scheme with configurable header
+security = ConfigurableHTTPBearer(auto_error=False)
 
 # Module-level sync Redis client for rate-limiting (lazy-initialized)
 _SYNC_REDIS_CLIENT = None  # pylint: disable=invalid-name

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -74,7 +74,6 @@ import uuid
 from cpex.framework import GlobalContext, HttpAuthResolveUserPayload, HttpHeaderPayload, HttpHookType, PluginViolationError
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from fastapi.security.http import HTTPBase
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 
@@ -148,19 +147,13 @@ class ConfigurableHTTPBearer(HTTPBearer):
 
         if not authorization:
             if self.auto_error:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Not authenticated"
-                )
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authenticated")
             return None
 
         scheme, _, credentials = authorization.partition(" ")
         if scheme.lower() != "bearer":
             if self.auto_error:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Invalid authentication credentials"
-                )
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid authentication credentials")
             return None
 
         return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)

--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -74,6 +74,7 @@ from mcpgateway.utils.create_jwt_token import create_jwt_token
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
 from mcpgateway.utils.redis_client import get_redis_client
 from mcpgateway.utils.retry_manager import ResilientHttpClient
+from mcpgateway.utils.verify_credentials import _resolve_auth_header_name
 from mcpgateway.validation.jsonrpc import JSONRPCError
 
 # Initialize logging service first
@@ -2334,7 +2335,10 @@ class SessionRegistry(SessionBackend):
                 if settings.mcpgateway_session_affinity_enabled:
                     await self._register_session_mapping(transport.session_id, message, user.get("email") if hasattr(user, "get") else None)
 
-                headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+                # Internal /rpc auth must be sent under the configured AUTH_HEADER_NAME
+                # so that ConfigurableHTTPBearer in the loopback target reads the JWT.
+                _gw_auth = _resolve_auth_header_name(settings)
+                headers = {_gw_auth: f"Bearer {token}", "Content-Type": "application/json"}
                 if settings.mcpgateway_session_affinity_enabled:
                     headers["x-mcp-session-id"] = transport.session_id
                 # Forward passthrough headers captured at SSE connection time (see #3640).

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -331,6 +331,40 @@ class Settings(BaseSettings):
         default="Authorization",
         description="HTTP header name for JWT authentication. Use 'Authorization' (default) or alternative like 'X-MCP-Gateway-Auth' to avoid header collision with downstream servers.",
     )
+
+    @field_validator("auth_header_name")
+    @classmethod
+    def validate_auth_header_name(cls, v: str) -> str:
+        """Validate the auth header name is a syntactically valid HTTP token.
+
+        RFC 7230 limits header field names to a "token" (visible ASCII without
+        separators). We reject empty strings, whitespace-only values, and any
+        characters that could enable header smuggling (CR/LF, NUL, spaces, or
+        the HTTP separator characters), and fall back to ``Authorization`` when
+        the value is unset.
+
+        Args:
+            v: Raw configured value.
+
+        Returns:
+            The cleaned header name.
+
+        Raises:
+            ValueError: When the value is not a valid HTTP token.
+        """
+        if v is None:
+            return "Authorization"
+        cleaned = str(v).strip()
+        if not cleaned:
+            return "Authorization"
+        # RFC 7230 token = 1*tchar; tchar = "!" / "#" / "$" / "%" / "&" / "'"
+        # / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+        if not re.fullmatch(r"[A-Za-z0-9!#$%&'*+\-.^_`|~]+", cleaned):
+            raise ValueError(
+                f"AUTH_HEADER_NAME '{v}' is not a valid HTTP header token "
+                "(RFC 7230). Use only ASCII letters, digits, and !#$%&'*+-.^_`|~."
+            )
+        return cleaned
     basic_auth_user: str = "admin"
     basic_auth_password: SecretStr = Field(default=SecretStr("changeme"))
     jwt_algorithm: str = "HS256"

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -327,6 +327,10 @@ class Settings(BaseSettings):
     )
 
     # Authentication
+    auth_header_name: str = Field(
+        default="Authorization",
+        description="HTTP header name for JWT authentication. Use 'Authorization' (default) or alternative like 'X-MCP-Gateway-Auth' to avoid header collision with downstream servers.",
+    )
     basic_auth_user: str = "admin"
     basic_auth_password: SecretStr = Field(default=SecretStr("changeme"))
     jwt_algorithm: str = "HS256"

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -197,7 +197,15 @@ from mcpgateway.utils.redis_isready import wait_for_redis_ready
 from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.token_scoping import validate_server_access
 from mcpgateway.utils.trace_context import clear_trace_context, set_trace_context_from_teams, set_trace_session_id
-from mcpgateway.utils.verify_credentials import extract_websocket_bearer_token, is_proxy_auth_trust_active, require_admin_auth, require_docs_auth_override, verify_jwt_token
+from mcpgateway.utils.verify_credentials import (
+    _resolve_auth_header_name,
+    extract_websocket_bearer_token,
+    get_auth_header_value,
+    is_proxy_auth_trust_active,
+    require_admin_auth,
+    require_docs_auth_override,
+    verify_jwt_token,
+)
 from mcpgateway.validation.jsonrpc import JSONRPCError
 from mcpgateway.version import router as version_router
 
@@ -2431,7 +2439,7 @@ class DocsAuthMiddleware(BaseHTTPMiddleware):
 
         if is_protected:
             try:
-                token = request.headers.get("Authorization")
+                token = get_auth_header_value(request.headers)
                 cookie_token = request.cookies.get("jwt_token")
 
                 # Use dedicated docs authentication that bypasses global auth settings
@@ -2534,15 +2542,18 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
 
         # For protected admin routes, verify admin status
         try:
-            token = request.headers.get("Authorization")
+            token = get_auth_header_value(request.headers)
             cookie_token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
 
-            # Extract token from header or cookie
+            # Extract token from header or cookie. Bearer scheme matched
+            # case-insensitively to align with ConfigurableHTTPBearer.
             jwt_token = None
             if cookie_token:
                 jwt_token = cookie_token
-            elif token and token.startswith("Bearer "):
-                jwt_token = token.split(" ", 1)[1]
+            elif token:
+                scheme, _, credentials_value = token.partition(" ")
+                if scheme.lower() == "bearer" and credentials_value:
+                    jwt_token = credentials_value.strip() or None
 
             username = None
             token_teams = None
@@ -4045,7 +4056,7 @@ async def sse_endpoint(request: Request, server_id: str, db: Session = Depends(g
         # Extract auth token from request (header OR cookie, like get_current_user_with_permissions)
         # MUST be computed BEFORE create_sse_response to avoid race condition (Finding 1)
         auth_token = None
-        auth_header = request.headers.get("authorization", "")
+        auth_header = get_auth_header_value(request.headers) or ""
         if auth_header.lower().startswith("bearer "):
             auth_token = auth_header[7:]
         elif hasattr(request, "cookies") and request.cookies:
@@ -10627,10 +10638,12 @@ async def websocket_endpoint(websocket: WebSocket):
                 data = await websocket.receive_text()
                 client_args = {"timeout": settings.federation_timeout, "verify": internal_loopback_verify()}
 
-                # Build headers for /rpc request - forward auth credentials
+                # Build headers for /rpc request - forward auth credentials.
+                # Use the configured AUTH_HEADER_NAME so ConfigurableHTTPBearer in
+                # the loopback target finds the JWT.
                 rpc_headers: Dict[str, str] = {"Content-Type": "application/json"}
                 if auth_token:
-                    rpc_headers["Authorization"] = f"Bearer {auth_token}"
+                    rpc_headers[_resolve_auth_header_name(settings)] = f"Bearer {auth_token}"
                 if proxy_user:
                     rpc_headers[settings.proxy_user_header] = proxy_user
                 # Forward passthrough headers captured from the WebSocket handshake (see #3640).
@@ -10711,7 +10724,7 @@ async def utility_sse_endpoint(request: Request, user=Depends(get_current_user_w
 
         # Extract auth token from request (header OR cookie, like get_current_user_with_permissions)
         auth_token = None
-        auth_header = request.headers.get("authorization", "")
+        auth_header = get_auth_header_value(request.headers) or ""
         if auth_header.lower().startswith("bearer "):
             auth_token = auth_header[7:]
         elif hasattr(request, "cookies") and request.cookies:

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -144,9 +144,10 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
         if request.cookies:
             token = request.cookies.get("jwt_token") or request.cookies.get("access_token")
 
-        # 2. Try Authorization header
+        # 2. Try configured authentication header (default: Authorization)
         if not token:
-            auth_header = request.headers.get("authorization")
+            auth_header_name = settings.auth_header_name.lower()
+            auth_header = request.headers.get(auth_header_name)
             if auth_header and auth_header.startswith("Bearer "):
                 token = auth_header.replace("Bearer ", "")
 

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -33,6 +33,7 @@ from mcpgateway.config import settings
 from mcpgateway.db import SessionLocal
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.security_logger import get_security_logger
+from mcpgateway.utils.verify_credentials import get_auth_header_value
 
 logger = logging.getLogger(__name__)
 security_logger = get_security_logger()
@@ -146,10 +147,11 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
 
         # 2. Try configured authentication header (default: Authorization)
         if not token:
-            auth_header_name = settings.auth_header_name.lower()
-            auth_header = request.headers.get(auth_header_name)
-            if auth_header and auth_header.startswith("Bearer "):
-                token = auth_header.replace("Bearer ", "")
+            auth_header = get_auth_header_value(request.headers)
+            if auth_header:
+                scheme, _, credentials_value = auth_header.partition(" ")
+                if scheme.lower() == "bearer" and credentials_value:
+                    token = credentials_value
 
         # If no token found, continue without user context
         if not token:

--- a/mcpgateway/middleware/http_auth_middleware.py
+++ b/mcpgateway/middleware/http_auth_middleware.py
@@ -25,6 +25,7 @@ from starlette.types import ASGIApp
 from mcpgateway.config import settings
 from mcpgateway.plugins import get_plugin_manager
 from mcpgateway.utils.correlation_id import generate_correlation_id, get_correlation_id
+from mcpgateway.utils.verify_credentials import _resolve_auth_header_name
 
 logger = logging.getLogger(__name__)
 
@@ -94,22 +95,22 @@ async def run_pre_request_hooks(
         # This guard can be disabled with PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=true
         # for deployments that require plugin-driven token exchange (e.g. WXO auth).
         #
-        # Note: When using a custom auth header (e.g., X-MCP-Gateway-Auth), the
-        # standard Authorization header is NOT protected, allowing it to pass through
-        # to downstream servers for their authentication.
+        # When AUTH_HEADER_NAME is customized (e.g. X-MCP-Gateway-Auth), the
+        # standard Authorization header carries the downstream-server token and
+        # MUST also stay protected from plugin overrides — otherwise a plugin
+        # could swap out a client-supplied downstream token. Both headers are
+        # protected; plugins may still create either header when the client
+        # did not send it.
         if not settings.plugins_can_override_auth_headers:
-            # Get the configured auth header name (handle mocks in tests)
-            auth_header_name = getattr(settings, "auth_header_name", "Authorization")
-            if not isinstance(auth_header_name, str):
-                auth_header_name = "Authorization"  # Fallback for mocked settings
+            auth_header_name = _resolve_auth_header_name(settings)
 
-            # Build list of protected headers - always protect the configured auth header
-            _auth_protected_headers = {auth_header_name.lower(), "cookie", "x-api-key", "proxy-authorization"}
-
-            # If using custom auth header, don't protect standard Authorization header
-            # This allows Authorization to pass through to downstream servers
-            if auth_header_name.lower() != "authorization":
-                _auth_protected_headers.discard("authorization")
+            _auth_protected_headers = {
+                auth_header_name.lower(),
+                "authorization",
+                "cookie",
+                "x-api-key",
+                "proxy-authorization",
+            }
 
             original_lower = {h.lower() for h in headers}
             overridden = {k.lower() for k in modified_headers_dict if k.lower() in _auth_protected_headers and k.lower() in original_lower}

--- a/mcpgateway/middleware/http_auth_middleware.py
+++ b/mcpgateway/middleware/http_auth_middleware.py
@@ -93,8 +93,24 @@ async def run_pre_request_hooks(
         #
         # This guard can be disabled with PLUGINS_CAN_OVERRIDE_AUTH_HEADERS=true
         # for deployments that require plugin-driven token exchange (e.g. WXO auth).
+        #
+        # Note: When using a custom auth header (e.g., X-MCP-Gateway-Auth), the
+        # standard Authorization header is NOT protected, allowing it to pass through
+        # to downstream servers for their authentication.
         if not settings.plugins_can_override_auth_headers:
-            _auth_protected_headers = {"authorization", "cookie", "x-api-key", "proxy-authorization"}
+            # Get the configured auth header name (handle mocks in tests)
+            auth_header_name = getattr(settings, "auth_header_name", "Authorization")
+            if not isinstance(auth_header_name, str):
+                auth_header_name = "Authorization"  # Fallback for mocked settings
+
+            # Build list of protected headers - always protect the configured auth header
+            _auth_protected_headers = {auth_header_name.lower(), "cookie", "x-api-key", "proxy-authorization"}
+
+            # If using custom auth header, don't protect standard Authorization header
+            # This allows Authorization to pass through to downstream servers
+            if auth_header_name.lower() != "authorization":
+                _auth_protected_headers.discard("authorization")
+
             original_lower = {h.lower() for h in headers}
             overridden = {k.lower() for k in modified_headers_dict if k.lower() in _auth_protected_headers and k.lower() in original_lower}
             if overridden:

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -23,7 +23,7 @@ import warnings
 # Third-Party
 from cpex.framework import GlobalContext
 from fastapi import Cookie, Depends, HTTPException, Request, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -40,15 +40,16 @@ from mcpgateway.utils.trace_context import (
     set_trace_user_email,
     set_trace_user_is_admin,
 )
-from mcpgateway.utils.verify_credentials import is_proxy_auth_trust_active
+from mcpgateway.utils.verify_credentials import ConfigurableHTTPBearer, is_proxy_auth_trust_active
 
 logger = logging.getLogger(__name__)
 
 # Generic 403 message — intentionally vague to avoid leaking permission names to callers
 _ACCESS_DENIED_MSG = "Access denied"
 
-# HTTP Bearer security scheme for token extraction
-security = HTTPBearer(auto_error=False)
+# Bearer security scheme — uses the configured auth header (AUTH_HEADER_NAME)
+# so RBAC token extraction stays aligned with the rest of the auth flow.
+security = ConfigurableHTTPBearer(auto_error=False)
 
 
 def get_db(request: Request = None) -> Generator[Session, None, None]:

--- a/mcpgateway/middleware/request_logging_middleware.py
+++ b/mcpgateway/middleware/request_logging_middleware.py
@@ -68,6 +68,7 @@ from mcpgateway.middleware.path_filter import should_skip_request_logging
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.structured_logger import get_structured_logger
 from mcpgateway.utils.correlation_id import get_correlation_id
+from mcpgateway.utils.verify_credentials import get_auth_header_value
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -415,9 +416,13 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             token = request.cookies.get("jwt_token") or request.cookies.get("access_token") or request.cookies.get("token")
 
         if not token:
-            auth_header = request.headers.get("authorization")
-            if auth_header and auth_header.startswith("Bearer "):
-                token = auth_header.replace("Bearer ", "")
+            # Read from the configured AUTH_HEADER_NAME so identity logging keeps
+            # working when the gateway uses a customized auth header.
+            auth_header = get_auth_header_value(request.headers)
+            if auth_header:
+                scheme, _, raw_token = auth_header.partition(" ")
+                if scheme.lower() == "bearer" and raw_token:
+                    token = raw_token
 
         if not token:
             return (None, None)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -21,7 +21,6 @@ from typing import List, Optional, Pattern, Tuple
 
 # Third-Party
 from fastapi import HTTPException, Request, status
-from fastapi.security import HTTPBearer
 from sqlalchemy import and_, func, select
 
 # First-Party
@@ -32,10 +31,14 @@ from mcpgateway.db import Permissions
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.utils.orjson_response import ORJSONResponse
-from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
+from mcpgateway.utils.verify_credentials import (
+    ConfigurableHTTPBearer,
+    get_auth_bearer_token_from_request,
+    verify_jwt_token_cached,
+)
 
 # Security scheme
-bearer_scheme = HTTPBearer(auto_error=False)
+bearer_scheme = ConfigurableHTTPBearer(auto_error=False)
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -373,17 +376,11 @@ class TokenScopingMiddleware:
                 if isinstance(cookie_token, str) and cookie_token.strip():
                     return cookie_token.strip()
 
-        # Get authorization header and parse bearer scheme case-insensitively.
-        auth_header = request.headers.get("Authorization")
-        if not auth_header:
-            return None
-
-        parts = auth_header.split(" ", 1)
-        if len(parts) != 2 or parts[0].lower() != "bearer":
-            return None
-
-        token = parts[1].strip()
-        return token or None
+        # Get the configured auth header (default Authorization) and parse
+        # the Bearer scheme case-insensitively. Reading from the configured
+        # header keeps token scoping aligned with the auth dependency so
+        # scope restrictions cannot be bypassed by setting AUTH_HEADER_NAME.
+        return get_auth_bearer_token_from_request(request)
 
     async def _extract_token_scopes(self, request: Request) -> Optional[dict]:
         """Extract token scopes from JWT in request.

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -33,7 +33,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from mcpgateway.db import fresh_db_session
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.token_catalog_service import TokenCatalogService
-from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
+from mcpgateway.utils.verify_credentials import get_auth_header_value, verify_jwt_token_cached
 
 logger = logging.getLogger(__name__)
 
@@ -129,14 +129,19 @@ class TokenUsageMiddleware:
             if not user_email:
                 user_email = state.get("user_email") if state else None
 
-            # If we don't have JTI or email, try to decode the token from the header
+            # If we don't have JTI or email, try to decode the token from the header.
+            # Read from the configured AUTH_HEADER_NAME so token usage logging keeps
+            # working when the gateway uses a customized auth header.
             if not jti or not user_email:
                 try:
                     headers = Headers(scope=scope)
-                    auth_header = headers.get("authorization")
-                    if not auth_header or not auth_header.startswith("Bearer "):
+                    auth_header = get_auth_header_value(headers)
+                    if not auth_header:
                         return
-                    token = auth_header.replace("Bearer ", "")
+                    scheme, _, raw_token = auth_header.partition(" ")
+                    if scheme.lower() != "bearer" or not raw_token:
+                        return
+                    token = raw_token
                     request = Request(scope, receive)
                     try:
                         payload = await verify_jwt_token_cached(token, request)
@@ -168,10 +173,12 @@ class TokenUsageMiddleware:
             # without re-verifying it (the token identity is valid even if rejected).
             try:
                 headers = Headers(scope=scope)
-                auth_header = headers.get("authorization")
-                if not auth_header or not auth_header.startswith("Bearer "):
+                auth_header = get_auth_header_value(headers)
+                if not auth_header:
                     return
-                raw_token = auth_header[7:]  # strip "Bearer "
+                scheme, _, raw_token = auth_header.partition(" ")
+                if scheme.lower() != "bearer" or not raw_token:
+                    return
 
                 # Decode without signature/expiry check — for identification only, not auth.
                 unverified = _jwt.decode(raw_token, options={"verify_signature": False})

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -25,6 +25,7 @@ from mcpgateway.routers.email_auth import create_access_token, get_client_ip, ge
 from mcpgateway.schemas import AuthenticationResponse, EmailUserResponse
 from mcpgateway.services.email_auth_service import EmailAuthService
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.utils.verify_credentials import get_auth_header_value
 
 # Initialize logging
 logging_service = LoggingService()
@@ -218,12 +219,16 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
         # User is already authenticated via dependency injection
         user = current_user
 
-        # Extract JWT from Authorization header
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
+        # Extract JWT from the configured auth header (default: Authorization).
+        # Reading from settings.auth_header_name keeps logout aligned with the
+        # auth dependency that just validated the same caller; otherwise a custom
+        # AUTH_HEADER_NAME lets a request authenticate but never revoke its token.
+        auth_header = get_auth_header_value(request.headers) or ""
+        scheme, _, raw_token = auth_header.partition(" ")
+        if scheme.lower() != "bearer" or not raw_token:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No valid authorization token provided")
 
-        token = auth_header[7:]  # Remove "Bearer " prefix
+        token = raw_token.strip()
 
         # Decode token to get JTI and expiry
         # Third-Party

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -96,7 +96,14 @@ from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
 from mcpgateway.utils.trace_context import set_trace_context_from_teams, set_trace_session_id
-from mcpgateway.utils.verify_credentials import is_proxy_auth_trust_active, require_auth_header_first, verify_credentials, verify_oauth_access_token
+from mcpgateway.utils.verify_credentials import (
+    _resolve_auth_header_name,
+    get_auth_header_value,
+    is_proxy_auth_trust_active,
+    require_auth_header_first,
+    verify_credentials,
+    verify_oauth_access_token,
+)
 
 # Initialize logging service first
 logging_service = LoggingService()
@@ -2040,8 +2047,11 @@ async def _get_request_context_or_default() -> Tuple[str, dict[str, Any], dict[s
 
         # Extract and verify user context
         # Use require_auth_header_first to match streamable_http_auth token precedence:
-        # Authorization header > request cookies > jwt_token parameter
-        auth_header = req_headers.get("authorization")
+        # configured auth header (default Authorization) > request cookies > jwt_token parameter.
+        # When AUTH_HEADER_NAME is customized, the gateway token is read from that
+        # header so a downstream-bound Authorization header cannot be misvalidated
+        # as the gateway token.
+        auth_header = get_auth_header_value(req_headers)
         cookie_token = request.cookies.get("jwt_token")
 
         try:
@@ -4120,9 +4130,13 @@ class SessionManagerWrapper:
                         "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
                         "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
                     }
-                    # Copy auth header if present
-                    if "authorization" in headers:
-                        rpc_headers["authorization"] = headers["authorization"]
+                    # Forward the inbound gateway auth header (default: Authorization,
+                    # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
+                    # the same caller. Hardcoding "authorization" here would silently
+                    # drop auth on deployments using a custom AUTH_HEADER_NAME.
+                    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+                    if _gw_auth_lower in headers:
+                        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
                     # Forward passthrough headers for upstream MCP servers (see #3640).
                     # First-Party
                     from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
@@ -4287,8 +4301,9 @@ class SessionManagerWrapper:
                                 "x-mcp-session-id": mcp_session_id,
                                 "x-forwarded-internally": "true",
                             }
-                            if "authorization" in headers:
-                                rpc_headers["authorization"] = headers["authorization"]
+                            _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+                            if _gw_auth_lower in headers:
+                                rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
                             # Forward passthrough headers for upstream MCP servers (see #3640).
                             # First-Party
                             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
@@ -4785,7 +4800,7 @@ class _StreamableHttpAuthHandler:
             if origin and headers.get("access-control-request-method"):
                 return True
 
-        authorization = headers.get("authorization")
+        authorization = get_auth_header_value(headers)
         proxy_trusted = is_proxy_auth_trust_active(settings)
         proxy_user = headers.get(settings.proxy_user_header) if proxy_trusted else None
 

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -572,19 +572,31 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
 def _loopback_skip_set() -> frozenset[str]:
     """Return the full set of headers to skip in loopback forwarding.
 
-    Extends ``_LOOPBACK_SKIP_HEADERS`` with the configurable
-    ``proxy_user_header`` (default ``X-Authenticated-User``) so that
-    passthrough headers can never overwrite the gateway-internal proxy
-    user identity — even if that header name is added to the passthrough
-    allowlist by mistake.
+    Extends ``_LOOPBACK_SKIP_HEADERS`` with:
+
+    * ``proxy_user_header`` (default ``X-Authenticated-User``) — so passthrough
+      headers can never overwrite the gateway-internal proxy user identity.
+    * ``auth_header_name`` (default ``Authorization``) — so passthrough
+      headers can never overwrite the gateway-internal JWT carried under a
+      customized ``AUTH_HEADER_NAME``. The default ``authorization`` is
+      already in ``_LOOPBACK_SKIP_HEADERS``; this adds the configured name
+      when it differs.
 
     Returns:
         frozenset[str]: Header names to skip during loopback forwarding.
     """
+    extra: set[str] = set()
     proxy = settings.proxy_user_header.lower()
-    if proxy in _LOOPBACK_SKIP_HEADERS:
+    if proxy not in _LOOPBACK_SKIP_HEADERS:
+        extra.add(proxy)
+    auth_header = getattr(settings, "auth_header_name", "Authorization")
+    if isinstance(auth_header, str):
+        auth_lower = auth_header.strip().lower()
+        if auth_lower and auth_lower not in _LOOPBACK_SKIP_HEADERS:
+            extra.add(auth_lower)
+    if not extra:
         return _LOOPBACK_SKIP_HEADERS
-    return _LOOPBACK_SKIP_HEADERS | {proxy}
+    return _LOOPBACK_SKIP_HEADERS | extra
 
 
 class _LoopbackAllowlistCache:

--- a/mcpgateway/utils/token_scoping.py
+++ b/mcpgateway/utils/token_scoping.py
@@ -14,11 +14,15 @@ from typing import Optional
 from fastapi import HTTPException, Request
 
 # First-Party
-from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
+from mcpgateway.utils.verify_credentials import get_auth_bearer_token_from_request, verify_jwt_token_cached
 
 
 async def extract_token_scopes_from_request(request: Request) -> Optional[dict]:
     """Extract token scopes from JWT in request.
+
+    Reads the JWT from the configured auth header (default ``Authorization``)
+    so that token scope enforcement stays aligned with the auth dependency
+    when ``AUTH_HEADER_NAME`` is customized.
 
     Args:
         request: FastAPI request object
@@ -53,22 +57,16 @@ async def extract_token_scopes_from_request(request: Request) -> Optional[dict]:
         >>> asyncio.run(extract_token_scopes_from_request(mock_request)) is None
         True
     """
-    # Get authorization header
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
+    token = get_auth_bearer_token_from_request(request)
+    if not token:
         return None
 
-    token = auth_header.split(" ", 1)[1]
-
     try:
-        # Use the centralized verify_jwt_token_cached function for consistent JWT validation
         payload = await verify_jwt_token_cached(token, request)
         return payload.get("scopes")
     except HTTPException:
-        # Token validation failed (expired, invalid, etc.)
         return None
     except Exception:
-        # Any other error in token validation
         return None
 
 

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -74,11 +74,143 @@ from mcpgateway.utils.paths import resolve_root_path
 from mcpgateway.utils.time_restrictions import validate_time_restrictions
 
 basic_security = HTTPBasic(auto_error=False)
-security = HTTPBearer(auto_error=False)
 
 # Initialize logging service first
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
+
+
+def _resolve_auth_header_name(settings_obj: Any | None = None) -> str:
+    """Return the configured auth header name, defensive against mocks/misconfig.
+
+    Falls back to ``"Authorization"`` when the setting is missing, not a
+    string, or empty/whitespace-only.
+
+    Args:
+        settings_obj: Optional settings override (defaults to the global settings).
+
+    Returns:
+        Resolved auth header name (always a non-empty string).
+    """
+    s = settings_obj or settings
+    name = getattr(s, "auth_header_name", "Authorization")
+    if not isinstance(name, str):
+        return "Authorization"
+    name = name.strip()
+    return name or "Authorization"
+
+
+def get_auth_header_value(headers: Any, settings_obj: Any | None = None) -> Optional[str]:
+    """Look up the configured auth header value (case-insensitive).
+
+    Tries the lowercase form first (matches Starlette's normalized
+    ``request.headers``) and falls back to the configured casing for
+    plain dicts and ASGI scope-style mappings.
+
+    Args:
+        headers: Headers mapping supporting ``.get(name)``.
+        settings_obj: Optional settings override (defaults to the global settings).
+
+    Returns:
+        Header value when present, otherwise ``None``.
+    """
+    if headers is None or not hasattr(headers, "get"):
+        return None
+    header_name = _resolve_auth_header_name(settings_obj)
+    lower = header_name.lower()
+    val = headers.get(lower)
+    if val:
+        return val
+    if header_name != lower:
+        val = headers.get(header_name)
+        if val:
+            return val
+    return None
+
+
+def get_auth_bearer_token_from_request(request: Any) -> Optional[str]:
+    """Extract a Bearer token from the configured auth header on a request.
+
+    The Bearer scheme match is case-insensitive ("bearer" / "Bearer" / "BEARER").
+    Returns ``None`` when the header is missing, the scheme is not Bearer,
+    or the token is empty.
+
+    Args:
+        request: FastAPI/Starlette ``Request``-like object exposing ``.headers``.
+
+    Returns:
+        The bearer token string when present, otherwise ``None``.
+    """
+    if request is None or not hasattr(request, "headers"):
+        return None
+    auth_header = get_auth_header_value(request.headers)
+    if not auth_header:
+        return None
+    parts = auth_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    token = parts[1].strip()
+    return token or None
+
+
+class ConfigurableHTTPBearer(HTTPBearer):
+    """HTTPBearer with a configurable header name.
+
+    Reads the auth header named by ``settings.auth_header_name`` (default
+    ``Authorization``). Header lookup is case-insensitive. Bearer scheme
+    match is case-insensitive. Subclasses ``HTTPBearer`` so OpenAPI security
+    metadata is preserved.
+    """
+
+    def __init__(self, *, scheme_name: Optional[str] = None, auto_error: bool = True):
+        """Initialize the configurable bearer authentication scheme.
+
+        Args:
+            scheme_name: Optional scheme name shown in OpenAPI docs.
+            auto_error: When ``True`` (default), raise 403 on missing or
+                malformed credentials; when ``False``, return ``None``.
+        """
+        super().__init__(scheme_name=scheme_name, auto_error=auto_error)
+
+    async def __call__(self, request: Request) -> Optional[HTTPAuthorizationCredentials]:
+        """Extract bearer credentials from the configured auth header.
+
+        Args:
+            request: Incoming FastAPI/Starlette ``Request``.
+
+        Returns:
+            ``HTTPAuthorizationCredentials`` when a Bearer token is found,
+            otherwise ``None`` (or raises 403 when ``auto_error`` is set).
+
+        Raises:
+            HTTPException: 403 when ``auto_error`` is enabled and credentials
+                are missing or use an unsupported scheme.
+        """
+        authorization = get_auth_header_value(request.headers)
+
+        if not authorization:
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not authenticated",
+                )
+            return None
+
+        scheme, _, credentials = authorization.partition(" ")
+        if scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Invalid authentication credentials",
+                )
+            return None
+
+        return HTTPAuthorizationCredentials(scheme=scheme, credentials=credentials)
+
+
+# Default security dependency. Reads from the configured auth header so all
+# auth dependencies behave consistently when AUTH_HEADER_NAME is customized.
+security = ConfigurableHTTPBearer(auto_error=False)
 
 
 def is_proxy_auth_trust_active(settings_obj: Any | None = None) -> bool:
@@ -123,16 +255,7 @@ def extract_websocket_bearer_token(query_params: Any, headers: Any, *, query_par
     if legacy_token and query_param_warning:
         logger.warning(f"{query_param_warning}; token ignored")
 
-    header_values = headers or {}
-
-    # Use configured authentication header name (default: Authorization)
-    auth_header_name = settings.auth_header_name.lower()
-    auth_header = header_values.get(auth_header_name) if hasattr(header_values, "get") else None
-
-    # Try case-sensitive version if lowercase didn't work
-    if not auth_header and hasattr(header_values, "get"):
-        auth_header = header_values.get(settings.auth_header_name)
-
+    auth_header = get_auth_header_value(headers)
     if auth_header:
         scheme, _, credentials = auth_header.partition(" ")
         if scheme.lower() == "bearer" and credentials:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -106,7 +106,7 @@ def is_proxy_auth_trust_active(settings_obj: Any | None = None) -> bool:
 
 
 def extract_websocket_bearer_token(query_params: Any, headers: Any, *, query_param_warning: Optional[str] = None) -> Optional[str]:
-    """Extract bearer token from WebSocket Authorization headers.
+    """Extract bearer token from WebSocket headers using configured auth header name.
 
     Args:
         query_params: WebSocket query parameters mapping-like object.
@@ -124,9 +124,15 @@ def extract_websocket_bearer_token(query_params: Any, headers: Any, *, query_par
         logger.warning(f"{query_param_warning}; token ignored")
 
     header_values = headers or {}
-    auth_header = header_values.get("authorization") if hasattr(header_values, "get") else None
+
+    # Use configured authentication header name (default: Authorization)
+    auth_header_name = settings.auth_header_name.lower()
+    auth_header = header_values.get(auth_header_name) if hasattr(header_values, "get") else None
+
+    # Try case-sensitive version if lowercase didn't work
     if not auth_header and hasattr(header_values, "get"):
-        auth_header = header_values.get("Authorization")
+        auth_header = header_values.get(settings.auth_header_name)
+
     if auth_header:
         scheme, _, credentials = auth_header.partition(" ")
         if scheme.lower() == "bearer" and credentials:

--- a/tests/unit/mcpgateway/test_configurable_auth_header.py
+++ b/tests/unit/mcpgateway/test_configurable_auth_header.py
@@ -8,7 +8,7 @@ server authentication.
 """
 
 # Standard
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 # Third-Party
 import pytest
@@ -17,7 +17,12 @@ from starlette.requests import Request
 
 # First-Party
 from mcpgateway.auth import ConfigurableHTTPBearer
-from mcpgateway.config import settings
+from mcpgateway.config import Settings, settings
+from mcpgateway.utils.verify_credentials import (
+    _resolve_auth_header_name,
+    get_auth_bearer_token_from_request,
+    get_auth_header_value,
+)
 
 
 class TestConfigurableHTTPBearer:
@@ -160,3 +165,196 @@ class TestWebSocketTokenExtraction:
             token = extract_websocket_bearer_token(None, headers)
 
             assert token == "mixed-case-token"
+
+
+class TestSharedAuthHelpers:
+    """Tests for the shared header-extraction helpers used by every auth path."""
+
+    def test_resolve_auth_header_name_default(self):
+        """Missing/None setting falls back to ``Authorization``."""
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            assert _resolve_auth_header_name() == "Authorization"
+
+    def test_resolve_auth_header_name_strips_whitespace(self):
+        """Whitespace is stripped; empty values fall back to default."""
+        with patch.object(settings, "auth_header_name", "   "):
+            assert _resolve_auth_header_name() == "Authorization"
+
+    def test_resolve_auth_header_name_handles_non_string(self):
+        """Non-string mocked settings fall back to default rather than raising."""
+        with patch.object(settings, "auth_header_name", MagicMock()):
+            assert _resolve_auth_header_name() == "Authorization"
+
+    def test_get_auth_header_value_lowercase_lookup(self):
+        """Starlette-normalized lowercase headers resolve correctly."""
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_header_value({"x-mcp-gateway-auth": "Bearer t"}) == "Bearer t"
+
+    def test_get_auth_header_value_case_preserving_dict(self):
+        """Plain dict with original casing also resolves."""
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_header_value({"X-MCP-Gateway-Auth": "Bearer t"}) == "Bearer t"
+
+    def test_get_auth_header_value_missing(self):
+        """Returns None when the header is absent."""
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_header_value({"authorization": "Bearer downstream"}) is None
+
+    def test_get_auth_bearer_token_from_request(self):
+        """Extracts bearer token from configured header on a request-like object."""
+        request = MagicMock(spec=Request)
+        request.headers = {"x-mcp-gateway-auth": "Bearer gw-token"}
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_bearer_token_from_request(request) == "gw-token"
+
+    def test_get_auth_bearer_token_rejects_non_bearer(self):
+        """Non-Bearer schemes return None even when the configured header is present."""
+        request = MagicMock(spec=Request)
+        request.headers = {"x-mcp-gateway-auth": "Basic dXNlcjpwYXNz"}
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_bearer_token_from_request(request) is None
+
+    def test_get_auth_bearer_token_case_insensitive_scheme(self):
+        """Bearer scheme is matched case-insensitively (matches ConfigurableHTTPBearer)."""
+        request = MagicMock(spec=Request)
+        request.headers = {"x-mcp-gateway-auth": "BEARER tok"}
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_bearer_token_from_request(request) == "tok"
+
+    def test_gateway_token_not_extracted_from_authorization_when_custom_set(self):
+        """Critical: a downstream-bound Authorization header must NOT be read as the gateway token."""
+        request = MagicMock(spec=Request)
+        request.headers = {"authorization": "Bearer downstream-token"}
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            assert get_auth_bearer_token_from_request(request) is None
+            assert get_auth_header_value(request.headers) is None
+
+
+class TestAuthHeaderNameValidator:
+    """Tests for the Pydantic validator on Settings.auth_header_name."""
+
+    def test_default_value(self):
+        """Default value passes validation."""
+        s = Settings(auth_header_name="Authorization")
+        assert s.auth_header_name == "Authorization"
+
+    def test_custom_token_accepted(self):
+        """A standard custom header token is accepted."""
+        s = Settings(auth_header_name="X-MCP-Gateway-Auth")
+        assert s.auth_header_name == "X-MCP-Gateway-Auth"
+
+    def test_strips_whitespace(self):
+        """Surrounding whitespace is stripped."""
+        s = Settings(auth_header_name="  X-Custom-Auth  ")
+        assert s.auth_header_name == "X-Custom-Auth"
+
+    def test_empty_falls_back_to_default(self):
+        """Empty/whitespace-only values fall back to ``Authorization`` rather than failing."""
+        s = Settings(auth_header_name="   ")
+        assert s.auth_header_name == "Authorization"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "X Bad Header",  # contains space
+            "X-Bad\r\nInjected",  # CRLF injection attempt
+            "X-Bad\x00",  # NUL byte
+            "X-Bad:Header",  # colon (separator)
+            "X-Bad/Header",  # slash (separator)
+        ],
+    )
+    def test_rejects_invalid_token_chars(self, bad_value):
+        """Header-injection / RFC 7230 violations are rejected at config time."""
+        with pytest.raises(ValueError):
+            Settings(auth_header_name=bad_value)
+
+
+class TestLoopbackSkipSet:
+    """Regression tests for the passthrough loopback skip set.
+
+    The configured AUTH_HEADER_NAME must always be in the skip set so that a
+    client-supplied passthrough header can never overwrite the gateway-internal
+    JWT on the loopback /rpc call.
+    """
+
+    def test_default_authorization_in_skip_set(self):
+        """The default Authorization header is in the loopback skip set."""
+        from mcpgateway.utils.passthrough_headers import _loopback_skip_set
+
+        with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
+            mock_settings.proxy_user_header = "X-Authenticated-User"
+            mock_settings.auth_header_name = "Authorization"
+            assert "authorization" in _loopback_skip_set()
+
+    def test_custom_auth_header_in_skip_set(self):
+        """A customized AUTH_HEADER_NAME is added to the loopback skip set."""
+        from mcpgateway.utils.passthrough_headers import _loopback_skip_set
+
+        with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
+            mock_settings.proxy_user_header = "X-Authenticated-User"
+            mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+            skip = _loopback_skip_set()
+            assert "x-mcp-gateway-auth" in skip
+            assert "authorization" in skip
+
+    def test_skip_set_handles_non_string_setting(self):
+        """Non-string mocked setting falls back gracefully (no crash)."""
+        from mcpgateway.utils.passthrough_headers import _loopback_skip_set
+
+        with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
+            mock_settings.proxy_user_header = "X-Authenticated-User"
+            mock_settings.auth_header_name = MagicMock()
+            assert "authorization" in _loopback_skip_set()
+
+
+class TestPluginAuthHeaderProtection:
+    """Tests for the plugin pre-request hook auth-header protection guard."""
+
+    @pytest.mark.asyncio
+    async def test_authorization_protected_when_custom_auth_header_set(self):
+        """A plugin must NOT be able to override a client-supplied Authorization header
+        even when AUTH_HEADER_NAME is customized — preserves the threat model.
+        """
+        from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
+
+        plugin_manager = MagicMock()
+        plugin_manager.has_hooks_for.return_value = True
+
+        modified_payload = MagicMock()
+        modified_payload.root = {
+            "authorization": "Bearer EVIL-PLUGIN-TOKEN",
+            "x-mcp-gateway-auth": "Bearer EVIL-GATEWAY-TOKEN",
+            "x-trace-id": "abc",
+        }
+        pre_result = MagicMock()
+        pre_result.modified_payload = modified_payload
+
+        async def _invoke_hook(*args, **kwargs):
+            return pre_result, None
+
+        plugin_manager.invoke_hook = _invoke_hook
+        from cpex.framework import HttpHookType as _Hook
+
+        plugin_manager.has_hooks_for = lambda hook_type: hook_type == _Hook.HTTP_PRE_REQUEST
+
+        original_headers = {
+            "authorization": "Bearer CLIENT-DOWNSTREAM-TOKEN",
+            "x-mcp-gateway-auth": "Bearer CLIENT-GATEWAY-TOKEN",
+        }
+
+        with patch("mcpgateway.middleware.http_auth_middleware.settings") as mock_settings:
+            mock_settings.plugins_can_override_auth_headers = False
+            mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+
+            merged, _, _ = await run_pre_request_hooks(
+                plugin_manager=plugin_manager,
+                headers=original_headers,
+                path="/mcp",
+                method="POST",
+            )
+
+        # Both headers must be stripped from the plugin's modified payload — the client values must remain.
+        assert merged["authorization"] == "Bearer CLIENT-DOWNSTREAM-TOKEN"
+        assert merged["x-mcp-gateway-auth"] == "Bearer CLIENT-GATEWAY-TOKEN"
+        # Non-auth headers from the plugin should still be merged
+        assert merged.get("x-trace-id") == "abc"

--- a/tests/unit/mcpgateway/test_configurable_auth_header.py
+++ b/tests/unit/mcpgateway/test_configurable_auth_header.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+"""Tests for configurable JWT authentication header feature.
+
+This module tests the AUTH_HEADER_NAME configuration that allows ContextForge
+to use alternative HTTP headers for JWT authentication (e.g., X-MCP-Gateway-Auth)
+instead of the standard Authorization header, avoiding collisions with downstream
+server authentication.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+# First-Party
+from mcpgateway.auth import ConfigurableHTTPBearer
+from mcpgateway.config import settings
+
+
+class TestConfigurableHTTPBearer:
+    """Test suite for ConfigurableHTTPBearer class."""
+
+    @pytest.fixture
+    def mock_request(self):
+        """Create a mock request object."""
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        return request
+
+    @pytest.mark.asyncio
+    async def test_default_authorization_header(self, mock_request):
+        """Test that default Authorization header is used when not configured."""
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            bearer = ConfigurableHTTPBearer(auto_error=False)
+            mock_request.headers = {"authorization": "Bearer test-token-123"}
+
+            result = await bearer(mock_request)
+
+            assert result is not None
+            assert result.scheme == "Bearer"
+            assert result.credentials == "test-token-123"
+
+    @pytest.mark.asyncio
+    async def test_custom_auth_header(self, mock_request):
+        """Test that custom authentication header is used when configured."""
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            bearer = ConfigurableHTTPBearer(auto_error=False)
+            mock_request.headers = {"x-mcp-gateway-auth": "Bearer custom-token-456"}
+
+            result = await bearer(mock_request)
+
+            assert result is not None
+            assert result.scheme == "Bearer"
+            assert result.credentials == "custom-token-456"
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_no_auto_error(self, mock_request):
+        """Test that None is returned when credentials are missing and auto_error=False."""
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            bearer = ConfigurableHTTPBearer(auto_error=False)
+            mock_request.headers = {}
+
+            result = await bearer(mock_request)
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_with_auto_error(self, mock_request):
+        """Test that HTTPException is raised when credentials are missing and auto_error=True."""
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            bearer = ConfigurableHTTPBearer(auto_error=True)
+            mock_request.headers = {}
+
+            with pytest.raises(HTTPException) as exc_info:
+                await bearer(mock_request)
+
+            assert exc_info.value.status_code == 403
+            assert "Not authenticated" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_invalid_scheme(self, mock_request):
+        """Test that invalid authentication scheme is rejected."""
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            bearer = ConfigurableHTTPBearer(auto_error=True)
+            mock_request.headers = {"authorization": "Basic dXNlcjpwYXNz"}
+
+            with pytest.raises(HTTPException) as exc_info:
+                await bearer(mock_request)
+
+            assert exc_info.value.status_code == 403
+            assert "Invalid authentication credentials" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_header_lookup(self, mock_request):
+        """Test that header lookup is case-insensitive."""
+        with patch.object(settings, "auth_header_name", "X-Custom-Auth"):
+            bearer = ConfigurableHTTPBearer(auto_error=False)
+            # Header name in different case
+            mock_request.headers = {"x-custom-auth": "Bearer token-789"}
+
+            result = await bearer(mock_request)
+
+            assert result is not None
+            assert result.credentials == "token-789"
+
+    @pytest.mark.asyncio
+    async def test_authorization_passthrough_with_custom_header(self, mock_request):
+        """Test that Authorization header is preserved when using custom auth header."""
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            bearer = ConfigurableHTTPBearer(auto_error=False)
+            # Both headers present - custom for gateway auth, Authorization for downstream
+            mock_request.headers = {
+                "x-mcp-gateway-auth": "Bearer gateway-token",
+                "authorization": "Bearer downstream-token",
+            }
+
+            result = await bearer(mock_request)
+
+            # Should extract from custom header
+            assert result is not None
+            assert result.credentials == "gateway-token"
+            # Authorization header should still be present in request
+            assert "authorization" in mock_request.headers
+            assert mock_request.headers["authorization"] == "Bearer downstream-token"
+
+
+class TestWebSocketTokenExtraction:
+    """Test suite for WebSocket token extraction with custom header."""
+
+    def test_extract_from_custom_header(self):
+        """Test extracting token from custom WebSocket header."""
+        from mcpgateway.utils.verify_credentials import extract_websocket_bearer_token
+
+        with patch.object(settings, "auth_header_name", "X-MCP-Gateway-Auth"):
+            headers = {"x-mcp-gateway-auth": "Bearer ws-token-123"}
+            token = extract_websocket_bearer_token(None, headers)
+
+            assert token == "ws-token-123"
+
+    def test_extract_from_default_header(self):
+        """Test extracting token from default Authorization header."""
+        from mcpgateway.utils.verify_credentials import extract_websocket_bearer_token
+
+        with patch.object(settings, "auth_header_name", "Authorization"):
+            headers = {"authorization": "Bearer default-token-456"}
+            token = extract_websocket_bearer_token(None, headers)
+
+            assert token == "default-token-456"
+
+    def test_case_insensitive_extraction(self):
+        """Test case-insensitive header extraction."""
+        from mcpgateway.utils.verify_credentials import extract_websocket_bearer_token
+
+        with patch.object(settings, "auth_header_name", "X-Custom-Auth"):
+            # Mixed case header
+            headers = {"X-Custom-Auth": "Bearer mixed-case-token"}
+            token = extract_websocket_bearer_token(None, headers)
+
+            assert token == "mixed-case-token"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4392

---

## 📝 Summary

Implements configurable JWT authentication header support to resolve header collision issues when client applications need to pass their own JWT tokens to downstream MCP servers.

**Problem Solved**: Client tooling using the `Authorization` header for downstream MCP server authentication experienced collisions with ContextForge's authentication mechanism, which also used the `Authorization` header. This prevented proper authentication with backend servers.

**Solution**: Added `AUTH_HEADER_NAME` environment variable (default: `Authorization`) allowing ContextForge to use alternative headers like `X-MCP-Gateway-Auth` for its own authentication while preserving the original `Authorization` header for passthrough to downstream servers.

**Key Changes**:
- Added `auth_header_name` configuration field in [`mcpgateway/config.py`](mcpgateway/config.py:329-332)
- Created `ConfigurableHTTPBearer` class in [`mcpgateway/auth.py`](mcpgateway/auth.py:97-161) for flexible header extraction
- Updated authentication middleware in [`mcpgateway/middleware/auth_middleware.py`](mcpgateway/middleware/auth_middleware.py:148-151)
- Modified header protection logic in [`mcpgateway/middleware/http_auth_middleware.py`](mcpgateway/middleware/http_auth_middleware.py:94-109) to allow `Authorization` passthrough when using custom auth header
- Added WebSocket support in [`mcpgateway/utils/verify_credentials.py`](mcpgateway/utils/verify_credentials.py:108-140)
- Comprehensive test suite with 10 tests in [`tests/unit/mcpgateway/test_configurable_auth_header.py`](tests/unit/mcpgateway/test_configurable_auth_header.py:1)
- Complete documentation in [`docs/docs/manage/configurable-auth-header.md`](docs/docs/manage/configurable-auth-header.md:1)

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (10 new tests)
- [x] Documentation updated ([`configurable-auth-header.md`](docs/docs/manage/configurable-auth-header.md:1))
- [x] No secrets or credentials committed

---

## 📓 Notes

### Design Decisions

1. **Backward Compatibility**: Default value is `Authorization` to maintain existing behavior for all deployments
2. **Case-Insensitive Lookup**: Implemented case-insensitive header matching to handle various client implementations
3. **FastAPI Integration**: Extended `HTTPBearer` instead of `HTTPBase` to maintain OpenAPI schema compatibility
4. **Test Mocking Compatibility**: Added defensive programming with `getattr()` and type checking to handle mocked settings in test environments
5. **Header Protection**: When using a custom auth header, the standard `Authorization` header is automatically allowed for passthrough to downstream servers

### Usage Example

```bash
# Use custom header for ContextForge authentication
export AUTH_HEADER_NAME=X-MCP-Gateway-Auth

# Client sends both headers:
# X-MCP-Gateway-Auth: Bearer <gateway-token>  # For ContextForge
# Authorization: Bearer <client-token>         # Passes through to MCP servers
```

### Test Coverage

All 10 new tests passing:
- Default `Authorization` header behavior
- Custom header configuration
- Case-insensitive header matching
- Header passthrough when using custom auth header
- WebSocket authentication with custom headers
- Invalid/missing token scenarios
- Middleware header protection
- Settings mocking compatibility
