### PR TITLE
fix(auth): cache get_token_revocation / is_token_revoked to eliminate hot-path DB queries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-29T14:22:57Z",
+  "generated_at": "2026-05-28T14:16:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,10 +89,34 @@
     ],
     ".env.example": [
       {
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 73,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 681,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -100,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 766,
+        "line_number": 876,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1039,
+        "line_number": 1163,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1065,
+        "line_number": 1189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1073,
+        "line_number": 1197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 1276,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1157,
+        "line_number": 1281,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1162,
+        "line_number": 1286,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1168,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1180,
+        "line_number": 1304,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1198,
+        "line_number": 1322,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1383,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -208,7 +232,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -216,7 +240,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 188,
+        "line_number": 217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -224,7 +248,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 219,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +256,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 262,
+        "line_number": 291,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -240,7 +264,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 263,
+        "line_number": 292,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -250,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 859,
+        "line_number": 1336,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -258,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 947,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1297,
+        "line_number": 1774,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -274,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 3140,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2754,
+        "line_number": 3231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2797,
+        "line_number": 3274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2802,
+        "line_number": 3279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 3284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -326,7 +350,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 491,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -334,7 +358,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 951,
+        "line_number": 960,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -342,7 +366,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 953,
+        "line_number": 962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +374,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1614,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +382,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1857,
+        "line_number": 1833,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6263,
+        "line_number": 6358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6760,
+        "line_number": 6855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6772,
+        "line_number": 6867,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6844,
+        "line_number": 6939,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7923,
+        "line_number": 8020,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -610,7 +634,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 813,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -618,7 +642,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 968,
+        "line_number": 984,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -626,7 +650,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1071,
+        "line_number": 1087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +658,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1074,
+        "line_number": 1090,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +666,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +674,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +682,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +690,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1423,
+        "line_number": 1439,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +698,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1794,
+        "line_number": 1810,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -970,15 +994,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 359,
+        "line_number": 364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -986,7 +1002,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 412,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +1010,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1018,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 457,
+        "line_number": 468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1026,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 972,
+        "line_number": 1004,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1034,15 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1072,
+        "line_number": 1107,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1050,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1136,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1058,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1171,
+        "line_number": 1257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1066,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1710,
+        "line_number": 1796,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1050,7 +1074,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1873,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1058,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2102,
+        "line_number": 2189,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2559,
+        "line_number": 2646,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1074,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2559,
+        "line_number": 2646,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2572,
+        "line_number": 2659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2720,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2741,
+        "line_number": 2828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2749,
+        "line_number": 2836,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2754,
+        "line_number": 2841,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1300,7 +1324,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1308,7 +1332,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1447,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1354,7 +1378,7 @@
         "hashed_secret": "e62854369199d65b6a66cd90fe8203ac4d5be26c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1362,7 +1386,7 @@
         "hashed_secret": "35722442567571107241e7e6ca2b554515e485da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1370,7 +1394,7 @@
         "hashed_secret": "0608c4054662dd902e1314f7e450e3eaa81c1143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 339,
+        "line_number": 340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1378,7 +1402,7 @@
         "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 346,
+        "line_number": 347,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1410,7 @@
         "hashed_secret": "564289a5f34546401bbc727c20a14069761f9143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 419,
+        "line_number": 420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1418,7 @@
         "hashed_secret": "37745ed7a0f005fb14522c5cc7c1ba3d9e0df579",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 423,
+        "line_number": 424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1426,7 @@
         "hashed_secret": "0c8207b92779c0a42507a293a23106814cc381e1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 426,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1434,7 @@
         "hashed_secret": "ce5070ef8a0cf3e595ae4cf3f73f6a0eca87e346",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 428,
+        "line_number": 429,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1442,7 @@
         "hashed_secret": "46a808cfd5beafa5e60aefee867bf92025dc2849",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 433,
+        "line_number": 434,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1450,7 @@
         "hashed_secret": "e4ae36d7ffd9dd805a909ac5a20de165a2629ba4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 435,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1458,7 @@
         "hashed_secret": "9f08d40159a4b035fc7998b398bd16b38f91e806",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 439,
+        "line_number": 440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1466,7 @@
         "hashed_secret": "61a135089eac561a2ff7cedeefb03975bed000f8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1474,7 @@
         "hashed_secret": "5bdcd3c0d4d24ae3e71b3b452a024c6324c7e4bb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 644,
+        "line_number": 645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1482,7 @@
         "hashed_secret": "a4b3ee46e1384e5b0be8cfdb2169977d8a160136",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 649,
+        "line_number": 650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1490,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 744,
+        "line_number": 745,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1498,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 745,
+        "line_number": 746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1506,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1514,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 782,
+        "line_number": 783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1522,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1035,
+        "line_number": 1036,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1530,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1036,
+        "line_number": 1037,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1538,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1037,
+        "line_number": 1038,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1546,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1055,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1554,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1154,
+        "line_number": 1155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1562,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1189,
+        "line_number": 1190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1570,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1578,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1204,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1586,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1211,
+        "line_number": 1212,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1594,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1220,
+        "line_number": 1221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1602,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1225,
+        "line_number": 1226,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1586,7 +1610,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1237,
+        "line_number": 1238,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1594,7 +1618,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1258,
+        "line_number": 1259,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1602,7 +1626,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1260,
+        "line_number": 1261,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1610,7 +1634,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1263,
+        "line_number": 1264,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1618,7 +1642,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1270,
+        "line_number": 1271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1626,7 +1650,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1271,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1634,7 +1658,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1309,
+        "line_number": 1310,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1642,7 +1666,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1320,
+        "line_number": 1321,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1650,7 +1674,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1322,
+        "line_number": 1323,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1658,7 +1682,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1354,
+        "line_number": 1355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1666,7 +1690,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1357,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1770,7 +1794,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2145,16 +2169,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/development/release-management.md": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 902,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2184,7 +2198,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 319,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2192,7 +2206,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 358,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2260,7 +2274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 584,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2343,12 +2357,38 @@
         "verified_result": null
       }
     ],
+    "docs/docs/manage/configurable-auth-header.md": [
+      {
+        "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 164,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 255,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/docs/manage/configuration.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2356,7 +2396,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 476,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2364,7 +2404,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2372,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1218,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2380,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1263,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3062,7 +3102,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 205,
+        "line_number": 204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3070,7 +3110,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3078,7 +3118,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3086,7 +3126,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3094,7 +3134,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 414,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3102,7 +3142,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 454,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3110,7 +3150,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 633,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3118,7 +3158,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 844,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3146,7 +3186,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 149,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -3747,6 +3787,24 @@
         "verified_result": null
       }
     ],
