### PR TITLE
fix(resources): Implement resource URI deduplication and graceful ambiguity handling for federated resources

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-16T09:52:04Z",
+  "generated_at": "2026-06-17T08:51:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4224,7 +4224,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4403,
+        "line_number": 4404,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2125,6 +2125,7 @@ class ResourceRead(BaseModelWithConfigDict):
     description: Optional[str]
     mime_type: Optional[str]
     gateway_id: Optional[str] = Field(None, description="ID of the gateway for the resource")
+    gateway_name: Optional[str] = Field(None, description="Name of the gateway for the resource (for disambiguation)")
     uri_template: Optional[str] = Field(None, description="URI template for parameterized resources")
     size: Optional[int]
     created_at: datetime

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -403,6 +403,16 @@ class ResourceService(BaseService):
         resource_dict["updated_at"] = getattr(resource, "updated_at", None)
         resource_dict["version"] = getattr(resource, "version", None)
         resource_dict["gateway_id"] = getattr(resource, "gateway_id", None)
+
+        # Include gateway name for disambiguation when multiple gateways expose the same resource URI
+        gateway = getattr(resource, "gateway", None)
+        if gateway and hasattr(gateway, "name"):
+            gateway_name = getattr(gateway, "name", None)
+            # Ensure it's a string (not a MagicMock or other object)
+            resource_dict["gateway_name"] = str(gateway_name) if gateway_name is not None else None
+        else:
+            resource_dict["gateway_name"] = None
+
         return ResourceRead.model_validate(resource_dict)
 
     def _get_team_name(self, db: Session, team_id: Optional[str]) -> Optional[str]:
@@ -1260,10 +1270,22 @@ class ResourceService(BaseService):
 
             # Convert to ResourceRead (common for both pagination types)
             result = []
+            seen_uris = set()  # Track URIs to deduplicate when gateway_id is not filtered
             for s in resources_db:
                 try:
                     s.team = team_map.get(s.team_id) if s.team_id else None
-                    result.append(self.convert_resource_to_read(s, include_metrics=False))
+                    resource_read = self.convert_resource_to_read(s, include_metrics=False)
+
+                    # Deduplicate resources by URI when not filtering by gateway_id
+                    # This prevents ambiguity errors when multiple gateways expose the same resource URI
+                    # Only the first occurrence (by created_at DESC) is included
+                    if gateway_id is None and hasattr(resource_read, "uri") and resource_read.uri in seen_uris:
+                        logger.debug(f"Skipping duplicate resource URI '{resource_read.uri}' from gateway {s.gateway_id}")
+                        continue
+
+                    if hasattr(resource_read, "uri"):
+                        seen_uris.add(resource_read.uri)
+                    result.append(resource_read)
                 except (ValidationError, ValueError, KeyError, TypeError, binascii.Error) as e:
                     logger.exception("Failed to convert resource %s (%s): %s", getattr(s, "id", "unknown"), getattr(s, "name", "unknown"), e)
                     # Continue with remaining resources instead of failing completely
@@ -2375,7 +2397,10 @@ class ResourceService(BaseService):
                     except MultipleResultsFound as exc:
                         if server_id:
                             raise ResourceError(f"Multiple resources matched URI '{uri}' for server '{server_id}'.") from exc
-                        raise ResourceError(f"Resource URI '{uri}' is ambiguous across multiple servers; use /servers/{{id}}/mcp.") from exc
+                        # For generic /mcp/ endpoint without server_id, pick the first match (by created_at DESC)
+                        # This allows resources/read to succeed even when multiple gateways expose the same URI
+                        logger.warning(f"Resource URI '{uri}' is ambiguous across multiple servers; returning first match. Use /servers/{{id}}/mcp for deterministic selection.")
+                        resource_db = db.execute(query.limit(1)).scalar_one_or_none()
 
                     # Check for direct_proxy mode
                     if resource_db and resource_db.gateway and getattr(resource_db.gateway, "gateway_mode", "cache") == "direct_proxy" and settings.mcpgateway_direct_proxy_enabled:
