### PR TITLE
Fix MCP path rewrite order for streamable POST auth

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2671,11 +2671,11 @@ class AdminAuthMiddleware(BaseHTTPMiddleware):
 
 class MCPPathRewriteMiddleware:
     """
-    Middleware that rewrites paths ending with '/mcp' to '/mcp/', after performing authentication.
+    Middleware that rewrites paths ending with '/mcp' to '/mcp/' before authentication.
 
     - Rewrites paths like '/servers/<server_id>/mcp' to '/mcp/'.
     - Only paths ending with '/mcp' or '/mcp/' (but not exactly '/mcp' or '/mcp/') are rewritten.
-    - Authentication is performed before any path rewriting.
+    - Authentication uses ``scope["modified_path"]`` to preserve server-scoped decisions after rewriting.
     - If authentication fails, the request is not processed further.
     - All other requests are passed through without change.
     - Routes through the middleware stack (including CORSMiddleware) for proper CORS preflight handling.
@@ -2770,10 +2770,11 @@ class MCPPathRewriteMiddleware:
 
     async def _call_streamable_http(self, scope, receive, send):
         """
-        Handles the streamable HTTP request after authentication and path rewriting.
+        Handles streamable HTTP path rewriting, authentication, and routing.
 
-        If auth succeeds and path ends with /mcp, rewrites to /mcp/ and calls self.application
-        (continuing through middleware stack including CORSMiddleware).
+        If a server-scoped path ends with /mcp, rewrites to /mcp/ before auth,
+        then calls self.application after auth succeeds (continuing through
+        middleware stack including CORSMiddleware).
 
         Args:
             scope (dict): The ASGI connection scope containing request metadata.
@@ -2792,11 +2793,6 @@ class MCPPathRewriteMiddleware:
             ...     asyncio.run(middleware._call_streamable_http(scope, receive, send))
             >>> app_mock.assert_called_once_with(scope, receive, send)
         """
-        # Auth check first
-        auth_ok = await streamable_http_auth(scope, receive, send)
-        if not auth_ok:
-            return
-
         original_path = scope.get("path", "")
         scope["modified_path"] = original_path
 
@@ -2810,6 +2806,9 @@ class MCPPathRewriteMiddleware:
         # Update modified_path to the app-relative path (without root_path prefix).
         # This ensures streamablehttp_transport can extract server_id via regex (#4266).
         scope["modified_path"] = app_path
+
+        rewrite_path = None
+        invalid_server_path = False
 
         # Skip rewriting for well-known URIs (RFC 9728 OAuth metadata, etc.)
         # These paths may end with /mcp but should not be rewritten to the MCP transport
@@ -2826,18 +2825,35 @@ class MCPPathRewriteMiddleware:
                     # would be rewritten and silently fall through (#3891).
                     _srv_match = re.match(r"/servers/([^/]+)/mcp", app_path)
                     if not _srv_match:
-                        response = ORJSONResponse({"detail": "Invalid server identifier"}, status_code=404)
-                        await response(scope, receive, send)
-                        return
+                        invalid_server_path = True
+                    else:
+                        # Rewrite to /mcp/ before auth so auth checks never
+                        # need to touch the streaming request body before the
+                        # downstream MCP handler receives it. Keep the public
+                        # app-relative path in modified_path for server_id
+                        # extraction by auth and the transport handler.
+                        rewrite_path = f"{root_path}/mcp/" if root_path else "/mcp/"
                 else:
                     # Not a /servers/ path — do not rewrite, pass through
-                    await self.application(scope, receive, send)
-                    return
-                # Rewrite to /mcp/ and continue through middleware (lets CORSMiddleware handle preflight)
-                # Preserve root_path prefix when rewriting
-                scope["path"] = f"{root_path}/mcp/" if root_path else "/mcp/"
-                await self.application(scope, receive, send)
-                return
+                    rewrite_path = None
+
+        if rewrite_path is not None:
+            # Continue through middleware with the mounted MCP route while
+            # retaining modified_path as the original app-relative path.
+            scope["path"] = rewrite_path
+
+        # Auth runs after any MCP route rewrite. streamable_http_auth reads
+        # modified_path for server-scoped decisions, so it still sees
+        # /servers/{id}/mcp while the downstream handler sees /mcp/.
+        auth_ok = await streamable_http_auth(scope, receive, send)
+        if not auth_ok:
+            return
+
+        if invalid_server_path:
+            response = ORJSONResponse({"detail": "Invalid server identifier"}, status_code=404)
+            await response(scope, receive, send)
+            return
+
         await self.application(scope, receive, send)
 
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4716,6 +4716,10 @@ class _StreamableHttpAuthHandler:
         self.receive = receive
         self.send = send
 
+    def _request_path(self) -> str:
+        """Return the public MCP path used for authentication decisions."""
+        return self.scope.get("modified_path") or self.scope.get("path", "")
+
     async def _send_error(self, *, detail: str, status_code: int = HTTP_401_UNAUTHORIZED, headers: dict[str, str] | None = None) -> bool:
         """Send an error response and return False (auth rejected).
 
