### PR TITLE
fix(auth): owner cannot access their own private resources with a scoped token

### DIFF
--- a/mcpgateway/services/a2a_server_service.py
+++ b/mcpgateway/services/a2a_server_service.py
@@ -54,12 +54,12 @@ def _check_server_access(server: DbServer, user_email: Optional[str], token_team
     if not user_email:
         return False
 
+    if server.visibility == "private" and server.owner_email and server.owner_email == user_email:
+        return True
+
     is_public_only_token = token_teams is not None and len(token_teams) == 0
     if is_public_only_token:
         return False
-
-    if server.visibility == "private" and server.owner_email and server.owner_email == user_email:
-        return True
 
     if server.visibility == "team":
         if token_teams is None:

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -347,14 +347,14 @@ class A2AAgentService(BaseService):
         if not user_email:
             return False
 
+        # Owner can access their own private agents (ownership overrides token scoping)
+        if agent.visibility == "private" and agent.owner_email and agent.owner_email == user_email:
+            return True
+
         # Public-only tokens (empty teams array) can ONLY access public agents
         is_public_only_token = token_teams is not None and len(token_teams) == 0
         if is_public_only_token:
             return False  # Already checked public above
-
-        # Owner can access their own private agents
-        if agent.visibility == "private" and agent.owner_email and agent.owner_email == user_email:
-            return True
 
         # Team agents: check team membership
         # token_teams=None means admin bypass — allow all team agents
@@ -398,7 +398,9 @@ class A2AAgentService(BaseService):
 
         query = db.query(DbA2AAgent.id).filter(DbA2AAgent.enabled.is_(True))
 
-        # Build visibility predicate matching _check_agent_access rules.
+        # Build visibility predicate for the listing path.
+        # Intentionally diverges from _check_agent_access: listing suppresses owner rows
+        # for public-only tokens, consistent with base_service._apply_access_control.
         visibility_filters = [DbA2AAgent.visibility == "public"]
 
         is_public_only = not user_email or (token_teams is not None and len(token_teams) == 0)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2739,13 +2739,13 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         if not user_email:
             return False
 
-        is_public_only_token = token_teams is not None and len(token_teams) == 0
-        if is_public_only_token:
-            return False
-
         gateway_owner_email = getattr(gateway, "owner_email", None)
         if visibility == "private" and gateway_owner_email and gateway_owner_email == user_email:
             return True
+
+        is_public_only_token = token_teams is not None and len(token_teams) == 0
+        if is_public_only_token:
+            return False
 
         gateway_team_id = getattr(gateway, "team_id", None)
         if gateway_team_id and visibility in ("team", "public"):

--- a/mcpgateway/services/prompt_service.py
+++ b/mcpgateway/services/prompt_service.py
@@ -1811,14 +1811,14 @@ class PromptService(BaseService):
         if not user_email:
             return False
 
+        # Owner can access their own private prompts (ownership overrides token scoping)
+        if visibility == "private" and prompt_owner_email and prompt_owner_email == user_email:
+            return True
+
         # Public-only tokens (empty teams array) can ONLY access public prompts
         is_public_only_token = token_teams is not None and len(token_teams) == 0
         if is_public_only_token:
             return False  # Already checked public above
-
-        # Owner can access their own private prompts
-        if visibility == "private" and prompt_owner_email and prompt_owner_email == user_email:
-            return True
 
         # Team prompts: check team membership (matches list_prompts behavior)
         if prompt_team_id:

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -1097,14 +1097,14 @@ class ResourceService(BaseService):
         if not user_email:
             return False
 
+        # Owner can access their own private resources (ownership overrides token scoping)
+        if visibility == "private" and resource_owner_email and resource_owner_email == user_email:
+            return True
+
         # Public-only tokens (empty teams array) can ONLY access public resources
         is_public_only_token = token_teams is not None and len(token_teams) == 0
         if is_public_only_token:
             return False  # Already checked public above
-
-        # Owner can access their own private resources
-        if visibility == "private" and resource_owner_email and resource_owner_email == user_email:
-            return True
 
         # Team resources: check team membership (matches list_resources behavior)
         if resource_team_id:

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1022,13 +1022,13 @@ class ServerService(BaseService):
         if not user_email:
             return False
 
-        is_public_only_token = token_teams is not None and len(token_teams) == 0
-        if is_public_only_token:
-            return False
-
         server_owner_email = getattr(server, "owner_email", None)
         if visibility == "private" and server_owner_email and server_owner_email == user_email:
             return True
+
+        is_public_only_token = token_teams is not None and len(token_teams) == 0
+        if is_public_only_token:
+            return False
 
         server_team_id = getattr(server, "team_id", None)
         if server_team_id and visibility in ("team", "public"):

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1161,14 +1161,14 @@ class ToolService(BaseService):
         if not user_email:
             return False
 
+        # Owner can access their own private tools (ownership overrides token scoping)
+        if visibility == "private" and tool_owner_email and tool_owner_email == user_email:
+            return True
+
         # Public-only tokens (empty teams array) can ONLY access public tools
         is_public_only_token = token_teams is not None and len(token_teams) == 0
         if is_public_only_token:
             return False  # Already checked public above
-
-        # Owner can access their own private tools
-        if visibility == "private" and tool_owner_email and tool_owner_email == user_email:
-            return True
 
         # Team tools: check team membership (matches list_tools behavior)
         if tool_team_id:

--- a/tests/unit/mcpgateway/services/test_a2a_server_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_server_service.py
@@ -426,12 +426,14 @@ class TestCheckServerAccess:
         assert _check_server_access(server, None, ["team-a"]) is False
 
     # -- Public-only token (empty teams) ------------------------------------
+    # Owner with token_teams=[] is allowed (ownership overrides token scoping, #4473).
+    # Non-owner with token_teams=[] is still denied.
 
-    def test_empty_teams_denied_for_private(self):
+    def test_empty_teams_owner_allowed_for_private(self):
         from mcpgateway.services.a2a_server_service import _check_server_access
 
         server = self._make_server(visibility="private", owner_email="user@test.com")
-        assert _check_server_access(server, "user@test.com", []) is False
+        assert _check_server_access(server, "user@test.com", []) is True
 
     def test_empty_teams_denied_for_team(self):
         from mcpgateway.services.a2a_server_service import _check_server_access

--- a/tests/unit/mcpgateway/services/test_a2a_service.py
+++ b/tests/unit/mcpgateway/services/test_a2a_service.py
@@ -1040,8 +1040,8 @@ class TestA2AAgentService:
         assert await service._check_agent_access(mock_db, agent, user_email="someone@example.com", token_teams=["other"]) is False
 
         agent.visibility = "private"
-        # Public-only tokens (token_teams=[]) cannot access private agents even as owner
-        assert await service._check_agent_access(mock_db, agent, user_email="owner@example.com", token_teams=[]) is False
+        # Owner with a public-only token (token_teams=[]) should still be allowed (ownership overrides token scoping, #4473)
+        assert await service._check_agent_access(mock_db, agent, user_email="owner@example.com", token_teams=[]) is True
         # Team-scoped tokens: owner can access their own private agents
         assert await service._check_agent_access(mock_db, agent, user_email="owner@example.com", token_teams=["team-1"]) is True
         assert await service._check_agent_access(mock_db, agent, user_email="other@example.com", token_teams=["team-1"]) is False
@@ -3854,8 +3854,13 @@ class TestCancelTask:
         assert result["status"]["state"] == "canceled"
 
     @pytest.mark.asyncio
-    async def test_cancel_task_public_only_user_denied_for_private(self, service, mock_db):
-        """Public-only user (empty teams) cannot cancel private agent tasks."""
+    async def test_cancel_task_owner_allowed_with_public_only_token(self, service, mock_db):
+        """Owner can cancel their own private agent tasks even with a public-only token.
+
+        Ownership overrides token scoping — the owner must be able to manage
+        their own private agents regardless of which teams their JWT is scoped to.
+        Regression test for issue #4473.
+        """
         task = self._make_task("submitted")
         agent = MagicMock()
         agent.visibility = "private"
@@ -3863,7 +3868,7 @@ class TestCancelTask:
         self._setup_task_and_agent(mock_db, task, agent)
 
         result = await service.cancel_task(mock_db, "task-1", user_email="user@test.com", token_teams=[])
-        assert result is None
+        assert result is not None
 
 
 class TestPushConfigCRUD:
@@ -4963,8 +4968,13 @@ class TestGetTask:
         assert result["id"] == "t1"
 
     @pytest.mark.asyncio
-    async def test_public_only_user_cannot_see_private_agent_task(self, service, mock_db):
-        """Public-only user (empty teams) cannot see tasks for private agents."""
+    async def test_owner_can_see_private_agent_task_with_public_only_token(self, service, mock_db):
+        """Owner can see their own private agent tasks even with a public-only token.
+
+        Ownership overrides token scoping — the owner must be able to view and manage
+        their own private agents regardless of which teams their JWT is scoped to.
+        Regression test for issue #4473.
+        """
         task = MagicMock()
         task.a2a_agent_id = "agent-1"
         agent = MagicMock()
@@ -4974,7 +4984,7 @@ class TestGetTask:
 
         result = await service.get_task(mock_db, "t1", user_email="user@test.com", token_teams=[])
 
-        assert result is None
+        assert result is not None
 
 
 class TestListTasks:

--- a/tests/unit/mcpgateway/services/test_authorization_access.py
+++ b/tests/unit/mcpgateway/services/test_authorization_access.py
@@ -27,7 +27,6 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.services.prompt_service import PromptService
 from mcpgateway.services.resource_service import ResourceNotFoundError, ResourceService
 from mcpgateway.services.tool_service import ToolNotFoundError, ToolService
-from tests.helpers.admin_mocks import install_admin_user
 
 
 @pytest.fixture
@@ -185,8 +184,13 @@ class TestToolAccessChecks:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_private_tool_denied_to_owner_with_public_only_token(self, tool_service, mock_db):
-        """Private tools should NOT be accessible to owner if they have a public-only token."""
+    async def test_private_tool_accessible_to_owner_with_public_only_token(self, tool_service, mock_db):
+        """Private tools should be accessible to the owner even with a public-only token.
+
+        Ownership overrides token scoping — the owner must be able to view and edit
+        their own private tools regardless of which teams their JWT is scoped to.
+        Regression test for issue #4473.
+        """
         tool_payload = {
             "id": "tool-123",
             "visibility": "private",
@@ -194,9 +198,9 @@ class TestToolAccessChecks:
             "team_id": None,
         }
 
-        # Owner with a public-only token (token_teams=[]) should be denied
+        # Owner with a public-only token (token_teams=[]) should still be allowed
         result = await tool_service._check_tool_access(mock_db, tool_payload, user_email="owner@example.com", token_teams=[])
-        assert result is False
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_private_tool_denied_to_non_owner(self, tool_service, mock_db):
@@ -313,13 +317,18 @@ class TestResourceAccessChecks:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_private_resource_denied_to_owner_with_public_only_token(self, resource_service, mock_db):
-        """Private resources should NOT be accessible to owner with public-only token."""
+    async def test_private_resource_accessible_to_owner_with_public_only_token(self, resource_service, mock_db):
+        """Private resources should be accessible to the owner even with a public-only token.
+
+        Ownership overrides token scoping — the owner must be able to view and edit
+        their own private resources regardless of which teams their JWT is scoped to.
+        Regression test for issue #4473.
+        """
         mock_resource = create_mock_resource(visibility="private", owner_email="owner@example.com")
 
-        # Owner with public-only token should be denied
+        # Owner with a public-only token (token_teams=[]) should still be allowed
         result = await resource_service._check_resource_access(mock_db, mock_resource, user_email="owner@example.com", token_teams=[])
-        assert result is False
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_team_resource_accessible_to_team_member(self, resource_service, mock_db):
@@ -354,6 +363,18 @@ class TestResourceAccessChecks:
         result = await resource_service._check_resource_access(mock_db, mock_resource, user_email=None, token_teams=None)
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_non_owner_public_only_token_denied_private_resource(self, resource_service, mock_db):
+        """Non-owner with public-only token must still be denied access to private resources.
+
+        Symmetry test: the owner check in _check_resource_access requires owner_email == user_email,
+        so a different user with token_teams=[] must still be denied. Guards against future
+        refactors accidentally broadening the owner check.
+        """
+        mock_resource = create_mock_resource(visibility="private", owner_email="owner@example.com")
+        result = await resource_service._check_resource_access(mock_db, mock_resource, user_email="other@example.com", token_teams=[])
+        assert result is False
+
 
 class TestPromptAccessChecks:
     """Tests for prompt access authorization."""
@@ -384,13 +405,18 @@ class TestPromptAccessChecks:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_private_prompt_denied_to_owner_with_public_only_token(self, prompt_service, mock_db):
-        """Private prompts should NOT be accessible to owner with public-only token."""
+    async def test_private_prompt_accessible_to_owner_with_public_only_token(self, prompt_service, mock_db):
+        """Private prompts should be accessible to the owner even with a public-only token.
+
+        Ownership overrides token scoping — the owner must be able to view and edit
+        their own private prompts regardless of which teams their JWT is scoped to.
+        Regression test for issue #4473.
+        """
         mock_prompt = create_mock_prompt(visibility="private", owner_email="owner@example.com")
 
-        # Owner with public-only token should be denied
+        # Owner with a public-only token (token_teams=[]) should still be allowed
         result = await prompt_service._check_prompt_access(mock_db, mock_prompt, user_email="owner@example.com", token_teams=[])
-        assert result is False
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_team_prompt_accessible_to_team_member(self, prompt_service, mock_db):
@@ -424,6 +450,18 @@ class TestPromptAccessChecks:
         mock_prompt = create_mock_prompt(visibility="team", owner_email="owner@example.com", team_id="team-abc")
         result = await prompt_service._check_prompt_access(mock_db, mock_prompt, user_email=None, token_teams=None)
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_non_owner_public_only_token_denied_private_prompt(self, prompt_service, mock_db):
+        """Non-owner with public-only token must still be denied access to private prompts.
+
+        Symmetry test: the owner check in _check_prompt_access requires owner_email == user_email,
+        so a different user with token_teams=[] must still be denied. Guards against future
+        refactors accidentally broadening the owner check.
+        """
+        mock_prompt = create_mock_prompt(visibility="private", owner_email="owner@example.com")
+        result = await prompt_service._check_prompt_access(mock_db, mock_prompt, user_email="other@example.com", token_teams=[])
+        assert result is False
 
 
 class TestInvokeToolAuthorization:
@@ -1446,12 +1484,22 @@ class TestServerAccessCheckMatrix:
         assert await service._check_server_access(MagicMock(), self._server("team", team_id="team-x"), user_email=None, token_teams=["team-x"]) is False
 
     @pytest.mark.asyncio
-    async def test_public_only_token_denies_non_public(self, service):
-        """(email, []) public-only token: covers server_service.py line 1025-1027."""
+    async def test_public_only_token_denies_team_resources(self, service):
+        """(email, []) public-only token: team-visibility server is denied."""
         s_team = self._server("team", team_id="team-x")
-        s_private = self._server("private", owner_email="user@test.com")
         assert await service._check_server_access(MagicMock(), s_team, user_email="user@test.com", token_teams=[]) is False
-        assert await service._check_server_access(MagicMock(), s_private, user_email="user@test.com", token_teams=[]) is False
+
+    @pytest.mark.asyncio
+    async def test_owner_with_public_only_token_allowed_private_server(self, service):
+        """Owner with token_teams=[] must be allowed to access their own private server (fix for issue #4473)."""
+        s_private = self._server("private", owner_email="user@test.com")
+        assert await service._check_server_access(MagicMock(), s_private, user_email="user@test.com", token_teams=[]) is True
+
+    @pytest.mark.asyncio
+    async def test_non_owner_public_only_token_denied_private_server(self, service):
+        """Non-owner with token_teams=[] must still be denied access to private servers."""
+        s_private = self._server("private", owner_email="owner@test.com")
+        assert await service._check_server_access(MagicMock(), s_private, user_email="other@test.com", token_teams=[]) is False
 
     @pytest.mark.asyncio
     async def test_own_private_allowed(self, service):
@@ -1519,12 +1567,22 @@ class TestGatewayAccessCheckMatrix:
         assert await service._check_gateway_access(MagicMock(), self._gw("team", team_id="team-x"), user_email=None, token_teams=["team-x"]) is False
 
     @pytest.mark.asyncio
-    async def test_public_only_token_denies_non_public(self, service):
-        """(email, []) public-only token: covers line 2742-2744."""
+    async def test_public_only_token_denies_team_resources(self, service):
+        """(email, []) public-only token: team-visibility gateway is denied."""
         g_team = self._gw("team", team_id="team-x")
-        g_private = self._gw("private", owner_email="user@test.com")
         assert await service._check_gateway_access(MagicMock(), g_team, user_email="user@test.com", token_teams=[]) is False
-        assert await service._check_gateway_access(MagicMock(), g_private, user_email="user@test.com", token_teams=[]) is False
+
+    @pytest.mark.asyncio
+    async def test_owner_with_public_only_token_allowed_private_gateway(self, service):
+        """Owner with token_teams=[] must be allowed to access their own private gateway (fix for issue #4473)."""
+        g_private = self._gw("private", owner_email="user@test.com")
+        assert await service._check_gateway_access(MagicMock(), g_private, user_email="user@test.com", token_teams=[]) is True
+
+    @pytest.mark.asyncio
+    async def test_non_owner_public_only_token_denied_private_gateway(self, service):
+        """Non-owner with token_teams=[] must still be denied access to private gateways."""
+        g_private = self._gw("private", owner_email="owner@test.com")
+        assert await service._check_gateway_access(MagicMock(), g_private, user_email="other@test.com", token_teams=[]) is False
 
     @pytest.mark.asyncio
     async def test_own_private_allowed(self, service):
@@ -1551,3 +1609,51 @@ class TestGatewayAccessCheckMatrix:
 
         assert allowed is True
         mock_tms_cls.return_value.get_user_teams.assert_awaited_once_with("user@test.com")
+
+
+class TestA2AServerAccessCheck:
+    """Branch coverage for _check_server_access (a2a_server_service.py).
+
+    The function is module-level (not a method) and synchronous. Tests mirror
+    the same shapes covered by TestServerAccessCheckMatrix and
+    TestGatewayAccessCheckMatrix.
+    """
+
+    def _server(self, visibility, owner_email=None, team_id=None):
+        s = SimpleNamespace(visibility=visibility, owner_email=owner_email, team_id=team_id)
+        return s
+
+    def test_anonymous_admin_bypass_denies_private(self):
+        """(None, None) admin bypass: private denied, team allowed."""
+        from mcpgateway.services.a2a_server_service import _check_server_access
+
+        assert _check_server_access(self._server("private", owner_email="o@t.com"), user_email=None, token_teams=None) is False
+        assert _check_server_access(self._server("team", team_id="t"), user_email=None, token_teams=None) is True
+
+    def test_no_user_email_denied(self):
+        """No user_email → denied regardless of visibility."""
+        from mcpgateway.services.a2a_server_service import _check_server_access
+
+        assert _check_server_access(self._server("team", team_id="t"), user_email=None, token_teams=["t"]) is False
+
+    def test_owner_with_public_only_token_allowed(self):
+        """Owner with token_teams=[] must be allowed to access their own private server (fix for issue #4473)."""
+        from mcpgateway.services.a2a_server_service import _check_server_access
+
+        s = self._server("private", owner_email="user@test.com")
+        assert _check_server_access(s, user_email="user@test.com", token_teams=[]) is True
+
+    def test_non_owner_public_only_token_denied(self):
+        """Non-owner with token_teams=[] must still be denied access to private a2a servers."""
+        from mcpgateway.services.a2a_server_service import _check_server_access
+
+        s = self._server("private", owner_email="owner@test.com")
+        assert _check_server_access(s, user_email="other@test.com", token_teams=[]) is False
+
+    def test_team_member_via_jwt_token_teams(self):
+        """Token with matching team_id allows access to team-visibility server."""
+        from mcpgateway.services.a2a_server_service import _check_server_access
+
+        s = self._server("team", team_id="team-x")
+        assert _check_server_access(s, user_email="user@test.com", token_teams=["team-x"]) is True
+        assert _check_server_access(s, user_email="user@test.com", token_teams=["team-y"]) is False

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -6300,11 +6300,11 @@ class TestToolAccessAuthorization:
 
     @pytest.mark.asyncio
     async def test_check_tool_access_public_only_token_denied_private(self, tool_service, mock_db):
-        """Public-only tokens (token_teams=[]) should only access public tools."""
+        """Public-only tokens (token_teams=[]) deny access to private tools for non-owners."""
         private_tool = {"id": "1", "visibility": "private", "owner_email": "owner@test.com", "team_id": None}
 
-        # Even owner with public-only token is denied
-        assert await tool_service._check_tool_access(mock_db, private_tool, user_email="owner@test.com", token_teams=[]) is False
+        # Non-owner with a public-only token is denied (#4473: owner would be allowed)
+        assert await tool_service._check_tool_access(mock_db, private_tool, user_email="other@test.com", token_teams=[]) is False
 
     @pytest.mark.asyncio
     async def test_get_tool_access_denied_raises_not_found(self, tool_service, mock_db):

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -9870,6 +9870,6 @@ class TestInvokeToolLookupLogic:
             mock_cache.get = AsyncMock(return_value=None)
             mock_cache_fn.return_value = mock_cache
 
-            # Even though user_email matches owner, public-only token should deny access
+            # Non-owner with public-only token cannot access any private tool (#4473: owner would be allowed)
             with pytest.raises(ToolNotFoundError, match="not found"):
-                await tool_service.invoke_tool(db, "test_tool", {}, user_email="me@test.com", token_teams=[])
+                await tool_service.invoke_tool(db, "test_tool", {}, user_email="nobody@test.com", token_teams=[])


### PR DESCRIPTION
# Bug-fix PR

## 📌 Summary

Owners of private resources (tools, prompts, resources, A2A agents, virtual servers, gateways) were receiving a 404 when accessing their own resources using a scoped token (`token_teams=[]`). The owner check was inadvertently blocked before it could run, because the `is_public_only_token` early-return gate came first in all `_check_*_access` methods. This PR fixes the ordering across all seven affected services so that an owner is always granted access to their own private resource regardless of token scope.

## 🔗 Related Issue

Closes: #4473

## 🔁 Reproduction Steps

1. Create a tool (or prompt, resource, virtual server, gateway, or A2A agent) and set its visibility to `private`.
2. Generate a scoped JWT for the owner with an explicit `teams` claim set to `[]`.
3. `GET /tools/{id}` (or equivalent) with that token → **404 Not Found**.
4. After this fix, the same request returns **200 OK**.

## 🐞 Root Cause

In all seven `_check_*_access` helper functions the code evaluated:

```python
is_public_only_token = token_teams is not None and len(token_teams) == 0
if is_public_only_token:
    return False          # ← owner also hits this early return
# … owner check follows, never reached
```

Because `token_teams=[]` is the "public-only" scope, the gate fired before the `owner_email == user_email` check, denying the owner access to their own private resource.

Affected services: `tool_service`, `prompt_service`, `resource_service`, `a2a_service`, `server_service`, `gateway_service`, `a2a_server_service`.

## 💡 Fix Description

In each of the seven functions, the owner equality check is moved **above** the `is_public_only_token` gate:

```python
# owner check first — token scope does not restrict ownership
if visibility == "private" and owner_email and owner_email == user_email:
    return True

is_public_only_token = token_teams is not None and len(token_teams) == 0
if is_public_only_token:
    return False
```

**Design invariants preserved:**
- `(None, None)` anonymous admin bypass fires before this block and is unchanged.
- Non-owner callers with `token_teams=[]` still get `False` — the owner check requires `owner_email == user_email`.
- **Listing paths** (`_visible_agent_ids`, `base_service._apply_access_control`) deliberately keep owner rows suppressed for public-only tokens — this is a documented policy and is **not** changed here. Only point-lookup (`_check_*_access`) is affected.

Tests updated/added:
- Existing `owner + token_teams=[]` assertions flipped from `False` → `True` for all seven functions.
- New symmetry tests assert that **non-owners** with `token_teams=[]` are still denied.
- New `TestA2AServerAccessCheck` class for the previously untested `a2a_server_service._check_server_access`.
- Stale comment in `_visible_agent_ids` updated to document the intentional divergence from `_check_agent_access`.

## 🧪 Verification

| Check                             | Command                          | Status |
|-----------------------------------|----------------------------------|--------|
| Lint suite                        | `make lint`                      |     Pass   |
| Unit tests                        | `make test`                      |    Pass    |
| Coverage ≥ 90 %                   | `make coverage`                  |    Pass    |
| Manual regression no longer fails | steps above (scoped token + GET) |   Pass     |

## 📐 MCP Compliance (if relevant)

- [x] No breaking change to MCP clients — access control is server-side only

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed