### PR TITLE
fix(db): add ondelete="CASCADE" to 6 FK constraints that prevented tool/resource/prompt deletion after invocation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4487,6 +4487,24 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py": [
+      {
+        "hashed_secret": "77ff62910d759a0d1cc7080497e7b3627a540428",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6fc2a8a23c7db93d6624d3e40d9db9f3157c715e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/alembic/versions/a23a08d61eb0_add_observability_tables.py": [
       {
         "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",

--- a/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
+++ b/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
@@ -1,0 +1,217 @@
+"""add_ondelete_cascade_to_metrics_and_associations
+
+Revision ID: 9fb98535724d
+Revises: 926d3e07d098
+Create Date: 2026-04-28 15:14:01.089813
+
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "9fb98535724d"
+down_revision: Union[str, Sequence[str], None] = "926d3e07d098"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _get_fk_names(inspector, table_name: str, referred_table: str | None = None) -> list[str]:
+    """Return foreign-key constraint names for a table, optionally filtered by target table."""
+    names: list[str] = []
+    for fk in inspector.get_foreign_keys(table_name):
+        if referred_table is not None and fk.get("referred_table") != referred_table:
+            continue
+        name = fk.get("name")
+        if name:
+            names.append(name)
+    return names
+
+
+def _has_cascade_fk(inspector, table_name: str, referred_table: str) -> bool:
+    """Return True when the FK to the referred table already uses ON DELETE CASCADE."""
+    for fk in inspector.get_foreign_keys(table_name):
+        if fk.get("referred_table") != referred_table:
+            continue
+        if (fk.get("options") or {}).get("ondelete") == "CASCADE":
+            return True
+    return False
+
+
+def _replace_single_fk_with_cascade(table_name: str, referred_table: str, local_cols: list[str], remote_cols: list[str]) -> None:
+    """Replace a single FK to the referred table with an ON DELETE CASCADE version."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if table_name not in inspector.get_table_names():
+        return
+
+    if _has_cascade_fk(inspector, table_name, referred_table):
+        return
+
+    fk_names = _get_fk_names(inspector, table_name, referred_table)
+    if len(fk_names) != 1:
+        raise RuntimeError(f"Expected exactly one foreign key from {table_name} to {referred_table}, found {fk_names}")
+
+    fk_name = fk_names[0]
+    new_fk_name = f"fk_{table_name}_{local_cols[0]}"
+
+    with op.batch_alter_table(table_name, schema=None) as batch_op:
+        batch_op.drop_constraint(fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(new_fk_name, referred_table, local_cols, remote_cols, ondelete="CASCADE")
+
+
+def _replace_all_fks_with_cascade(table_name: str, fk_specs: list[tuple[str, list[str], list[str]]]) -> None:
+    """Replace all FKs on an association table with ON DELETE CASCADE versions."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if table_name not in inspector.get_table_names():
+        return
+
+    current_fks = inspector.get_foreign_keys(table_name)
+    if not current_fks:
+        return
+
+    all_cascade = True
+    for referred_table, _local_cols, _remote_cols in fk_specs:
+        if not _has_cascade_fk(inspector, table_name, referred_table):
+            all_cascade = False
+            break
+
+    if all_cascade:
+        return
+
+    fk_names = [fk.get("name") for fk in current_fks if fk.get("name")]
+    expected_targets = {spec[0] for spec in fk_specs}
+    actual_targets = {fk.get("referred_table") for fk in current_fks}
+
+    if actual_targets != expected_targets:
+        raise RuntimeError(f"Unexpected foreign key layout for {table_name}: targets={sorted(actual_targets)} names={fk_names}")
+
+    with op.batch_alter_table(table_name, schema=None) as batch_op:
+        for fk_name in fk_names:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+
+        for referred_table, local_cols, remote_cols in fk_specs:
+            batch_op.create_foreign_key(f"fk_{table_name}_{local_cols[0]}", referred_table, local_cols, remote_cols, ondelete="CASCADE")
+
+
+def upgrade() -> None:
+    """Add CASCADE ondelete to foreign keys in metrics and association tables."""
+    _replace_single_fk_with_cascade("tool_metrics", "tools", ["tool_id"], ["id"])
+    _replace_single_fk_with_cascade("resource_metrics", "resources", ["resource_id"], ["id"])
+    _replace_single_fk_with_cascade("prompt_metrics", "prompts", ["prompt_id"], ["id"])
+
+    _replace_all_fks_with_cascade(
+        "server_tool_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("tools", ["tool_id"], ["id"]),
+        ],
+    )
+    _replace_all_fks_with_cascade(
+        "server_resource_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("resources", ["resource_id"], ["id"]),
+        ],
+    )
+    _replace_all_fks_with_cascade(
+        "server_prompt_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("prompts", ["prompt_id"], ["id"]),
+        ],
+    )
+
+
+def _replace_single_fk_without_cascade(table_name: str, referred_table: str, local_cols: list[str], remote_cols: list[str]) -> None:
+    """Replace a single FK to the referred table with a default NO ACTION version."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if table_name not in inspector.get_table_names():
+        return
+
+    if not _has_cascade_fk(inspector, table_name, referred_table):
+        return
+
+    fk_names = _get_fk_names(inspector, table_name, referred_table)
+    if len(fk_names) != 1:
+        raise RuntimeError(f"Expected exactly one foreign key from {table_name} to {referred_table}, found {fk_names}")
+
+    fk_name = fk_names[0]
+    new_fk_name = f"fk_{table_name}_{local_cols[0]}"
+
+    with op.batch_alter_table(table_name, schema=None) as batch_op:
+        batch_op.drop_constraint(fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(new_fk_name, referred_table, local_cols, remote_cols)
+
+
+def _replace_all_fks_without_cascade(table_name: str, fk_specs: list[tuple[str, list[str], list[str]]]) -> None:
+    """Replace all FKs on an association table with default NO ACTION versions."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if table_name not in inspector.get_table_names():
+        return
+
+    current_fks = inspector.get_foreign_keys(table_name)
+    if not current_fks:
+        return
+
+    any_cascade = False
+    for referred_table, _local_cols, _remote_cols in fk_specs:
+        if _has_cascade_fk(inspector, table_name, referred_table):
+            any_cascade = True
+            break
+
+    if not any_cascade:
+        return
+
+    fk_names = [fk.get("name") for fk in current_fks if fk.get("name")]
+    expected_targets = {spec[0] for spec in fk_specs}
+    actual_targets = {fk.get("referred_table") for fk in current_fks}
+
+    if actual_targets != expected_targets:
+        raise RuntimeError(f"Unexpected foreign key layout for {table_name}: targets={sorted(actual_targets)} names={fk_names}")
+
+    with op.batch_alter_table(table_name, schema=None) as batch_op:
+        for fk_name in fk_names:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+
+        for referred_table, local_cols, remote_cols in fk_specs:
+            batch_op.create_foreign_key(f"fk_{table_name}_{local_cols[0]}", referred_table, local_cols, remote_cols)
+
+
+def downgrade() -> None:
+    """Revert CASCADE ondelete back to default (NO ACTION)."""
+    _replace_all_fks_without_cascade(
+        "server_prompt_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("prompts", ["prompt_id"], ["id"]),
+        ],
+    )
+    _replace_all_fks_without_cascade(
+        "server_resource_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("resources", ["resource_id"], ["id"]),
+        ],
+    )
+    _replace_all_fks_without_cascade(
+        "server_tool_association",
+        [
+            ("servers", ["server_id"], ["id"]),
+            ("tools", ["tool_id"], ["id"]),
+        ],
+    )
+    _replace_single_fk_without_cascade("prompt_metrics", "prompts", ["prompt_id"], ["id"])
+    _replace_single_fk_without_cascade("resource_metrics", "resources", ["resource_id"], ["id"])
+    _replace_single_fk_without_cascade("tool_metrics", "tools", ["tool_id"], ["id"])

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -2430,24 +2430,24 @@ class PendingUserApproval(Base):
 server_tool_association = Table(
     "server_tool_association",
     Base.metadata,
-    Column("server_id", String(36), ForeignKey("servers.id"), primary_key=True),
-    Column("tool_id", String(36), ForeignKey("tools.id"), primary_key=True),
+    Column("server_id", String(36), ForeignKey("servers.id", ondelete="CASCADE"), primary_key=True),
+    Column("tool_id", String(36), ForeignKey("tools.id", ondelete="CASCADE"), primary_key=True),
 )
 
 # Association table for servers and resources
 server_resource_association = Table(
     "server_resource_association",
     Base.metadata,
-    Column("server_id", String(36), ForeignKey("servers.id"), primary_key=True),
-    Column("resource_id", String(36), ForeignKey("resources.id"), primary_key=True),
+    Column("server_id", String(36), ForeignKey("servers.id", ondelete="CASCADE"), primary_key=True),
+    Column("resource_id", String(36), ForeignKey("resources.id", ondelete="CASCADE"), primary_key=True),
 )
 
 # Association table for servers and prompts
 server_prompt_association = Table(
     "server_prompt_association",
     Base.metadata,
-    Column("server_id", String(36), ForeignKey("servers.id"), primary_key=True),
-    Column("prompt_id", String(36), ForeignKey("prompts.id"), primary_key=True),
+    Column("server_id", String(36), ForeignKey("servers.id", ondelete="CASCADE"), primary_key=True),
+    Column("prompt_id", String(36), ForeignKey("prompts.id", ondelete="CASCADE"), primary_key=True),
 )
 
 # Association table for servers and A2A agents
@@ -2491,7 +2491,7 @@ class ToolMetric(Base):
     __tablename__ = "tool_metrics"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    tool_id: Mapped[str] = mapped_column(String(36), ForeignKey("tools.id"), nullable=False, index=True)
+    tool_id: Mapped[str] = mapped_column(String(36), ForeignKey("tools.id", ondelete="CASCADE"), nullable=False, index=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, index=True)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
@@ -2517,7 +2517,7 @@ class ResourceMetric(Base):
     __tablename__ = "resource_metrics"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    resource_id: Mapped[str] = mapped_column(String(36), ForeignKey("resources.id"), nullable=False, index=True)
+    resource_id: Mapped[str] = mapped_column(String(36), ForeignKey("resources.id", ondelete="CASCADE"), nullable=False, index=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, index=True)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)
@@ -2569,7 +2569,7 @@ class PromptMetric(Base):
     __tablename__ = "prompt_metrics"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    prompt_id: Mapped[str] = mapped_column(String(36), ForeignKey("prompts.id"), nullable=False, index=True)
+    prompt_id: Mapped[str] = mapped_column(String(36), ForeignKey("prompts.id", ondelete="CASCADE"), nullable=False, index=True)
     timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, index=True)
     response_time: Mapped[float] = mapped_column(Float, nullable=False)
     is_success: Mapped[bool] = mapped_column(Boolean, nullable=False)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4478

**Related Issues:**
- Addresses similar FK constraint pattern as #4449 (which proposes CASCADE for `server_*_association` tables)
- Both issues stem from missing `ondelete` clauses causing FK constraint violations

---

## 📝 Summary

Fixed a critical bug where DELETE operations on tools, resources, and prompts would fail with `sqlite3.IntegrityError: FOREIGN KEY constraint failed` after the entities had been invoked at least once. The issue was caused by missing `ondelete` clauses on foreign key constraints in metrics and association tables, which defaulted to `NO ACTION` and blocked parent row deletion.

**Root Cause:**
- `tool_metrics.tool_id`, `resource_metrics.resource_id`, and `prompt_metrics.prompt_id` lacked `ondelete` clauses
- Association tables (`server_tool_association`, `server_resource_association`, `server_prompt_association`) also lacked `ondelete` clauses
- Once metrics were created (after first invocation), the parent entity became permanently un-deletable through the REST API

**Solution:**
- Added `ondelete="CASCADE"` to all 6 missing foreign key constraints in [`mcpgateway/db.py`](mcpgateway/db.py:2415-2554)
- Created idempotent Alembic migration [`9fb98535724d`](mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py) to update existing databases
- Metrics and association rows now automatically cascade delete when parent is removed

**Impact:**
- Tools/resources/prompts can now be deleted via REST API after invocation
- Consistent with existing patterns (`tool_metrics_hourly`, `a2a_agents.tool_id` already use `ondelete="SET NULL"`)
- No manual database manipulation required

**Scope vs Issue #4449:**
- **Issue #4449** proposes CASCADE for `server_*_association` FKs + cleanup code removal
- **This PR** implements CASCADE for both `*_metrics` AND `server_*_association` FKs
- This PR fully addresses #4478 and partially addresses #4449 (association tables only; cleanup code removal not included)

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

**Manual Verification:**
- Migration successfully created: `9fb98535724d_add_ondelete_cascade_to_metrics_and_.py`
- Migration applied successfully: `alembic upgrade head` ✅
- Single migration head confirmed: `alembic heads` shows `9fb98535724d` ✅

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [x] Documentation updated (migration includes comprehensive docstrings)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Files Changed:**
1. [`mcpgateway/db.py`](mcpgateway/db.py) - Added `ondelete="CASCADE"` to 6 FK constraints
2. [`mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py`](mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py) - New migration

**Migration Details:**
- Idempotent: Checks for table existence before modifying (supports fresh DBs)
- Cross-database: Works with both SQLite and PostgreSQL
- Reversible: Includes complete downgrade path
- Safe: Uses batch operations for SQLite compatibility

**Cascade Behavior:**
```
DELETE tool → Automatically deletes:
              - All tool_metrics rows
              - All server_tool_association rows
              
DELETE resource → Automatically deletes:
                  - All resource_metrics rows
                  - All server_resource_association rows
                  
DELETE prompt → Automatically deletes:
                - All prompt_metrics rows
                - All server_prompt_association rows
```

**Follow-up Work (per #4449):**
- Remove redundant explicit cleanup code from `tool_service.py` and `gateway_service.py` (lines 1647, 2436, 3015, 3323, 5176, etc.)
- Add real-DB FK enforcement regression tests for all four entity-delete paths
- These can be addressed in a separate PR focused on code cleanup