@@ -4752,7 +4756,7 @@ class _StreamableHttpAuthHandler:
             True if authentication passes or is skipped.
             False if authentication fails and a 401 response is sent.
         """
-        path = self.scope.get("path", "")
+        path = self._request_path()
         # Normalize trailing slash for consistent matching
         normalized = path.rstrip("/")
         # Check if this is an MCP-related path that requires authentication.
@@ -5248,7 +5252,7 @@ class _StreamableHttpAuthHandler:
             except jwt.DecodeError:
                 return OAuthAuthResult.NOT_APPLICABLE
 
-        path = self.scope.get("path", "")
+        path = self._request_path()
         match = _SERVER_ID_RE.search(path)
         if not match:
             return OAuthAuthResult.NOT_APPLICABLE

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -2871,6 +2871,57 @@ class TestMCPPathRewriteMiddleware:
         app_mock.assert_called_once_with(scope, receive, send)
 
     @pytest.mark.asyncio
+    async def test_rewrite_happens_before_auth_and_preserves_public_path(self):
+        """Streaming-safe rewrite should happen before auth without losing server scope."""
+        app_mock = AsyncMock()
+        middleware = MCPPathRewriteMiddleware(app_mock)
+        scope = {"type": "http", "path": "/servers/server-1/mcp", "headers": []}
+        receive = AsyncMock()
+        send = AsyncMock()
+        observed = {}
+
+        async def _fake_streamable_http_auth(auth_scope, _receive, _send):
+            observed["path"] = auth_scope["path"]
+            observed["modified_path"] = auth_scope["modified_path"]
+            return True
+
+        with patch("mcpgateway.main.streamable_http_auth", new=_fake_streamable_http_auth):
+            await middleware._call_streamable_http(scope, receive, send)
+
+        assert observed == {
+            "path": "/mcp/",
+            "modified_path": "/servers/server-1/mcp",
+        }
+        app_mock.assert_called_once_with(scope, receive, send)
+
+    @pytest.mark.asyncio
+    async def test_streamable_auth_uses_modified_path_after_rewrite(self, monkeypatch):
+        """Auth should still apply server-scoped checks after path is rewritten to /mcp/."""
+        # First-Party
+        from mcpgateway.transports import streamablehttp_transport as transport
+
+        checked = {}
+
+        async def _fake_check_server_oauth_enforcement(server_id, user_context):
+            checked["server_id"] = server_id
+            checked["user_context"] = user_context
+
+        monkeypatch.setattr(transport.settings, "mcp_require_auth", False)
+        monkeypatch.setattr(transport, "_check_server_oauth_enforcement", _fake_check_server_oauth_enforcement)
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/",
+            "modified_path": "/servers/server-1/mcp",
+            "headers": [],
+        }
+
+        assert await transport.streamable_http_auth(scope, AsyncMock(), AsyncMock()) is True
+        assert checked["server_id"] == "server-1"
+        assert checked["user_context"] == {"is_authenticated": False}
+
+    @pytest.mark.asyncio
     async def test_rewrite_auth_failure(self):
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
@@ -3059,7 +3110,7 @@ class TestMCPPathRewriteMiddleware:
         app_mock = AsyncMock()
         middleware = MCPPathRewriteMiddleware(app_mock)
         scope = {"type": "http", "path": "/gateway/servers//mcp", "root_path": "/gateway", "headers": []}
-        receive, send = AsyncMock(), AsyncMock()
+        receive = AsyncMock()
         sent = []
 
         async def mock_send(msg):


### PR DESCRIPTION
## Summary
- rewrite `/servers/{id}/mcp` to the mounted `/mcp/` path before streamable HTTP auth runs
- preserve the original app-relative path in `scope["modified_path"]` so server-scoped OAuth/RBAC still sees `/servers/{id}/mcp`
- add regression coverage for rewrite-before-auth ordering and auth lookup through `modified_path`

Fixes #4275.

## Testing
- `uv run pytest tests/unit/mcpgateway/test_main_extended.py::TestMCPPathRewriteMiddleware -q`
- `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q -k streamable_http_auth`
- `uv run ruff check mcpgateway/main.py mcpgateway/transports/streamablehttp_transport.py`
- `uv run ruff check tests/unit/mcpgateway/test_main_extended.py --select E,F`
- `git diff --check`