### PR TITLE
Improve test coverage on rbac admin delete tool

### DIFF
--- a/tests/integration/test_rbac_ownership_http.py
+++ b/tests/integration/test_rbac_ownership_http.py
@@ -166,7 +166,7 @@ class TestRBACOwnershipHTTP:
         app.dependency_overrides.clear()
 
     @patch("mcpgateway.main.tool_service.delete_tool", new_callable=AsyncMock)
-    @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
+    # @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
     def test_delete_private_tool_non_owner_admin_returns_403(
         self,
         mock_delete_tool: AsyncMock,
@@ -175,9 +175,6 @@ class TestRBACOwnershipHTTP:
         """Test that non-owner admin cannot delete private tool owned by another admin.
         """
         TestSessionLocal, _ = test_db_and_client
-
-        # Mock service to raise PermissionError for private tool deletion
-        mock_delete_tool.side_effect = PermissionError("Only the owner can delete this private tool")
 
         # Set up user context as admin but NOT the owner
         mock_user = MagicMock()
@@ -199,7 +196,7 @@ class TestRBACOwnershipHTTP:
 
         # Verify HTTP 403 Forbidden - admin cannot delete another admin's private tool
         assert response.status_code == 403
-        assert "Only the owner can delete this private tool" in response.json()["detail"]
+        assert "Access denied" in response.json()["detail"]
 
         # Cleanup
         app.dependency_overrides.clear()

--- a/tests/integration/test_rbac_ownership_http.py
+++ b/tests/integration/test_rbac_ownership_http.py
@@ -165,6 +165,45 @@ class TestRBACOwnershipHTTP:
         # Cleanup
         app.dependency_overrides.clear()
 
+    @patch("mcpgateway.main.tool_service.delete_tool", new_callable=AsyncMock)
+    @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
+    def test_delete_private_tool_non_owner_admin_returns_403(
+        self,
+        mock_delete_tool: AsyncMock,
+        test_db_and_client,
+    ):
+        """Test that non-owner admin cannot delete private tool owned by another admin.
+        """
+        TestSessionLocal, _ = test_db_and_client
+
+        # Mock service to raise PermissionError for private tool deletion
+        mock_delete_tool.side_effect = PermissionError("Only the owner can delete this private tool")
+
+        # Set up user context as admin but NOT the owner
+        mock_user = MagicMock()
+        mock_user.email = "admin-b@example.com"
+
+        app.dependency_overrides[require_auth] = lambda: "admin-b@example.com"
+        app.dependency_overrides[get_current_user] = lambda: mock_user
+        app.dependency_overrides[get_current_user_with_permissions] = create_user_context(
+            "admin-b@example.com", is_admin=True, TestSessionLocal=TestSessionLocal
+        )
+
+        client = TestClient(app)
+
+        # Attempt to delete private tool owned by admin-a@example.com
+        response = client.delete(
+            "/tools/private-tool-123",
+            headers={"Authorization": "Bearer test-token"}
+        )
+
+        # Verify HTTP 403 Forbidden - admin cannot delete another admin's private tool
+        assert response.status_code == 403
+        assert "Only the owner can delete this private tool" in response.json()["detail"]
+
+        # Cleanup
+        app.dependency_overrides.clear()
+
     @patch("mcpgateway.main.tool_service.update_tool", new_callable=AsyncMock)
     @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
     def test_update_tool_non_owner_returns_403(

--- a/tests/integration/test_rbac_ownership_http.py
+++ b/tests/integration/test_rbac_ownership_http.py
@@ -233,18 +233,25 @@ class TestRBACOwnershipHTTP:
         # Cleanup
         app.dependency_overrides.clear()
 
-    @patch("mcpgateway.main.server_service.delete_server", new_callable=AsyncMock)
     @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
     def test_delete_server_owner_succeeds(
         self,
-        mock_delete_server: AsyncMock,
         test_db_and_client,
     ):
         """Test that owner can successfully delete their own server."""
         TestSessionLocal, _ = test_db_and_client
 
-        # Mock service to succeed
-        mock_delete_server.return_value = None
+        # Create a server in the database
+        with TestSessionLocal() as db:
+            from mcpgateway.db import Server
+            server = Server(
+                id="server-123",
+                name="Test Server",
+                owner_email="owner@example.com",
+                team_id="public",
+            )
+            db.add(server)
+            db.commit()
 
         # Set up user context as owner
         mock_user = MagicMock()
@@ -298,18 +305,27 @@ class TestRBACOwnershipHTTP:
         # Cleanup
         app.dependency_overrides.clear()
 
-    @patch("mcpgateway.main.gateway_service.delete_gateway", new_callable=AsyncMock)
     @patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService)
     def test_delete_gateway_team_admin_succeeds(
         self,
-        mock_delete_gateway: AsyncMock,
         test_db_and_client,
     ):
         """Test that team admin can delete team member's gateway."""
         TestSessionLocal, _ = test_db_and_client
 
-        # Mock service to succeed (team admin has permission)
-        mock_delete_gateway.return_value = None
+        # Create a gateway in the database
+        with TestSessionLocal() as db:
+            from mcpgateway.db import Gateway
+            gateway = Gateway(
+                id="gateway-123",
+                name="Test Gateway",
+                url="http://test.example.com",
+                owner_email="member@example.com",
+                team_id="public",
+                capabilities={},  # Required field
+            )
+            db.add(gateway)
+            db.commit()
 
         # Set up user context as team admin
         mock_user = MagicMock()

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -101,8 +101,11 @@ class MockPermissionService:
         resource_type: Optional[str] = None,
         resource_id: Optional[str] = None,
         team_id: Optional[str] = None,
+        token_teams: Optional[list] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        allow_admin_bypass: bool = True,
+        check_any_team: bool = False,
     ) -> bool:
         """Mock permission check that returns configured result.
 
@@ -112,8 +115,11 @@ class MockPermissionService:
             resource_type: Optional resource type
             resource_id: Optional resource ID
             team_id: Optional team context
+            token_teams: Normalized token team scope from auth context
             ip_address: Optional IP address
             user_agent: Optional user agent
+            allow_admin_bypass: Whether to allow admin bypass
+            check_any_team: Whether to check permission across all team-scoped roles
 
         Returns:
             bool: Permission result


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #4515

---

## 📝 Summary
_What does this PR do and why?_

Manual test and test coverage for RBAC

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [X] Other Testing

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   X    |
| Unit tests                | `make test`     |   X    |
| Coverage ≥ 80%            | `make coverage` |   X    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
