### PR TITLE
fix(tools): restore tool reachability status during gateway refresh

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -4598,6 +4598,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             jsonpath_filter=tool.jsonpath_filter,
             auth_type=gateway.auth_type,
             auth_value=encode_auth(gateway.auth_value) if isinstance(gateway.auth_value, dict) else gateway.auth_value,
+            # Status fields - tools successfully fetched from gateway are reachable
+            enabled=True,
+            reachable=True,
             # Federation metadata - consistent across all scenarios
             created_by=created_by or "system",
             created_from_ip=created_from_ip,
@@ -4693,6 +4696,12 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                     if basic_fields_changed or schema_fields_changed or auth_fields_changed or title_changed:
                         fields_to_update = True
+
+                    # Always mark tool as reachable when successfully fetched from gateway
+                    if not existing_tool.reachable:
+                        existing_tool.reachable = True
+                        fields_to_update = True
+
                     if fields_to_update:
                         existing_tool.url = gateway.url
                         # Only overwrite user-facing description if it hasn't been customized

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -7804,3 +7804,173 @@ def test_resolve_tool_title():
     # Case 6: No title anywhere
     tool_no_title = MCPTool.model_validate(_BASE)
     assert _resolve_tool_title(tool_no_title) is None
+
+
+
+class TestToolReachabilityRestoration:
+    """Test that tools are marked as reachable when successfully fetched during gateway refresh."""
+
+    @pytest.mark.asyncio
+    async def test_unreachable_tool_restored_during_refresh(self, gateway_service):
+        """Test that an unreachable tool is marked as reachable when successfully fetched."""
+        # Setup mock database
+        mock_db = MagicMock()
+
+        # Create a mock gateway
+        mock_gateway = MagicMock(spec=DbGateway)
+        mock_gateway.id = "gateway-123"
+        mock_gateway.name = "test-gateway"
+        mock_gateway.url = "http://example.com"
+        mock_gateway.auth_type = "bearer"
+        mock_gateway.auth_value = {"token": "test-token"}
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.owner_email = None
+
+        # Create a mock tool that is currently unreachable
+        mock_existing_tool = MagicMock(spec=DbTool)
+        mock_existing_tool.original_name = "test-tool"
+        mock_existing_tool.reachable = False  # Tool is currently offline
+        mock_existing_tool.enabled = True
+        mock_existing_tool.url = "http://example.com"
+        mock_existing_tool.original_description = "Test tool"
+        mock_existing_tool.description = "Test tool"
+        mock_existing_tool.integration_type = "MCP"
+        mock_existing_tool.request_type = "POST"
+        mock_existing_tool.headers = {}
+        mock_existing_tool.input_schema = {}
+        mock_existing_tool.output_schema = None
+        mock_existing_tool.jsonpath_filter = ""
+        mock_existing_tool.title = "Test Tool"
+        mock_existing_tool.auth_type = "bearer"
+        mock_existing_tool.auth_value = "encrypted-value"
+        mock_existing_tool.visibility = "public"
+
+        # Mock the database query to return the existing tool
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_existing_tool]
+        mock_db.execute.return_value = mock_result
+
+        # Create a tool from the gateway (simulating successful fetch)
+        from mcpgateway.schemas import ToolCreate
+        fetched_tool = ToolCreate(
+            name="test-tool",
+            description="Test tool",
+            input_schema={},
+            integration_type="REST",
+            request_type="POST",
+        )
+
+        # Call _update_or_create_tools
+        tools_to_add = gateway_service._update_or_create_tools(
+            db=mock_db,
+            tools=[fetched_tool],
+            gateway=mock_gateway,
+            created_via="health_check"
+        )
+
+        # Verify that the existing tool's reachable status was set to True
+        assert mock_existing_tool.reachable is True, "Tool should be marked as reachable after successful fetch"
+
+        # Verify no new tools were created (existing tool was updated)
+        assert len(tools_to_add) == 0, "No new tools should be created when updating existing tool"
+
+    def test_create_db_tool_sets_reachable_true(self, gateway_service):
+        """Test that _create_db_tool sets reachable=True for new tools."""
+        # Create a mock gateway
+        mock_gateway = MagicMock(spec=DbGateway)
+        mock_gateway.id = "gateway-123"
+        mock_gateway.name = "test-gateway"
+        mock_gateway.url = "http://example.com"
+        mock_gateway.auth_type = "bearer"
+        mock_gateway.auth_value = {"token": "test-token"}
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.owner_email = None
+
+        # Create a tool schema
+        from mcpgateway.schemas import ToolCreate
+        tool = ToolCreate(
+            name="new-tool",
+            description="New test tool",
+            input_schema={},
+            integration_type="REST",
+            request_type="POST",
+        )
+
+        # Call _create_db_tool
+        db_tool = gateway_service._create_db_tool(
+            tool=tool,
+            gateway=mock_gateway,
+            created_by="system",
+            created_via="health_check"
+        )
+
+        # Verify the new tool has reachable=True and enabled=True
+        assert db_tool.reachable is True, "New tool should be created with reachable=True"
+        assert db_tool.enabled is True, "New tool should be created with enabled=True"
+
+    @pytest.mark.asyncio
+    async def test_reachable_tool_stays_reachable(self, gateway_service):
+        """Test that tools already marked as reachable stay reachable."""
+        # Setup mock database
+        mock_db = MagicMock()
+
+        # Create a mock gateway
+        mock_gateway = MagicMock(spec=DbGateway)
+        mock_gateway.id = "gateway-123"
+        mock_gateway.name = "test-gateway"
+        mock_gateway.url = "http://example.com"
+        mock_gateway.auth_type = "bearer"
+        mock_gateway.auth_value = {"token": "test-token"}
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.owner_email = None
+
+        # Create a mock tool that is already reachable
+        mock_existing_tool = MagicMock(spec=DbTool)
+        mock_existing_tool.original_name = "test-tool"
+        mock_existing_tool.reachable = True  # Tool is already online
+        mock_existing_tool.enabled = True
+        mock_existing_tool.url = "http://example.com"
+        mock_existing_tool.original_description = "Test tool"
+        mock_existing_tool.description = "Test tool"
+        mock_existing_tool.integration_type = "MCP"
+        mock_existing_tool.request_type = "POST"
+        mock_existing_tool.headers = {}
+        mock_existing_tool.input_schema = {}
+        mock_existing_tool.output_schema = None
+        mock_existing_tool.jsonpath_filter = ""
+        mock_existing_tool.title = "Test Tool"
+        mock_existing_tool.auth_type = "bearer"
+        mock_existing_tool.auth_value = "encrypted-value"
+        mock_existing_tool.visibility = "public"
+
+        # Mock the database query to return the existing tool
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_existing_tool]
+        mock_db.execute.return_value = mock_result
+
+        # Create a tool from the gateway (simulating successful fetch)
+        from mcpgateway.schemas import ToolCreate
+        fetched_tool = ToolCreate(
+            name="test-tool",
+            description="Test tool",
+            input_schema={},
+            integration_type="REST",
+            request_type="POST",
+        )
+
+        # Call _update_or_create_tools
+        tools_to_add = gateway_service._update_or_create_tools(
+            db=mock_db,
+            tools=[fetched_tool],
+            gateway=mock_gateway,
+            created_via="health_check"
+        )
+
+        # Verify that the tool remains reachable
+        assert mock_existing_tool.reachable is True, "Tool should remain reachable"
+
+        # Verify no new tools were created
+        assert len(tools_to_add) == 0, "No new tools should be created"

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -7806,7 +7806,6 @@ def test_resolve_tool_title():
     assert _resolve_tool_title(tool_no_title) is None
 
 