@@ -2451,7 +2476,9 @@ class ResourceService(BaseService):
                         except MultipleResultsFound as exc:
                             if server_id:
                                 raise ResourceError(f"Multiple inactive resources matched URI '{resource_uri}' for server '{server_id}'.") from exc
-                            raise ResourceError(f"Resource URI '{resource_uri}' is ambiguous across multiple servers; use /servers/{{id}}/mcp.") from exc
+                            # For generic /mcp/ endpoint, check if any inactive resource exists (pick first)
+                            logger.debug(f"Multiple inactive resources found for URI '{resource_uri}'; checking first match")
+                            check_inactivity = db.execute(inactive_query.where(DbResource.uri == str(resource_uri)).where(not_(DbResource.enabled)).limit(1)).scalar_one_or_none()
                         if check_inactivity:
                             raise ResourceNotFoundError(f"Resource '{resource_uri}' exists but is inactive")
 

--- a/tests/live_gateway/mcp/test_mcp_protocol_e2e.py
+++ b/tests/live_gateway/mcp/test_mcp_protocol_e2e.py
@@ -174,6 +174,29 @@ class TestDiscovery:
         resources = await client.list_resources()
         print(f"    -> {len(resources)} resources")
 
+    async def test_resources_list_deduplicates_uris(self, client: Client) -> None:
+        """Verify that resources/list deduplicates resources by URI.
+
+        When multiple gateways expose the same resource URI (e.g., timezone://info),
+        the generic /mcp/ endpoint should return only one entry per unique URI.
+        This prevents ambiguity errors in resources/read.
+
+        Regression test for #4418.
+        """
+        resources = await client.list_resources()
+        if not resources:
+            pytest.skip("No resources registered on gateway")
+
+        # Check for duplicate URIs
+        uris = [str(r.uri) for r in resources]
+        unique_uris = set(uris)
+
+        assert len(uris) == len(unique_uris), (
+            f"resources/list returned duplicate URIs: {len(uris)} total, "
+            f"{len(unique_uris)} unique. Duplicates: {[u for u in uris if uris.count(u) > 1]}"
+        )
+        print(f"    -> all {len(resources)} resources have unique URIs")
+
     async def test_resources_read_roundtrip(self, client: Client) -> None:
         """Round-trip any advertised resource through resources/read.
 
@@ -181,32 +204,25 @@ class TestDiscovery:
         read path (content encoding, mime negotiation, gateway decoration).
         Skips cleanly when no resources are registered on the stack.
 
-        When the gateway federates multiple upstream servers the same
-        resource URI can appear on more than one server.  Reading such a
-        URI through the generic ``/mcp/`` endpoint (no server scope)
-        raises an ambiguity error.  We iterate through the advertised
-        resources so we can skip ambiguous URIs and still exercise the
-        read path.
+        After fix for #4418: resources/list deduplicates by URI when called
+        via the generic /mcp/ endpoint, and resources/read picks the first
+        match instead of raising an ambiguity error. This allows the test
+        to succeed without special handling for duplicate URIs.
         """
         resources = await client.list_resources()
         if not resources:
             pytest.skip("No resources registered on gateway — nothing to read")
-        last_error: McpError | None = None
-        for target in resources:
-            try:
-                contents = await client.read_resource(str(target.uri))
-            except McpError as exc:
-                # URI is ambiguous across servers — try the next one
-                last_error = exc
-                continue
-            assert contents, f"read_resource({target.uri}) returned empty contents"
-            first = contents[0]
-            # Empty string is still valid text content per spec; check attribute presence
-            # rather than truthiness so empty bodies don't trip the assertion.
-            assert hasattr(first, "text") or hasattr(first, "blob"), f"first content item has neither text nor blob attribute: {first}"
-            print(f"    -> read {target.uri} -> {len(contents)} content item(s)")
-            return
-        pytest.skip(f"All {len(resources)} resource(s) returned errors via generic /mcp/ (last: {last_error})")
+
+        # Pick the first resource to test
+        target = resources[0]
+        contents = await client.read_resource(str(target.uri))
+
+        assert contents, f"read_resource({target.uri}) returned empty contents"
+        first = contents[0]
+        # Empty string is still valid text content per spec; check attribute presence
+        # rather than truthiness so empty bodies don't trip the assertion.
+        assert hasattr(first, "text") or hasattr(first, "blob"), f"first content item has neither text nor blob attribute: {first}"
+        print(f"    -> read {target.uri} -> {len(contents)} content item(s)")
 
     async def test_prompts_list(self, client: Client) -> None:
         prompts = await client.list_prompts()

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -5926,6 +5926,146 @@ class TestReadResourceCoverageEdges:
             assert result.uri == "time://formats"
 
     @pytest.mark.asyncio
