### PR TITLE
feat: auto-build React client with hot reload in dev mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,9 +373,10 @@ check-env-dev:
         js-build
 
 ## --- JS build ----------------------------------------------------------------
-js-build:                        ## Install npm dependencies and build JS bundle with Vite
+js-build:                        ## Install npm dependencies and build JS bundle with Vite (includes client React app)
 	@if command -v npm >/dev/null 2>&1; then \
-		npm install --no-audit --no-fund && npm run vite:build; \
+		npm install --no-audit --no-fund && npm run vite:build && \
+		cd client && npm install --no-audit --no-fund && npm run build; \
 	else \
 		echo "WARNING: npm not found — skipping JS bundle build (admin UI may not load)"; \
 	fi
@@ -397,6 +398,8 @@ serve-granian-http2: js-build certs ## Run Granian with HTTP/2 and TLS
 	SSL=true GRANIAN_HTTP=2 CERT_FILE=certs/cert.pem KEY_FILE=certs/key.pem ./run-granian.sh
 
 dev: js-build
+	@echo "🚀 Starting dev server with React hot reload..."
+	@cd client && npm install --no-audit --no-fund && npm run build:watch & echo $$! > /tmp/mcpgateway-client-watch.pid
 	@TEMPLATES_AUTO_RELOAD=true $(VENV_DIR)/bin/uvicorn mcpgateway.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude='public/'
 
 .PHONY: dev-echo
@@ -416,13 +419,15 @@ dev-remote: js-build             ## Run dev server with remote debugging (debugp
 
 stop:                            ## Stop all mcpgateway server processes
 	@echo "Stopping all mcpgateway processes..."
+	@if [ -f /tmp/mcpgateway-client-watch.pid ]; then kill -9 $$(cat /tmp/mcpgateway-client-watch.pid) 2>/dev/null || true; rm -f /tmp/mcpgateway-client-watch.pid; fi
 	@if [ -f /tmp/mcpgateway-gunicorn.lock ]; then kill -9 $$(cat /tmp/mcpgateway-gunicorn.lock) 2>/dev/null || true; rm -f /tmp/mcpgateway-gunicorn.lock; fi
 	@if [ -f /tmp/mcpgateway-granian.lock ]; then kill -9 $$(cat /tmp/mcpgateway-granian.lock) 2>/dev/null || true; rm -f /tmp/mcpgateway-granian.lock; fi
 	@lsof -ti:8000 2>/dev/null | xargs -r kill -9 || true
 	@lsof -ti:4444 2>/dev/null | xargs -r kill -9 || true
 	@echo "Done."
 
-stop-dev:                        ## Stop uvicorn dev server (port 8000)
+stop-dev:                        ## Stop uvicorn dev server (port 8000) and client watch process
+	@if [ -f /tmp/mcpgateway-client-watch.pid ]; then kill -9 $$(cat /tmp/mcpgateway-client-watch.pid) 2>/dev/null || true; rm -f /tmp/mcpgateway-client-watch.pid; fi
 	@lsof -ti:8000 2>/dev/null | xargs -r kill -9 || true
 
 stop-serve:                      ## Stop gunicorn production server (port 4444)

--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ serve-granian-http2: js-build certs ## Run Granian with HTTP/2 and TLS
 
 dev: js-build
 	@echo "🚀 Starting dev server with React hot reload..."
-	@cd client && npm install --no-audit --no-fund && npm run build:watch & echo $$! > /tmp/mcpgateway-client-watch.pid
+	@cd client && npm install --no-audit --no-fund && npm run build:watch > /dev/null 2>&1 & echo $$! > /tmp/mcpgateway-client-watch.pid
 	@TEMPLATES_AUTO_RELOAD=true $(VENV_DIR)/bin/uvicorn mcpgateway.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude='public/'
 
 .PHONY: dev-echo

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:e2e": "vite --base=/ --port 5173 --strictPort",
     "build": "tsc -b && vite build",
+    "build:watch": "vite build --watch",
     "preview": "vite preview",
     "lint": "eslint src e2e",
     "lint:fix": "eslint src e2e --fix",


### PR DESCRIPTION
## Closes
#4187 

## Summary

Eliminates the need to manually run `npm run build` in the client folder when running `make dev`. The React app now rebuilds automatically on file changes during development.

## Changes

- **client/package.json**: Added `build:watch` script for Vite watch mode
- **Makefile**: 
  - Modified `js-build` target to build both admin UI and client React app
  - Updated `dev` target to start client build:watch in background for hot reload
  - Updated `stop` and `stop-dev` targets to properly cleanup client watch process

## How It Works

### Production Builds (`make serve`, `make install`)
- `js-build` builds both UIs once in production mode

### Development (`make dev`)
- Builds both UIs initially
- Starts Vite watch mode in background for React app
- React changes auto-rebuild on file save
- PID tracked in `/tmp/mcpgateway-client-watch.pid`

### Cleanup
- `make stop` or `make stop-dev` kills watch process automatically

## Testing

```bash
# Start dev server (React will auto-rebuild on changes)
make dev

# Make changes to client/src/* files - they'll rebuild automatically

# Stop everything (including watch process)
make stop-dev
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have signed my commits (DCO)