-
 class TestToolReachabilityRestoration:
     """Test that tools are marked as reachable when successfully fetched during gateway refresh."""
 
@@ -7974,3 +7973,67 @@ class TestToolReachabilityRestoration:
 
         # Verify no new tools were created
         assert len(tools_to_add) == 0, "No new tools should be created"
+
+    @pytest.mark.asyncio
+    async def test_disabled_tool_reachable_flipped_but_enabled_preserved(self, gateway_service):
+        """Admin-disabled tool: refresh flips reachable=True but must NOT re-enable it."""
+        # Setup mock database
+        mock_db = MagicMock()
+
+        # Create a mock gateway
+        mock_gateway = MagicMock(spec=DbGateway)
+        mock_gateway.id = "gateway-123"
+        mock_gateway.name = "test-gateway"
+        mock_gateway.url = "http://example.com"
+        mock_gateway.auth_type = "bearer"
+        mock_gateway.auth_value = {"token": "test-token"}
+        mock_gateway.visibility = "public"
+        mock_gateway.team_id = None
+        mock_gateway.owner_email = None
+
+        # Create a mock tool that admin disabled (enabled=False) AND offline (reachable=False)
+        mock_existing_tool = MagicMock(spec=DbTool)
+        mock_existing_tool.original_name = "test-tool"
+        mock_existing_tool.reachable = False  # Tool is currently offline
+        mock_existing_tool.enabled = False  # Admin disabled the tool
+        mock_existing_tool.url = "http://example.com"
+        mock_existing_tool.original_description = "Test tool"
+        mock_existing_tool.description = "Test tool"
+        mock_existing_tool.integration_type = "MCP"
+        mock_existing_tool.request_type = "POST"
+        mock_existing_tool.headers = {}
+        mock_existing_tool.input_schema = {}
+        mock_existing_tool.output_schema = None
+        mock_existing_tool.jsonpath_filter = ""
+        mock_existing_tool.title = "Test Tool"
+        mock_existing_tool.auth_type = "bearer"
+        mock_existing_tool.auth_value = "encrypted-value"
+        mock_existing_tool.visibility = "public"
+
+        # Mock the database query to return the existing tool
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_existing_tool]
+        mock_db.execute.return_value = mock_result
+
+        # Create a tool from the gateway (simulating successful fetch)
+        from mcpgateway.schemas import ToolCreate
+        fetched_tool = ToolCreate(
+            name="test-tool",
+            description="Test tool",
+            input_schema={},
+            integration_type="REST",
+            request_type="POST",
+        )
+
+        # Call _update_or_create_tools
+        gateway_service._update_or_create_tools(
+            db=mock_db,
+            tools=[fetched_tool],
+            gateway=mock_gateway,
+            created_via="health_check"
+        )
+
+        # Verify reachable was flipped True (gateway is up so the tool is reachable)
+        assert mock_existing_tool.reachable is True, "Tool should be marked reachable on successful fetch"
+        # Critical security invariant: refresh must NOT re-enable admin-disabled tools
+        assert mock_existing_tool.enabled is False, "Admin-disabled tool must remain disabled after refresh"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4454
**Jira Issue:** https://jsw.ibm.com/browse/ICACF-32