+    async def test_list_resources_deduplicates_uris_without_gateway_filter(self):
+        """Test that list_resources deduplicates resources by URI when gateway_id is not specified.
+
+        This covers the debug log at lines 1304-1305 when duplicate URIs are skipped.
+        Regression test for #4418.
+        """
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+
+        # Create two resources with the same URI but different gateway_ids
+        mock_resource1 = MagicMock()
+        mock_resource1.id = "resource-1"
+        mock_resource1.uri = "timezone://info"
+        mock_resource1.name = "Timezone Info"
+        mock_resource1.description = "From gateway 1"
+        mock_resource1.enabled = True
+        mock_resource1.visibility = "public"
+        mock_resource1.gateway_id = "gateway-1"
+        mock_resource1.team_id = None
+        mock_resource1.created_at = datetime.now(timezone.utc)
+        mock_resource1.gateway = MagicMock()
+        mock_resource1.gateway.name = "fast_time"
+
+        mock_resource2 = MagicMock()
+        mock_resource2.id = "resource-2"
+        mock_resource2.uri = "timezone://info"  # Same URI
+        mock_resource2.name = "Timezone Info"
+        mock_resource2.description = "From gateway 2"
+        mock_resource2.enabled = True
+        mock_resource2.visibility = "public"
+        mock_resource2.gateway_id = "gateway-2"
+        mock_resource2.team_id = None
+        mock_resource2.created_at = datetime.now(timezone.utc)
+        mock_resource2.gateway = MagicMock()
+        mock_resource2.gateway.name = "fast_test"
+
+        # Create ResourceRead objects for the conversion
+        resource_read1 = MagicMock()
+        resource_read1.uri = "timezone://info"
+        resource_read1.gateway_name = "fast_time"
+
+        resource_read2 = MagicMock()
+        resource_read2.uri = "timezone://info"  # Same URI
+        resource_read2.gateway_name = "fast_test"
+
+        # Mock unified_paginate to return both resources and convert_resource_to_read to return ResourceRead objects
+        with (
+            patch("mcpgateway.services.resource_service.unified_paginate", new_callable=AsyncMock, return_value=([mock_resource1, mock_resource2], None)),
+            patch.object(svc, "convert_resource_to_read", side_effect=[resource_read1, resource_read2]),
+            patch("mcpgateway.services.resource_service.logger") as mock_logger,
+        ):
+            # Call without gateway_id filter - should deduplicate
+            result, next_cursor = await svc.list_resources(
+                db=db,
+                gateway_id=None,  # No gateway filter - triggers deduplication
+            )
+
+            # Should return only one resource (first occurrence)
+            assert len(result) == 1
+            assert result[0].uri == "timezone://info"
+            assert result[0].gateway_name == "fast_time"
+
+            # Verify debug log was called for the duplicate
+            mock_logger.debug.assert_called_once()
+            debug_call = mock_logger.debug.call_args[0][0]
+            assert "Skipping duplicate resource URI 'timezone://info'" in debug_call
+            assert "gateway-2" in debug_call
+
+    @pytest.mark.asyncio
+    async def test_read_resource_handles_multiple_inactive_resources(self):
+        """Test that read_resource handles multiple inactive resources gracefully.
+
+        This covers the debug log and limit query at lines 2497-2498 when multiple
+        inactive resources are found for the same URI on the generic /mcp/ endpoint.
+        Regression test for #4418.
+        """
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+        db.close = MagicMock()
+
+        # Mock inactive resource
+        mock_inactive_resource = MagicMock()
+        mock_inactive_resource.id = "inactive-resource-id"
+        mock_inactive_resource.uri = "timezone://info"
+        mock_inactive_resource.enabled = False
+
+        call_count = [0]
+        def execute_side_effect(statement, *args, **kwargs):
+            sql = str(statement)
+            call_count[0] += 1
+
+            # First query for active resource returns None
+            if "resources.uri" in sql and "resources.enabled" in sql and "NOT" not in sql.upper():
+                result = MagicMock()
+                result.scalar_one_or_none.return_value = None
+                return result
+
+            # Query for inactive resources
+            if "NOT" in sql.upper() and "resources.enabled" in sql:
+                if "LIMIT" not in sql.upper():
+                    # First call without LIMIT raises MultipleResultsFound
+                    raise MultipleResultsFound("multiple inactive resources")
+                else:
+                    # Second call with LIMIT 1 returns the first inactive resource
+                    result = MagicMock()
+                    result.scalar_one_or_none.return_value = mock_inactive_resource
+                    return result
+
+            # Mock gateway lookup
+            if "gateways.id" in sql:
+                result = MagicMock()
+                result.scalar_one_or_none.return_value = None
+                return result
+
+            raise AssertionError(f"Unexpected SQL: {sql}")
+
+        db.execute.side_effect = execute_side_effect
+
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.resource_service.logger") as mock_logger,
+        ):
+            # Should raise ResourceNotFoundError because the resource is inactive
+            with pytest.raises(Exception) as exc_info:
+                await svc.read_resource(db, resource_uri="timezone://info")
+
+            assert "inactive" in str(exc_info.value).lower()
+
+            # Verify debug log was called for multiple inactive resources
+            debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+            assert any("Multiple inactive resources found for URI 'timezone://info'" in call for call in debug_calls)
+
+    @pytest.mark.asyncio
     async def test_read_resource_quack_branch_stateful_hasattr_covers_unreachable_elif_false_arc(self):
         """Cover the (practically unreachable) branch arc (2296->2321) by using a stateful __getattr__."""
         # First-Party

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -5863,25 +5863,67 @@ class TestReadResourceCoverageEdges:
 
     @pytest.mark.asyncio
     async def test_read_resource_generic_uri_lookup_reports_ambiguity(self):
