### PR TITLE
Fix regex timeout detection

### DIFF
--- a/mcpgateway/services/content_security.py
+++ b/mcpgateway/services/content_security.py
@@ -16,7 +16,6 @@ from issue #538.
 import hashlib
 import logging
 import re
-import sys
 import threading
 from typing import List, Optional, Union
 
@@ -49,10 +48,20 @@ except ImportError:
     content_size_violations_counter = NoOpCounter()
     content_type_violations_counter = NoOpCounter()
 
-# re.search() gained a `timeout` keyword in Python 3.13 that actually aborts
-# pathological regex execution. Older versions only have the thread.join
-# fallback, which is a soft timeout (see _regex_search_with_timeout).
-_HAS_NATIVE_REGEX_TIMEOUT: bool = sys.version_info >= (3, 13)
+
+def _supports_native_regex_timeout() -> bool:
+    """Return whether stdlib re.Pattern.search accepts timeout=."""
+    try:
+        re.compile("").search("", timeout=0.01)  # type: ignore[call-arg]
+    except TypeError:
+        return False
+    return True
+
+
+# If stdlib re ever grows a native timeout, prefer it because it can abort
+# pathological regex execution. Current Python releases still require the
+# thread.join fallback (see _regex_search_with_timeout).
+_HAS_NATIVE_REGEX_TIMEOUT: bool = _supports_native_regex_timeout()
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/mcpgateway/services/test_content_pattern_detection.py
+++ b/tests/unit/mcpgateway/services/test_content_pattern_detection.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 
 # First-Party
-from mcpgateway.services.content_security import ContentPatternError, ContentSecurityService
+from mcpgateway.services.content_security import _supports_native_regex_timeout, ContentPatternError, ContentSecurityService
 
 
 class TestMaliciousPatternDetection:
@@ -240,6 +240,10 @@ class TestClassifyViolation:
 
 class TestTimeoutAndEdgeCases:
     """Test timeout handling and edge cases for coverage."""
+
+    def test_stdlib_re_search_has_no_native_timeout(self):
+        """Test stdlib re.Pattern.search does not enable the native timeout path."""
+        assert _supports_native_regex_timeout() is False
 
     def test_timeout_error_handling(self):
         """Test TimeoutError is caught and converted to ContentPatternError."""


### PR DESCRIPTION
## Summary
- replace the Python-version regex timeout assumption with feature detection against stdlib `re.Pattern.search`
- keep the existing thread-based timeout fallback active on Python 3.13, where `timeout=` is still unsupported
- add a regression test for the stdlib timeout capability check

Fixes #4509.

## Validation
- `uv run pytest tests/unit/mcpgateway/services/test_content_pattern_detection.py -q`
- `uv run --python 3.13 pytest tests/unit/mcpgateway/services/test_content_pattern_detection.py -q`
- `uv tool run ruff==0.15.1 check mcpgateway/services/content_security.py tests/unit/mcpgateway/services/test_content_pattern_detection.py`
- `uv tool run black==26.3.1 --check mcpgateway/services/content_security.py tests/unit/mcpgateway/services/test_content_pattern_detection.py`
- `git diff --check`