### PR TITLE
fix(health): unauthenticated liveness probe for authorization_code gateways + POST ping for StreamableHTTP

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -4298,6 +4298,12 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             # Use isolated client for gateway health checks (each gateway may have custom CA cert)
             # Use admin timeout for health checks (fail fast, don't wait 120s for slow upstreams)
             # Pass ssl_context if present, otherwise let get_isolated_http_client use skip_ssl_verify setting
+            # Track whether this is an unauthenticated liveness probe
+            # (authorization_code gateway without system token).  When True,
+            # HTTP 401/403 responses are treated as "server alive" rather
+            # than health-check failures.
+            unauthenticated_probe = False
+
             async with get_isolated_http_client(timeout=settings.httpx_admin_read_timeout, verify=ssl_context) as client:
                 logger.debug("Checking health of gateway: %s (%s)", gateway_name, gateway_url_sanitized)
                 try:
@@ -4308,40 +4314,40 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         grant_type = gateway_oauth_config.get("grant_type", "client_credentials")
 
                         if grant_type == "authorization_code":
-                            # For Authorization Code flow, try to get stored tokens
+                            # Authorization Code flow requires an interactive user
+                            # to complete the OAuth dance.  The health-check runs
+                            # under a system identity (platform_admin_email) which
+                            # typically has NO stored token for these gateways.
+                            #
+                            # Strategy: try to use a stored token if available;
+                            # otherwise proceed WITHOUT auth.  An unauthenticated
+                            # probe still tests connectivity:
+                            #   - 401/403 → server is alive (auth rejected, not down)
+                            #   - timeout/DNS/connection error → real outage
+                            # This avoids the old behaviour of marking the gateway
+                            # as failed just because the system account has no token.
+                            access_token = None
                             try:
                                 # First-Party
                                 from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
 
-                                # Use fresh session for OAuth token lookup
-                                with fresh_db_session() as token_db:
-                                    token_storage = TokenStorageService(token_db)
-
-                                    # Get user-specific OAuth token
-                                    if not user_email:
-                                        if span:
-                                            set_span_attribute(span, "health.status", "unhealthy")
-                                            set_span_error(span, "User email required for OAuth token")
-                                        await self._handle_gateway_failure(gateway)
-                                        return
-
-                                    access_token = await token_storage.get_user_token(gateway_id, user_email)
-
-                                if access_token:
-                                    headers["Authorization"] = f"Bearer {access_token}"
-                                else:
-                                    if span:
-                                        set_span_attribute(span, "health.status", "unhealthy")
-                                        set_span_error(span, "No valid OAuth token for user")
-                                    await self._handle_gateway_failure(gateway)
-                                    return
+                                if user_email:
+                                    with fresh_db_session() as token_db:
+                                        token_storage = TokenStorageService(token_db)
+                                        access_token = await token_storage.get_user_token(gateway_id, user_email)
                             except Exception as e:
-                                logger.error("Failed to obtain stored OAuth token for gateway %s: %s", gateway_name, e)
-                                if span:
-                                    set_span_attribute(span, "health.status", "unhealthy")
-                                    set_span_error(span, "Failed to obtain stored OAuth token")
-                                await self._handle_gateway_failure(gateway)
-                                return
+                                logger.debug(f"Could not look up OAuth token for health check on {gateway_name}: {e}")
+
+                            if access_token:
+                                headers["Authorization"] = f"Bearer {access_token}"
+                            else:
+                                # No token — proceed without auth.  The probe will
+                                # likely get 401/403 which is fine (proves liveness).
+                                unauthenticated_probe = True
+                                logger.debug(
+                                    f"Health-checking authorization_code gateway "
+                                    f"{gateway_name} without auth (no system token)"
+                                )
                         else:
                             # For Client Credentials flow, get token directly
                             try:
@@ -4365,26 +4371,49 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         else:
                             headers = {}
 
-                    # Perform the GET and raise on 4xx/5xx
+                    # Perform the actual connectivity probe.
+                    # For unauthenticated probes (auth_code gateways without
+                    # a system token), 401/403 proves the server is alive —
+                    # only network errors indicate a real outage.
                     if (gateway_transport).lower() == "sse":
                         timeout = httpx.Timeout(settings.health_check_timeout)
                         async with client.stream("GET", gateway_url, headers=headers, timeout=timeout) as response:
-                            # This will raise immediately if status is 4xx/5xx
-                            response.raise_for_status()
+                            if unauthenticated_probe and response.status_code in (401, 403):
+                                logger.debug(f"Gateway {gateway_name} returned {response.status_code} (auth rejected, server alive)")
+                            else:
+                                response.raise_for_status()
                             if span:
                                 set_span_attribute(span, "http.status_code", response.status_code)
                     elif (gateway_transport).lower() == "streamablehttp":
-                        # Health checks are system operations with no downstream MCP session,
-                        # so they don't go through the UpstreamSessionRegistry (which requires
-                        # a downstream session id). A fresh per-call session suffices — the
-                        # probe is cheap and verifies that an initialize round-trip works.
-                        async with streamablehttp_client(url=gateway_url, headers=headers, timeout=settings.health_check_timeout, httpx_client_factory=get_httpx_client_factory) as (
-                            read_stream,
-                            write_stream,
-                            _get_session_id,
-                        ):
-                            async with ClientSession(read_stream, write_stream) as session:
-                                response = await session.initialize()
+                        # Use a lightweight JSON-RPC POST ``initialize`` instead of the
+                        # full SDK client.  The SDK opens a GET SSE stream after
+                        # initialize, which returns 405 on servers that don't support
+                        # server-initiated messages (M365, Kubernetes MCP, GitHub).
+                        # The MCP spec says GET is optional, so a successful POST
+                        # ``initialize`` is sufficient proof of health.
+                        # NOTE: ``ping`` would require an existing session, so
+                        # ``initialize`` is the only stateless RPC we can send.
+                        init_payload = {
+                            "jsonrpc": "2.0",
+                            "id": "health-check",
+                            "method": "initialize",
+                            "params": {
+                                "protocolVersion": "2024-11-05",
+                                "capabilities": {},
+                                "clientInfo": {"name": "mcpgateway-health", "version": "1.0.0"},
+                            },
+                        }
+                        init_headers = {
+                            **headers,
+                            "Content-Type": "application/json",
+                            "Accept": "application/json, text/event-stream",
+                        }
+                        timeout = httpx.Timeout(settings.health_check_timeout)
+                        response = await client.post(gateway_url, json=init_payload, headers=init_headers, timeout=timeout)
+                        if unauthenticated_probe and response.status_code in (401, 403):
+                            logger.debug(f"Gateway {gateway_name} returned {response.status_code} (auth rejected, server alive)")
+                        else:
+                            response.raise_for_status()
 
                     # Reactivate gateway if it was previously inactive and health check passed now
                     if gateway_enabled and not gateway_reachable:
@@ -4462,6 +4491,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     if span:
                         set_span_attribute(span, "health.status", "healthy")
                         set_span_attribute(span, "success", True)
+                        if unauthenticated_probe:
+                            set_span_attribute(span, "health.probe_type", "unauthenticated_liveness")
 
                 except Exception as e:
                     if span:

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -5986,7 +5986,12 @@ class TestCheckSingleGatewayHealth:
 
     @pytest.mark.asyncio
     async def test_health_check_oauth_auth_code_no_user(self, gateway_service, monkeypatch):
-        """Auth code OAuth without user_email → marks gateway unhealthy."""
+        """Auth code OAuth without user_email → unauthenticated liveness probe.
+
+        Forterro behaviour: missing system token is no longer fatal; we emit
+        an unauthenticated probe and treat 401/403 as proof of liveness.  The
+        gateway is only marked unhealthy on real network errors.
+        """
         gw = _make_gateway(
             id="gw-1",
             name="oauth-authcode-gw",
@@ -6003,7 +6008,14 @@ class TestCheckSingleGatewayHealth:
             last_refresh_at=None,
             refresh_interval_seconds=None,
         )
+
+        # SSE probe: client.stream("GET", ...) returns a 401 — proves liveness.
+        response_mock = MagicMock(status_code=401)
+        stream_ctx = AsyncMock()
+        stream_ctx.__aenter__ = AsyncMock(return_value=response_mock)
+        stream_ctx.__aexit__ = AsyncMock(return_value=False)
         mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=stream_ctx)
         mock_ctx = AsyncMock()
         mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
         mock_ctx.__aexit__ = AsyncMock(return_value=False)
@@ -6022,7 +6034,7 @@ class TestCheckSingleGatewayHealth:
         gateway_service._handle_gateway_failure = AsyncMock()
 
         await gateway_service._check_single_gateway_health(gw, user_email=None)
