### PR TITLE
feat: Add populate-tiny to Makefile

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-01T10:39:39Z",
+  "generated_at": "2026-05-01T11:01:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -350,7 +350,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1644,
+        "line_number": 1656,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1857,
+        "line_number": 1869,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6263,
+        "line_number": 6275,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6760,
+        "line_number": 6772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6772,
+        "line_number": 6784,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6844,
+        "line_number": 6856,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7923,
+        "line_number": 7935,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-01T11:01:47Z",
+  "generated_at": "2026-05-05T12:37:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Makefile
+++ b/Makefile
@@ -1274,6 +1274,7 @@ generate-report:                           ## Display most recent load test repo
 # 📊 REST API POPULATION - Populate via HTTP endpoints (full write path)
 # =============================================================================
 # help: 📊 REST API POPULATION
+# help: populate-tiny        - Populate via REST API (50 each, ~500 entities, ~30 sec)
 # help: populate-small       - Populate via REST API (100 users, ~3K entities, ~2 min)
 # help: populate-medium      - Populate via REST API (10K users, ~300K entities, ~1 hr)
 # help: populate-large       - Populate via REST API (500K users, ~13M entities, ~4-12 hrs)
@@ -1282,7 +1283,18 @@ generate-report:                           ## Display most recent load test repo
 # help: populate-clean       - Delete all loadtest.example.com entities via API
 # help: populate-report      - Show latest population report
 
-.PHONY: populate-small populate-medium populate-large populate-dry populate-verify populate-clean populate-report
+.PHONY: populate-tiny populate-small populate-medium populate-large populate-dry populate-verify populate-clean populate-report
+
+populate-tiny:                             ## Populate via REST API - tiny (50 each)
+	@echo "📊 Populating via REST API (tiny profile)..."
+	@echo "   Target: 50 of each entity type, ~500 entities"
+	@echo "   Time: ~30 seconds"
+	@test -d "$(VENV_DIR)" || $(MAKE) venv
+	@/bin/bash -c "source $(VENV_DIR)/bin/activate && \
+		python -m tests.populate --profile tiny"
+	@echo ""
+	@echo "✅ Tiny API population complete!"
+	@echo "📄 Report: reports/tiny_populate_report.json"
 
 populate-small:                            ## Populate via REST API - small (100 users)
 	@echo "📊 Populating via REST API (small profile)..."

--- a/tests/populate/configs/tiny.yaml
+++ b/tests/populate/configs/tiny.yaml
@@ -1,0 +1,90 @@
+# Tiny REST API population profile - Quick testing
+# Target: 50 of each entity type, ~500 entities total
+# Estimated time: ~30 seconds (network + validation bound)
+# Database: SQLite OK
+
+profile:
+  name: tiny
+  description: "Tiny-scale API population (50 each, ~500 entities)"
+  version: 1.0
+
+global:
+  random_seed: 42
+  progress_bar: true
+  progress_update_frequency: 5
+  email_domain: "loadtest.example.com"
+  output_report: "reports/tiny_populate_report.json"
+  log_level: INFO
+
+concurrency:
+  # Tune these to increase throughput (RPS):
+  #   max_connections  - httpx connection pool size (upper bound)
+  #   max_concurrent   - semaphore: max in-flight HTTP requests at any time
+  #   batch_size       - populator batch: how many entities created in parallel per batch
+  # Rule of thumb: max_concurrent >= batch_size, max_connections >= max_concurrent
+  max_connections: 100
+  max_concurrent: 50
+  batch_size: 50
+  max_retries: 3
+  retry_base_delay: 1.0
+  timeout: 30.0
+
+scale:
+  # Users
+  users: 50
+  users_admin_percent: 10
+
+  # Teams
+  additional_teams_per_user: 1
+  teams_private_percent: 60
+  teams_public_percent: 40
+  members_per_team_min: 1
+  members_per_team_max: 3
+
+  # API Tokens
+  tokens_per_user_min: 1
+  tokens_per_user_max: 1
+  tokens_per_user_avg: 1
+
+  # Gateways
+  gateways: 50
+  tools_per_gateway_min: 5
+  tools_per_gateway_max: 15
+  tools_per_gateway_avg: 10
+
+  # Resources
+  resources_per_user_min: 1
+  resources_per_user_max: 1
+  resources_per_user_avg: 1
+
+  # Prompts
+  prompts_per_user_min: 1
+  prompts_per_user_max: 1
+  prompts_per_user_avg: 1
+
+  # Virtual Servers
+  servers_per_user_min: 1
+  servers_per_user_max: 1
+  servers_per_user_avg: 1
+
+  # A2A Agents
+  a2a_agents_per_user_min: 0
+  a2a_agents_per_user_max: 1
+  a2a_agents_per_user_avg: 0
+
+population_order:
+  - users
+  - teams
+  - rbac
+  - gateways
+  - tools
+  - resources
+  - prompts
+  - servers
+  - a2a_agents
+  - tokens
+
+reporting:
+  enabled: true
+  format: json
+  output_file: "reports/tiny_populate_report.json"

--- a/tests/populate/populate.py
+++ b/tests/populate/populate.py
@@ -255,7 +255,7 @@ Examples:
     parser.add_argument(
         "--profile",
         type=str,
-        choices=["small", "medium", "large"],
+        choices=["tiny", "small", "medium", "large"],
         default="small",
         help="Population profile (default: small)",
     )


### PR DESCRIPTION
Add a new `populate` level, that adds less objects (about 50/each) for a quicker execution.