+    "docs/docs/using/servers/external/notion-mcp-setup.md": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "09a28376ef8de09a0614fa3a62c47beeb525551d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "docs/docs/using/servers/python/csv-pandas-chat-server.md": [
       {
         "hashed_secret": "1d3b1295c282649864a65fe3bd1631bcf7499ef5",
@@ -3813,6 +3871,108 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/security/password-policy-pentesting-response.md": [
+      {
+        "hashed_secret": "367ad0449ccb6236d757759bfa2b2e1b17fbe197",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5e79cffd9cec958879476a76bbdb55e13f1ffb56",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 175,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "66bf29d0724bceb3e121126ffda523374a9b209a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae4b759ed39e6c14f09775a5a2d442178ac57f7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/security/uaid-cross-gateway-auth.md": [
+      {
+        "hashed_secret": "6567ef5b01d3ef05dbabf70de37d042c658e2008",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "29c32f233d04598b3181c0e27ea0ec7a5c949297",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 122,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "51a13bb774ef66e75e0c638fe91ea5bb8341acd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 223,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 226,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 228,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/testing/manual-test-uaid-cross-gateway-auth.md": [
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "366307712bf20a9c0759b6d68f68ae14e0e95cb7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4097,82 +4257,6 @@
         "verified_result": null
       }
     ],
-    "mcp-servers/python/mcp_eval_server/test_all_providers.py": [
-      {
-        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "58e0b5360036b03c093c01fe6e95242a83b12ff7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 54,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 57,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3658a95db0b214e73694335448df084f979c526f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcp-servers/python/mcp_eval_server/validate_models.py": [
-      {
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 204,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 207,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "mcp-servers/python/output_schema_test_server/CURL_TESTING.md": [
       {
         "hashed_secret": "df82ebbbe5479d4e322f4c35f4740804751a53fa",
@@ -4180,40 +4264,6 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/admin.py": [
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4825,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4827,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15206,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4227,688 +4277,22 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/alembic/versions/04cda6733305_add_admin_types_to_email_users.py": [
-      {
-        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/0f81d4a5efe0_new_table_email_team_member_history_for_.py": [
-      {
-        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/14ac971cee42_add_user_context_to_oauth_tokens.py": [
-      {
-        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py": [
-      {
-        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/1fc1795f6983_merge_a2a_and_custom_name_changes.py": [
-      {
-        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/34492f99a0c4_add_comprehensive_metadata_to_all_.py": [
-      {
-        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py": [
-      {
-        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/3b17fdc40a8d_add_passthrough_headers_to_gateways_and_.py": [
-      {
-        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/3c89a45f32e5_add_grpc_services_table.py": [
-      {
-        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/43c07ed25a24_add_oauth_fields_to_servers.py": [
-      {
-        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/4e6273136e56_normalize_registered_oauth_client_issuer.py": [
-      {
-        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/5f3c681b05e1_add_index_for_team_name.py": [
-      {
-        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/61ee11c482d6_add_code_verifier_to_oauth_states_for_.py": [
-      {
-        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/64acf94cb7f2_cleanup_inactive_duplicate_user_roles.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/733159a4fa74_add_display_name_to_tools.py": [
-      {
-        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/77243f5bfce5_add_tool_id_to_a2a_agents.py": [
-      {
-        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/8a16a77260f0_adding_original_description_column_to_.py": [
-      {
-        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/8a2934be50c0_rest_pass_api_fld_tools.py": [
-      {
-        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py": [
-      {
-        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9f5d93ced2b3_add_llm_permissions_to_default_roles.py": [
-      {
-        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a23a08d61eb0_add_observability_tables.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a3c38b6c2437_fix_a2a_agents_auth_value.py": [
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a4f1c7d8e9b0_add_app_user_email_to_oauth_states.py": [
-      {
-        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a8f3b2c1d4e5_add_gateway_refresh_fields.py": [
-      {
-        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/aac21d6f9522_merge_ca_cert_and_observability_heads.py": [
-      {
-        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/abf8ac3b6008_add_admin_overview_and_servers_use_to_.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/add_oauth_tokens_table.py": [
-      {
-        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/b2d9c6e4f1a7_add_explicit_team_and_token_permissions.py": [
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/b9e496e91e71_merge_gateway_refresh_and_sso_provider_.py": [
-      {
-        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
-      {
-        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 39,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/c96c11c111b4_create_index_on_user_name.py": [
-      {
-        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/cbedf4e580e0_add_tools_execute_to_viewer_role.py": [
-      {
-        "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 27,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/cfc3d6aa0fb2_consolidated_multiuser_team_rbac_.py": [
-      {
-        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/d9e0f1a2b3c4_change_token_uniqueness_to_per_team.py": [
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py": [
-      {
-        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e1f2a3b4c5d6_add_grant_source_to_user_roles.py": [
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e5a59c16e041_unique_const_changes_for_prompt_and_.py": [
-      {
-        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/eb17fd368f9d_merge_passthrough_headers_and_tags_.py": [
-      {
-        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/ee288b094280_add_auth_query_params_to_gateways.py": [
-      {
-        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f1a2b3c4d5e6_add_auth_query_params_to_a2a_agents.py": [
-      {
-        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f3a3a3d901b8_remove_gateway_url_unique_constraint.py": [
-      {
-        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f8c9d3e2a1b4_add_oauth_config_to_gateways.py": [
-      {
-        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/g1a2b3c4d5e6_add_pagination_indexes.py": [
-      {
-        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py": [
-      {
-        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/i3c4d5e6f7g8_add_observability_performance_indexes.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/k5e6f7g8h9i0_add_structured_logging_tables.py": [
-      {
-        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/u5f6g7h8i9j0_add_provider_metadata_to_sso_providers.py": [
-      {
-        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/v1a2b3c4d5e6_assign_default_viewer_role_to_existing_users.py": [
-      {
-        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 39,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py": [
-      {
-        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/cache/session_registry.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 152,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 753,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 221,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2420,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 80,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/llm_provider_configs.py": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 316,
-        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],
     "mcpgateway/middleware/request_logging_middleware.py": [
       {
-        "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 176,
+        "line_number": 177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4916,7 +4300,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4924,73 +4308,7 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/hooks/policies.py": [
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/plugins/framework/validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/routers/auth.py": [
-      {
-        "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 151,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/routers/email_auth.py": [
-      {
-        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 401,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 402,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 684,
+        "line_number": 270,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5000,7 +4318,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5010,211 +4328,61 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4220,
+        "line_number": 4317,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5352,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5701,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5758,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5796,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5797,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/scripts/validate_env.py": [
-      {
-        "hashed_secret": "b0fb9e3dbf6beca57a1e203dddab80910598ec3d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/argon2_service.py": [
-      {
-        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/email_auth_service.py": [
-      {
-        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 573,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/services/mcp_client_chat_service.py": [
       {
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 526,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "94b778a67d72bc0e8fa5838e7fa48b37739a9e30",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 624,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 719,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1157,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1796,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1809,
+        "line_number": 590,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "mcpgateway/services/oauth_manager.py": [
+    "mcpgateway/templates/admin.html": [
       {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 107,
+        "line_number": 15099,
         "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "819ef87051ee2837fefbb462d846b8d282d3b756",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/observability_service.py": [
-      {
-        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/resource_service.py": [
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 357,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3517,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/sso_service.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 785,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/support_bundle_service.py": [
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 157,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
     "mcpgateway/templates/change-password-required.html": [
       {
+        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 166,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 193,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 223,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 582,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5226,70 +4394,6 @@
         "is_verified": false,
         "line_number": 667,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/toolops_altk_service.py": [
-      {
-        "hashed_secret": "772fabfec4c6f068c046e516ab0b946909697d32",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 283,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/utils/db_util.py": [
-      {
-        "hashed_secret": "e2eea31cf61d791c922b110554ce1f0a6ed046e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 178,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/utils/llm_util.py": [
-      {
-        "hashed_secret": "e6a51c968d41fd1d3437e6b7d9101e527ee1b83f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 67,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9c4006403b5388cd34ccfe3ed1b1d3e53cf35700",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 81,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d01e71e4c47a4022acd25c74bffedd2641a60c70",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 96,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "39fc8e4accd6a3563c4be159e507195ad3d7274c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/tools/builder/common.py": [
-      {
-        "hashed_secret": "2a1027e8abaef8567159c09ddca81604fb1ba8c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 428,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5316,15 +4420,7 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 262,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5332,92 +4428,12 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/create_jwt_token.py": [
-      {
-        "hashed_secret": "2fcd9b91b955db1627d18720cb7395ef2893a497",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/generate_keys.py": [
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 89,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/services_auth.py": [
-      {
-        "hashed_secret": "a2fe5a0cdcbf2e84dbf868a11c5f2ca79f2d7b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/sso_bootstrap.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 43,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b44bf05d644c15c4d84f78771de011e3cce924c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "999a3419d9959d3c39b11dcc67d79c7888b4b765",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bacac952b5cb942687d38a9eda6531d570f88b22",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 85,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cd1ecfcd67c8b85800a483d77e550d36727e8925",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 99,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/utils/url_auth.py": [
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -5440,52 +4456,6 @@
         "is_verified": false,
         "line_number": 138,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 203,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/verify_credentials.py": [
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 681,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/version.py": [
-      {
-        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 851,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 913,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 118,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5579,34 +4549,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 295,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "plugins/examples/custom_auth_example/custom_auth.py": [
-      {
-        "hashed_secret": "79acc7201378a3d075db4c3b716187b65d4369ba",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 260,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "plugins/examples/simple_token_auth/simple_token_auth.py": [
-      {
-        "hashed_secret": "8a9e9e42f8e154a255c1455267654ab4ec13528b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 157,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3d75cbdb604907851e109e4ced7161c178648532",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5750,7 +4692,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 296,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5778,7 +4720,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 448,
+        "line_number": 643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5786,18 +4728,8 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 455,
+        "line_number": 652,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "scripts/demo_a2a_agent_auth.py": [
-      {
-        "hashed_secret": "e415dfafffe0c1859396cee8659521eaeb789ced",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 45,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5831,194 +4763,10 @@
     ],
     "scripts/test_email_auth_api.py": [
       {
-        "hashed_secret": "55ae024ac61278627948dc9375b31bbbbfd7b442",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 304,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 329,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0378e32875a5f7f922d2cce11b0741096d61c5f2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 483,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8b5f2dff4edd3be66dd04ef8f9b6da4f6a4d0463",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 506,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1c5d7338a53cbdce0a6d26c4572e9725eb94ffc0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 519,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "673563640ec0c172e8d6f1316ae097269e3986c4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 527,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0269ac00d06201bd7bcf234fed607b713469d2d0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 551,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 742,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "scripts/test_mcp_client.py": [
-      {
-        "hashed_secret": "1ee61ed8e67eecf5f1e97c4786b6728b478b8fae",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "scripts/test_mcp_token_scoping.py": [
-      {
-        "hashed_secret": "ae28b10c8c7ef67658ef1de7b29ee23556a32eef",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 348,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/conftest.py": [
-      {
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 202,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_admin_apis.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_main_apis.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 766,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_mcp_rbac_transport.py": [
-      {
-        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 851,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_oauth_protected_resource.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_translate_dynamic_env_e2e.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 201,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 290,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 554,
+        "line_number": 341,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6028,37 +4776,7 @@
         "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_dcr_flow_integration.py": [
-      {
-        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 144,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_integration.py": [
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_translate_dynamic_env.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 211,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6096,70 +4814,6 @@
         "is_verified": false,
         "line_number": 80,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile.py": [
-      {
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3783,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6626,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6982,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7006,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_baseline.py": [
-      {
-        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_echo_delay.py": [
-      {
-        "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 103,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_mcp_isolation.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -6339,16 +4993,6 @@
         "verified_result": null
       }
     ],
-    "tests/migration/conftest.py": [
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 273,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "tests/migration/docker-compose.test.yml": [
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
@@ -6364,16 +5008,6 @@
         "is_verified": false,
         "line_number": 34,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/migration/utils/container_manager.py": [
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 384,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -6423,37 +5057,9 @@
         "verified_result": null
       }
     ],
-    "tests/performance/test_postgresql_percentile_performance.py": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 59,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/performance/utils/generate_docker_compose.py": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 70,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "tests/playwright/README.md": [
       {
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 138,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
         "line_number": 142,
@@ -6461,46 +5067,18 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
         "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
-      }
-    ],
-    "tests/playwright/conftest.py": [
-      {
-        "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 520,
-        "type": "Secret Keyword",
-        "verified_result": null
       },
       {
-        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 629,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/operations/test_llm_config.py": [
-      {
-        "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
+        "line_number": 150,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6515,3279 +5093,73 @@
         "verified_result": null
       }
     ],
-    "tests/playwright/security/conftest.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/security/owasp/conftest.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/security/owasp/test_a01_broken_access_control.py": [
-      {
-        "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/security/test_playwright_security_e2e_top30.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 35,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 585,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/security/test_sso_management.py": [
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/playwright/security/test_team_selector_e2e.py": [
       {
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/teams/conftest.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/test_admin_menu_visibility.py": [
-      {
-        "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 45,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/test_agents.py": [
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 263,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/test_rbac_permissions.py": [
-      {
-        "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 46,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/cleanup.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 42,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/populators/users.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/verify.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 120,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/security/test_input_validation.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 288,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "120340c3d011e9621b9bb88b5884221b25251b88",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2065,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_a2a_agents_auth_value_migration.py": [
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 27,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_observability_migrations.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 126,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_rbac_permission_backfill_migration.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 27,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_token_uniqueness_migration.py": [
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_auth_method_propagation.py": [
-      {
-        "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 52,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_http_auth_headers.py": [
-      {
-        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 83,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "35e6ca489e73a8991165cdcfc2b79eb0d25ed0a3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 105,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "59df6723fb54fd8dde6dcf51034e51491bfbff24",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 947,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 955,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_http_auth_integration.py": [
-      {
-        "hashed_secret": "6f865e7e20c773e3483eaa74a07d03cec02bde2e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 159,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 180,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 250,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 262,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 450,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 472,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 512,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 674,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_rbac.py": [
-      {
-        "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1387,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1474,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_request_logging_middleware.py": [
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 116,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 213,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
-      {
-        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 225,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 104,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 230,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
-      {
-        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 247,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 248,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 265,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 311,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
-      {
-        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 233,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 238,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
-      {
-        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 121,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 616,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 801,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 815,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 85,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation.py": [
-      {
-        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 247,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation_integration.py": [
-      {
-        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 301,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 381,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py": [
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 417,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "83ff9f4e0d16d61727cbdf47d769fb707b652217",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 462,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py": [
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 143,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/virus_total_checker/test_virus_total_checker.py": [
-      {
-        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 436,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_integration.py": [
-      {
-        "hashed_secret": "a8ae1520ce69381a9cf8dbd5082d8512fcace493",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 216,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_notification.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_auth.py": [
-      {
-        "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 192,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 272,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_email_auth_router.py": [
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 165,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 523,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 658,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1422,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1491,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1595,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1626,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1643,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1677,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2136,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_llm_admin_router.py": [
-      {
-        "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 532,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 538,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_llmchat_router.py": [
-      {
-        "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 126,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_oauth_router.py": [
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 275,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_reverse_proxy.py": [
-      {
-        "hashed_secret": "c56486f8b638f63e04251d0c8ab0b4fbfee8e06b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 796,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_teams.py": [
-      {
-        "hashed_secret": "1e418031f4ec8505cff3cde4f41efc0ee83ec2d1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 254,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_a2a_query_param_auth.py": [
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 278,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 343,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 344,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 431,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 562,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_a2a_service.py": [
-      {
-        "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 77,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 195,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 196,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 391,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 392,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 428,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 455,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 807,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 809,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2423,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2432,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3292,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3453,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3485,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_argon2_service.py": [
-      {
-        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 152,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4be80aee9bf2223071eedfc002ba2546abd1f5ea",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 230,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 388,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 487,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 538,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_async_crypto_wrappers.py": [
-      {
-        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 74,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4bb297c014026ace455b1ad5926033d795bf016",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_catalog_service.py": [
-      {
-        "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 563,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_correlation_id_json_formatter.py": [
-      {
-        "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 129,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 130,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_dcr_service.py": [
-      {
-        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 404,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 650,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 785,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_basic.py": [
-      {
-        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
-        "is_secret": false,
-        "is_verified": false,
         "line_number": 283,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 701,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "454f9bfcc5f7523c755896f9d2c7281f83aec668",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 727,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 754,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 959,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 991,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1066,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1280,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1504,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1516,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1579,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1601,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1643,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1660,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2176,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2261,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_service.py": [
-      {
-        "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 389,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
-      {
-        "hashed_secret": "759521118cabf4f8bbc46e6d6344d0e700aa4be5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 321,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6fa5edecdc44e7209e0678c5dea72a95d63bf554",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 365,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_notification_service.py": [
-      {
-        "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 154,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_encryption_service.py": [
-      {
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 376,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 378,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 416,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 417,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 418,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 718,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 719,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 781,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 782,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 803,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_export_service.py": [
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1162,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6578fca8b62f49457e4cd7e66554a310a1a64be8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1753,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_query_param_auth.py": [
-      {
-        "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 205,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 229,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service.py": [
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 636,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 637,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1522,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5096,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5101,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6642,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7239,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7258,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7464,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7483,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_extended.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 183,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py": [
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 502,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py": [
-      {
-        "hashed_secret": "ee131046fbfad0f5fac08926f9b928539da950cd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 102,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 615,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 637,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_import_service.py": [
-      {
-        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 517,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1449,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1602,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1613,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2504,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2521,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2670,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_llm_provider_service.py": [
-      {
-        "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 269,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 540,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 551,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 769,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 775,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_llm_proxy_service.py": [
-      {
-        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 434,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 447,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 460,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_mcp_client_chat_service.py": [
-      {
-        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 69,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 125,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 148,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 167,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
-        "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 256,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 337,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 807,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1155,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1191,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1289,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1554,
+        "line_number": 1412,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_metrics.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
-      {
-        "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 421,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 440,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 689,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 765,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 768,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager_pkce.py": [
-      {
-        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 62,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 366,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 489,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_observability_service.py": [
-      {
-        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 405,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 406,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_resource_service.py": [
       {
-        "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4117,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4830,
+        "line_number": 883,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_server_service.py": [
-      {
-        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1406,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1495,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1635,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1636,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "498e738c70c40fb156a240d26f866f2d50e9cb51",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1848,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a6bf0a0e01efe836c52ef316f030bf50ac2f716c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1866,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_sso_service.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 176,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 197,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 334,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_support_bundle_service.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 82,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 196,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_token_storage_service.py": [
-      {
-        "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 331,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 539,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_tool_service.py": [
-      {
-        "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 549,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 550,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 566,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1985,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3571,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4204,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7560,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8052,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9399,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9541,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 10023,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_tool_service_coverage.py": [
-      {
-        "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2980,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3666,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3675,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4125,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7052,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7070,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7094,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7158,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7169,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7216,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8410,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1602,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1774,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2774,
+        "line_number": 10670,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5171,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5824,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5888,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6140,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9123,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9172,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9211,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9268,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14343,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17100,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17119,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_admin_catalog_htmx.py": [
-      {
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 239,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_admin_module.py": [
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 453,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1106,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_auth.py": [
       {
-        "hashed_secret": "b5920aa41ccde1341077fdb2636afc16d6da0e1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "467be688b21f5d43370f5dc983fe5ed58dea4b00",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 216,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d955debea8e960a293ecbb257048680898cc9d94",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 231,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ee9e7b8482f6e0282b0117eb81651c98b537589",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 265,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "500886a66d19ebfe2d5c0ee86cf4612f9458ee4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2169f1a808382eb7b521206debaef01c91f1b60",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 377,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cd61d9f689e9992aec40aeec7210b45a681309f9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 411,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae97d9e9201a9bc1806069d80e5809ab745a91e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 446,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "eb2344b0e2d6529ced74f8b09be362a460defa15",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 483,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "89be7e8e88bc7b0cdb5ddaa01dab1cd1728541e2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 547,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5a539b200edec3aaa5167e1cde5d8fd0e8cf4aee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 560,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8be6db326ca95f74590bd09c9c328fc9a3db3b6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 698,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2368055dc74fca43f2f9c849dbbaaa04616670cf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 747,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8ce647089e0614d3b924f4a0b8fb78268562ec7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1436,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc6f6cc49f767ae38db110a9e6c1adf5c651ecbf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1480,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7939ea1cdfc6d73115b0d736fa04012be2b25b18",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1571,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "91014bcbf183cf77807b4bd24f2e8652f67b56a0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2079,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61ac75f7e6677b79c219ce819d954e05f61b5d2c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2097,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8223fafd35f399e55c3cf611c3d6ebbf43d68d71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2743,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dfd99b5f25f839608a3c275c0f8ceb363f8f0bc0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3538,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3647,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f5cd573c18bf811f82a886ceb6866b05d5ef02cd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3725,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "79bead8e6d65862a00cffaa12ccde1189ec34d29",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4108,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_cli_export_import_coverage.py": [
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 685,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_config.py": [
-      {
-        "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 192,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 499,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 512,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 518,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 587,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 647,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1017,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1269,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2421,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_db_isready.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 224,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_display_name_uuid_features.py": [
-      {
-        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 620,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 621,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_final_coverage_push.py": [
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 200,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_llm_schemas.py": [
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 67,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_main.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 128,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 141,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_main_error_handlers.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
+        "line_number": 2716,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_main_extended.py": [
       {
-        "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2523,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2811,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_multi_auth_headers.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 298,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_oauth_manager.py": [
       {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 70,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1313,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1505,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1973,
+        "line_number": 1484,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_observability.py": [
-      {
-        "hashed_secret": "8f1b63868b5d31deb06a0ff740b192aa490e8950",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 327,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1fb844731bf1e5928ae606915b54e21264da4768",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 756,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 167,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas.py": [
-      {
-        "hashed_secret": "22fcf027f5caee316ca4f2963c475f62e87e9b76",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 829,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1081,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas_auth_validation.py": [
-      {
-        "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 333,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 352,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 371,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 382,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas_validators_extra.py": [
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 775,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 956,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 961,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 987,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1005,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1218,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1334,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_team_governance_flags.py": [
-      {
-        "hashed_secret": "8ac21c6ecda35ffb18d58264aeb43ca800b3d758",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 580,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_toolops_utils.py": [
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 135,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_translate_stdio_endpoint.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 277,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_version.py": [
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/tools/builder/test_common.py": [
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 673,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 961,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/tools/builder/test_schema.py": [
-      {
-        "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 201,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/transports/test_streamablehttp_transport.py": [
-      {
-        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 13105,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14280,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_create_jwt_token.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 42,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_db_isready.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_generate_keys.py": [
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_proxy_auth.py": [
-      {
-        "hashed_secret": "b2d898cda25886738c0cd002eb080745b09e2332",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_sso_bootstrap.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 370,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 454,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_trace_redaction.py": [
-      {
-        "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_url_auth.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 57,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 65,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 80,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 155,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 215,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_verify_credentials.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 53,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "29534257453ead25854695b1b7c95e3857a7238d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1042,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1191,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/validation/test_validators_advanced.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1142,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/plugins/test_encoded_exfil_detector.py": [
-      {
-        "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 136,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 504,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 548,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 561,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 930,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1179,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/plugins/test_jwt_claims_extraction.py": [
-      {
-        "hashed_secret": "dccfe30496fb85f5bb560ea18b582b9aa50372bb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/test_conc_01_helpers.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 160,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-28T13:31:00Z",
+  "generated_at": "2026-04-29T14:22:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,34 +89,10 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 73,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 571,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +100,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 876,
+        "line_number": 766,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +108,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1163,
+        "line_number": 1039,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +116,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1189,
+        "line_number": 1065,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +124,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1197,
+        "line_number": 1073,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +132,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1152,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +140,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1281,
+        "line_number": 1157,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +148,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1286,
+        "line_number": 1162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +156,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +164,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1304,
+        "line_number": 1180,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +172,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1322,
+        "line_number": 1198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +180,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1383,
+        "line_number": 1259,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -232,7 +208,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +216,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 188,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +224,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -256,7 +232,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 262,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -264,7 +240,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 263,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -274,7 +250,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1336,
+        "line_number": 859,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +258,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +266,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1297,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +274,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3140,
+        "line_number": 2663,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3231,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +290,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3274,
+        "line_number": 2797,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +298,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3279,
+        "line_number": 2802,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +306,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3284,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -350,7 +326,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 491,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +334,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 960,
+        "line_number": 951,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +342,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1614,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1833,
+        "line_number": 1857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6358,
+        "line_number": 6263,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6855,
+        "line_number": 6760,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6867,
+        "line_number": 6772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6939,
+        "line_number": 6844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8020,
+        "line_number": 7923,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -634,7 +610,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 813,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +618,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 984,
+        "line_number": 968,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +626,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1071,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +634,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1090,
+        "line_number": 1074,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +642,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1256,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +650,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +658,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1344,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +666,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +674,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1810,
+        "line_number": 1794,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -994,47 +970,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 364,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 412,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 420,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 468,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1004,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1107,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +978,47 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 359,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 401,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 457,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 972,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1026,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1136,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1034,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1257,
+        "line_number": 1171,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1066,7 +1042,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1796,
+        "line_number": 1710,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1050,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1873,
+        "line_number": 1787,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1058,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2189,
+        "line_number": 2102,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1066,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2559,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1074,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2559,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1082,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2659,
+        "line_number": 2572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1090,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2720,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1098,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2828,
+        "line_number": 2741,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1106,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2836,
+        "line_number": 2749,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1114,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2841,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1300,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1308,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1447,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1378,7 +1354,7 @@
         "hashed_secret": "e62854369199d65b6a66cd90fe8203ac4d5be26c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1362,7 @@
         "hashed_secret": "35722442567571107241e7e6ca2b554515e485da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1370,7 @@
         "hashed_secret": "0608c4054662dd902e1314f7e450e3eaa81c1143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 340,
+        "line_number": 339,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1378,7 @@
         "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 347,
+        "line_number": 346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1386,7 @@
         "hashed_secret": "564289a5f34546401bbc727c20a14069761f9143",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 420,
+        "line_number": 419,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1394,7 @@
         "hashed_secret": "37745ed7a0f005fb14522c5cc7c1ba3d9e0df579",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 424,
+        "line_number": 423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1402,7 @@
         "hashed_secret": "0c8207b92779c0a42507a293a23106814cc381e1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 426,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1410,7 @@
         "hashed_secret": "ce5070ef8a0cf3e595ae4cf3f73f6a0eca87e346",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 429,
+        "line_number": 428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1418,7 @@
         "hashed_secret": "46a808cfd5beafa5e60aefee867bf92025dc2849",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 433,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1426,7 @@
         "hashed_secret": "e4ae36d7ffd9dd805a909ac5a20de165a2629ba4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 435,
+        "line_number": 434,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1434,7 @@
         "hashed_secret": "9f08d40159a4b035fc7998b398bd16b38f91e806",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 440,
+        "line_number": 439,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1442,7 @@
         "hashed_secret": "61a135089eac561a2ff7cedeefb03975bed000f8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 633,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1450,7 @@
         "hashed_secret": "5bdcd3c0d4d24ae3e71b3b452a024c6324c7e4bb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 645,
+        "line_number": 644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1458,7 @@
         "hashed_secret": "a4b3ee46e1384e5b0be8cfdb2169977d8a160136",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 649,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1466,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 745,
+        "line_number": 744,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1474,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 746,
+        "line_number": 745,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1482,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 754,
+        "line_number": 753,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1490,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 783,
+        "line_number": 782,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1498,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1036,
+        "line_number": 1035,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1506,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1037,
+        "line_number": 1036,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1514,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1038,
+        "line_number": 1037,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1522,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1055,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1530,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1154,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1538,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 1189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1546,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 1190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1554,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1204,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1586,7 +1562,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1212,
+        "line_number": 1211,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1594,7 +1570,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1221,
+        "line_number": 1220,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1602,7 +1578,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1226,
+        "line_number": 1225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1610,7 +1586,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 1237,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1618,7 +1594,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 1258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1626,7 +1602,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1261,
+        "line_number": 1260,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1634,7 +1610,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1264,
+        "line_number": 1263,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1642,7 +1618,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1271,
+        "line_number": 1270,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1650,7 +1626,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1658,7 +1634,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1310,
+        "line_number": 1309,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1666,7 +1642,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1321,
+        "line_number": 1320,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1674,7 +1650,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1322,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1682,7 +1658,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1355,
+        "line_number": 1354,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1690,7 +1666,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1358,
+        "line_number": 1357,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1794,7 +1770,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2169,6 +2145,16 @@
         "verified_result": null
       }
     ],
+    "docs/docs/development/release-management.md": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 902,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
     "docs/docs/faq/index.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
@@ -2198,7 +2184,7 @@
         "hashed_secret": "1e10e8864bfeec80212f07846cfa7def1b4aa38b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 317,
+        "line_number": 319,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2206,7 +2192,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 358,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2274,7 +2260,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 584,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2357,38 +2343,12 @@
         "verified_result": null
       }
     ],
-    "docs/docs/manage/configurable-auth-header.md": [
-      {
-        "hashed_secret": "fa143b10b3a03fb6ac32676aa4813c0d30845c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 164,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a1d24cfbcfcc637211c88366b5260120a523d8b5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 215,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 255,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "docs/docs/manage/configuration.md": [
       {
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 195,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2396,7 +2356,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 476,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2404,7 +2364,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 793,
+        "line_number": 842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2412,7 +2372,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1259,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2380,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1263,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3102,7 +3062,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 204,
+        "line_number": 205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3110,7 +3070,7 @@
         "hashed_secret": "d8aae2c7a30fa154c7bf3e7c32ca32212f9320d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3118,7 +3078,7 @@
         "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 337,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3126,7 +3086,7 @@
         "hashed_secret": "e3881428d6c5f285fdd894d8e2892629651a78dd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3134,7 +3094,7 @@
         "hashed_secret": "0fecd742545413abec6ab7e27c3aeecf00c534a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3142,7 +3102,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 453,
+        "line_number": 454,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3150,7 +3110,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -3158,7 +3118,7 @@
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3186,7 +3146,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 152,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -3787,24 +3747,6 @@
         "verified_result": null
       }
     ],
-    "docs/docs/using/servers/external/notion-mcp-setup.md": [
-      {
-        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "09a28376ef8de09a0614fa3a62c47beeb525551d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "docs/docs/using/servers/python/csv-pandas-chat-server.md": [
       {
         "hashed_secret": "1d3b1295c282649864a65fe3bd1631bcf7499ef5",
@@ -3871,108 +3813,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 102,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/security/password-policy-pentesting-response.md": [
-      {
-        "hashed_secret": "367ad0449ccb6236d757759bfa2b2e1b17fbe197",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5e79cffd9cec958879476a76bbdb55e13f1ffb56",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 175,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "66bf29d0724bceb3e121126ffda523374a9b209a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 184,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae4b759ed39e6c14f09775a5a2d442178ac57f7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/security/uaid-cross-gateway-auth.md": [
-      {
-        "hashed_secret": "6567ef5b01d3ef05dbabf70de37d042c658e2008",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "29c32f233d04598b3181c0e27ea0ec7a5c949297",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 122,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "51a13bb774ef66e75e0c638fe91ea5bb8341acd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 171,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e689846dfc65621eeab3a906bb8b0ddd52f5c514",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 223,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 226,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 228,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/testing/manual-test-uaid-cross-gateway-auth.md": [
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 117,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "366307712bf20a9c0759b6d68f68ae14e0e95cb7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 260,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4257,6 +4097,82 @@
         "verified_result": null
       }
     ],
+    "mcp-servers/python/mcp_eval_server/test_all_providers.py": [
+      {
+        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "58e0b5360036b03c093c01fe6e95242a83b12ff7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3658a95db0b214e73694335448df084f979c526f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcp-servers/python/mcp_eval_server/validate_models.py": [
+      {
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 204,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "mcp-servers/python/output_schema_test_server/CURL_TESTING.md": [
       {
         "hashed_secret": "df82ebbbe5479d4e322f4c35f4740804751a53fa",
@@ -4264,6 +4180,40 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/admin.py": [
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4825,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4827,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15206,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4277,22 +4227,688 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/alembic/versions/04cda6733305_add_admin_types_to_email_users.py": [
+      {
+        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/0f81d4a5efe0_new_table_email_team_member_history_for_.py": [
+      {
+        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/14ac971cee42_add_user_context_to_oauth_tokens.py": [
+      {
+        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py": [
+      {
+        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/1fc1795f6983_merge_a2a_and_custom_name_changes.py": [
+      {
+        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/34492f99a0c4_add_comprehensive_metadata_to_all_.py": [
+      {
+        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py": [
+      {
+        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/3b17fdc40a8d_add_passthrough_headers_to_gateways_and_.py": [
+      {
+        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/3c89a45f32e5_add_grpc_services_table.py": [
+      {
+        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/43c07ed25a24_add_oauth_fields_to_servers.py": [
+      {
+        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/4e6273136e56_normalize_registered_oauth_client_issuer.py": [
+      {
+        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/5f3c681b05e1_add_index_for_team_name.py": [
+      {
+        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/61ee11c482d6_add_code_verifier_to_oauth_states_for_.py": [
+      {
+        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/64acf94cb7f2_cleanup_inactive_duplicate_user_roles.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/733159a4fa74_add_display_name_to_tools.py": [
+      {
+        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/77243f5bfce5_add_tool_id_to_a2a_agents.py": [
+      {
+        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/8a16a77260f0_adding_original_description_column_to_.py": [
+      {
+        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/8a2934be50c0_rest_pass_api_fld_tools.py": [
+      {
+        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py": [
+      {
+        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/9f5d93ced2b3_add_llm_permissions_to_default_roles.py": [
+      {
+        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a23a08d61eb0_add_observability_tables.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a3c38b6c2437_fix_a2a_agents_auth_value.py": [
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a4f1c7d8e9b0_add_app_user_email_to_oauth_states.py": [
+      {
+        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a8f3b2c1d4e5_add_gateway_refresh_fields.py": [
+      {
+        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/aac21d6f9522_merge_ca_cert_and_observability_heads.py": [
+      {
+        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/abf8ac3b6008_add_admin_overview_and_servers_use_to_.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/add_oauth_tokens_table.py": [
+      {
+        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/b2d9c6e4f1a7_add_explicit_team_and_token_permissions.py": [
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/b9e496e91e71_merge_gateway_refresh_and_sso_provider_.py": [
+      {
+        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/ba202ac1665f_migrate_user_roles_to_configurable_.py": [
+      {
+        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/c96c11c111b4_create_index_on_user_name.py": [
+      {
+        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/cbedf4e580e0_add_tools_execute_to_viewer_role.py": [
+      {
+        "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/cfc3d6aa0fb2_consolidated_multiuser_team_rbac_.py": [
+      {
+        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/d9e0f1a2b3c4_change_token_uniqueness_to_per_team.py": [
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py": [
+      {
+        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e1f2a3b4c5d6_add_grant_source_to_user_roles.py": [
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e5a59c16e041_unique_const_changes_for_prompt_and_.py": [
+      {
+        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/eb17fd368f9d_merge_passthrough_headers_and_tags_.py": [
+      {
+        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/ee288b094280_add_auth_query_params_to_gateways.py": [
+      {
+        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f1a2b3c4d5e6_add_auth_query_params_to_a2a_agents.py": [
+      {
+        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f3a3a3d901b8_remove_gateway_url_unique_constraint.py": [
+      {
+        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f8c9d3e2a1b4_add_oauth_config_to_gateways.py": [
+      {
+        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/g1a2b3c4d5e6_add_pagination_indexes.py": [
+      {
+        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py": [
+      {
+        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/i3c4d5e6f7g8_add_observability_performance_indexes.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/k5e6f7g8h9i0_add_structured_logging_tables.py": [
+      {
+        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/u5f6g7h8i9j0_add_provider_metadata_to_sso_providers.py": [
+      {
+        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/v1a2b3c4d5e6_assign_default_viewer_role_to_existing_users.py": [
+      {
+        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py": [
+      {
+        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/cache/session_registry.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 751,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 221,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2420,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/llm_provider_configs.py": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 308,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 316,
+        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],
     "mcpgateway/middleware/request_logging_middleware.py": [
       {
+        "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 177,
+        "line_number": 176,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4300,7 +4916,7 @@
         "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 183,
+        "line_number": 182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4308,7 +4924,73 @@
         "hashed_secret": "d4fe581561f18ee5006254a7e53f53cbed780bc2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 269,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/external/grpc/tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/hooks/policies.py": [
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/plugins/framework/validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/routers/auth.py": [
+      {
+        "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 151,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/routers/email_auth.py": [
+      {
+        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 401,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 402,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 684,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4318,7 +5000,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 658,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4328,61 +5010,211 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4317,
+        "line_number": 4220,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5352,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5701,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5758,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5796,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5797,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/scripts/validate_env.py": [
+      {
+        "hashed_secret": "b0fb9e3dbf6beca57a1e203dddab80910598ec3d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/argon2_service.py": [
+      {
+        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/email_auth_service.py": [
+      {
+        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 573,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/services/mcp_client_chat_service.py": [
       {
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 526,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "94b778a67d72bc0e8fa5838e7fa48b37739a9e30",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 624,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 719,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 590,
+        "line_number": 1796,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1809,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
-    "mcpgateway/templates/admin.html": [
+    "mcpgateway/services/oauth_manager.py": [
       {
-        "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15099,
+        "line_number": 107,
         "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "819ef87051ee2837fefbb462d846b8d282d3b756",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/observability_service.py": [
+      {
+        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/resource_service.py": [
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 357,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3517,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/sso_service.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 785,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/support_bundle_service.py": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
     "mcpgateway/templates/change-password-required.html": [
       {
-        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 166,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 193,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 223,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 582,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4394,6 +5226,70 @@
         "is_verified": false,
         "line_number": 667,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/toolops_altk_service.py": [
+      {
+        "hashed_secret": "772fabfec4c6f068c046e516ab0b946909697d32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/utils/db_util.py": [
+      {
+        "hashed_secret": "e2eea31cf61d791c922b110554ce1f0a6ed046e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 178,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/utils/llm_util.py": [
+      {
+        "hashed_secret": "e6a51c968d41fd1d3437e6b7d9101e527ee1b83f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9c4006403b5388cd34ccfe3ed1b1d3e53cf35700",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d01e71e4c47a4022acd25c74bffedd2641a60c70",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 96,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "39fc8e4accd6a3563c4be159e507195ad3d7274c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/tools/builder/common.py": [
+      {
+        "hashed_secret": "2a1027e8abaef8567159c09ddca81604fb1ba8c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -4420,7 +5316,15 @@
         "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 262,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4428,12 +5332,92 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 317,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/create_jwt_token.py": [
+      {
+        "hashed_secret": "2fcd9b91b955db1627d18720cb7395ef2893a497",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/generate_keys.py": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/services_auth.py": [
+      {
+        "hashed_secret": "a2fe5a0cdcbf2e84dbf868a11c5f2ca79f2d7b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 218,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/sso_bootstrap.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b44bf05d644c15c4d84f78771de011e3cce924c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "999a3419d9959d3c39b11dcc67d79c7888b4b765",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bacac952b5cb942687d38a9eda6531d570f88b22",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cd1ecfcd67c8b85800a483d77e550d36727e8925",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 99,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/utils/url_auth.py": [
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -4456,6 +5440,52 @@
         "is_verified": false,
         "line_number": 138,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/verify_credentials.py": [
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 681,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/version.py": [
+      {
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 851,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 913,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "plugin_templates/external/{{cookiecutter.plugin_slug}}/.env.template": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4549,6 +5579,34 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 295,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "plugins/examples/custom_auth_example/custom_auth.py": [
+      {
+        "hashed_secret": "79acc7201378a3d075db4c3b716187b65d4369ba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 260,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "plugins/examples/simple_token_auth/simple_token_auth.py": [
+      {
+        "hashed_secret": "8a9e9e42f8e154a255c1455267654ab4ec13528b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3d75cbdb604907851e109e4ced7161c178648532",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4692,7 +5750,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 296,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4720,7 +5778,7 @@
         "hashed_secret": "1d193899f802762003a56b1cbcfeb55f2b04d61b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 643,
+        "line_number": 448,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4728,8 +5786,18 @@
         "hashed_secret": "dcdf24a1d4440d5ebe319bf804f96c81e08350f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 652,
+        "line_number": 455,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "scripts/demo_a2a_agent_auth.py": [
+      {
+        "hashed_secret": "e415dfafffe0c1859396cee8659521eaeb789ced",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4763,10 +5831,194 @@
     ],
     "scripts/test_email_auth_api.py": [
       {
+        "hashed_secret": "55ae024ac61278627948dc9375b31bbbbfd7b442",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 304,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 329,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0378e32875a5f7f922d2cce11b0741096d61c5f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 483,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b5f2dff4edd3be66dd04ef8f9b6da4f6a4d0463",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 506,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1c5d7338a53cbdce0a6d26c4572e9725eb94ffc0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 519,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "673563640ec0c172e8d6f1316ae097269e3986c4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 527,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0269ac00d06201bd7bcf234fed607b713469d2d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 341,
+        "line_number": 742,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "scripts/test_mcp_client.py": [
+      {
+        "hashed_secret": "1ee61ed8e67eecf5f1e97c4786b6728b478b8fae",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "scripts/test_mcp_token_scoping.py": [
+      {
+        "hashed_secret": "ae28b10c8c7ef67658ef1de7b29ee23556a32eef",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 348,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/conftest.py": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_admin_apis.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_main_apis.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 766,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_mcp_rbac_transport.py": [
+      {
+        "hashed_secret": "6e2e8a100b17f5c9083b5f8c6f2ed58ae6286e5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 851,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_oauth_protected_resource.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_translate_dynamic_env_e2e.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 201,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4f1a495029e6aec0aeb30aa3ce002dab645f08c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb6c2cbb5141e95639121909fe1b5a7012d1041a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 338,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8590ea4c4485851eeb808692bf07b80640a3619e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 554,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4776,7 +6028,37 @@
         "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 62,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_dcr_flow_integration.py": [
+      {
+        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_integration.py": [
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 218,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_translate_dynamic_env.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4814,6 +6096,70 @@
         "is_verified": false,
         "line_number": 80,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile.py": [
+      {
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3783,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6626,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6982,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7006,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_baseline.py": [
+      {
+        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_echo_delay.py": [
+      {
+        "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 103,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_mcp_isolation.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4993,6 +6339,16 @@
         "verified_result": null
       }
     ],
+    "tests/migration/conftest.py": [
+      {
+        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 273,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "tests/migration/docker-compose.test.yml": [
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
@@ -5008,6 +6364,16 @@
         "is_verified": false,
         "line_number": 34,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/migration/utils/container_manager.py": [
+      {
+        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 384,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5057,12 +6423,32 @@
         "verified_result": null
       }
     ],
+    "tests/performance/test_postgresql_percentile_performance.py": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/performance/utils/generate_docker_compose.py": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "tests/playwright/README.md": [
       {
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 138,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5070,7 +6456,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5078,7 +6464,43 @@
         "hashed_secret": "64438ee426438161da88554b3e2de796b0ca265e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 150,
+        "line_number": 146,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/conftest.py": [
+      {
+        "hashed_secret": "d6d6b8c66ab3ade1bfcf206e7df58e296827ef17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 520,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1c58bd92003bbaa0538e249fff6ee19a270dec5f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 585,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 629,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/operations/test_llm_config.py": [
+      {
+        "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5093,73 +6515,3279 @@
         "verified_result": null
       }
     ],
+    "tests/playwright/security/conftest.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/security/owasp/conftest.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/security/owasp/test_a01_broken_access_control.py": [
+      {
+        "hashed_secret": "8e45fe2388a6c4604ee0ccdba14ca0df092bc904",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 238,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/security/test_playwright_security_e2e_top30.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 585,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/security/test_sso_management.py": [
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/playwright/security/test_team_selector_e2e.py": [
       {
         "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
         "is_secret": false,
         "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/teams/conftest.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/test_admin_menu_visibility.py": [
+      {
+        "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/test_agents.py": [
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 263,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/test_rbac_permissions.py": [
+      {
+        "hashed_secret": "119ffab9fda36e29816a09097c441eb8bcd8b684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/cleanup.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/populators/users.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/verify.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/security/test_input_validation.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 288,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "120340c3d011e9621b9bb88b5884221b25251b88",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2065,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_a2a_agents_auth_value_migration.py": [
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_observability_migrations.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_rbac_permission_backfill_migration.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_token_uniqueness_migration.py": [
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_auth_method_propagation.py": [
+      {
+        "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_http_auth_headers.py": [
+      {
+        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "35e6ca489e73a8991165cdcfc2b79eb0d25ed0a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "59df6723fb54fd8dde6dcf51034e51491bfbff24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 947,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 955,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_http_auth_integration.py": [
+      {
+        "hashed_secret": "6f865e7e20c773e3483eaa74a07d03cec02bde2e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 250,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 262,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 450,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 472,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 512,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 674,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_rbac.py": [
+      {
+        "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1387,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1474,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_request_logging_middleware.py": [
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_grpc_models.py": [
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/grpc/test_tls_utils.py": [
+      {
+        "hashed_secret": "623e76c36aa2a886542011e28412cc761d7ceb01",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 225,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/external/mcp/test_tls_utils.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/hooks/test_http.py": [
+      {
+        "hashed_secret": "5dc0dc43e8ac987476af951a9e5bed1b19b24028",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 247,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7e7f74d2579ebec3b3f2c125e756269a29782497",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 248,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b20dc22a6cb086e0d990ccc74ec819b16dc68b8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 311,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f9ac14b63a75faf57d8db6f919bfabb2502d273c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_plugin_models_coverage.py": [
+      {
+        "hashed_secret": "48a7b8889e1542650266c14a18c8708488fa1951",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 233,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "81f344a7686a80b4c5293e8fdc0b0160c82c06a8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 238,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_policies.py": [
+      {
+        "hashed_secret": "37c6c57bedf4305ef41249c1794760b5cb8fad17",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d73ef92426f2b11dfc4aed4d4bfc41c49ee1087c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 616,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e812ba8d00b270ef3502bb53ceb31e8c5188f14e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 801,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bf31c52c32b0fcda1dc3e7c0c91803a7d1c9e891",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 815,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/framework/test_validators.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation.py": [
+      {
+        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 247,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation_integration.py": [
+      {
+        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 301,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 381,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py": [
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "83ff9f4e0d16d61727cbdf47d769fb707b652217",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 462,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py": [
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 143,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/virus_total_checker/test_virus_total_checker.py": [
+      {
+        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 436,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_integration.py": [
+      {
+        "hashed_secret": "a8ae1520ce69381a9cf8dbd5082d8512fcace493",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_notification.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_auth.py": [
+      {
+        "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 272,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_email_auth_router.py": [
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 165,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 523,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 658,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1422,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1491,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1595,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1626,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1643,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1677,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2136,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_llm_admin_router.py": [
+      {
+        "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 532,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_llmchat_router.py": [
+      {
+        "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_oauth_router.py": [
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 275,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_reverse_proxy.py": [
+      {
+        "hashed_secret": "c56486f8b638f63e04251d0c8ab0b4fbfee8e06b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 796,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_teams.py": [
+      {
+        "hashed_secret": "1e418031f4ec8505cff3cde4f41efc0ee83ec2d1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 254,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_a2a_query_param_auth.py": [
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 278,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 343,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 344,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 431,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 562,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_a2a_service.py": [
+      {
+        "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 77,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 195,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 196,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 391,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 392,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 455,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 807,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 809,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2423,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2432,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3292,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3453,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3485,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_argon2_service.py": [
+      {
+        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4be80aee9bf2223071eedfc002ba2546abd1f5ea",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 487,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_async_crypto_wrappers.py": [
+      {
+        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4bb297c014026ace455b1ad5926033d795bf016",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_catalog_service.py": [
+      {
+        "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 563,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_correlation_id_json_formatter.py": [
+      {
+        "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 129,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 130,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_dcr_service.py": [
+      {
+        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 404,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 650,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 785,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_basic.py": [
+      {
+        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
+        "is_secret": false,
+        "is_verified": false,
         "line_number": 283,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1816851d10187b57a93235b52495e615629f906d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 701,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "454f9bfcc5f7523c755896f9d2c7281f83aec668",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 727,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aafdc23870ecbcd3d557b6423a8982134e17927e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 754,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 959,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 991,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1066,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1280,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1504,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1516,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1579,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1601,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1643,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1660,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2176,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2261,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_service.py": [
+      {
+        "hashed_secret": "862511dc4b5b31885dd85a83c2af1a4adc685f19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 389,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
+      {
+        "hashed_secret": "759521118cabf4f8bbc46e6d6344d0e700aa4be5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6c55803d6f1d7a177a0db3eb4b343b0d50f9c111",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 321,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6fa5edecdc44e7209e0678c5dea72a95d63bf554",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 365,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_notification_service.py": [
+      {
+        "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_encryption_service.py": [
+      {
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 376,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 378,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 416,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 418,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 718,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 719,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 781,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 782,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 803,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_export_service.py": [
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1162,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6578fca8b62f49457e4cd7e66554a310a1a64be8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1753,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_query_param_auth.py": [
+      {
+        "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 205,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 229,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service.py": [
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 636,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 637,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1522,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5096,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5101,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6642,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7239,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7258,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7464,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7483,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_extended.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 183,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py": [
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 502,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py": [
+      {
+        "hashed_secret": "ee131046fbfad0f5fac08926f9b928539da950cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 615,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 637,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_import_service.py": [
+      {
+        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 308,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 517,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1449,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1602,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1613,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2504,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2521,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2670,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_llm_provider_service.py": [
+      {
+        "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 269,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 540,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 769,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 775,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_llm_proxy_service.py": [
+      {
+        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 434,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 447,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 460,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_mcp_client_chat_service.py": [
+      {
+        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 69,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 148,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 187,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
+        "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 256,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 337,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 807,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1155,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1191,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1289,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1412,
+        "line_number": 1554,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_metrics.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 164,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
+      {
+        "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 421,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 440,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 689,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 765,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 768,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager_pkce.py": [
+      {
+        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 366,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 489,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_observability_service.py": [
+      {
+        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 405,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 406,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_resource_service.py": [
       {
+        "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 883,
+        "line_number": 4830,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_server_service.py": [
+      {
+        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1406,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1495,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1635,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1636,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "498e738c70c40fb156a240d26f866f2d50e9cb51",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1848,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a6bf0a0e01efe836c52ef316f030bf50ac2f716c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1866,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_sso_service.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 176,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 197,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 334,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_support_bundle_service.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 196,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_token_storage_service.py": [
+      {
+        "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 331,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 539,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_tool_service.py": [
+      {
+        "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 549,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 550,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 566,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1985,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3571,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4204,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7560,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8052,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9399,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9541,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10023,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_tool_service_coverage.py": [
+      {
+        "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2980,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3666,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3675,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4125,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7052,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7070,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7094,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7158,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7169,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8410,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10670,
+        "line_number": 1602,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1774,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2774,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5171,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5824,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5888,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6140,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9123,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9172,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9211,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9268,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14343,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17100,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17119,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_admin_catalog_htmx.py": [
+      {
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 239,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_admin_module.py": [
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 453,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1106,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_auth.py": [
       {
+        "hashed_secret": "b5920aa41ccde1341077fdb2636afc16d6da0e1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "467be688b21f5d43370f5dc983fe5ed58dea4b00",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d955debea8e960a293ecbb257048680898cc9d94",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 231,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ee9e7b8482f6e0282b0117eb81651c98b537589",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 265,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "500886a66d19ebfe2d5c0ee86cf4612f9458ee4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 338,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2169f1a808382eb7b521206debaef01c91f1b60",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 377,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cd61d9f689e9992aec40aeec7210b45a681309f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 411,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae97d9e9201a9bc1806069d80e5809ab745a91e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 446,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb2344b0e2d6529ced74f8b09be362a460defa15",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 483,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "89be7e8e88bc7b0cdb5ddaa01dab1cd1728541e2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 547,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5a539b200edec3aaa5167e1cde5d8fd0e8cf4aee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 560,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8be6db326ca95f74590bd09c9c328fc9a3db3b6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 698,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2368055dc74fca43f2f9c849dbbaaa04616670cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 747,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8ce647089e0614d3b924f4a0b8fb78268562ec7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1436,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc6f6cc49f767ae38db110a9e6c1adf5c651ecbf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1480,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7939ea1cdfc6d73115b0d736fa04012be2b25b18",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1571,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "91014bcbf183cf77807b4bd24f2e8652f67b56a0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2079,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61ac75f7e6677b79c219ce819d954e05f61b5d2c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2097,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8223fafd35f399e55c3cf611c3d6ebbf43d68d71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2743,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dfd99b5f25f839608a3c275c0f8ceb363f8f0bc0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2716,
+        "line_number": 3647,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f5cd573c18bf811f82a886ceb6866b05d5ef02cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3725,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79bead8e6d65862a00cffaa12ccde1189ec34d29",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4108,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_cli_export_import_coverage.py": [
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 685,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_config.py": [
+      {
+        "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 499,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 512,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 518,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 587,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 647,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1017,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1269,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2421,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_db_isready.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 224,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_display_name_uuid_features.py": [
+      {
+        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 620,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 621,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_final_coverage_push.py": [
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 200,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_llm_schemas.py": [
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_main.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 128,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_main_error_handlers.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_main_extended.py": [
       {
+        "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2523,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2811,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_multi_auth_headers.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 298,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_oauth_manager.py": [
       {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1313,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1505,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1484,
+        "line_number": 1973,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_observability.py": [
+      {
+        "hashed_secret": "8f1b63868b5d31deb06a0ff740b192aa490e8950",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 327,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1fb844731bf1e5928ae606915b54e21264da4768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 756,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas.py": [
+      {
+        "hashed_secret": "22fcf027f5caee316ca4f2963c475f62e87e9b76",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 829,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1081,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas_auth_validation.py": [
+      {
+        "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 333,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 352,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 371,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 382,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas_validators_extra.py": [
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 775,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 956,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 961,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 987,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1005,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1218,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1334,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_team_governance_flags.py": [
+      {
+        "hashed_secret": "8ac21c6ecda35ffb18d58264aeb43ca800b3d758",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 580,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_toolops_utils.py": [
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_translate_stdio_endpoint.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 277,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_version.py": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/tools/builder/test_common.py": [
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 673,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 961,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/tools/builder/test_schema.py": [
+      {
+        "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 201,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/transports/test_streamablehttp_transport.py": [
+      {
+        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13105,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14280,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_create_jwt_token.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_db_isready.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 75,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_generate_keys.py": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_proxy_auth.py": [
+      {
+        "hashed_secret": "b2d898cda25886738c0cd002eb080745b09e2332",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_sso_bootstrap.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 370,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 454,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_trace_redaction.py": [
+      {
+        "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_url_auth.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 65,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 155,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_verify_credentials.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "29534257453ead25854695b1b7c95e3857a7238d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1042,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1191,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/validation/test_validators_advanced.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1142,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/plugins/test_encoded_exfil_detector.py": [
+      {
+        "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 504,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 548,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 561,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 930,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1179,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/plugins/test_jwt_claims_extraction.py": [
+      {
+        "hashed_secret": "dccfe30496fb85f5bb560ea18b582b9aa50372bb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/test_conc_01_helpers.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 160,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ]

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -1274,6 +1274,33 @@ class AuthCache:
 
         return None
 
+    async def set_not_revoked(self, jti: str) -> None:
+        """Cache a confirmed DB result that a token is not revoked (negative result caching).
+
+        Call this immediately after a DB query returns None for the given JTI so
+        subsequent callers skip the DB round-trip within the revocation TTL window.
+        ``invalidate_revocation()`` evicts this entry atomically on revocation, so
+        there is no window where a freshly-revoked token receives a stale False.
+
+        Args:
+            jti: JWT ID confirmed by DB as not revoked
+
+        Examples:
+            >>> import asyncio
+            >>> cache = AuthCache()
+            >>> asyncio.run(cache.set_not_revoked("some-jti"))
+            >>> asyncio.run(cache.is_token_revoked("some-jti"))
+            False
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            if jti not in self._revoked_jtis:
+                self._revocation_cache[jti] = CacheEntry(
+                    value=False,
+                    expiry=time.time() + self._revocation_ttl,
+                )
+
     async def sync_revoked_tokens(self) -> None:
         """Sync revoked tokens from database to cache on startup.
 

--- a/mcpgateway/services/token_catalog_service.py
+++ b/mcpgateway/services/token_catalog_service.py
@@ -986,7 +986,24 @@ class TokenCatalogService:
             >>> service = TokenCatalogService(None)  # Would use real DB session
             >>> # Returns bool: True if token is revoked
         """
+        try:
+            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+            cached = await auth_cache.is_token_revoked(jti)
+            if cached is not None:
+                return cached
+        except Exception as cache_error:
+            logger.debug(f"Auth cache revocation check failed, falling back to DB: {cache_error}")
+
         revocation = self.db.execute(select(TokenRevocation).where(TokenRevocation.jti == jti)).scalar_one_or_none()
+
+        if revocation is None:
+            try:
+                from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                await auth_cache.set_not_revoked(jti)
+            except Exception:
+                pass
 
         return revocation is not None
 
@@ -1201,8 +1218,29 @@ class TokenCatalogService:
             >>> service = TokenCatalogService(None)  # Would use real DB session
             >>> # Returns Optional[TokenRevocation] if token is revoked
         """
+        try:
+            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+            cached = await auth_cache.is_token_revoked(jti)
+            if cached is False:
+                return None
+            # cached is True: still need DB for full ORM object (revoked_by, reason, revoked_at)
+            # cached is None: cache miss — fall through to DB
+        except Exception as cache_error:
+            logger.debug(f"Auth cache revocation check failed, falling back to DB: {cache_error}")
+
         result = self.db.execute(select(TokenRevocation).where(TokenRevocation.jti == jti))
-        return result.scalar_one_or_none()
+        revocation = result.scalar_one_or_none()
+
+        if revocation is None:
+            try:
+                from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                await auth_cache.set_not_revoked(jti)
+            except Exception:
+                pass
+
+        return revocation
 
     async def get_token_revocations_batch(self, jtis: List[str]) -> Dict[str, TokenRevocation]:
         """Get token revocation information for multiple JTIs in a single query.

--- a/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py
@@ -1291,3 +1291,57 @@ class TestRedisMissCounts:
 
         assert result is None
         assert auth_cache._redis_miss_count == initial + 1
+
+
+class TestSetNotRevoked:
+    """Tests for set_not_revoked() negative result caching (Issue #2692)."""
+
+    @pytest.mark.asyncio
+    async def test_set_not_revoked_stores_false(self, auth_cache):
+        """set_not_revoked stores False in L1 so is_token_revoked skips DB."""
+        jti = "not-revoked-jti"
+
+        await auth_cache.set_not_revoked(jti)
+
+        result = await auth_cache.is_token_revoked(jti)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_set_not_revoked_no_op_when_disabled(self):
+        """Disabled cache: set_not_revoked is a no-op and is_token_revoked returns None."""
+        cache = AuthCache(enabled=False)
+        jti = "some-jti"
+
+        await cache.set_not_revoked(jti)
+
+        result = await cache.is_token_revoked(jti)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_set_not_revoked_ignored_if_already_revoked(self, auth_cache):
+        """If JTI is in _revoked_jtis, set_not_revoked must not overwrite it."""
+        jti = "confirmed-revoked-jti"
+        auth_cache._revoked_jtis.add(jti)
+
+        await auth_cache.set_not_revoked(jti)
+
+        # Fast path via _revoked_jtis must still return True
+        result = await auth_cache.is_token_revoked(jti)
+        assert result is True
+        # L1 cache must not hold a False entry for this JTI
+        entry = auth_cache._revocation_cache.get(jti)
+        assert entry is None or entry.value is True
+
+    @pytest.mark.asyncio
+    async def test_invalidate_revocation_evicts_false_entry(self, auth_cache):
+        """invalidate_revocation() must evict a cached False so revocation takes effect."""
+        jti = "to-be-revoked-jti"
+        auth_cache._redis_available = False
+
+        await auth_cache.set_not_revoked(jti)
+        assert await auth_cache.is_token_revoked(jti) is False
+
+        await auth_cache.invalidate_revocation(jti)
+
+        result = await auth_cache.is_token_revoked(jti)
+        assert result is True

--- a/tests/unit/mcpgateway/test_token_catalog_service_cache.py
+++ b/tests/unit/mcpgateway/test_token_catalog_service_cache.py
@@ -119,6 +119,17 @@ class TestIsTokenRevokedCaching:
 
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_set_not_revoked_error_is_silenced(self, service, mock_auth_cache):
+        """set_not_revoked raises → exception is silenced, False still returned."""
+        mock_auth_cache.is_token_revoked.return_value = None
+        mock_auth_cache.set_not_revoked.side_effect = RuntimeError("redis write error")
+
+        with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+            result = await service.is_token_revoked("clean-jti-error")
+
+        assert result is False
+
 
 # ---------------------------------------------------------------------------
 # get_token_revocation
@@ -185,3 +196,14 @@ class TestGetTokenRevocationCaching:
 
         assert result is not None
         assert result.jti == jti
+
+    @pytest.mark.asyncio
+    async def test_set_not_revoked_error_is_silenced(self, service, mock_auth_cache):
+        """set_not_revoked raises → exception is silenced, None still returned."""
+        mock_auth_cache.is_token_revoked.return_value = None
+        mock_auth_cache.set_not_revoked.side_effect = RuntimeError("redis write error")
+
+        with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+            result = await service.get_token_revocation("clean-jti-error")
+
+        assert result is None

--- a/tests/unit/mcpgateway/test_token_catalog_service_cache.py
+++ b/tests/unit/mcpgateway/test_token_catalog_service_cache.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_token_catalog_service_cache.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for TokenCatalogService revocation caching (Issue #2692).
+
+Verifies that is_token_revoked() and get_token_revocation() consult
+auth_cache before hitting the database, and populate the cache after
+a DB miss so subsequent calls skip the round-trip.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import Base, TokenRevocation
+from mcpgateway.services.token_catalog_service import TokenCatalogService
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory SQLite session with the TokenRevocation table."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture()
+def service(db_session):
+    return TokenCatalogService(db_session)
+
+
+@pytest.fixture()
+def mock_auth_cache():
+    cache = MagicMock()
+    cache.is_token_revoked = AsyncMock(return_value=None)
+    cache.set_not_revoked = AsyncMock()
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# is_token_revoked
+# ---------------------------------------------------------------------------
+
+
+class TestIsTokenRevokedCaching:
+    @pytest.mark.asyncio
+    async def test_cache_hit_true_skips_db(self, service, mock_auth_cache):
+        """Cache returns True → DB is never queried."""
+        mock_auth_cache.is_token_revoked.return_value = True
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                with patch.object(service.db, "execute", wraps=service.db.execute) as mock_execute:
+                    result = await service.is_token_revoked("some-jti")
+
+        assert result is True
+        mock_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_false_skips_db(self, service, mock_auth_cache):
+        """Cache returns False → DB is never queried."""
+        mock_auth_cache.is_token_revoked.return_value = False
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                with patch.object(service.db, "execute", wraps=service.db.execute) as mock_execute:
+                    result = await service.is_token_revoked("some-jti")
+
+        assert result is False
+        mock_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_db_revoked_returns_true(self, service, db_session, mock_auth_cache):
+        """Cache miss (None) + DB has revocation row → returns True."""
+        jti = "revoked-jti"
+        db_session.add(TokenRevocation(jti=jti, revoked_by="admin@example.com"))
+        db_session.commit()
+
+        mock_auth_cache.is_token_revoked.return_value = None
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.is_token_revoked(jti)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_db_clean_populates_not_revoked(self, service, mock_auth_cache):
+        """Cache miss + DB has no revocation row → set_not_revoked called."""
+        mock_auth_cache.is_token_revoked.return_value = None
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.is_token_revoked("clean-jti")
+
+        assert result is False
+        mock_auth_cache.set_not_revoked.assert_called_once_with("clean-jti")
+
+    @pytest.mark.asyncio
+    async def test_cache_error_falls_back_to_db(self, service, db_session, mock_auth_cache):
+        """Cache raises → falls back to DB, still returns correct result."""
+        jti = "revoked-jti-fallback"
+        db_session.add(TokenRevocation(jti=jti, revoked_by="admin@example.com"))
+        db_session.commit()
+
+        mock_auth_cache.is_token_revoked.side_effect = RuntimeError("redis down")
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.is_token_revoked(jti)
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# get_token_revocation
+# ---------------------------------------------------------------------------
+
+
+class TestGetTokenRevocationCaching:
+    @pytest.mark.asyncio
+    async def test_cache_false_skips_db_returns_none(self, service, mock_auth_cache):
+        """Cache returns False → None returned without a DB query."""
+        mock_auth_cache.is_token_revoked.return_value = False
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                with patch.object(service.db, "execute", wraps=service.db.execute) as mock_execute:
+                    result = await service.get_token_revocation("clean-jti")
+
+        assert result is None
+        mock_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_true_still_queries_db_for_orm_object(self, service, db_session, mock_auth_cache):
+        """Cache returns True → DB queried to get the full TokenRevocation ORM object."""
+        jti = "revoked-full"
+        revocation = TokenRevocation(jti=jti, revoked_by="admin@example.com", reason="test")
+        db_session.add(revocation)
+        db_session.commit()
+
+        mock_auth_cache.is_token_revoked.return_value = True
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.get_token_revocation(jti)
+
+        assert result is not None
+        assert result.jti == jti
+        assert result.revoked_by == "admin@example.com"
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_db_miss_populates_not_revoked(self, service, mock_auth_cache):
+        """Cache miss + DB miss → set_not_revoked called, None returned."""
+        mock_auth_cache.is_token_revoked.return_value = None
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.get_token_revocation("no-such-jti")
+
+        assert result is None
+        mock_auth_cache.set_not_revoked.assert_called_once_with("no-such-jti")
+
+    @pytest.mark.asyncio
+    async def test_cache_error_falls_back_to_db(self, service, db_session, mock_auth_cache):
+        """Cache raises → falls back to DB and returns correct ORM object."""
+        jti = "revoked-fallback"
+        revocation = TokenRevocation(jti=jti, revoked_by="admin@example.com")
+        db_session.add(revocation)
+        db_session.commit()
+
+        mock_auth_cache.is_token_revoked.side_effect = RuntimeError("redis down")
+
+        with patch("mcpgateway.services.token_catalog_service.auth_cache", mock_auth_cache, create=True):
+            with patch("mcpgateway.cache.auth_cache.auth_cache", mock_auth_cache, create=True):
+                result = await service.get_token_revocation(jti)
+
+        assert result is not None
+        assert result.jti == jti


### PR DESCRIPTION
Closes #4526

## Summary

- `TokenCatalogService.is_token_revoked()` and `get_token_revocation()` hit the database unconditionally on every request; `auth_cache` was unused on the read path despite already being the source of truth for revocations.
- Added `set_not_revoked(jti)` to `auth_cache` to cache negative results with a TTL, guarded against overwriting confirmed revocations.
- Both service methods now check the cache first and fall back to DB only on a miss; they call `set_not_revoked()` to warm the cache after a DB non-revocation result.
- All paths fall through to DB on cache errors (fail-closed).

## Files Changed

| File | Change |
|------|--------|
| `mcpgateway/cache/auth_cache.py` | Add `set_not_revoked(jti)` |
| `mcpgateway/services/token_catalog_service.py` | Cache-first logic in `is_token_revoked` and `get_token_revocation` |
| `tests/unit/mcpgateway/cache/test_auth_cache_l1_l2.py` | 4 new tests for `set_not_revoked` |
| `tests/unit/mcpgateway/test_token_catalog_service_cache.py` | 11 new tests covering cache-hit, cache-miss, and error-fallback paths |