### PR TITLE
chore: bump retry backoff plugin to 0.2.0

### DIFF
--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -105,8 +105,8 @@ mcpContextForge:
         - name: "RetryWithBackoffPlugin"
           kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
           description: "Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay"
-          version: "0.1.0"
-          author: "Mihai Criveti"
+          version: "0.2.0"
+          author: "ContextForge Contributors"
           hooks: ["tool_post_invoke"]
           tags: ["retry", "backoff", "resilience"]
           mode: "permissive"

--- a/plugins/config-pii-guardian-policy.yaml
+++ b/plugins/config-pii-guardian-policy.yaml
@@ -321,8 +321,8 @@ plugins:
   - name: "RetryWithBackoffPlugin"
     kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
     description: "Annotates retry/backoff policy in metadata"
-    version: "0.1.0"
-    author: "Mihai Criveti"
+    version: "0.2.0"
+    author: "ContextForge Contributors"
     hooks: ["tool_post_invoke", "resource_post_fetch"]
     tags: ["reliability", "retry"]
     mode: "disabled"

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -393,8 +393,8 @@ plugins:
   - name: "RetryWithBackoffPlugin"
     kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
     description: "Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay"
-    version: "0.1.0"
-    author: "Mihai Criveti"
+    version: "0.2.0"
+    author: "ContextForge Contributors"
     hooks: ["tool_post_invoke"]
     tags: ["retry", "backoff", "resilience"]
     mode: "permissive"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ cpex-url-reputation = "2026-04-20T23:59:59Z"
 cpex-rate-limiter = "2026-04-22T23:59:59Z"
 cpex-encoded-exfil-detection = "2026-04-09T23:59:59Z"
 cpex-pii-filter = "2026-04-21T23:59:59Z"
-cpex-retry-with-backoff = "2026-04-09T23:59:59Z"
+cpex-retry-with-backoff = "2026-04-28T23:59:59Z"
 cpex-secrets-detection = "2026-04-20T23:59:59Z"
 cryptography = "2026-04-11T23:59:59Z"
 langchain-core = "2026-04-22T23:59:59Z"
@@ -279,7 +279,7 @@ plugins = [
     "cpex-encoded-exfil-detection>=0.2.0",
     "cpex-pii-filter>=0.2.1",
     "cpex-rate-limiter>=0.0.4",
-    "cpex-retry-with-backoff>=0.1.0",
+    "cpex-retry-with-backoff>=0.2.0",
     "cpex-secrets-detection>=0.2.0",
     "cpex-url-reputation>=0.2.0",
 ]

--- a/tests/performance/plugins/config.yaml
+++ b/tests/performance/plugins/config.yaml
@@ -455,8 +455,8 @@ plugins:
   - name: RetryWithBackoffPlugin
     kind: cpex_retry_with_backoff.RetryWithBackoffPlugin
     description: Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay
-    version: 0.1.0
-    author: ContextForge
+    version: 0.2.0
+    author: ContextForge Contributors
     hooks: [tool_post_invoke]
     tags: [retry, backoff, resilience]
     mode: permissive

--- a/tests/unit/mcpgateway/plugins/fixtures/configs/init_hooks_plugins_test.yaml
+++ b/tests/unit/mcpgateway/plugins/fixtures/configs/init_hooks_plugins_test.yaml
@@ -320,8 +320,8 @@ plugins:
   - name: "RetryWithBackoffPlugin"
     kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
     description: "Annotates retry/backoff policy in metadata"
-    version: "0.1.0"
-    author: "Mihai Criveti"
+    version: "0.2.0"
+    author: "ContextForge Contributors"
     hooks: ["tool_post_invoke", "resource_post_fetch"]
     tags: ["reliability", "retry"]
     mode: "permissive"


### PR DESCRIPTION
## Related Issue
Related: IBM/cpex-plugins#54

---

## Summary
Updates ContextForge references for the upcoming `cpex-retry-with-backoff` `0.2.0` release.

- Bumps the optional plugin dependency floor to `cpex-retry-with-backoff>=0.2.0`.
- Updates the retry plugin version in shipped plugin configs, OCP profile config, and matching test/performance fixtures.
- Refreshes the uv exclude-newer package date for the retry package.

Draft until `cpex-retry-with-backoff` `0.2.0` is published to PyPI and `uv.lock` can be refreshed.

---

## Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Diff whitespace           | `git diff --check` | Passed |
| Commit hooks              | `git commit -s` | Passed |
| TOML/YAML syntax          | pre-commit hooks | Passed |
| Lock resolution           | `uv lock --check` | Blocked: PyPI only has `cpex-retry-with-backoff==0.1.0` |

---

## Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## Notes (optional)
Follow-up after PyPI release: refresh `uv.lock` once `cpex-retry-with-backoff` `0.2.0` is available.