-        gateway_service._handle_gateway_failure.assert_awaited_once()
+        gateway_service._handle_gateway_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_health_check_query_param_auth(self, gateway_service, monkeypatch):

--- a/tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py
@@ -310,19 +310,18 @@ class TestCheckSingleGatewayHealthReal:
 
     @pytest.mark.asyncio
     async def test_streamablehttp_health_uses_per_call_session(self):
-        """#4205: gateway health checks always use per-call sessions (no registry, no pool).
+        """streamablehttp gateway health probe uses a stateless JSON-RPC initialize POST.
 
-        Health checks are system operations with no downstream MCP session, so they
-        can't key the registry. A fresh per-call initialize() round-trip is the
-        whole probe — cheap enough that pooling isn't worth it.
+        Forterro replaced the SDK ``streamablehttp_client``/``ClientSession`` round-trip
+        with a lightweight ``client.post(...)`` carrying a JSON-RPC ``initialize`` payload.
+        The SDK opens a follow-up GET SSE stream that returns 405 on servers without
+        server-initiated message support (M365, Kubernetes MCP, GitHub), so a successful
+        POST is sufficient proof of liveness.
         """
         service = GatewayService()
         service._handle_gateway_failure = AsyncMock()
 
         gateway = self._make_gateway(transport="streamablehttp")
-
-        session = AsyncMock()
-        session.initialize = AsyncMock(return_value=None)
 
         update_db = MagicMock()
         db_gateway = MagicMock()
@@ -343,11 +342,16 @@ class TestCheckSingleGatewayHealthReal:
             def __exit__(self, *exc):
                 return False
 
-        class _IsoClientCM:
-            async def __aenter__(self):
-                return MagicMock()
+        post_response = MagicMock(status_code=200)
+        post_response.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.post = AsyncMock(return_value=post_response)
 
-            async def __aexit__(self, *exc):
+        class _IsoClientCM:
+            async def __aenter__(self_inner):
+                return http_client
+
+            async def __aexit__(self_inner, *exc):
                 return False
 
         with (
@@ -366,23 +370,27 @@ class TestCheckSingleGatewayHealthReal:
             ),
             patch("mcpgateway.services.gateway_service.create_span", return_value=_SpanCM()),
             patch("mcpgateway.services.gateway_service.get_isolated_http_client", return_value=_IsoClientCM()),
-            patch("mcpgateway.services.gateway_service.streamablehttp_client") as mock_http,
-            patch("mcpgateway.services.gateway_service.ClientSession") as MockCS,
             patch("mcpgateway.services.gateway_service.fresh_db_session", return_value=_DBCM()),
         ):
-            mock_http.return_value.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock(), MagicMock(return_value="sid")))
-            mock_http.return_value.__aexit__ = AsyncMock(return_value=False)
-            MockCS.return_value.__aenter__ = AsyncMock(return_value=session)
-            MockCS.return_value.__aexit__ = AsyncMock(return_value=False)
-
             await service._check_single_gateway_health(gateway)
 
-        session.initialize.assert_awaited_once()
+        http_client.post.assert_awaited_once()
+        # Verify the JSON-RPC initialize payload is sent
+        _, kwargs = http_client.post.call_args
+        assert kwargs["json"]["method"] == "initialize"
+        assert kwargs["json"]["jsonrpc"] == "2.0"
+        post_response.raise_for_status.assert_called_once()
         service._handle_gateway_failure.assert_not_called()
         update_db.commit.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_oauth_authorization_code_missing_user_email_marks_unhealthy_and_handles_failure(self):
+        """auth_code gateway with no user_email falls back to an unauthenticated probe.
+
+        Forterro changed the behaviour: a missing system token is no longer fatal.
+        We treat 401/403 from the upstream as proof of liveness, so the gateway is
+        only marked unhealthy on real connectivity failures.
+        """
         service = GatewayService()
         service._handle_gateway_failure = AsyncMock()
 
@@ -393,6 +401,9 @@ class TestCheckSingleGatewayHealthReal:
         )
 
         update_db = MagicMock()
+        db_gateway = MagicMock()
+        update_db.execute.return_value.scalar_one_or_none.return_value = db_gateway
+        update_db.commit = MagicMock()
 
         class _DBCM:
             def __enter__(self):
@@ -408,11 +419,19 @@ class TestCheckSingleGatewayHealthReal:
             def __exit__(self, *exc):
                 return False
 
-        class _IsoClientCM:
-            async def __aenter__(self):
-                return MagicMock()
+        # SSE probe: client.stream("GET", ...) yields a 401 → liveness proven.
+        response_mock = MagicMock(status_code=401)
+        stream_ctx = AsyncMock()
+        stream_ctx.__aenter__ = AsyncMock(return_value=response_mock)
+        stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        http_client = MagicMock()
+        http_client.stream = MagicMock(return_value=stream_ctx)
 
-            async def __aexit__(self, *exc):
+        class _IsoClientCM:
+            async def __aenter__(self_inner):
+                return http_client
+
+            async def __aexit__(self_inner, *exc):
                 return False
 
         with (
@@ -434,12 +453,11 @@ class TestCheckSingleGatewayHealthReal:
             patch("mcpgateway.services.gateway_service.create_span", return_value=_SpanCM()),
             patch("mcpgateway.services.gateway_service.get_isolated_http_client", return_value=_IsoClientCM()),
             patch("mcpgateway.services.gateway_service.fresh_db_session", return_value=_DBCM()),
-            patch("mcpgateway.services.token_storage_service.TokenStorageService") as mock_tss,
         ):
-            mock_tss.return_value.get_user_token = AsyncMock(return_value="token")
             await service._check_single_gateway_health(gateway, user_email=None)
 
-        service._handle_gateway_failure.assert_awaited_once()
+        http_client.stream.assert_called_once()
+        service._handle_gateway_failure.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_oauth_client_credentials_failure_marks_unhealthy_and_handles_failure(self):


### PR DESCRIPTION
Fixes #4495

## Summary

The gateway health check marks all `authorization_code` OAuth gateways as unreachable after pod restarts because the system account (`PLATFORM_ADMIN_EMAIL`) has no stored OAuth tokens. This PR introduces an **unauthenticated liveness probe** strategy: when no token is available, the health check proceeds without auth — HTTP 401/403 proves the server is alive, while timeouts/DNS/connection errors indicate a real outage.

Additionally, replaces the full MCP SDK `ClientSession.initialize()` for StreamableHTTP health checks with a lightweight JSON-RPC POST `initialize` request. The SDK opens a GET SSE stream after initialize which returns 405 on servers that don't support server-initiated messages (the MCP spec says GET is optional).

## Changes

**`mcpgateway/services/gateway_service.py`** — `_check_single_gateway_health()`:

### 1. Unauthenticated liveness probe (`unauthenticated_probe` flag)

For `authorization_code` gateways, the health check now:
- Tries to use a stored token if available (existing behavior)
- If no token exists (typical for system accounts): **proceeds without auth** instead of calling `_handle_gateway_failure()`
- Sets `unauthenticated_probe = True` so that HTTP 401/403 responses are treated as "server alive" for both SSE and StreamableHTTP transports
- Timeouts, DNS failures, and connection errors still trigger `_handle_gateway_failure` as before

Previously, the code did an early return to `_handle_gateway_failure()` when `user_email` was missing or when no stored token was found, making it impossible for authorization_code gateways to pass health checks under a system account.

### 2. Lightweight StreamableHTTP health check

Replaced the full SDK client session:
```python
# Before (causes 405 on servers without server-initiated messages):
async with streamablehttp_client(url=...) as (read, write, _):
    async with ClientSession(read, write) as session:
        response = await session.initialize()

# After (lightweight POST only):
response = await client.post(url, json=init_payload, headers=..., timeout=...)
```

The MCP SDK `ClientSession.initialize()` opens a GET SSE stream after the initialize handshake. Servers that don't support server-initiated messages (M365 MCP, Kubernetes MCP, GitHub MCP) return 405 on GET, causing a false health failure. A successful POST `initialize` is sufficient proof of health per the MCP spec.

### 3. Observability

Added `health.probe_type: unauthenticated_liveness` span attribute when probing without auth, for tracing visibility.

## Testing

Validated in production with 13 gateways (8 `authorization_code` + 5 non-OAuth). After deployment:
- All 13 gateways report `reachable=true`
- Previously, all 8 authorization_code gateways were stuck at `reachable=false` after every pod restart
- StreamableHTTP gateways (M365, Kubernetes, GitHub) no longer fail with 405

Signed-off-by: Olivier Gintrand <olivier.gintrand@forterro.com>