-        """Generic URI reads should fail cleanly when the same URI exists on multiple servers."""
+        """Test that ambiguous URIs are handled gracefully by returning the first match.
+
+        After fix for #4418: When MultipleResultsFound is raised for a generic /mcp/
+        endpoint request (no server_id), we log a warning and return the first match
+        instead of raising an error.
+        """
         # First-Party
         from mcpgateway.services.resource_service import ResourceService
+        from mcpgateway.common.models import ResourceContent
 
         svc = ResourceService()
         db = MagicMock()
         db.commit = MagicMock()
         db.close = MagicMock()
 
+        # Mock resource to return on second call (after MultipleResultsFound)
+        mock_resource = MagicMock()
+        mock_resource.id = "test-resource-id"
+        mock_resource.uri = "time://formats"
+        mock_resource.enabled = True
+        mock_resource.content = ResourceContent(
+            type="resource",
+            id="test-resource-id",
+            uri="time://formats",
+            text="Test content"
+        )
+        mock_resource.visibility = "public"
+        mock_resource.gateway = None
+        mock_resource.gateway_id = None
+
+        call_count = [0]
         def execute_side_effect(statement, *args, **kwargs):
             sql = str(statement)
+            call_count[0] += 1
             if "resources.uri" in sql and "resources.enabled" in sql:
-                raise MultipleResultsFound("duplicate URI across gateways")
-            raise AssertionError(sql)
+                if call_count[0] == 1:
+                    # First call raises MultipleResultsFound
+                    raise MultipleResultsFound("duplicate URI across gateways")
+                else:
+                    # Second call (with LIMIT 1) returns the first match
+                    result = MagicMock()
+                    result.scalar_one_or_none.return_value = mock_resource
+                    return result
+            # Mock gateway lookup (returns None since gateway_id is None)
+            if "gateways.id" in sql:
+                result = MagicMock()
+                result.scalar_one_or_none.return_value = None
+                return result
+            raise AssertionError(f"Unexpected SQL: {sql}")
 
         db.execute.side_effect = execute_side_effect
 
-        with pytest.raises(ResourceError, match=r"ambiguous across multiple servers; use /servers/\{id\}/mcp"):
-            await svc.read_resource(db, resource_uri="time://formats")
+        with (
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=mock_resource.content),
+        ):
+            # Should succeed and return the first match instead of raising an error
+            result = await svc.read_resource(db, resource_uri="time://formats")
+            assert result is not None
+            assert result.uri == "time://formats"
 
     @pytest.mark.asyncio
     async def test_read_resource_quack_branch_stateful_hasattr_covers_unreachable_elif_false_arc(self):


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4418

---

## 📝 Summary

This PR fixes the federated resource URI ambiguity issue where multiple upstream MCP servers exposing the same resource URI (e.g., `timezone://info`) caused failures on the generic `/mcp/` endpoint.

**Problem**: When `fast_time_server` (Go) and `fast_test_server` (Rust) both register `timezone://info`, the generic `/mcp/` endpoint would:
- Return duplicate URIs in `resources/list`
- Fail with `ResourceError: Resource URI 'timezone://info' is ambiguous` on `resources/read`

**Solution**: Implements the recommended combination approach from the bug report:

1. **Short-term fixes**:
   - **Deduplication**: `list_resources()` now deduplicates resources by URI when `gateway_id` is not specified, returning only the first occurrence (by `created_at DESC`)
   - **Graceful handling**: `read_resource()` picks the first match instead of raising an error when `MultipleResultsFound` occurs on the generic `/mcp/` endpoint

2. **Long-term fix**:
   - **Transparency**: Added `gateway_name` field to `ResourceRead` schema so clients can see which gateway each resource originates from

**Impact**: The default docker-compose stack now works correctly via the generic `/mcp/` endpoint when multiple servers expose the same resource URI.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Implementation Details

**Files Modified**:
1. `mcpgateway/services/resource_service.py`:
   - Lines 1295-1313: URI deduplication logic in `list_resources()`
   - Lines 2415-2421: Graceful `MultipleResultsFound` handling in `read_resource()` for active resources
   - Lines 2493-2498: Similar handling for inactive resource checks
   - Lines 428-437: Gateway name population in `convert_resource_to_read()`

2. `mcpgateway/schemas.py`:
   - Line 2044: Added `gateway_name` field to `ResourceRead` schema

3. Test updates:
   - `tests/e2e/test_mcp_protocol_e2e.py`: Updated `test_resources_read_roundtrip` and added `test_resources_list_deduplicates_uris`
   - `tests/unit/mcpgateway/services/test_resource_service.py`: Updated `test_read_resource_generic_uri_lookup_reports_ambiguity`

### Design Decisions

- **Deduplication strategy**: Returns first occurrence by `created_at DESC` to ensure deterministic behavior
- **Backward compatibility**: Server-scoped endpoints (`/servers/{id}/mcp`) maintain strict ambiguity checks
- **Transparency**: The `gateway_name` field allows clients to understand resource origin without breaking existing integrations
- **Logging**: Added warning logs when ambiguous URIs are encountered to aid debugging

### Behavior Changes

**Before**:
```
GET /mcp/resources/list → [{"uri": "timezone://info"}, {"uri": "timezone://info"}]
GET /mcp/resources/read?uri=timezone://info → 500 ResourceError
```

**After**:
```
GET /mcp/resources/list → [{"uri": "timezone://info", "gateway_name": "fast_time"}]
GET /mcp/resources/read?uri=timezone://info → 200 OK (returns first match with warning log)
```