---

## 📝 Summary

This PR fixes a critical bug where tools from registered gateways were appearing as offline even though the gateways were functional and successfully returning tools during health checks and refresh operations.

**Problem:** Tools have a `reachable` boolean field that tracks their availability. When tools were updated during gateway refresh operations (health checks, manual refresh, OAuth flows), the `reachable` field was never updated. This meant that if a tool was previously marked as `reachable=False` during a gateway failure, it would remain offline indefinitely, even after the gateway recovered and successfully returned the tool.

**Solution:** Modified [`gateway_service.py`](mcpgateway/services/gateway_service.py) to ensure tools are marked as reachable when successfully fetched:

1. **[`_create_db_tool()`](mcpgateway/services/gateway_service.py:4584-4615)**: Explicitly set `enabled=True` and `reachable=True` for newly created tools
2. **[`_update_or_create_tools()`](mcpgateway/services/gateway_service.py:4697-4700)**: Added logic to mark existing tools as `reachable=True` when successfully fetched from gateway during refresh operations

**Impact:** Tools are now automatically restored to online status when gateways successfully return them, resolving the issue where users couldn't invoke tools despite having functional gateway connections.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (existing tests validate the fix)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Root Cause Analysis

The issue was in the [`_update_or_create_tools()`](mcpgateway/services/gateway_service.py:4614-4731) method. When tools were updated during gateway refresh/health checks:

1. **New tools** were created via [`_create_db_tool()`](mcpgateway/services/gateway_service.py:4562-4612) which didn't explicitly set `reachable=True` (relied on model default)
2. **Existing tools** were updated at lines 4696-4713, but the `reachable` field was **never updated**
3. If a tool was previously marked as `reachable=False` (e.g., during a gateway failure), it stayed offline even after successful gateway health checks and tool refreshes

The gateway's `reachable` status was correctly updated during health checks ([`gateway_service.py:3827`](mcpgateway/services/gateway_service.py:3827)), but the individual tools' `reachable` status was not propagated.

### Code Changes

**File:** `mcpgateway/services/gateway_service.py`

**Change 1 - New tool creation (lines 4584-4615):**
```python
return DbTool(
    # ... existing fields ...
    # Status fields - tools successfully fetched from gateway are reachable
    enabled=True,
    reachable=True,
    # ... rest of fields ...
)
```

**Change 2 - Existing tool update (lines 4697-4700):**
```python
# Always mark tool as reachable when successfully fetched from gateway
if not existing_tool.reachable:
    existing_tool.reachable = True
    fields_to_update = True
```

### User Impact

**Before:** Users reported tools showing as offline in the UI and receiving errors like:
```
ERROR: Tool 'github-com-read-tools-search-repositories' exists but is currently offline. 
Please verify if it is running.
```

**After:** Tools are automatically restored to online status when gateways successfully return them during any refresh operation (health checks, manual refresh, OAuth flows).