### PR TITLE
docs: fix strict docs link warnings

### DIFF
--- a/docs/docs/architecture/adr/052-get-stream-and-server-initiated-requests.md
+++ b/docs/docs/architecture/adr/052-get-stream-and-server-initiated-requests.md
@@ -11,7 +11,7 @@ The MCP Streamable HTTP spec defines a server-to-client stream: the client opens
 
 **What we have today (post-#4205, #4299).** Both the Python gateway (`streamablehttp_transport.py:3004-3031`) and the Rust runtime (`crates/mcp_runtime/src/lib.rs:4654-4706`) return `405 Method Not Allowed` on `GET /mcp` whenever stateful sessions are disabled OR no `Mcp-Session-Id` header is present. The 405 was correct under #4205 because there was no infrastructure to deliver server-initiated messages to a downstream listener — the per-session message handler in `services/notification_service.py:369-431` consumes upstream notifications only to trigger internal list-refresh, and `routers/reverse_proxy.py:532` carries an explicit `# TODO: Implement message queue for SSE delivery`.
 
-**Why we need it back.** Restoring the GET stream is a prerequisite for several upcoming features that all depend on server-to-client delivery: structured logging visible to the client, progress notifications, sampling/elicitation passthrough (extending the work in [ADR-022](022-elicitation-passthrough.md) to streamable HTTP), and list-changed notifications that today are absorbed into refresh logic instead of forwarded.
+**Why we need it back.** Restoring the GET stream is a prerequisite for several upcoming features that all depend on server-to-client delivery: structured logging visible to the client, progress notifications, sampling/elicitation passthrough (extending the work in [ADR-022](022-elicitation-passthrough-implementation.md) to streamable HTTP), and list-changed notifications that today are absorbed into refresh logic instead of forwarded.
 
 **The multi-node problem.** The downstream client opens GET on whatever node the load balancer picks (call it node A). The upstream MCP session lives on the worker that owns it via the affinity machinery (ADR-038) — call it node B. Notifications from upstream arrive at node B, but the client is listening on node A. We need cross-node delivery without forcing the GET to land on the affinity owner.
 
@@ -224,4 +224,4 @@ compose, and `make testing-up` (3-replica multi-node with Redis).
   - `tests/unit/mcpgateway/transports/test_redis_event_store.py` (cross-stream, evicted-cursor, no-cursor replay)
   - `tests/unit/mcpgateway/services/test_notification_service.py` (request correlation, id-collision, publish-failure telemetry, shutdown timeout)
 - Spec: [Streamable HTTP — Listening for messages from the server](https://modelcontextprotocol.io/specification/draft/basic/transports#listening-for-messages-from-the-server)
-- Prior ADRs: [ADR-022](022-elicitation-passthrough.md), [ADR-038](038-multi-worker-session-affinity.md), [ADR-043](043-rust-mcp-runtime-sidecar-mode-model.md)
+- Prior ADRs: [ADR-022](022-elicitation-passthrough-implementation.md), [ADR-038](038-multi-worker-session-affinity.md), [ADR-043](043-rust-mcp-runtime-sidecar-mode-model.md)

--- a/docs/docs/architecture/get-stream-quickstart.md
+++ b/docs/docs/architecture/get-stream-quickstart.md
@@ -191,5 +191,5 @@ make testing-down
 
 - [ADR-052: GET /mcp Stream and Server-Initiated Request Correlation](adr/052-get-stream-and-server-initiated-requests.md)
 - [ADR-038: Multi-Worker Session Affinity](adr/038-multi-worker-session-affinity.md)
-- [Rust MCP Runtime — DEVELOPING § GET /mcp Stream Relay](../../crates/mcp_runtime/DEVELOPING.md)
+- [Rust MCP Runtime — DEVELOPING § GET /mcp Stream Relay](https://github.com/IBM/mcp-context-forge/blob/main/crates/mcp_runtime/DEVELOPING.md)
 - [MCP Streamable HTTP — Listening for messages from the server](https://modelcontextprotocol.io/specification/draft/basic/transports#listening-for-messages-from-the-server)

--- a/docs/docs/architecture/performance-architecture.md
+++ b/docs/docs/architecture/performance-architecture.md
@@ -231,7 +231,7 @@ Important current behavior:
 
 Every enabled feature registers middleware, routers, or background tasks that consume resources even when not actively used. ContextForge has ~90 feature flags; each disabled feature removes its middleware and background tasks from the request path.
 
-The most impactful features to disable when not needed are: admin UI, A2A protocol, LLM chat, catalog, observability, audit trail, and database-backed structured logging. See the [disable unused features](../manage/tuning.md#10---disable-unused-features) section in the tuning guide for deployment profiles.
+The most impactful features to disable when not needed are: admin UI, A2A protocol, LLM chat, catalog, observability, audit trail, and database-backed structured logging. See the [disable unused features](../manage/tuning.md#10-disable-unused-features) section in the tuning guide for deployment profiles.
 
 ### Key Architectural Insight
 

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -263,7 +263,7 @@ The plugin framework uses **hybrid AND/OR condition evaluation** for precise con
 !!! warning "Breaking Change in 1.0.0-RC3"
     Plugin condition evaluation logic changed from pure OR to hybrid AND/OR in version 1.0.0-RC3. If you're upgrading from 0.9.x, review your plugin configurations to ensure they work as expected with the new evaluation model.
 
-    **Migration Guide:** See [Plugin Condition Migration Guide](MIGRATION-PLUGIN-CONDITIONS.md) for detailed migration instructions and validation scripts.
+    **Migration Guide:** See [Plugin Condition Migration Guide](https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/architecture/MIGRATION-PLUGIN-CONDITIONS.md) for detailed migration instructions and validation scripts.
 
 
 

--- a/docs/docs/deployment/index.md
+++ b/docs/docs/deployment/index.md
@@ -45,7 +45,7 @@ ContextForge loads configuration from:
 - Environment variables (overrides `.env`)
 - CLI flags (e.g., via `run.sh`)
 
-⚠️ **Security Note**: Never store sensitive credentials directly in environment variables. Use a secrets management system in production. See the [Security Guide](../manage/securing.md#10-secrets-management) for details.
+⚠️ **Security Note**: Never store sensitive credentials directly in environment variables. Use a secrets management system in production. See the [Security Guide](../manage/securing.md#11-secrets-management) for details.
 
 ---
 
@@ -72,4 +72,4 @@ The default container image:
 
 > For Kubernetes, you can mount a ConfigMap or Secret as `.env`.
 
-**Important**: For production deployments, ensure you follow the container hardening guidelines in our [Security Guide](../manage/securing.md#9-container-security).
+**Important**: For production deployments, ensure you follow the container hardening guidelines in our [Security Guide](../manage/securing.md#10-container-security).

--- a/docs/docs/deployment/openshift-pgo.md
+++ b/docs/docs/deployment/openshift-pgo.md
@@ -126,7 +126,7 @@ testing:
 
 ## Setup and deployment steps
 
-The Make commands below wrap Ansible playbooks under the hood (`ansible/ocp/playbooks/`). You can also run the playbooks directly — see [ansible/ocp/README.md](../../../ansible/ocp/README.md) for details.
+The Make commands below wrap Ansible playbooks under the hood (`ansible/ocp/playbooks/`). You can also run the playbooks directly — see [ansible/ocp/README.md](https://github.com/IBM/mcp-context-forge/blob/main/ansible/ocp/README.md) for details.
 
 **0. Create Docker Hub pull secret** (one-time per namespace, required to pull `redis:7` without hitting anonymous rate limits):
 

--- a/docs/docs/development/profiling.md
+++ b/docs/docs/development/profiling.md
@@ -800,7 +800,7 @@ except Exception as e:
 - Enable response caching
 - Paginate large result sets
 - Use orjson for serialization (enabled by default)
-- Disable unused features (A2A, catalog, LLM chat, admin UI) — see [disable unused features](../manage/tuning.md#10---disable-unused-features) in the tuning guide
+- Disable unused features (A2A, catalog, LLM chat, admin UI) — see [disable unused features](../manage/tuning.md#10-disable-unused-features) in the tuning guide
 - Tune `GUNICORN_WORKERS` to match CPU cores (not exceed them)
 
 ---

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -10,13 +10,13 @@ This document describes the complete release process for ContextForge, from pre-
 |-------|-------|
 | [1. Version Update](#1-version-update) | Bump version, update references, CHANGELOG, roadmap, security advisories, base images |
 | [2. Python Dependency Updates](#2-python-dependency-updates) | Update pyproject.toml/requirements.txt, pip-audit |
-| [3. Rust, Go & JS Dependency Updates](#3-rust-go--javascript-dependency-updates) | cargo update, go get -u, npm update |
+| [3. Rust, Go & JS Dependency Updates](#3-rust-go-javascript-dependency-updates) | cargo update, go get -u, npm update |
 | [4. Quality Gates](#4-quality-gates) | Code formatting, linting, secrets scanning, security analysis |
 | [5. Test Gates](#5-test-gates) | Unit tests, JS tests, UI tests, MCP tests, load tests |
 | [6. Build Verification](#6-build-verification) | Docker build, compose stack, embedded mode, package validation |
 | [7. SSO Verification](#7-sso-verification) | Keycloak SSO login flow |
 | [8. Observability Verification](#8-observability-verification) | Monitoring stack under load |
-| [9. Security & Analysis](#9-security--analysis) | SonarQube, container scanning |
+| [9. Security & Analysis](#9-security-analysis) | SonarQube, container scanning |
 | [10. Deployment Verification](#10-deployment-verification) | Helm chart lint, IaC scanning, Minikube deploy |
 | [11. Documentation Verification](#11-documentation-verification) | Broken links, build, deploy |
 | [12. Plugin Testing](#12-plugin-testing) | PII filter, plugin framework, tool invocation hooks |

--- a/docs/docs/manage/observability/.pages
+++ b/docs/docs/manage/observability/.pages
@@ -1,6 +1,6 @@
 title: Observability
 nav:
-  - index.md
+  - observability.md
   - opentelemetry.md
   - internal.md
   - prometheus.md

--- a/docs/docs/manage/observability/internal-observability.md
+++ b/docs/docs/manage/observability/internal-observability.md
@@ -823,7 +823,7 @@ OBSERVABILITY_EXCLUDE_PATHS=["/health.*","/metrics.*"]
 - Review [Configuration Reference](../configuration.md) for all observability settings
 - Explore [OpenTelemetry Integration](observability.md) for external monitoring
 - Set up [Phoenix Integration](phoenix.md) for AI-specific observability
-- Configure [Prometheus Metrics](../observability.md#prometheus-metrics-important) for time-series monitoring
+- Configure [Prometheus Metrics](../observability.md#prometheus-metrics) for time-series monitoring
 - Implement [Custom Dashboards](#admin-ui-dashboards) based on your metrics
 
 ## Related Documentation

--- a/docs/docs/manage/span-attribute-customization.md
+++ b/docs/docs/manage/span-attribute-customization.md
@@ -397,4 +397,4 @@ grep "Failed to apply transformation" logs/gateway.log
 - [OpenTelemetry Span Attributes](../architecture/otel-span-attributes.md)
 - [Plugin Framework](../architecture/plugins.md)
 - [Observability Configuration](./observability.md)
-- [Plugin README](../../plugins/span_attribute_customizer/README.md)
+- [Plugin README](https://github.com/IBM/mcp-context-forge/blob/main/plugins/span_attribute_customizer/README.md)

--- a/docs/docs/manage/upgrade-to-1.0.0-rc3.md
+++ b/docs/docs/manage/upgrade-to-1.0.0-rc3.md
@@ -192,7 +192,7 @@ curl -X POST http://localhost:4444/mcp/sse \
 
 #### Reference
 
-- **Full Migration Guide:** [MIGRATION-PLUGIN-CONDITIONS.md](../architecture/MIGRATION-PLUGIN-CONDITIONS.md)
+- **Full Migration Guide:** [MIGRATION-PLUGIN-CONDITIONS.md](https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/architecture/MIGRATION-PLUGIN-CONDITIONS.md)
 - **Validation Script:** `scripts/validate_plugin_conditions.py`
 - **Issue:** #3930
 - **PR:** #4078
@@ -662,10 +662,10 @@ cp plugins/config.yaml.backup plugins/config.yaml
 
 ### Documentation
 
-- **CHANGELOG:** [CHANGELOG.md](../../CHANGELOG.md)
+- **CHANGELOG:** [CHANGELOG.md](https://github.com/IBM/mcp-context-forge/blob/main/CHANGELOG.md)
 - **Configuration Reference:** [configuration.md](configuration.md)
 - **RBAC Guide:** [rbac.md](rbac.md)
-- **Plugin Migration:** [MIGRATION-PLUGIN-CONDITIONS.md](../architecture/MIGRATION-PLUGIN-CONDITIONS.md)
+- **Plugin Migration:** [MIGRATION-PLUGIN-CONDITIONS.md](https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/architecture/MIGRATION-PLUGIN-CONDITIONS.md)
 - **MySQL Migration:** [mysql-to-postgresql-migration.md](mysql-to-postgresql-migration.md)
 
 ### Support Channels


### PR DESCRIPTION
## Summary

Fixes unrelated MkDocs link warnings that were found while validating the release-management chapter 12 documentation update.

## Details

- Corrects stale intra-page anchors in release-management, tuning, deployment, observability, and ADR docs.
- Replaces repo-external relative links with GitHub links where MkDocs cannot resolve files outside `docs/docs`.
- Fixes the observability `.pages` nav entry to point at the existing page.

## Validation

- `cd docs && /Users/luca/dev/mcp-context-forge/docs/.venv/bin/mkdocs build` passed.
- `cd docs && /Users/luca/dev/mcp-context-forge/docs/.venv/bin/mkdocs build --strict` no longer reports link or anchor warnings; it still aborts on the existing PDF-export-disabled warning.
