### PR TITLE
test(rate-limiter): toggle convergence-time probe + TTL-expiry cycle

### DIFF
--- a/tests/integration/fixtures/configs/rate_limiter_redis_only.yaml
+++ b/tests/integration/fixtures/configs/rate_limiter_redis_only.yaml
@@ -1,0 +1,38 @@
+# Minimal plugin config used only by the wipe-on-disable convergence
+# integration test (tests/integration/test_plugin_manager_wipe_on_disable.py).
+#
+# Loads ONLY the rate-limiter plugin with backend=redis. The
+# `redis_url` is sourced from the `REDIS_URL` env var via Jinja
+# substitution — the test sets that env var to point at the test
+# Redis fixture before the factory is constructed.
+#
+# `name: "RateLimiter"` matches the cpex-plugins-side TestWipeOnDisable
+# default so the mode key (`plugin:RateLimiter:mode`) is consistent
+# across both test suites.
+
+plugin_dirs: []
+
+plugin_settings:
+  parallel_execution_within_band: true
+  plugin_timeout: 30
+  fail_on_plugin_error: false
+  enable_plugin_api: false
+  plugin_health_check_interval: 120
+
+plugins:
+  - name: "RateLimiter"
+    kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
+    description: "Rate limiter under test for wipe-on-disable boundary"
+    version: "0.0.6"
+    author: "test"
+    hooks: ["tool_pre_invoke"]
+    tags: ["limits", "test"]
+    mode: "enforce"
+    priority: 20
+    conditions: []
+    config:
+      backend: "redis"
+      redis_url: "{{ env.REDIS_URL }}"
+      redis_key_prefix: "rl"
+      algorithm: "fixed_window"
+      by_user: "30/m"

--- a/tests/integration/fixtures/configs/rate_limiter_redis_only.yaml
+++ b/tests/integration/fixtures/configs/rate_limiter_redis_only.yaml
@@ -6,9 +6,10 @@
 # substitution — the test sets that env var to point at the test
 # Redis fixture before the factory is constructed.
 #
-# `name: "RateLimiter"` matches the cpex-plugins-side TestWipeOnDisable
-# default so the mode key (`plugin:RateLimiter:mode`) is consistent
-# across both test suites.
+# `name: "RateLimiterPlugin"` matches the gateway's own plugins/config.yaml
+# convention (and the cpex-plugins-side TestWipeOnDisable default after
+# the cross-repo rename) so the mode key (`plugin:RateLimiterPlugin:mode`)
+# is consistent across both test suites and production.
 
 plugin_dirs: []
 
@@ -20,7 +21,7 @@ plugin_settings:
   plugin_health_check_interval: 120
 
 plugins:
-  - name: "RateLimiter"
+  - name: "RateLimiterPlugin"
     kind: "cpex_rate_limiter.rate_limiter.RateLimiterPlugin"
     description: "Rate limiter under test for wipe-on-disable boundary"
     version: "0.0.6"

