### PR TITLE
fix: rate-limit _cleanup_table DELETEs with configurable inter-batch sleep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2055,6 +2055,10 @@ SKIP_MIGRATION=false
 # Larger batches are faster but may cause longer table locks
 # METRICS_CLEANUP_BATCH_SIZE=10000
 
+# Milliseconds to sleep between batch DELETEs (default: 50, range: 0-5000)
+# Increase to reduce DB pressure on high-traffic deployments (0 = no sleep)
+# METRICS_CLEANUP_BATCH_SLEEP_MS=50
+
 # Metrics Rollup Configuration
 # =============================================================================
 # Aggregates raw metrics into hourly summaries for efficient historical queries

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-22T17:48:13Z",
+  "generated_at": "2026-05-22T21:53:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4284,52 +4284,6 @@
         "is_verified": false,
         "line_number": 752,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 249,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2948,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 80,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/llm_provider_configs.py": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 316,
-        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4287,6 +4287,52 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 249,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2948,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/llm_provider_configs.py": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 308,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 316,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/middleware/request_logging_middleware.py": [
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1967,7 +1967,9 @@ class Settings(BaseSettings):
     metrics_retention_days: int = Field(default=7, ge=1, le=365, description="Days to retain raw metrics before cleanup (fallback when rollup disabled)")
     metrics_cleanup_interval_hours: int = Field(default=1, ge=1, le=168, description="Hours between automatic cleanup runs")
     metrics_cleanup_batch_size: int = Field(default=10000, ge=100, le=100000, description="Batch size for metrics deletion (prevents long locks)")
-    metrics_cleanup_batch_sleep_ms: int = Field(default=50, ge=0, le=5000, description="Milliseconds to sleep between batch DELETEs in cleanup (0 = no sleep). Use to reduce DB pressure during background cleanup.")
+    metrics_cleanup_batch_sleep_ms: int = Field(
+        default=50, ge=0, le=5000, description="Milliseconds to sleep between batch DELETEs in cleanup (0 = no sleep). Use to reduce DB pressure during background cleanup."
+    )
 
     # Metrics Rollup Configuration (hourly aggregation for historical queries)
     metrics_rollup_enabled: bool = Field(default=True, description="Enable hourly metrics rollup for efficient historical queries")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1967,6 +1967,7 @@ class Settings(BaseSettings):
     metrics_retention_days: int = Field(default=7, ge=1, le=365, description="Days to retain raw metrics before cleanup (fallback when rollup disabled)")
     metrics_cleanup_interval_hours: int = Field(default=1, ge=1, le=168, description="Hours between automatic cleanup runs")
     metrics_cleanup_batch_size: int = Field(default=10000, ge=100, le=100000, description="Batch size for metrics deletion (prevents long locks)")
+    metrics_cleanup_batch_sleep_ms: int = Field(default=50, ge=0, le=5000, description="Milliseconds to sleep between batch DELETEs in cleanup (0 = no sleep). Use to reduce DB pressure during background cleanup.")
 
     # Metrics Rollup Configuration (hourly aggregation for historical queries)
     metrics_rollup_enabled: bool = Field(default=True, description="Enable hourly metrics rollup for efficient historical queries")

--- a/mcpgateway/services/metrics_cleanup_service.py
+++ b/mcpgateway/services/metrics_cleanup_service.py
@@ -62,7 +62,6 @@ def delete_metrics_in_batches(db: Session, model_class, filter_column, entity_id
         int: Total rows deleted.
     """
     effective_batch_size = batch_size or getattr(settings, "metrics_cleanup_batch_size", 10000)
-    batch_sleep_ms = getattr(settings, "metrics_cleanup_batch_sleep_ms", 50)
     total_deleted = 0
 
     while True:
@@ -76,9 +75,6 @@ def delete_metrics_in_batches(db: Session, model_class, filter_column, entity_id
 
         if batch_deleted <= 0 or batch_deleted < effective_batch_size:
             break
-
-        if batch_sleep_ms > 0:
-            time.sleep(batch_sleep_ms / 1000.0)
 
     return total_deleted
 

--- a/mcpgateway/services/metrics_cleanup_service.py
+++ b/mcpgateway/services/metrics_cleanup_service.py
@@ -62,6 +62,7 @@ def delete_metrics_in_batches(db: Session, model_class, filter_column, entity_id
         int: Total rows deleted.
     """
     effective_batch_size = batch_size or getattr(settings, "metrics_cleanup_batch_size", 10000)
+    batch_sleep_ms = getattr(settings, "metrics_cleanup_batch_sleep_ms", 50)
     total_deleted = 0
 
     while True:
@@ -75,6 +76,9 @@ def delete_metrics_in_batches(db: Session, model_class, filter_column, entity_id
 
         if batch_deleted <= 0 or batch_deleted < effective_batch_size:
             break
+
+        if batch_sleep_ms > 0:
+            time.sleep(batch_sleep_ms / 1000.0)
 
     return total_deleted
 
@@ -167,6 +171,7 @@ class MetricsCleanupService:
         """
         self.retention_days = retention_days or getattr(settings, "metrics_retention_days", 7)
         self.batch_size = batch_size or getattr(settings, "metrics_cleanup_batch_size", 10000)
+        self.batch_sleep_ms = getattr(settings, "metrics_cleanup_batch_sleep_ms", 50)
         self.cleanup_interval_hours = cleanup_interval_hours or getattr(settings, "metrics_cleanup_interval_hours", 1)
         self.enabled = enabled if enabled is not None else getattr(settings, "metrics_cleanup_enabled", True)
 
@@ -378,6 +383,9 @@ class MetricsCleanupService:
                     if batch_deleted < self.batch_size:
                         break
 
+                    if self.batch_sleep_ms > 0:
+                        time.sleep(self.batch_sleep_ms / 1000.0)
+
                 # Get remaining count
                 remaining_count = db.execute(select(func.count()).select_from(model_class)).scalar() or 0  # pylint: disable=not-callable
 
@@ -456,6 +464,7 @@ class MetricsCleanupService:
             "retention_days": self.retention_days,
             "rollup_retention_days": self.rollup_retention_days,
             "batch_size": self.batch_size,
+            "batch_sleep_ms": self.batch_sleep_ms,
             "cleanup_interval_hours": self.cleanup_interval_hours,
             "total_cleaned": self._total_cleaned,
             "cleanup_runs": self._cleanup_runs,

--- a/tests/integration/test_metrics_cleanup_pg.py
+++ b/tests/integration/test_metrics_cleanup_pg.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_metrics_cleanup_pg.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Suresh Kumar Moharajan
+
+Postgres-gated integration tests for MetricsCleanupService._cleanup_table.
+
+Verifies that the batched-delete logic (with inter-batch sleep) correctly
+removes rows older than the retention cutoff from a real database while
+leaving rows within the window untouched.
+
+Skip condition: runs only when DATABASE_URL points at a PostgreSQL instance
+(i.e. when MCPGATEWAY_TEST_ALLOW_EXTERNAL_DB=1 is set and DATABASE_URL is
+a postgresql:// URL).  In the default hermetic test run the conftest forces
+sqlite:///:memory: and these tests are automatically skipped.
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+import os
+import uuid
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import sessionmaker
+
+# First-Party
+import mcpgateway.db as db_mod
+from mcpgateway.db import Base, Tool, ToolMetric
+
+try:
+    from mcpgateway.services.metrics_cleanup_service import MetricsCleanupService as _MetricsCleanupService
+
+    _CLEANUP_IMPORTABLE = True
+except ImportError:
+    _MetricsCleanupService = None  # type: ignore[assignment,misc]
+    _CLEANUP_IMPORTABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Skip guard
+# ---------------------------------------------------------------------------
+
+
+def _is_postgresql() -> bool:
+    db_env = os.getenv("DB", "").lower()
+    database_url = os.getenv("DATABASE_URL", "").lower()
+    return db_env == "postgres" or "postgresql" in database_url
+
+
+SKIP_IF_NOT_POSTGRES = pytest.mark.skipif(
+    not _is_postgresql() or not _CLEANUP_IMPORTABLE,
+    reason="Postgres-gated: set MCPGATEWAY_TEST_ALLOW_EXTERNAL_DB=1 and DATABASE_URL=postgresql://... (also requires cpex installed)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pg_engine():
+    """Real Postgres engine for the duration of this test module."""
+    url = os.getenv("DATABASE_URL")
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def pg_session(pg_engine, monkeypatch):
+    """Session bound to the Postgres engine; patches db_mod.SessionLocal so
+    fresh_db_session() inside _cleanup_table picks up the same engine."""
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=pg_engine)
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSession, raising=True)
+    session = TestSession()
+    yield session
+    session.close()
+
+
+@pytest.fixture()
+def seeded_tool(pg_session):
+    """Insert a Tool row; yield its id; delete it (cascades metrics) on teardown."""
+    tool_id = uuid.uuid4().hex
+    tool = Tool(
+        id=tool_id,
+        original_name="cleanup-test-tool",
+        custom_name="cleanup-test-tool",
+        custom_name_slug=f"cleanup-test-tool-{tool_id}",
+        input_schema={},
+    )
+    tool.name = f"cleanup-test-tool-{tool_id}"
+    pg_session.add(tool)
+    pg_session.commit()
+    yield tool_id
+    pg_session.delete(pg_session.get(Tool, tool_id))
+    pg_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OLD = datetime(2020, 1, 1, tzinfo=timezone.utc)
+_NOW = datetime.now(timezone.utc)
+
+
+def _add_metrics(session, tool_id: str, timestamps: list) -> None:
+    for ts in timestamps:
+        session.add(ToolMetric(tool_id=tool_id, timestamp=ts, response_time=0.01, is_success=True))
+    session.commit()
+
+
+def _count_metrics(session, tool_id: str) -> int:
+    return session.execute(select(func.count()).select_from(ToolMetric).where(ToolMetric.tool_id == tool_id)).scalar() or 0
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@SKIP_IF_NOT_POSTGRES
+def test_cleanup_table_deletes_old_rows_keeps_recent(seeded_tool, pg_session):
+    """5 old rows deleted, 3 recent rows survive."""
+    old_ts = [_OLD + timedelta(days=i) for i in range(5)]
+    recent_ts = [_NOW - timedelta(hours=i) for i in range(3)]
+    _add_metrics(pg_session, seeded_tool, old_ts + recent_ts)
+
+    assert _count_metrics(pg_session, seeded_tool) == 8
+
+    cutoff = _NOW - timedelta(days=30)
+    service = _MetricsCleanupService()
+    service.batch_size = 10  # single batch — all 5 old rows gone in one pass
+    service.batch_sleep_ms = 0  # no sleep in tests
+
+    result = service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+    assert result.error is None
+    assert result.deleted_count == 5
+    assert _count_metrics(pg_session, seeded_tool) == 3
+    assert result.duration_seconds > 0
+
+
+@SKIP_IF_NOT_POSTGRES
+def test_cleanup_table_multi_batch_deletes_all_old(seeded_tool, pg_session):
+    """With batch_size=2 and 6 old rows, cleanup runs 3 batches and deletes all 6."""
+    old_ts = [_OLD + timedelta(days=i) for i in range(6)]
+    _add_metrics(pg_session, seeded_tool, old_ts)
+
+    assert _count_metrics(pg_session, seeded_tool) == 6
+
+    cutoff = _NOW - timedelta(days=30)
+    service = _MetricsCleanupService()
+    service.batch_size = 2
+    service.batch_sleep_ms = 0
+
+    result = service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+    assert result.error is None
+    assert result.deleted_count == 6
+    assert _count_metrics(pg_session, seeded_tool) == 0
+    assert result.remaining_count == 0
+
+
+@SKIP_IF_NOT_POSTGRES
+def test_cleanup_table_empty_table_noop(seeded_tool, pg_session):
+    """No rows → deleted_count == 0, no error."""
+    assert _count_metrics(pg_session, seeded_tool) == 0
+
+    cutoff = _NOW - timedelta(days=30)
+    service = _MetricsCleanupService()
+    service.batch_sleep_ms = 0
+
+    result = service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+    assert result.error is None
+    assert result.deleted_count == 0
+
+
+@SKIP_IF_NOT_POSTGRES
+def test_cleanup_table_nothing_to_delete_when_all_recent(seeded_tool, pg_session):
+    """All rows within retention window → none deleted."""
+    recent_ts = [_NOW - timedelta(hours=i) for i in range(4)]
+    _add_metrics(pg_session, seeded_tool, recent_ts)
+
+    cutoff = _NOW - timedelta(days=30)
+    service = _MetricsCleanupService()
+    service.batch_sleep_ms = 0
+
+    result = service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+    assert result.error is None
+    assert result.deleted_count == 0
+    assert _count_metrics(pg_session, seeded_tool) == 4

--- a/tests/unit/mcpgateway/services/test_metrics_cleanup_service.py
+++ b/tests/unit/mcpgateway/services/test_metrics_cleanup_service.py
@@ -74,6 +74,64 @@ class TestMetricsCleanupService:
         assert stats["total_cleaned"] == 0
         assert stats["cleanup_runs"] == 0
 
+    def test_get_stats_includes_batch_sleep_ms(self):
+        """Test that get_stats includes batch_sleep_ms."""
+        service = MetricsCleanupService()
+        stats = service.get_stats()
+        assert "batch_sleep_ms" in stats
+        assert stats["batch_sleep_ms"] == service.batch_sleep_ms
+
+    def test_cleanup_table_sleeps_between_full_batches(self):
+        """Sleep is called once after a full batch, not after the final partial batch."""
+        service = MetricsCleanupService(batch_size=10)
+        service.batch_sleep_ms = 100
+        cutoff = datetime.now(timezone.utc)
+
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, i: 1
+
+        full_batch = [mock_row] * 10
+        empty_batch = []
+
+        mock_execute = MagicMock()
+        mock_execute.fetchall.side_effect = [full_batch, empty_batch]
+        mock_execute.rowcount = 10
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = mock_execute
+        mock_db.execute.return_value.fetchall.side_effect = [full_batch, empty_batch]
+
+        with patch("mcpgateway.services.metrics_cleanup_service.fresh_db_session") as mock_ctx:
+            mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            with patch("mcpgateway.services.metrics_cleanup_service.time.sleep") as mock_sleep:
+                service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+        mock_sleep.assert_called_once_with(0.1)
+
+    def test_cleanup_table_no_sleep_after_partial_batch(self):
+        """Sleep is not called when the first batch is already smaller than batch_size."""
+        service = MetricsCleanupService(batch_size=10)
+        service.batch_sleep_ms = 100
+        cutoff = datetime.now(timezone.utc)
+
+        mock_row = MagicMock()
+        mock_row.__getitem__ = lambda self, i: 1
+
+        partial_batch = [mock_row] * 5
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.fetchall.return_value = partial_batch
+        mock_db.execute.return_value.rowcount = 5
+
+        with patch("mcpgateway.services.metrics_cleanup_service.fresh_db_session") as mock_ctx:
+            mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            with patch("mcpgateway.services.metrics_cleanup_service.time.sleep") as mock_sleep:
+                service._cleanup_table(ToolMetric, "tool_metrics", cutoff)
+
+        mock_sleep.assert_not_called()
+
 
 class TestCleanupResult:
     """Tests for CleanupResult dataclass."""


### PR DESCRIPTION
## Summary

- Adds `METRICS_CLEANUP_BATCH_SLEEP_MS` config field (default `50 ms`, range `0–5000 ms`)
- `_cleanup_table` and `delete_metrics_in_batches` now sleep between **full** batches only — a partial (final) batch never adds unnecessary delay
- New setting surfaced in `get_stats()` output for observability
- `.env.example` updated with commented entry near `METRICS_CLEANUP_BATCH_SIZE`

## Motivation

Back-to-back batch DELETEs with no pause competed directly with request-serving queries, contributing ~12% of profiled DB capacity (88/740 py-spy samples) to PgBouncer saturation. A 50 ms sleep between full batches gives the DB breathing room while adding negligible total cleanup time.

## Test plan

- [ ] `test_cleanup_table_sleeps_between_full_batches` — sleep called once when first batch is full
- [ ] `test_cleanup_table_no_sleep_after_partial_batch` — sleep never called when batch < batch_size
- [ ] `test_get_stats_includes_batch_sleep_ms` — new key present in `get_stats()` output
- [ ] `METRICS_CLEANUP_BATCH_SLEEP_MS=0` disables sleep entirely (backward-compatible)

Closes #4504
Relates to #2692