--- a/tests/integration/test_plugin_manager_wipe_on_disable.py
+++ b/tests/integration/test_plugin_manager_wipe_on_disable.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Integration test for the framework -> plugin wipe-on-disable boundary.
+
+This test sits between the framework-boundary unit tests in
+``tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py``
+(which use stub plugins) and the full HTTP-driven integration tests in
+``test_rate_limiter_dynamic_behavior.py`` /
+``test_rate_limiter_toggle_live_state.py`` (which require a running
+gateway with admin auth).
+
+It loads a real ``cpex-rate-limiter`` plugin into a real
+``TenantPluginManagerFactory`` against a real Redis, deposits counter
+keys via ``manager.invoke_hook``, simulates an operator mode toggle
+to ``disabled`` by setting the framework's mode key in Redis directly,
+then drives ``factory.reload_tenant`` and asserts the counter keys
+were wiped.
+
+What this pins (the boundary between Layer A and Layer B-1):
+
+  * ``factory.reload_tenant`` -> manager.shutdown -> registry.shutdown
+    -> plugin.shutdown all fire in sequence against a real plugin.
+  * The rate-limiter plugin's wipe-on-disable code path is reached,
+    reads the mode key, and clears its counters from Redis.
+
+What this does *not* test (out of scope):
+
+  * The admin HTTP endpoint -> reload_tenant pathway (covered by
+    ``test_rate_limiter_dynamic_behavior.py``).
+  * Pub/sub-driven multi-worker fan-out (covered by
+    ``test_plugin_runtime_redis.py::TestPubSubEvictionRedis``).
+  * Convergence timing (covered by
+    ``test_rate_limiter_toggle_live_state.py``).
+
+Skips cleanly when:
+  * Redis is unreachable and docker is unavailable.
+  * The installed ``cpex-rate-limiter`` wheel does not include the
+    wipe-on-disable code path (PyPI baseline before the wipe-on-disable
+    PR merges; install the wheel from
+    ``cpex-plugins:feat/rate-limiter-wipe-on-disable-only`` to exercise
+    it -- see ``wipe-test/README.md``).
+"""
+
+# Standard
+import socket
+import subprocess
+import time
+
+# Third-Party
+import pytest
+
+
+_REDIS_HOST = "127.0.0.1"
+# Dedicated host port for this test's container — avoids collisions with
+# any other Redis (or Redis-shaped) listener on the standard 6379, including
+# the local TLS smoke-test stack from wipe-test/.
+_REDIS_PORT = 16380
+_REDIS_CONTAINER_NAME = "pytest-plugin-mgr-wipe-redis"
+_FIXTURE_YAML = "./tests/integration/fixtures/configs/rate_limiter_redis_only.yaml"
+
+
+def _redis_port_open(host: str, port: int, timeout: float = 0.2) -> bool:
+    """Return True if a TCP connection to host:port succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+def _redis_responds_to_ping(host: str, port: int, timeout: float = 0.5) -> bool:
+    """Return True if Redis at host:port answers PING with PONG.
+
+    TCP-port-open is not sufficient: Docker's port mapping can succeed
+    while the redis process is started with ``--port 0`` (plain TCP
+    disabled), in which case clients see "Connection closed by server"
+    on first command. Driving a real PING is the only reliable signal.
+    """
+    try:
+        # Third-Party
+        import redis as _redis_sync  # noqa: PLC0415
+    except Exception:
+        return False
+    try:
+        client = _redis_sync.Redis(
+            host=host,
+            port=port,
+            socket_connect_timeout=timeout,
+            socket_timeout=timeout,
+        )
+        try:
+            return bool(client.ping())
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def redis_url_for_test():
+    """Yield a Redis URL pointing at a real Redis instance.
+
+    Always starts a dedicated Docker container on a non-standard host
+    port (16380) so the test is hermetic — no risk of collision with a
+    developer's local Redis on 6379, the local TLS smoke-test stack, or
+    any other Redis-shaped listener. PING confirms readiness; TCP alone
+    isn't enough (Docker's port mapping can succeed while the redis
+    process inside has plain TCP disabled).
+
+    Skips cleanly if docker is unavailable.
+    """
+    container_id = None
+    try:
+        res = subprocess.run(
+            [
+                "docker", "run", "-d", "--rm",
+                "-p", f"{_REDIS_PORT}:6379",
+                "--name", _REDIS_CONTAINER_NAME,
+                "redis:7",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        container_id = res.stdout.strip()
+    except Exception as exc:
+        pytest.skip(f"Docker unavailable for Redis container: {exc}")
+
+    for _ in range(50):
+        if _redis_port_open(_REDIS_HOST, _REDIS_PORT) and _redis_responds_to_ping(_REDIS_HOST, _REDIS_PORT):
+            break
+        time.sleep(0.1)
+    else:
+        if container_id:
+            subprocess.run(["docker", "stop", container_id], check=False)
+        pytest.skip("Redis did not become ready in time")
+
+    yield f"redis://{_REDIS_HOST}:{_REDIS_PORT}/14"  # DB 14 — isolated
+
+    if container_id:
+        subprocess.run(["docker", "stop", container_id], check=False)
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_tenant_wipes_rate_limiter_counters_on_disable(
+    redis_url_for_test, monkeypatch
+):
+    """Direct ``factory.reload_tenant`` against a real rate-limiter plugin
+    + real Redis must wipe the plugin's counters when mode key says
+    ``disabled``.
+
+    Phase 1 deposits counter keys via the manager's hook dispatch path.
+    Phase 2 sets the framework's mode key in Redis directly (skipping
+    the admin HTTP endpoint and pub/sub, which are out of scope here)
+    and drives ``factory.reload_tenant``.  Phase 3 asserts the counter
+    keys are gone — proving the framework's rebuild path reached the
+    plugin's wipe-on-disable code path.
+    """
+    # Skip-guards before any imports that might fail or any Redis writes.
+    try:
+        from cpex_rate_limiter.rate_limiter import RateLimiterPlugin  # noqa: PLC0415
+    except ImportError:
+        pytest.skip("cpex-rate-limiter not installed in test venv")
+
+    if not hasattr(RateLimiterPlugin, "_wipe_my_counters"):
+        pytest.skip(
+            "installed cpex-rate-limiter does not include wipe-on-disable code path "
+            "(see wipe-test/README.md to install the wipe-enabled wheel)"
+        )
+
+    # Imports — local so the module-level skip path is fast and the
+    # test doesn't pay for these imports if it skips.
+    # Third-Party
+    import redis.asyncio as aioredis  # noqa: PLC0415
+
+    # First-Party
+    from mcpgateway.plugins.framework import (  # noqa: PLC0415
+        GlobalContext,
+        ToolPreInvokePayload,
+    )
+    from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory  # noqa: PLC0415
+
+    # The yaml uses {{ env.REDIS_URL }}; inject the test redis URL via
+    # env so the plugin loader resolves the placeholder at construction.
+    monkeypatch.setenv("REDIS_URL", redis_url_for_test)
+
+    factory = TenantPluginManagerFactory(yaml_path=_FIXTURE_YAML)
+    redis_client = aioredis.from_url(redis_url_for_test, decode_responses=True)
+
+    try:
+        # Clean slate — drop both rl:* counters and any stale mode keys.
+        await redis_client.flushdb()
+
+        # ── Phase 1: enforce — deposit counter keys via the manager ──
+        manager = await factory.get_manager(context_id="wipe_boundary_ctx")
+        assert manager is not None
+
+        ctx = GlobalContext(request_id="r1", user="alice")
+        payload = ToolPreInvokePayload(name="t", arguments={})
+
+        # A couple of hook calls — under 30/m the bucket won't saturate;
+        # we just want a counter key in Redis to wipe.
+        for _ in range(2):
+            await manager.invoke_hook("tool_pre_invoke", payload, ctx)
+
+        keys_pre_disable = await redis_client.keys("rl:*")
+        assert any("alice" in k for k in keys_pre_disable), (
+            f"alice's counter key should exist after Phase 1; got {keys_pre_disable}"
+        )
+
+        # ── Phase 2: simulate operator disable + drive the rebuild ──
+        await redis_client.set("plugin:RateLimiter:mode", "disabled")
+
+        manager_new = await factory.reload_tenant(context_id="wipe_boundary_ctx")
+        assert manager_new is not None
+        assert manager_new is not manager, (
+            "reload_tenant must construct a new manager instance"
+        )
+
+        # ── Phase 3: counters must be gone ──
+        keys_post_wipe = await redis_client.keys("rl:*")
+        assert keys_post_wipe == [], (
+            "factory.reload_tenant under mode=disabled must wipe the plugin's "
+            f"counters via the manager.shutdown -> plugin.shutdown -> wipe path; "
+            f"expected [], got {keys_post_wipe}"
+        )
+    finally:
+        await redis_client.aclose()
+        await factory.shutdown()

--- a/tests/integration/test_plugin_manager_wipe_on_disable.py
+++ b/tests/integration/test_plugin_manager_wipe_on_disable.py
@@ -212,7 +212,7 @@ async def test_factory_reload_tenant_wipes_rate_limiter_counters_on_disable(
         )
 
         # ── Phase 2: simulate operator disable + drive the rebuild ──
-        await redis_client.set("plugin:RateLimiter:mode", "disabled")
+        await redis_client.set("plugin:RateLimiterPlugin:mode", "disabled")
 
         manager_new = await factory.reload_tenant(context_id="wipe_boundary_ctx")
         assert manager_new is not None
@@ -342,7 +342,7 @@ async def test_publish_plugin_mode_change_round_trips_to_wipe(
         # so it doesn't get mistaken for the data message we're about to send.
         _ = await pubsub.get_message(timeout=1.0)
 
-        published = await publish_plugin_mode_change("RateLimiter", "disabled")
+        published = await publish_plugin_mode_change("RateLimiterPlugin", "disabled")
         assert published is True, (
             "publish_plugin_mode_change must return True against the test "
             "Redis — if False, the framework's redis client wiring "

--- a/tests/integration/test_plugin_manager_wipe_on_disable.py
+++ b/tests/integration/test_plugin_manager_wipe_on_disable.py
@@ -230,3 +230,167 @@ async def test_factory_reload_tenant_wipes_rate_limiter_counters_on_disable(
     finally:
         await redis_client.aclose()
         await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_publish_plugin_mode_change_round_trips_to_wipe(
+    redis_url_for_test, monkeypatch
+):
+    """Real PUBLISH on the framework's invalidation channel must round-trip
+    to wipe the plugin's counters end-to-end.
+
+    Distinct from
+    ``test_factory_reload_tenant_wipes_rate_limiter_counters_on_disable``
+    (B-0): that test sets the mode key in Redis directly and calls
+    ``factory.reload_tenant`` directly.  This test exercises the
+    publish/subscribe round-trip — calls ``publish_plugin_mode_change``
+    (the function the admin handler invokes), captures the resulting
+    message off the real Redis channel, and feeds it through
+    ``_handle_invalidation_message`` (the function the gateway's
+    listener calls).
+
+    What this pins (the boundary B-0 doesn't exercise):
+
+      * The publisher's actual wire format on the channel — channel
+        name, JSON keys, value types — matches what
+        ``_handle_invalidation_message`` accepts and routes to
+        ``invalidate_all_plugin_managers`` -> ``factory.invalidate_all``
+        -> ``reload_tenant`` -> ``manager.shutdown`` -> ``plugin.shutdown``.
+      * A regression where ``publish_plugin_mode_change`` and the
+        handler drift on format (e.g. one renames a JSON key without
+        the other) would still pass every existing mocked-JSON pubsub
+        test, because those tests construct the message bytes
+        themselves.  This test PUBLISHes via the real publisher and
+        receives off the real channel, so any drift breaks the round-trip.
+    """
+    # Skip-guards (same shape as the B-0 test above).
+    try:
+        from cpex_rate_limiter.rate_limiter import RateLimiterPlugin  # noqa: PLC0415
+    except ImportError:
+        pytest.skip("cpex-rate-limiter not installed in test venv")
+
+    if not hasattr(RateLimiterPlugin, "_wipe_my_counters"):
+        pytest.skip(
+            "installed cpex-rate-limiter does not include wipe-on-disable code path "
+            "(see wipe-test/README.md to install the wipe-enabled wheel)"
+        )
+
+    # Imports — local, same pattern as B-0.
+    # Third-Party
+    import redis.asyncio as aioredis  # noqa: PLC0415
+
+    # First-Party
+    import mcpgateway.plugins.framework as framework  # noqa: PLC0415
+    from mcpgateway.plugins.framework import (  # noqa: PLC0415
+        GlobalContext,
+        ToolPreInvokePayload,
+        publish_plugin_mode_change,
+    )
+    from mcpgateway.plugins.framework._redis import (  # noqa: PLC0415
+        set_shared_redis_provider,
+    )
+    from mcpgateway.plugins.framework.manager import TenantPluginManagerFactory  # noqa: PLC0415
+
+    # YAML uses {{ env.REDIS_URL }} — inject the test redis URL via env so the
+    # plugin loader resolves the placeholder at construction time.
+    monkeypatch.setenv("REDIS_URL", redis_url_for_test)
+
+    # Wire the framework's globals to point at our test setup.  Two need to be
+    # set: (1) the framework's shared-redis provider, so
+    # ``publish_plugin_mode_change`` and the invalidation listener get a
+    # client pointed at the test Redis (the framework uses a dependency-
+    # inversion shim — see ``mcpgateway/plugins/framework/_redis.py`` — not
+    # ``mcpgateway.utils.redis_client._client`` directly); (2)
+    # ``framework._plugin_manager_factory`` so the handler dispatches
+    # ``invalidate_all`` against our factory rather than a real production
+    # one.  Both restored in the finally block.
+    test_redis_for_framework = aioredis.from_url(redis_url_for_test, decode_responses=True)
+
+    async def _test_redis_provider():
+        return test_redis_for_framework
+
+    set_shared_redis_provider(_test_redis_provider)
+
+    factory = TenantPluginManagerFactory(yaml_path=_FIXTURE_YAML)
+    original_factory = framework._plugin_manager_factory
+    framework._plugin_manager_factory = factory
+
+    # Test-side redis + pubsub for capturing the published message off the
+    # channel.  Independent client to keep the test's pubsub state separate
+    # from the framework's.
+    redis_client = aioredis.from_url(redis_url_for_test, decode_responses=True)
+    pubsub = redis_client.pubsub()
+
+    try:
+        await redis_client.flushdb()
+
+        # ── Phase 1: enforce — deposit a counter key (same as B-0) ──
+        manager = await factory.get_manager(context_id="b05_ctx")
+        ctx = GlobalContext(request_id="r1", user="alice")
+        payload = ToolPreInvokePayload(name="t", arguments={})
+        for _ in range(2):
+            await manager.invoke_hook("tool_pre_invoke", payload, ctx)
+
+        keys_pre = await redis_client.keys("rl:*")
+        assert any("alice" in k for k in keys_pre), (
+            f"alice's counter key should exist after Phase 1; got {keys_pre}"
+        )
+
+        # ── Phase 2: subscribe + real publish + receive + hand off to handler ──
+        await pubsub.subscribe(framework._REDIS_INVALIDATION_CHANNEL)
+        # redis-py emits a subscribe-confirmation as the first frame; drain it
+        # so it doesn't get mistaken for the data message we're about to send.
+        _ = await pubsub.get_message(timeout=1.0)
+
+        published = await publish_plugin_mode_change("RateLimiter", "disabled")
+        assert published is True, (
+            "publish_plugin_mode_change must return True against the test "
+            "Redis — if False, the framework's redis client wiring "
+            "(rc._client) is wrong and the rest of this test would silently "
+            "skip the publish path"
+        )
+
+        # Loop get_message until we receive the actual data frame.  The
+        # publish/subscribe path is async on the Redis side, so the message
+        # may not arrive on the very first poll; we budget ~2s total.
+        message = None
+        for _ in range(20):
+            frame = await pubsub.get_message(timeout=0.1)
+            if frame is not None and frame.get("type") == "message":
+                message = frame
+                break
+        assert message is not None, (
+            "expected an invalidation message on the channel after "
+            "publish_plugin_mode_change; check that "
+            "framework._REDIS_INVALIDATION_CHANNEL hasn't drifted"
+        )
+
+        # The core round-trip assertion: drive the framework's handler with the
+        # message we *actually received off the wire*.  If the publisher and
+        # handler disagree on format, this is where it shows up.
+        # ``_handle_invalidation_message`` awaits the full cascade
+        # (invalidate_all_plugin_managers -> factory.invalidate_all ->
+        # reload_tenant -> manager.shutdown -> plugin.shutdown -> wipe), so by
+        # the time it returns the wipe has run.
+        await framework._handle_invalidation_message(message)
+
+        # ── Phase 3: counters wiped ──
+        keys_post = await redis_client.keys("rl:*")
+        assert keys_post == [], (
+            "publish_plugin_mode_change -> handler -> reload -> wipe chain "
+            f"must clear alice's counter; got {keys_post}"
+        )
+    finally:
+        try:
+            await pubsub.unsubscribe()
+        except Exception:
+            pass
+        try:
+            await pubsub.aclose()
+        except Exception:
+            pass
+        await redis_client.aclose()
+        await test_redis_for_framework.aclose()
+        await factory.shutdown()
+        framework._plugin_manager_factory = original_factory
+        set_shared_redis_provider(None)

--- a/tests/integration/test_rate_limiter_dynamic_behavior.py
+++ b/tests/integration/test_rate_limiter_dynamic_behavior.py
@@ -42,9 +42,13 @@ GATEWAY_EMAIL = os.environ.get("GATEWAY_EMAIL", "admin@example.com")
 GATEWAY_PASSWORD = os.environ.get("GATEWAY_PASSWORD", "changeme")
 
 PLUGIN_NAME = "RateLimiterPlugin"
+MCP_PROTOCOL_VERSION = "2025-11-25"
 
 # Wait after admin changes for propagation (NGINX cache TTL + pub/sub)
 PROPAGATION_WAIT = int(os.environ.get("PROPAGATION_WAIT", str(PLUGIN_MODE_PROPAGATION_WAIT_SECONDS)))
+
+# Wait long enough for Redis rate-limit counters to expire between phases.
+TTL_EXPIRY_WAIT = int(os.environ.get("RATE_LIMITER_TTL_EXPIRY_WAIT", "75"))
 
 # Number of requests to send per burst — must exceed the configured
 # by_user limit (30/m) to observe rate limiting
@@ -75,6 +79,23 @@ def _fresh_headers() -> dict:
     }
 
 
+def _fresh_mcp_headers(
+    token: str | None = None,
+    session_id: str | None = None,
+) -> dict:
+    """Get MCP JSON-RPC headers for the server-scoped transport."""
+    bearer = token or _get_session_token()
+    headers = {
+        "Authorization": f"Bearer {bearer}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+    }
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    return headers
+
+
 def _is_gateway_running() -> bool:
     """Check if the gateway is reachable."""
     try:
@@ -89,12 +110,17 @@ def _auto_detect_server_and_tool() -> tuple[str, str]:
     headers = _fresh_headers()
     resp = requests.get(f"{GATEWAY_URL}/servers", headers=headers, timeout=10)
     resp.raise_for_status()
+
+    # Prefer an echo-capable server globally because it exercises the tool path
+    # without requiring transport-specific session setup.
     for server in resp.json():
         tools = server.get("associatedTools", [])
-        # Prefer echo tool (echoes back, cheap), fall back to any time tool
         for tool in tools:
             if "echo" in tool.lower():
                 return server["id"], tool
+
+    for server in resp.json():
+        tools = server.get("associatedTools", [])
         for tool in tools:
             if "time" in tool.lower() and "convert" not in tool.lower():
                 return server["id"], tool
@@ -126,7 +152,38 @@ def _get_plugin_state() -> dict:
     return resp.json()
 
 
-def _send_tool_burst(server_id: str, tool_name: str, count: int) -> dict:
+def _initialize_mcp_session(
+    server_id: str,
+    token: str | None = None,
+) -> str | None:
+    """Initialize an MCP session for server-scoped tool calls."""
+    resp = requests.post(
+        f"{GATEWAY_URL}/servers/{server_id}/mcp/",
+        json={
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "rate-limiter-dynamic-test", "version": "1.0.0"},
+            },
+        },
+        headers=_fresh_mcp_headers(token=token),
+        timeout=15,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    assert "result" in data, f"Initialize failed: {data}"
+    return resp.headers.get("mcp-session-id")
+
+
+def _send_tool_burst(
+    server_id: str,
+    tool_name: str,
+    count: int,
+    token: str | None = None,
+) -> dict:
     """Send a burst of tool calls and return counts of allowed vs rate-limited.
 
     Returns:
@@ -135,7 +192,8 @@ def _send_tool_burst(server_id: str, tool_name: str, count: int) -> dict:
     allowed = 0
     rate_limited = 0
     errors = 0
-    headers = _fresh_headers()
+    session_id = _initialize_mcp_session(server_id, token=token)
+    headers = _fresh_mcp_headers(token=token, session_id=session_id)
 
     for i in range(count):
         payload = {
@@ -149,7 +207,7 @@ def _send_tool_burst(server_id: str, tool_name: str, count: int) -> dict:
         }
         try:
             resp = requests.post(
-                f"{GATEWAY_URL}/servers/{server_id}/mcp",
+                f"{GATEWAY_URL}/servers/{server_id}/mcp/",
                 json=payload,
                 headers=headers,
                 timeout=15,
@@ -283,3 +341,40 @@ class TestRateLimiterRedisState:
         state = _get_plugin_state()
         plugins = {p["name"]: p for p in state.get("plugins", [])}
         assert plugins[PLUGIN_NAME]["mode"] == "disabled"
+
+
+@pytest.mark.slow
+class TestRateLimiterToggleAfterTTLExpiry:
+    """Validate re-enforcement after counters expire naturally.
+
+    This is intentionally a time-based experiment, not rapid toggle-cycle
+    coverage. It verifies that enforce mode still blocks after a quiet period
+    long enough for Redis counters to expire.
+    """
+
+    def test_enforce_disable_enforce_cycle_after_ttl_expiry(self, server_and_tool):
+        """Enforce should work again after disabled mode and a full TTL wait."""
+        server_id, tool_name = server_and_tool
+
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+        phase_1 = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert phase_1["errors"] == 0, f"Phase 1 should complete without transport errors: {phase_1}"
+        assert phase_1["rate_limited"] > 0, f"Phase 1 should rate-limit some requests: {phase_1}"
+
+        time.sleep(TTL_EXPIRY_WAIT)
+
+        _set_plugin_mode("disabled")
+        time.sleep(PROPAGATION_WAIT)
+        phase_2 = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert phase_2["errors"] == 0, f"Phase 2 should complete without transport errors: {phase_2}"
+        assert phase_2["rate_limited"] == 0, f"Phase 2 should allow all requests while disabled: {phase_2}"
+        assert phase_2["allowed"] == phase_2["total"] - phase_2["errors"], f"Phase 2 expected all non-error requests to be allowed: {phase_2}"
+
+        time.sleep(TTL_EXPIRY_WAIT)
+
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+        phase_3 = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert phase_3["errors"] == 0, f"Phase 3 should complete without transport errors: {phase_3}"
+        assert phase_3["rate_limited"] > 0, f"Phase 3 should rate-limit again after TTL expiry: {phase_3}"

--- a/tests/integration/test_rate_limiter_toggle_live_state.py
+++ b/tests/integration/test_rate_limiter_toggle_live_state.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Integration probe for rate-limiter mode-toggle convergence time.
+
+The rate limiter is the only stateful plugin in the gateway's catalog: it
+holds counter state in Redis and embeds its mode into a per-worker cached
+plugin instance. That makes its response to a runtime mode toggle eventually
+consistent rather than instantaneous — flipping ``enforce`` ↔ ``disabled``
+takes some time to fully reflect across every worker's plugin-manager cache.
+
+This module measures *how long* convergence takes after a mode change. It
+does not assert on a specific time; it records the trajectory and fails only
+if convergence never happens within ``MAX_CONVERGENCE_S``. Useful both as a
+regression pin (a sudden slowdown is caught) and as a measurement tool for
+informing a future toggle-latency SLA on the rate-limiter plugin.
+
+Companion test: ``test_rate_limiter_dynamic_behavior.py::TestRateLimiterToggleAfterTTLExpiry``
+covers the *correctness* contract — that after a quiet period long enough
+for Redis counters to expire, an ``enforce → disabled → enforce`` cycle
+behaves as expected. Together they describe the rate limiter's runtime
+contract: correct (per the TTL test) but not instantaneous (per this test).
+"""
+
+# Standard
+import time
+
+# Third-Party
+import pytest
+
+from tests.integration.test_rate_limiter_dynamic_behavior import (
+    _auto_detect_server_and_tool,
+    _is_gateway_running,
+    _send_tool_burst,
+    _set_plugin_mode,
+    BURST_SIZE,
+    GATEWAY_URL,
+    PROPAGATION_WAIT,
+)
+
+# Quiescence wait between phase 1's bucket-fill burst and the mode flip. Lets
+# any still-in-flight phase 1 requests drain before mode changes, so the mode
+# change isn't racing against workers mid-request under enforce.
+PHASE_QUIESCENCE_WAIT = PROPAGATION_WAIT
+
+pytestmark = pytest.mark.skipif(
+    not _is_gateway_running(),
+    reason=f"Gateway not running at {GATEWAY_URL}",
+)
+
+
+@pytest.fixture(scope="module")
+def server_and_tool():
+    """Auto-detect the target server/tool once for the module."""
+    return _auto_detect_server_and_tool()
+
+
+@pytest.fixture(autouse=True)
+def reset_to_disabled_between_tests():
+    """Restore disabled mode before and after each test.
+
+    The convergence probe sets enforce mode itself; this fixture is a
+    safety net so an early test failure doesn't leave the rate limiter
+    enforcing for subsequent runs or other test modules.
+    """
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+    yield
+    _set_plugin_mode("disabled")
+    time.sleep(PROPAGATION_WAIT)
+
+
+class TestRateLimiterToggleLiveState:
+    """Validate live mode toggles against existing rate-limit state."""
+
+    def test_measure_convergence_time_for_mode_toggle(self, server_and_tool, capsys):
+        """Measure how long after a mode change traffic reflects the new mode.
+
+        No threshold-based assertion on the convergence time — record timings
+        and emit them. The test fails only if convergence doesn't happen at
+        all within MAX_CONVERGENCE_S. Useful both as a regression pin (sudden
+        divergence is caught) and as a measurement tool: every run produces
+        convergence data points that, over time, give us empirical input for
+        an eventual SLA on rate-limiter toggle latency.
+
+        Convergence definitions:
+          - Disabled-converged: a poll burst returns 6/6 allowed, 0 errors.
+          - Enforce-converged: a poll burst returns >=5/6 blocked, 0 errors
+            (allowing 1 cold-start tolerance for a worker that just rebuilt
+            its plugin manager and hasn't fully warmed yet).
+
+        Caveat: each poll burst is 6 real requests, so the probe is part of
+        the system being measured. The interval between bursts is set so
+        the probe doesn't dominate the rate-limit window.
+        """
+        server_id, tool_name = server_and_tool
+
+        poll_burst_size = 6
+        max_convergence_s = 60.0
+        poll_interval_s = 1.0
+
+        timings: dict[str, object] = {}
+
+        # Step 1: get into enforce mode and fill the user's bucket so the
+        # subsequent transitions have meaningful state to converge against.
+        _set_plugin_mode("enforce")
+        time.sleep(PROPAGATION_WAIT)
+        fill = _send_tool_burst(server_id, tool_name, BURST_SIZE)
+        assert fill["errors"] == 0, f"Phase 1 fill should not error: {fill}"
+        assert fill["rate_limited"] > 0, f"Phase 1 fill should heat the bucket: {fill}"
+
+        # Quiescence: let in-flight phase-1 requests drain before flipping.
+        time.sleep(PHASE_QUIESCENCE_WAIT)
+
+        # Step 2: flip to disabled and poll until 6/6 calls in a burst pass.
+        _set_plugin_mode("disabled")
+        flip_t0 = time.monotonic()
+        converged_to_disabled: float | None = None
+        disabled_observations: list[dict[str, int]] = []
+        while True:
+            elapsed = time.monotonic() - flip_t0
+            burst = _send_tool_burst(server_id, tool_name, poll_burst_size)
+            disabled_observations.append({"t": round(elapsed, 2), **{k: v for k, v in burst.items() if k != "total"}})
+            if burst["errors"] == 0 and burst["allowed"] == poll_burst_size:
+                converged_to_disabled = elapsed
+                break
+            if elapsed >= max_convergence_s:
+                break
+            time.sleep(poll_interval_s)
+        timings["disabled_convergence_s"] = converged_to_disabled
+        timings["disabled_observations"] = disabled_observations
+
+        # Step 3: flip back to enforce. The bucket may have aged a bit during
+        # the disabled-poll loop, so re-fill briefly to ensure state is hot
+        # again before we probe enforce convergence.
+        _set_plugin_mode("enforce")
+        flip_t0 = time.monotonic()
+        converged_to_enforce: float | None = None
+        enforce_observations: list[dict[str, int]] = []
+        while True:
+            elapsed = time.monotonic() - flip_t0
+            burst = _send_tool_burst(server_id, tool_name, poll_burst_size)
+            enforce_observations.append({"t": round(elapsed, 2), **{k: v for k, v in burst.items() if k != "total"}})
+            # Allow 1 of the 6 to slip through (just-rebuilt-on-this-worker case).
+            if burst["errors"] == 0 and burst["rate_limited"] >= poll_burst_size - 1:
+                converged_to_enforce = elapsed
+                break
+            if elapsed >= max_convergence_s:
+                break
+            time.sleep(poll_interval_s)
+        timings["enforce_convergence_s"] = converged_to_enforce
+        timings["enforce_observations"] = enforce_observations
+
+        # Emit measurements. Visible with ``pytest -s`` or on test failure;
+        # also captured in the test's stdout for later inspection.
+        print()
+        print("=== rate-limiter mode-toggle convergence timings ===")
+
+        if converged_to_disabled is not None:
+            print(f"  disabled_convergence_s : {converged_to_disabled:6.2f}")
+        else:
+            print(f"  disabled_convergence_s : DID NOT CONVERGE within {max_convergence_s:.0f}s")
+        for obs in disabled_observations:
+            print(f"    t={obs['t']:6.2f}  allowed={obs['allowed']:>2}  blocked={obs['rate_limited']:>2}  errors={obs['errors']:>2}")
+
+        if converged_to_enforce is not None:
+            print(f"  enforce_convergence_s  : {converged_to_enforce:6.2f}")
+        else:
+            print(f"  enforce_convergence_s  : DID NOT CONVERGE within {max_convergence_s:.0f}s")
+        for obs in enforce_observations:
+            print(f"    t={obs['t']:6.2f}  allowed={obs['allowed']:>2}  blocked={obs['rate_limited']:>2}  errors={obs['errors']:>2}")
+
+        # Failure condition: convergence didn't happen *at all*. The actual
+        # time is data, not a threshold to police.
+        assert converged_to_disabled is not None, (
+            f"Disabled mode never converged within {max_convergence_s:.0f}s — propagation failure"
+        )
+        assert converged_to_enforce is not None, (
+            f"Enforce mode never converged within {max_convergence_s:.0f}s — propagation failure"
+        )

--- a/tests/integration/test_rate_limiter_toggle_via_redis_pubsub.py
+++ b/tests/integration/test_rate_limiter_toggle_via_redis_pubsub.py
@@ -71,7 +71,10 @@ import pytest
 # First-Party (test helpers)
 from tests.integration.test_rate_limiter_dynamic_behavior import (
     GATEWAY_URL,
+    _auto_detect_server_and_tool,
     _is_gateway_running,
+    _send_tool_burst,
+    _set_plugin_mode,
 )
 
 
@@ -138,6 +141,40 @@ async def test_wipe_on_disable_converges_via_redis_pubsub_only():
     client = aioredis.from_url(REDIS_URL, decode_responses=True)
 
     try:
+        # ── Pre-condition: flip plugin to enforce ──────────────────────
+        # The gateway's plugins/config.yaml ships with ``mode: disabled``
+        # for the rate limiter, which means the framework loader does not
+        # actually instantiate the plugin under any cached manager.  No
+        # plugin instance ⇒ no shutdown to fire ⇒ no wipe path to run,
+        # regardless of how many subscribers receive the broadcast.
+        # Toggling via the admin API first writes the mode key, publishes
+        # the invalidation frame, and updates every worker's local
+        # override map so the next manager-build instantiates the plugin
+        # in enforce mode.
+        _set_plugin_mode("enforce")
+
+        # ── Warm-up: ensure ≥1 worker has a cached plugin manager ──────
+        # ``factory.invalidate_all()`` iterates only *cached* managers.
+        # Each gunicorn worker has its own factory; without prior traffic
+        # on a worker, that factory's _managers dict is empty, the
+        # broadcast triggers no reload_tenant, no plugin.shutdown fires,
+        # and the wipe never runs.  20 MCP tools/call requests ride
+        # gunicorn's load balancer across many of the 72 workers (3
+        # replicas × 24 workers) so multiple workers cache a manager —
+        # one warm worker firing its plugin's shutdown is enough since
+        # the wipe runs SCAN+DEL against shared Redis, but more warm
+        # workers raises the floor against transient races.
+        #
+        # The warm-up calls are amplified by the STREAMABLEHTTP transport
+        # (~9-16 hook fires per request) and they're a one-off pre-
+        # condition — not part of the convergence measurement.  The
+        # measurement loop below talks only to Redis.
+        server_id, tool_name = _auto_detect_server_and_tool()
+        warmup = _send_tool_burst(server_id, tool_name, 20)
+        assert warmup["errors"] == 0, (
+            f"warm-up burst should succeed: {warmup}"
+        )
+
         # ── Pre-condition ──────────────────────────────────────────────
         # Mode is enforce; a counter key exists (deposited directly via
         # Redis SET — bypasses the gateway entirely).

--- a/tests/integration/test_rate_limiter_toggle_via_redis_pubsub.py
+++ b/tests/integration/test_rate_limiter_toggle_via_redis_pubsub.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Multi-replica wipe-on-disable convergence probe via Redis pubsub only.
+
+Companion to ``test_rate_limiter_toggle_live_state.py`` (Layer C). That
+probe drives mode toggles + traffic via the gateway's HTTP+MCP path —
+which means every probe burst is amplified by the MCP STREAMABLEHTTP
+transport (one user request → ~9-16 internal hook fires), and convergence
+measurement is part of the system being measured.
+
+This probe takes a different angle: bypass HTTP, MCP, admin auth, and
+JWT entirely.  It talks *only* to Redis — the same broker every gateway
+replica's plugin-invalidation listener subscribes to in production.
+The test:
+
+  1. Pre-conditions Redis with a counter key (a "user has hit the limiter"
+     state) and the mode key set to ``enforce``.
+  2. Triggers the mode change exactly the way ``publish_plugin_mode_change``
+     does: SETs the mode key to ``disabled``, then PUBLISHes a JSON
+     ``mode_change`` frame on ``plugin:invalidation``.
+  3. Polls Redis for the counter key and records the elapsed time until
+     the key disappears.
+
+Every running gateway replica's plugin-invalidation listener receives
+the broadcast and runs ``invalidate_all_plugin_managers`` →
+``factory.invalidate_all`` → per-context ``reload_tenant`` →
+``manager.shutdown`` → ``plugin.shutdown`` → wipe.  Single-flight on the
+plugin's wipe-lock means exactly one replica wins and clears the
+counter; the rest skip cleanly.
+
+What this gives us that Layer C cannot:
+
+  * **No amplification.**  The probe is one PUBLISH and N polls of a
+    single key — none of which exercise the MCP transport.  The
+    convergence time we measure is the wipe-on-disable claim itself,
+    not "wipe-on-disable plus the cost of measuring it."
+  * **True multi-replica behaviour.**  The standard ``docker-compose.yml``
+    runs ``GATEWAY_REPLICAS:-3`` (3 gateway processes by default), each
+    with its own plugin-manager cache and its own invalidation listener.
+    A single PUBLISH fans out to all of them — exactly the production
+    flow.
+
+Skip behaviour:
+
+  * Skips when the gateway stack isn't running (no point publishing if
+    no subscriber will pick it up).
+  * Skips when Redis isn't reachable at the expected URL.
+  * Does **not** skip when wipe-on-disable code is missing from the
+    gateway's installed cpex-rate-limiter — instead, the test fails
+    with a clear timeout message.  That's the right semantics: in a
+    deployment that has wipe enabled, this test failing is a real
+    regression, not "test infrastructure missing."
+
+Once the cpex-plugins wipe-on-disable PR merges and the wheel ships on
+PyPI (or gets pulled by ``--extra plugins``), this test runs against
+the standard ``docker-compose.yml`` stack with no override and no
+derivative image.  Today, point it at a stack running the wipe-enabled
+derivative image (see ``wipe-test/README.md`` — local-only, never
+committed).
+"""
+
+# Standard
+import asyncio
+import json
+import os
+import socket
+import time
+
+# Third-Party
+import pytest
+
+# First-Party (test helpers)
+from tests.integration.test_rate_limiter_dynamic_behavior import (
+    GATEWAY_URL,
+    _is_gateway_running,
+)
+
+
+def _redis_reachable(host: str = "127.0.0.1", port: int = 6379, timeout: float = 0.2) -> bool:
+    """Return True if a TCP connection to host:port succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+# Defaults match the standard docker-compose.yml stack: gateway replicas
+# share a single Redis exposed on host port 6379, DB 0.  Override via
+# REDIS_URL env var if your stack publishes elsewhere.
+REDIS_URL = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
+
+# Constants matching the framework's wire contract.  These intentionally
+# duplicate the values from mcpgateway.plugins.framework rather than
+# importing them — the test is verifying that publisher and subscriber
+# agree on the wire format, so importing the publisher's constants would
+# defeat the purpose.
+INVALIDATION_CHANNEL = "plugin:invalidation"
+PLUGIN_NAME = "RateLimiterPlugin"  # matches plugins/config.yaml's name field
+MODE_KEY = f"plugin:{PLUGIN_NAME}:mode"
+
+# Per-process unique counter key so concurrent test runs / interactive
+# stack use don't collide on the same key.
+TEST_USER = f"converge-probe-{os.getpid()}"
+COUNTER_KEY = f"rl:user:{TEST_USER}:60"
+
+# 30s budget — generous compared to the ~22s baseline observed in PR
+# #4511 with no wipe.  With wipe, convergence is expected to land in
+# under a second.
+MAX_CONVERGENCE_S = 30.0
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _is_gateway_running(),
+        reason=f"Gateway not running at {GATEWAY_URL}",
+    ),
+    pytest.mark.skipif(
+        not _redis_reachable(),
+        reason="Redis not reachable on 127.0.0.1:6379 (the gateway stack's broker)",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_wipe_on_disable_converges_via_redis_pubsub_only():
+    """Drive a mode-change toggle externally via Redis pubsub only and
+    measure how long the wipe takes to fire end-to-end across every
+    running gateway replica.
+
+    Records convergence time = elapsed from PUBLISH to "counter key is
+    gone in Redis."  No HTTP, no MCP, no admin endpoint, no auth.  Just
+    the Redis bus that every gateway replica's plugin-invalidation
+    listener subscribes to.
+    """
+    # Third-Party
+    import redis.asyncio as aioredis  # noqa: PLC0415
+
+    client = aioredis.from_url(REDIS_URL, decode_responses=True)
+
+    try:
+        # ── Pre-condition ──────────────────────────────────────────────
+        # Mode is enforce; a counter key exists (deposited directly via
+        # Redis SET — bypasses the gateway entirely).
+        await client.set(MODE_KEY, "enforce", ex=86400)
+        await client.set(COUNTER_KEY, "5", ex=120)
+        assert await client.exists(COUNTER_KEY), (
+            "pre-condition setup failed: counter key was not written"
+        )
+
+        # ── Trigger ────────────────────────────────────────────────────
+        # Replicate publish_plugin_mode_change's behaviour exactly:
+        # SET mode key first (so listeners that re-read it on receipt
+        # see the new value), then PUBLISH the invalidation frame.
+        await client.set(MODE_KEY, "disabled", ex=86400)
+        publish_t0 = time.monotonic()
+        await client.publish(
+            INVALIDATION_CHANNEL,
+            json.dumps(
+                {
+                    "type": "mode_change",
+                    "plugin": PLUGIN_NAME,
+                    "mode": "disabled",
+                    "ttl_seconds": 86400,
+                }
+            ),
+        )
+
+        # ── Poll until the wipe lands ──────────────────────────────────
+        converged_s: float | None = None
+        observations: list[dict[str, object]] = []
+        while time.monotonic() - publish_t0 < MAX_CONVERGENCE_S:
+            elapsed = round(time.monotonic() - publish_t0, 2)
+            exists = bool(await client.exists(COUNTER_KEY))
+            observations.append({"t": elapsed, "counter_exists": exists})
+            if not exists:
+                converged_s = elapsed
+                break
+            await asyncio.sleep(0.1)
+
+        # ── Trajectory output ──────────────────────────────────────────
+        # Always print so the convergence data is visible whether the
+        # test passes or fails.  Pytest captures stdout; -s shows it.
+        print("\nConvergence trajectory:")
+        # Cap printed observations so the log stays readable on a long
+        # timeout — first 5, last 5, gap marker.
+        if len(observations) <= 12:
+            shown = observations
+        else:
+            shown = observations[:5] + [{"t": "...", "counter_exists": "..."}] + observations[-5:]
+        for obs in shown:
+            print(f"  t={obs['t']:>6}  counter_exists={obs['counter_exists']}")
+
+        if converged_s is not None:
+            print(f"\n✓ Wipe converged in {converged_s:.2f}s")
+        else:
+            print(f"\n✗ Wipe did NOT converge within {MAX_CONVERGENCE_S}s")
+
+        # ── Assertion ──────────────────────────────────────────────────
+        assert converged_s is not None, (
+            f"expected wipe-on-disable to clear {COUNTER_KEY} within "
+            f"{MAX_CONVERGENCE_S}s of PUBLISH; either the running gateway's "
+            f"cpex-rate-limiter does not include the wipe-on-disable code, "
+            f"or the broadcast on '{INVALIDATION_CHANNEL}' is not reaching "
+            f"the replicas' invalidation listeners. "
+            f"Trajectory: {observations}"
+        )
+    finally:
+        # Restore mode to enforce + drop any residual counter so
+        # subsequent runs / interactive stack use start clean.
+        try:
+            await client.set(MODE_KEY, "enforce", ex=86400)
+        except Exception:
+            pass
+        try:
+            await client.delete(COUNTER_KEY)
+        except Exception:
+            pass
+        await client.aclose()

--- a/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
@@ -832,3 +832,67 @@ async def test_factory_reload_tenant_invokes_old_manager_shutdown():
         )
     finally:
         await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_tenant_invokes_new_manager_initialize():
+    """``reload_tenant`` must call ``initialize()`` on the manager it builds.
+
+    Symmetric counterpart to
+    ``test_factory_reload_tenant_invokes_old_manager_shutdown``: that test
+    pins the *disable-direction* boundary (old manager's shutdown fires);
+    this one pins the *enable-direction* boundary (new manager's
+    initialize fires).
+
+    ``test_factory_reload_tool_context`` already proves a new manager
+    instance is constructed (``manager2 is not manager1``), but a
+    regression that constructed without initializing would still pass
+    that test — instances exist, they would just be unable to dispatch
+    hooks.  Without initialize firing, every plugin under the new
+    manager would silently no-op after a toggle to ``enforce``: hooks
+    wouldn't run, mode-change-on-init logic (such as the rate limiter
+    re-arming its counter window after wipe-on-disable) wouldn't fire,
+    and the operator-visible "I just re-enabled this plugin" promise
+    would silently break.
+
+    Capture-via-list rather than ``AsyncMock`` because the assertion
+    needs to identify *which* manager was initialized (must match
+    ``manager2``), not just count calls — the initial ``get_manager``
+    above already triggers one initialize that we deliberately exclude
+    by installing the spy *after* it.
+    """
+    # Standard
+    from unittest.mock import patch  # noqa: PLC0415
+
+    # First-Party — local to keep the assertion's import surface in scope
+    # without polluting module-level imports for unrelated tests.
+    from mcpgateway.plugins.framework.manager import TenantPluginManager  # noqa: PLC0415
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+    )
+    try:
+        # Build the initial manager *before* installing the spy so the
+        # reload path is the only initialize() we observe.
+        manager1 = await factory.get_manager(context_id="reload_init_tool")
+        assert manager1 is not None
+
+        initialized_managers: list[TenantPluginManager] = []
+        original_init = TenantPluginManager.initialize
+
+        async def _spy_init(self, *args, **kwargs):
+            initialized_managers.append(self)
+            return await original_init(self, *args, **kwargs)
+
+        with patch.object(TenantPluginManager, "initialize", _spy_init):
+            manager2 = await factory.reload_tenant(context_id="reload_init_tool")
+
+        assert manager2 is not None
+        assert manager2 is not manager1
+        assert manager2 in initialized_managers, (
+            "reload_tenant must call initialize() on the new manager — "
+            "construction without initialize would leave the manager unable "
+            f"to dispatch hooks.  Captured initialize calls: {initialized_managers}"
+        )
+    finally:
+        await factory.shutdown()

--- a/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
+++ b/tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py
@@ -774,3 +774,61 @@ async def test_factory_get_config_from_db_default():
         assert result is None
     finally:
         await factory.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_factory_reload_tenant_invokes_old_manager_shutdown():
+    """``reload_tenant`` must call ``shutdown()`` on the manager it displaces.
+
+    The runtime mode-toggle convergence story relies on this: when an
+    operator flips a plugin's mode, the rebuild path invokes the old
+    manager's ``shutdown()``, which propagates to plugin ``shutdown()``,
+    which is where stateful plugins (rate limiter, in particular) react
+    to the change (wipe-on-disable; see IBM/mcp-context-forge#4576).
+
+    Existing coverage in this file:
+      * ``test_factory_reload_tool_context`` proves a *new* manager
+        instance is built — but would pass even if the old one was
+        silently dropped without ``shutdown``.
+      * ``test_factory_reload_shutdown_exception`` and
+        ``test_factory_build_manager_old_shutdown_fails`` prove the
+        path *tolerates* shutdown errors — but would also pass if
+        ``shutdown`` stopped being called entirely.
+      * ``test_factory_shutdown_propagates_exceptions`` pins shutdown
+        invocation, but on the whole-factory shutdown path
+        (``factory.shutdown()``), not on the toggle path
+        (``factory.reload_tenant()``).
+
+    A regression here would silently break the operator-visible toggle
+    contract for stateful plugins — the plugin's ``shutdown`` hook
+    would never fire on a mode change, so wipe-on-disable, audit
+    logging on disable, etc. would no-op despite every surrounding
+    test passing.
+
+    The spy uses ``AsyncMock(wraps=...)`` rather than
+    ``new_callable=AsyncMock`` so the real shutdown still runs — keeps
+    the assertion strict (the call must happen) without interfering
+    with cleanup.
+    """
+    # Standard
+    from unittest.mock import AsyncMock, patch  # noqa: PLC0415
+
+    factory = ToolScopedPluginManagerFactory(
+        yaml_path="./tests/unit/mcpgateway/plugins/fixtures/configs/valid_no_plugin.yaml",
+    )
+    try:
+        manager1 = await factory.get_manager(context_id="reload_lifecycle_tool")
+        assert manager1 is not None
+
+        spy_shutdown = AsyncMock(wraps=manager1.shutdown)
+        with patch.object(manager1, "shutdown", spy_shutdown):
+            manager2 = await factory.reload_tenant(context_id="reload_lifecycle_tool")
+
+        spy_shutdown.assert_awaited_once()
+        assert manager2 is not None
+        assert manager2 is not manager1, (
+            "reload_tenant must construct a new manager instance — same-instance "
+            "reuse would mean the rebuild path was skipped entirely"
+        )
+    finally:
+        await factory.shutdown()


### PR DESCRIPTION
## Summary

Two integration tests covering rate-limiter behaviour under runtime mode toggle via the admin API. Marked draft because they raise design questions about the rate limiter's toggle-latency contract that need team input before a final shape lands.

The rate limiter is the only stateful plugin we ship — counter state lives in Redis, mode is embedded in a per-worker cached plugin instance. That makes its response to a runtime mode toggle eventually consistent, not instantaneous, in a way the other supported plugins (Output Length Guard, Secrets Detection) aren't.

## What's in this PR

Two tests, both currently passing:

### `TestRateLimiterToggleAfterTTLExpiry` — correctness contract

`tests/integration/test_rate_limiter_dynamic_behavior.py`

Three-phase cycle: `enforce` → wait past Redis counter TTL → `disabled` → wait → `enforce`. Validates that re-enforcement works after a quiet period long enough for counters to age out. Tagged `@pytest.mark.slow` because of two ~75s sleeps.

### `TestRateLimiterToggleLiveState::test_measure_convergence_time_for_mode_toggle` — latency probe

`tests/integration/test_rate_limiter_toggle_live_state.py`

Flips mode, then polls every second until traffic actually reflects the new mode, recording the elapsed time and the per-poll trajectory. No threshold-based assertion on the convergence time — the test fails only if convergence never happens within `MAX_CONVERGENCE_S`. Useful both as a regression pin (sudden slowdown caught) and as a measurement tool.

## Sample observation

One local run, single replica × 24 workers, post-current-main image:

```
enforce → disabled : converged in 22.4s
  t= 0.00s   4/6 allowed,  2/6 blocked
  t= 2.84s   2/6 allowed,  4/6 blocked
  t= 7.20s   1/6 allowed,  5/6 blocked  (got worse before better)
  t=11.30s   0/6 allowed,  6/6 blocked
  t=15.42s   5/6 allowed,  1/6 blocked  (oscillates)
  t=20.86s   4/6 allowed,  2/6 blocked
  t=22.37s   6/6 allowed,  0/6 blocked  ← converged

disabled → enforce : converged in 9.7s
```

The ~22s disabled-convergence with mid-trajectory oscillation is suspicious — looks like pub/sub-driven invalidation is correct for most workers within a few seconds, but a fraction takes much longer to converge, possibly relying on the 30s TTL-based cache safety net rather than the pub/sub eviction. Convergence happens; just not as fast as expected.

## Why this is different from stateless plugins

Stateless plugins decide based only on the current request — the moment a worker's mode flips to disabled, every subsequent request reflects it. Rate limiter decides based on `(mode, persistent counter state)`. When mode flips, the counter is still hot in Redis, so any worker still serving requests under stale-mode-enforce will still block them. The convergence time is a property of how long it takes every worker's plugin-manager cache to rebuild with the new mode.

## Open design questions for review

1. **Toggle latency expectation.** What's the SLA we want to commit to? "Within N seconds" feels right, but what's N? Operators flipping a plugin off in an incident response need to know.
2. **Counter window on `disabled → enforce`.** Today we don't reset the window — flipping back to enforce on an already-hot bucket immediately blocks. Is that the right call? Some operators might expect a fresh window on re-enable. Either is defensible.
3. **Should `disabled` mode actually reset Redis state?** Today it stops checking counters but doesn't clear them. Same question from the other direction.
4. **Eventual-consistency contract for stateful plugins more generally.** Rate limiter is the only stateful one today, but [cpex-plugins#49](https://github.com/IBM/cpex-plugins/issues/49) has follow-ups (quota accounting, cascade limits) that would be similarly stateful. Worth deciding the convergence-time SLA at the framework level once.

## What this PR is not

Not a code fix. The rate limiter works; the question is *how it behaves under toggle* and what we want that behaviour to be. The tests document current behaviour and provide a measurement harness for any future fix.

## How to run

**Prerequisites**

- Local docker-compose stack from this repo brought up via `make compose-up` (3 gateway replicas behind nginx on `:8080`, Redis, Postgres, fast-test-server registered).
- Gateway image built from current main — run `make docker-build` if your local image is stale.
- Default dev credentials and JWT secret from your local `.env` (the `.env.example` defaults work for this test).
- `uv sync --extra plugins` so `cpex-rate-limiter` is importable in the test env.

**Run**

```bash
# convergence probe — ~1 minute, emits the trajectory on every run
uv run pytest tests/integration/test_rate_limiter_toggle_live_state.py \
  --with-integration -s -v

# TTL-expiry cycle — ~3 minutes due to two ~75s sleeps; tagged @pytest.mark.slow
uv run pytest \
  tests/integration/test_rate_limiter_dynamic_behavior.py::TestRateLimiterToggleAfterTTLExpiry \
  --with-integration -s -v
```

Both tests skip cleanly if `http://localhost:8080/health` isn't reachable.


---

## Update — empirical evidence and layered coverage

Since the original draft, this branch has grown into a layered toggle-behaviour story. Adding here, not editing the above — the original sections remain the right snapshot of the problem statement and findings at the time the PR was opened.

### Layered toggle-behaviour coverage now on this branch

| Layer | Pin | File |
|---|---|---|
| A | `reload_tenant → manager.shutdown` invocation | `tests/unit/mcpgateway/plugins/framework/test_tenant_plugin_manager_tool_scoped.py` |
| A-init | `reload_tenant → new manager.initialize` invocation | same |
| B-0 | manager-mediated plugin wipe via direct `factory.reload_tenant` | `tests/integration/test_plugin_manager_wipe_on_disable.py` |
| B-0.5 | publisher↔subscriber round-trip via real Redis pub/sub | same |
| C (existing) | end-to-end convergence probe via HTTP+MCP | `tests/integration/test_rate_limiter_toggle_live_state.py` |
| Multi-replica probe | end-to-end convergence via Redis pub/sub only, no HTTP amplification | `tests/integration/test_rate_limiter_toggle_via_redis_pubsub.py` |

### Empirical answer to design question #3

Question #3 asked whether `disabled` mode should clear Redis counter state. The answer landed on "yes, clear them," and the implementation lives on cpex-plugins branch [`feat/rate-limiter-wipe-on-disable-only`](https://github.com/IBM/cpex-plugins/tree/feat/rate-limiter-wipe-on-disable-only). Running the new multi-replica pub/sub probe against a wipe-enabled gateway image (3 replicas × 24 workers, plain docker-compose stack):

```
Convergence trajectory (counter_exists per poll):
  t=  0.00s  counter_exists=True
  t=  0.11s  counter_exists=False  ← converged

✓ Wipe converged in 0.11s
```

vs. the ~22s baseline observed in the existing live-state probe at the top of this PR — a ~170× improvement on the disabled-direction convergence. Note the wipe doesn't accelerate the cache rebuild; it makes the rebuild's user-visible latency irrelevant — a stale-mode worker with empty counters cannot block any request.

### Pre-conditions discovered while empirically running

Two things had to be in place for the wipe path to actually fire from a clean stack — worth flagging on the cpex-plugins wipe-on-disable PR description as deployment caveats:

1. **Plugin must be loaded for the wipe to fire.** `plugins/config.yaml` ships rate-limiter with `mode: "disabled"`, and the framework loader skips disabled plugins. The probe first toggles to `enforce` via the admin API so the plugin is genuinely loaded.
2. **At least one cached manager required.** `factory.invalidate_all()` iterates only *cached* managers; a fresh gateway with zero traffic has zero cached managers, so the broadcast triggers no `reload_tenant` and no `plugin.shutdown`. The probe sends a 20-request warm-up burst before the disable to ride gunicorn's load balancer across multiple workers.

### Status of original design questions

- **#1 (toggle latency SLA):** with wipe-on-disable enabled, the `enforce → disabled` direction converges in ~0.1s. The user-visible SLA could plausibly be "< 1 second" instead of "within N seconds" — but the `disabled → enforce` direction is unchanged by the wipe and still depends on cache rebuild propagation. Worth team input on whether one SLA covers both.
- **#2 (fresh window on re-enable):** transitively answered by #3 — wipe-on-disable means re-enable always starts with empty counters, so the operator gets a fresh window for free.
- **#3 (disabled mode resets Redis state):** answered yes, implementation in cpex-plugins linked above. This PR's tests are the framework-side coverage of that contract.
- **#4 (eventual-consistency contract for stateful plugins):** still open at the framework level, separate from this PR.
