### PR TITLE
docs: update 1.0.0 release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,11 +507,11 @@ docker run -d --name mcpgateway \
   -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
   -e DATABASE_URL=sqlite:///./mcp.db \
   -e SECURE_COOKIES=false \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 
 # Tail logs and generate API key
 docker logs -f mcpgateway
-docker run --rm -it ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3 \
+docker run --rm -it ghcr.io/ibm/mcp-context-forge:1.0.0 \
   python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret my-test-key-but-now-longer-than-32-bytes
 ```
 
@@ -529,7 +529,7 @@ docker run -d --name mcpgateway --restart unless-stopped \
   -e MCPGATEWAY_UI_ENABLED=true -e MCPGATEWAY_ADMIN_API_ENABLED=true \
   -e HOST=0.0.0.0 -e JWT_SECRET_KEY=my-test-key-but-now-longer-than-32-bytes \
   -e PLATFORM_ADMIN_EMAIL=admin@example.com -e PLATFORM_ADMIN_PASSWORD=changeme \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 **Host networking** (access local MCP servers):
@@ -537,7 +537,7 @@ docker run -d --name mcpgateway --restart unless-stopped \
 docker run -d --name mcpgateway --network=host \
   -v $(pwd)/data:/data -e DATABASE_URL=sqlite:////data/mcp.db \
   -e MCPGATEWAY_UI_ENABLED=true -e HOST=0.0.0.0 -e PORT=4444 \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 **Airgapped deployment** (no internet):
@@ -558,7 +558,7 @@ docker run -d --name mcpgateway -p 4444:4444 \
 ```bash
 podman run -d --name mcpgateway \
   -p 4444:4444 -e HOST=0.0.0.0 -e DATABASE_URL=sqlite:///./mcp.db \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 <details>
@@ -570,14 +570,14 @@ mkdir -p $(pwd)/data && chmod 777 $(pwd)/data
 podman run -d --name mcpgateway --restart=on-failure \
   -p 4444:4444 -v $(pwd)/data:/data \
   -e DATABASE_URL=sqlite:////data/mcp.db \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 **Host networking:**
 ```bash
 podman run -d --name mcpgateway --network=host \
   -v $(pwd)/data:/data -e DATABASE_URL=sqlite:////data/mcp.db \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 </details>
@@ -588,7 +588,7 @@ podman run -d --name mcpgateway --network=host \
 <summary><strong>✏️ Docker/Podman tips</strong></summary>
 
 * **.env files** - Put all the `-e FOO=` lines into a file and replace them with `--env-file .env`. See the provided [.env.example](https://github.com/IBM/mcp-context-forge/blob/main/.env.example) for reference.
-* **Pinned tags** - Use an explicit version (e.g. `1.0.0-RC-3`) instead of `latest` for reproducible builds.
+* **Pinned tags** - Use an explicit version (e.g. `1.0.0`) instead of `latest` for reproducible builds.
 * **JWT tokens** - Generate one in the running container:
 
   ```bash
@@ -634,7 +634,7 @@ docker run --rm -i \
   -e MCP_SERVER_URL=http://host.docker.internal:4444/servers/UUID_OF_SERVER_1/mcp \
   -e MCP_TOOL_CALL_TIMEOUT=120 \
   -e MCP_WRAPPER_LOG_LEVEL=DEBUG \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3 \
+  ghcr.io/ibm/mcp-context-forge:1.0.0 \
   python3 -m mcpgateway.wrapper
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -262,7 +262,7 @@ except ValueError as e:
 
 ### Log Injection Protection (CWE-117)
 
-As of version 1.0.0-RC-2, ContextForge implements log injection protection to prevent attackers from forging log entries:
+As of version 1.0.0, ContextForge implements log injection protection to prevent attackers from forging log entries:
 
 **Protection Mechanism:**
 - [`sanitize_log_message()`](mcpgateway/common/validators.py:884) - Sanitizes user-controlled data in logs
@@ -277,7 +277,7 @@ As of version 1.0.0-RC-2, ContextForge implements log injection protection to pr
 
 ### Template Injection Protection (CWE-1336)
 
-As of version 1.0.0-RC-2, ContextForge implements comprehensive Jinja2 template injection protection to prevent code execution attacks through malicious prompt templates:
+As of version 1.0.0, ContextForge implements comprehensive Jinja2 template injection protection to prevent code execution attacks through malicious prompt templates:
 
 **Protection Mechanism:**
 - [`validate_prompt_template()`](mcpgateway/services/content_security.py:411) - Multi-layer template validation

--- a/charts/README.md
+++ b/charts/README.md
@@ -249,7 +249,7 @@ It is expected that users will change these values before deployment.
 mcpContextForge:
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: 0.9.0
+    tag: 1.0.0
   ingress:
     enabled: true
     host: gateway.local   # replace with real DNS
@@ -690,7 +690,7 @@ For every setting see the [full annotated `values.yaml`](https://github.com/IBM/
 * 💾 Stateful storage - PV + PVC for Postgres (`/var/lib/postgresql/data`), storage class selectable.
 * 🌐 Networking & access - ClusterIP services, optional NGINX Ingress, and `NOTES.txt` with port-forward plus safe secret-fetch commands (password, bearer token, `JWT_SECRET_KEY`).
 * 📈 Replicas & availability - Gateway (3) and Fast-Time-Server (2) provide basic HA; stateful components run single-instance.
-* 📦 Helm best-practice layout - Clear separation of Deployments, Services, ConfigMaps, Secrets, PVC/PV and Ingress; chart version 0.9.0.
+* 📦 Helm best-practice layout - Clear separation of Deployments, Services, ConfigMaps, Secrets, PVC/PV and Ingress; chart version 1.0.0.
 * ⚙️ Horizontal Pod Autoscaler (HPA) support for mcpgateway
 
 ---

--- a/charts/mcp-stack/CONTRIBUTING.md
+++ b/charts/mcp-stack/CONTRIBUTING.md
@@ -262,8 +262,8 @@ When making changes:
 Update both `version` and `appVersion` in `Chart.yaml`:
 
 ```yaml
-version: 0.9.0          # Chart version
-appVersion: "0.9.0"     # Application version
+version: 1.0.0          # Chart version
+appVersion: "1.0.0"     # Application version
 ```
 
 ### Release Checklist

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -1,6 +1,6 @@
 # mcp-stack
 
-![Version: 1.0.0-RC-3](https://img.shields.io/badge/Version-1.0.0--RC--3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0-RC-3](https://img.shields.io/badge/AppVersion-1.0.0--RC--3-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A full-stack Helm chart for IBM's **Model Context Protocol (MCP) Gateway
 & Registry - Context-Forge**.  It bundles:

--- a/charts/mcp-stack/values-minikube.yaml
+++ b/charts/mcp-stack/values-minikube.yaml
@@ -11,7 +11,7 @@ mcpContextForge:
 
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "1.0.0-RC-3"
+    tag: "1.0.0"
     pullPolicy: Never              # image is pre-loaded via minikube image load
 
   ingress:
@@ -61,7 +61,7 @@ mcpContextForge:
 migration:
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: "1.0.0-RC-3"
+    tag: "1.0.0"
     pullPolicy: Never
 
 # Disable TLS on fast-time-server ingress for minikube
@@ -118,7 +118,7 @@ testing:
   registration:
     image:
       repository: ghcr.io/ibm/mcp-context-forge
-      tag: "1.0.0-RC-3"
+      tag: "1.0.0"
       pullPolicy: Never
     jwt:
       secret: my-test-key-but-now-longer-than-32-bytes  # pragma: allowlist secret

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -260,8 +260,8 @@ The `conditions` array contains objects that specify when plugins should execute
 
 The plugin framework uses **hybrid AND/OR condition evaluation** for precise control over plugin execution.
 
-!!! warning "Breaking Change in 1.0.0-RC3"
-    Plugin condition evaluation logic changed from pure OR to hybrid AND/OR in version 1.0.0-RC3. If you're upgrading from 0.9.x, review your plugin configurations to ensure they work as expected with the new evaluation model.
+!!! warning "Breaking Change in 1.0.0"
+    Plugin condition evaluation logic changed from pure OR to hybrid AND/OR in version 1.0.0. If you're upgrading from 0.9.x, review your plugin configurations to ensure they work as expected with the new evaluation model.
 
     **Migration Guide:** See [Plugin Condition Migration Guide](https://github.com/IBM/mcp-context-forge/blob/main/docs/docs/architecture/MIGRATION-PLUGIN-CONDITIONS.md) for detailed migration instructions and validation scripts.
 

--- a/docs/docs/architecture/security-features.md
+++ b/docs/docs/architecture/security-features.md
@@ -1,6 +1,6 @@
 # ContextForge Security Features
 
-**Current Version: 1.0.0-RC-3** — The gateway ships with the controls described below. Everything listed here is present in the codebase today; future roadmap items live in `docs/docs/architecture/roadmap.md`.
+**Current Version: 1.0.0** — The gateway ships with the controls described below. Everything listed here is present in the codebase today; future roadmap items live in `docs/docs/architecture/roadmap.md`.
 
 ## Security Posture Overview
 

--- a/docs/docs/best-practices/selecting-an-mcp-gateway.md
+++ b/docs/docs/best-practices/selecting-an-mcp-gateway.md
@@ -682,7 +682,7 @@ flowchart LR
 | Source Files | 1,946 |
 | [CI Checks](https://github.com/IBM/mcp-context-forge/actions) | 50+ (build, test, security, lint, deploy) |
 | [GitHub Community Health](https://github.com/IBM/mcp-context-forge/community) | 100% |
-| [Releases](https://github.com/IBM/mcp-context-forge/releases) | Monthly (v0.7.0 → v0.8.0 → v0.9.0 → v1.0.0-BETA) |
+| [Releases](https://github.com/IBM/mcp-context-forge/releases) | Monthly (v0.7.0 → v0.8.0 → v0.9.0 → v1.0.0) |
 | [Helm Charts](https://github.com/IBM/mcp-context-forge/tree/main/charts) | Production-ready with HPA, ingress, and RBAC |
 | [Container Images](https://github.com/IBM/mcp-context-forge/pkgs/container/mcp-context-forge) | Multi-arch: amd64, arm64, s390x, ppc64le |
 | MCP Protocol Support | 2024-11-05 through 2025-03-26 |

--- a/docs/docs/deployment/compose.md
+++ b/docs/docs/deployment/compose.md
@@ -85,7 +85,7 @@ export COMPOSE_CMD="docker compose"
 ## 🐳/🦭 Build the images
 
 ```bash
-docker pull ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+docker pull ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 ## 🐳/🦭 Build the images (when doing local development)

--- a/docs/docs/deployment/container.md
+++ b/docs/docs/deployment/container.md
@@ -20,7 +20,7 @@ docker run -d --name mcpgateway \
   -e PLATFORM_ADMIN_PASSWORD=changeme \
   -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
   -e DATABASE_URL=sqlite:///./mcp.db \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 
 docker logs mcpgateway
 ```

--- a/docs/docs/deployment/google-cloud-run.md
+++ b/docs/docs/deployment/google-cloud-run.md
@@ -16,7 +16,7 @@ Google Cloud Run is an ideal platform for ContextForge due to its:
 You can deploy the public image directly:
 
 ```text
-ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 ---
@@ -336,7 +336,7 @@ mcpgw=> \dt;
 Use ContextForge container to generate a JWT token:
 
 ```bash
-docker run -it --rm ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3 \
+docker run -it --rm ghcr.io/ibm/mcp-context-forge:1.0.0 \
   python3 -m mcpgateway.utils.create_jwt_token -u admin@example.com --secret jwt-secret-key
 ```
 

--- a/docs/docs/deployment/minikube.md
+++ b/docs/docs/deployment/minikube.md
@@ -2,7 +2,7 @@
 
 1. **Install Minikube and kubectl** (Docker or Podman driver required).
 2. Start a local cluster with Ingress and DNS addons.
-3. Load the `ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3` image into Minikube.
+3. Load the `ghcr.io/ibm/mcp-context-forge:1.0.0` image into Minikube.
 4. Deploy with the Helm chart (`charts/mcp-stack`).
 5. Access the Gateway at [http://gateway.local](http://gateway.local) or `127.0.0.1:80` via NGINX Ingress.
 
@@ -131,21 +131,21 @@ kubectl get pods -n ingress-nginx
 make minikube-image-load
 ```
 
-This target builds the `ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3` image and loads it into Minikube.
+This target builds the `ghcr.io/ibm/mcp-context-forge:1.0.0` image and loads it into Minikube.
 
 ### Alternative methods
 
 * **Pre-cache a remote image:**
 
   ```bash
-  minikube cache add ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  minikube cache add ghcr.io/ibm/mcp-context-forge:1.0.0
   minikube cache reload
   ```
 
 * **Load a local tarball:**
 
   ```bash
-  docker save ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3 | minikube image load -
+  docker save ghcr.io/ibm/mcp-context-forge:1.0.0 | minikube image load -
   ```
 
 ---
@@ -305,7 +305,7 @@ curl http://gateway.local/health
 | Uninstall Helm release | -                   | `helm uninstall mcp-stack`                                   |
 | Pause cluster       | `make minikube-stop`   | `minikube stop -p mcpgw`                                     |
 | Delete cluster      | `make minikube-delete` | `minikube delete -p mcpgw`                                   |
-| Remove cached image | -                      | `minikube cache delete ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3` |
+| Remove cached image | -                      | `minikube cache delete ghcr.io/ibm/mcp-context-forge:1.0.0` |
 
 ---
 

--- a/docs/docs/deployment/proxy-auth.md
+++ b/docs/docs/deployment/proxy-auth.md
@@ -96,7 +96,7 @@ services:
         network_mode: host
 
     context-forge:
-        image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        image: ghcr.io/ibm/mcp-context-forge:1.0.0
         ports:
 
             - 4444:4444
@@ -151,7 +151,7 @@ services:
       OAUTH2_PROXY_SET_XAUTHREQUEST: true
 
   mcp-gateway:
-    image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    image: ghcr.io/ibm/mcp-context-forge:1.0.0
     environment:
       MCP_CLIENT_AUTH_ENABLED: false
       TRUST_PROXY_AUTH: true
@@ -174,7 +174,7 @@ services:
       TZ: America/New_York
 
   mcp-gateway:
-    image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    image: ghcr.io/ibm/mcp-context-forge:1.0.0
     environment:
       MCP_CLIENT_AUTH_ENABLED: false
       TRUST_PROXY_AUTH: true

--- a/docs/docs/development/mcp-developer-guide-json-rpc.md
+++ b/docs/docs/development/mcp-developer-guide-json-rpc.md
@@ -123,7 +123,7 @@ curl -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
     },
     "serverInfo": {
       "name": "ContextForge",
-      "version": "1.0.0-RC-3"
+      "version": "1.0.0"
     },
     "instructions": "ContextForge providing federated tools, resources and prompts. Use /admin interface for configuration."
   }

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -1042,7 +1042,7 @@ To test upgrades from a different release:
 
 ```bash
 make upgrade-validate \
-  UPGRADE_BASE_IMAGE=ghcr.io/ibm/mcp-context-forge:1.0.0-RC-1 \
+  UPGRADE_BASE_IMAGE=ghcr.io/ibm/mcp-context-forge:1.0.0 \
   UPGRADE_TARGET_IMAGE=mcpgateway/mcpgateway:latest
 ```
 

--- a/docs/docs/faq/index.md
+++ b/docs/docs/faq/index.md
@@ -16,7 +16,7 @@
     OCI image (Docker/Podman) - shares host network so localhost works:
 
     ```bash
-    podman run --network=host -p 4444:4444 ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    podman run --network=host -p 4444:4444 ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
 ???+ example "🗂️ What URLs are available for the admin interface and API docs?"
@@ -119,7 +119,7 @@
     Include a persistent volume with your container or Kubernetes deployment. Ex:
 
     ```bash
-    docker run -v $(pwd)/data:/app ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    docker run -v $(pwd)/data:/app ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
     For production use, we recommend PostgreSQL. A Docker Compose target with PostgreSQL and Redis is provided.

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -4,13 +4,13 @@ This guide provides comprehensive configuration options for ContextForge, includ
 
 ---
 
-## ⚠️ New in 1.0.0-RC3
+## ⚠️ New in 1.0.0
 
-**Breaking Changes:** Several security defaults have been strengthened in RC3. Review these changes before upgrading:
+**Breaking Changes:** Several security defaults have been strengthened in 1.0.0. Review these changes before upgrading:
 
 ### Changed Defaults
 
-| Variable | 0.9.x Default | 1.0.0-RC3 Default | Impact |
+| Variable | 0.9.x Default | 1.0.0 Default | Impact |
 |----------|---------------|-------------------|--------|
 | `SSRF_ALLOW_LOCALHOST` | `true` | `false` | Blocks connections to localhost/127.0.0.1 |
 | `SSRF_ALLOW_PRIVATE_NETWORKS` | `true` | `false` | Blocks RFC1918 private networks (10.x, 172.16.x, 192.168.x) |
@@ -50,7 +50,7 @@ This guide provides comprehensive configuration options for ContextForge, includ
 - `LANGFUSE_SECRET_KEY` - Langfuse project secret key
 - `LANGFUSE_OTEL_AUTH` - Base64-encoded OTLP auth override
 
-**See Also:** [Upgrade Guide to 1.0.0-RC3](upgrade-to-1.0.0-rc3.md) for detailed migration instructions.
+**See Also:** [Upgrade Guide to 1.0.0](upgrade-to-1.0.0.md) for detailed migration instructions.
 
 ---
 
@@ -828,7 +828,7 @@ ContextForge includes **vendor-agnostic OpenTelemetry support** for distributed 
 | ------------------------------- | ---------------------------------------------- | --------------------- | ------------------------------------------ |
 | `OTEL_ENABLE_OBSERVABILITY`     | Master switch for observability               | `false`               | bool                                       |
 | `OTEL_SERVICE_NAME`             | Service identifier in traces                   | `mcp-gateway`         | string                                     |
-| `OTEL_SERVICE_VERSION`          | Service version in traces                      | `1.0.0-RC-3`               | string                                     |
+| `OTEL_SERVICE_VERSION`          | Service version in traces                      | `1.0.0`               | string                                     |
 | `DEPLOYMENT_ENV` / `ENVIRONMENT` | Environment tag (dev/staging/prod)           | `development`         | string                                     |
 | `OTEL_TRACES_EXPORTER`          | Trace exporter backend                         | `otlp`                | `otlp`, `jaeger`, `zipkin`, `console`, `none` |
 | `OTEL_RESOURCE_ATTRIBUTES`      | Custom resource attributes                     | (empty)               | `key=value,key2=value2`                   |

--- a/docs/docs/manage/index.md
+++ b/docs/docs/manage/index.md
@@ -6,8 +6,8 @@ Whether you're self-hosting, running in the cloud, or deploying to Kubernetes, t
 
 ---
 
-!!! tip "What's new in 1.0.0-RC-3"
-    Multi‑tenancy (email auth, teams, RBAC, resource visibility) was introduced in v0.9.0 and is fully supported in 1.0.0-RC-3.
+!!! tip "What's new in 1.0.0"
+    Multi‑tenancy (email auth, teams, RBAC, resource visibility) was introduced in v0.9.0 and is fully supported in 1.0.0.
 
     - See the [Changelog](https://github.com/IBM/mcp-context-forge/blob/main/CHANGELOG.md)
     - Quick enablement (excerpt): `EMAIL_AUTH_ENABLED=true`, `PLATFORM_ADMIN_EMAIL=...`, `AUTO_CREATE_PERSONAL_TEAMS=true`

--- a/docs/docs/manage/logging-examples.md
+++ b/docs/docs/manage/logging-examples.md
@@ -116,7 +116,7 @@ LOG_FOLDER=logs
 # docker-compose.yml
 services:
   mcpgateway:
-    image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    image: ghcr.io/ibm/mcp-context-forge:1.0.0
     environment:
 
       - LOG_LEVEL=INFO

--- a/docs/docs/manage/mysql-to-postgresql-migration.md
+++ b/docs/docs/manage/mysql-to-postgresql-migration.md
@@ -1,14 +1,14 @@
 # MySQL/MariaDB to PostgreSQL Migration Guide
 
-**Applies to:** ContextForge 1.0.0-RC3 and later
-**Reason:** MySQL and MariaDB support removed in RC3
+**Applies to:** ContextForge 1.0.0 and later
+**Reason:** MySQL and MariaDB support removed in 1.0.0
 **Estimated Time:** 2-4 hours (depending on database size)
 
 ---
 
 ## Overview
 
-ContextForge 1.0.0-RC3 removed support for MySQL and MariaDB databases. Only **PostgreSQL** and **SQLite** are now supported. This guide provides step-by-step instructions for migrating your data from MySQL/MariaDB to PostgreSQL.
+ContextForge 1.0.0 removed support for MySQL and MariaDB databases. Only **PostgreSQL** and **SQLite** are now supported. This guide provides step-by-step instructions for migrating your data from MySQL/MariaDB to PostgreSQL.
 
 **⚠️ CRITICAL:** This is a one-way migration. Ensure you have complete backups before proceeding.
 

--- a/docs/docs/manage/observability/observability.md
+++ b/docs/docs/manage/observability/observability.md
@@ -147,7 +147,7 @@ export OTEL_ENABLE_OBSERVABILITY=true
 
 # Service identification
 export OTEL_SERVICE_NAME=mcp-gateway
-export OTEL_SERVICE_VERSION=1.0.0-RC-3
+export OTEL_SERVICE_VERSION=1.0.0
 export OTEL_DEPLOYMENT_ENVIRONMENT=development
 
 # Choose your backend (otlp, jaeger, zipkin, console, none)
@@ -261,7 +261,7 @@ mcpgateway
 # Or with Docker
 docker run -e OTEL_ENABLE_OBSERVABILITY=true \
            -e OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317 \
-           ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+           ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 ## Configuration Reference
@@ -272,7 +272,7 @@ docker run -e OTEL_ENABLE_OBSERVABILITY=true \
 |----------|-------------|---------|---------|
 | `OTEL_ENABLE_OBSERVABILITY` | Master switch | `false` | `true`, `false` |
 | `OTEL_SERVICE_NAME` | Service identifier | `mcp-gateway` | Any string |
-| `OTEL_SERVICE_VERSION` | Service version | `1.0.0-RC-3` | Any string |
+| `OTEL_SERVICE_VERSION` | Service version | `1.0.0` | Any string |
 | `DEPLOYMENT_ENV` / `ENVIRONMENT` | Environment tag | `development` | `development`, `staging`, `production` |
 | `OTEL_TRACES_EXPORTER` | Export backend | `otlp` | `otlp`, `jaeger`, `zipkin`, `console`, `none` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Custom attributes | - | `key=value,key2=value2` |
@@ -388,7 +388,7 @@ spec:
       containers:
 
       - name: gateway
-        image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        image: ghcr.io/ibm/mcp-context-forge:1.0.0
         env:
 
         - name: OTEL_ENABLE_OBSERVABILITY

--- a/docs/docs/manage/observability/opentelemetry.md
+++ b/docs/docs/manage/observability/opentelemetry.md
@@ -147,7 +147,7 @@ export OTEL_ENABLE_OBSERVABILITY=true
 
 # Service identification
 export OTEL_SERVICE_NAME=mcp-gateway
-export OTEL_SERVICE_VERSION=1.0.0-RC-3
+export OTEL_SERVICE_VERSION=1.0.0
 export OTEL_DEPLOYMENT_ENVIRONMENT=development
 
 # Choose your backend (otlp, jaeger, zipkin, console, none)
@@ -261,7 +261,7 @@ mcpgateway
 # Or with Docker
 docker run -e OTEL_ENABLE_OBSERVABILITY=true \
            -e OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:4317 \
-           ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+           ghcr.io/ibm/mcp-context-forge:1.0.0
 ```
 
 ## Configuration Reference
@@ -272,7 +272,7 @@ docker run -e OTEL_ENABLE_OBSERVABILITY=true \
 |----------|-------------|---------|---------|
 | `OTEL_ENABLE_OBSERVABILITY` | Master switch | `false` | `true`, `false` |
 | `OTEL_SERVICE_NAME` | Service identifier | `mcp-gateway` | Any string |
-| `OTEL_SERVICE_VERSION` | Service version | `1.0.0-RC-3` | Any string |
+| `OTEL_SERVICE_VERSION` | Service version | `1.0.0` | Any string |
 | `DEPLOYMENT_ENV` / `ENVIRONMENT` | Environment tag | `development` | `development`, `staging`, `production` |
 | `OTEL_TRACES_EXPORTER` | Export backend | `otlp` | `otlp`, `jaeger`, `zipkin`, `console`, `none` |
 | `OTEL_RESOURCE_ATTRIBUTES` | Custom attributes | - | `key=value,key2=value2` |
@@ -388,7 +388,7 @@ spec:
       containers:
 
       - name: gateway
-        image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        image: ghcr.io/ibm/mcp-context-forge:1.0.0
         env:
 
         - name: OTEL_ENABLE_OBSERVABILITY

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -4,7 +4,7 @@ This guide provides essential security configurations and best practices for dep
 
 ## ⚠️ Critical Security Notice
 
-**ContextForge is currently in beta (v1.0.0-RC-3)** and requires careful security configuration for production use:
+**ContextForge is currently in beta (v1.0.0)** and requires careful security configuration for production use:
 
 - The **Admin UI is development-only** and must be disabled in production
 - Expect **breaking changes** between versions until 1.0 release

--- a/docs/docs/manage/ui-customization.md
+++ b/docs/docs/manage/ui-customization.md
@@ -181,7 +181,7 @@ When packaging the gateway:
   docker run \
     -v $(pwd)/overrides/admin.html:/app/mcpgateway/templates/admin.html:ro \
     -v $(pwd)/overrides/static:/app/mcpgateway/static/custom:ro \
-    ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    ghcr.io/ibm/mcp-context-forge:1.0.0
   ```
   Then update template references to point at `static/custom/...`.
 

--- a/docs/docs/manage/upgrade-to-1.0.0.md
+++ b/docs/docs/manage/upgrade-to-1.0.0.md
@@ -1,6 +1,6 @@
-# Upgrade Guide: 0.9.x → 1.0.0-RC3
+# Upgrade Guide: 0.9.x → 1.0.0
 
-**Target Version:** 1.0.0-RC3 (2026-04-14)
+**Target Version:** 1.0.0 (2026-05-01)
 **Previous Version:** 0.9.x
 **Breaking Changes:** Yes (8 major changes)
 **Estimated Migration Time:** 2-4 hours
@@ -9,7 +9,7 @@
 
 ## Overview
 
-ContextForge 1.0.0-RC3 includes **242 commits** with significant breaking changes across authentication, plugins, database support, and security defaults. This guide provides step-by-step migration instructions.
+ContextForge 1.0.0 includes significant breaking changes across authentication, plugins, database support, and security defaults. This guide provides step-by-step migration instructions.
 
 **⚠️ CRITICAL:** Review all sections before upgrading. Some changes require configuration updates or data migration.
 
@@ -36,7 +36,7 @@ ContextForge 1.0.0-RC3 includes **242 commits** with significant breaking change
 
 Three SSRF defaults inverted to strict security mode:
 
-| Setting | 0.9.x Default | 1.0.0-RC3 Default | Impact |
+| Setting | 0.9.x Default | 1.0.0 Default | Impact |
 |---------|---------------|-------------------|--------|
 | `SSRF_ALLOW_LOCALHOST` | `true` | `false` | Blocks `127.0.0.1`, `localhost`, `::1` |
 | `SSRF_ALLOW_PRIVATE_NETWORKS` | `true` | `false` | Blocks RFC1918 ranges (10.x, 172.16.x, 192.168.x) |
@@ -108,7 +108,7 @@ conditions:
 # Matched if: team_id="team-a" OR user_email="admin@example.com"
 ```
 
-**After (1.0.0-RC3):** Conditions within same object use AND, different objects use OR
+**After (1.0.0):** Conditions within same object use AND, different objects use OR
 ```yaml
 conditions:
   - team_id: "team-a"
@@ -148,7 +148,7 @@ plugins:
       - user_email: "admin@example.com"
     # Matched: team-a OR team-b OR admin@example.com
 
-# NEW (1.0.0-RC3) - Hybrid logic
+# NEW (1.0.0) - Hybrid logic
 plugins:
   - name: "TeamFilter"
     conditions:
@@ -164,7 +164,7 @@ conditions:
     user_email: "admin@example.com"
 # Matched: team-a OR admin@example.com
 
-# NEW (1.0.0-RC3)
+# NEW (1.0.0)
 conditions:
   - team_id: "team-a"
     user_email: "admin@example.com"
@@ -232,7 +232,7 @@ curl -X POST http://localhost:4444/mcp/sse \
 
 Two transport endpoints now require explicit enablement:
 
-| Endpoint | 0.9.x Default | 1.0.0-RC3 Default | Feature Flag |
+| Endpoint | 0.9.x Default | 1.0.0 Default | Feature Flag |
 |----------|---------------|-------------------|--------------|
 | WebSocket Relay | Enabled | **Disabled** | `MCPGATEWAY_WS_RELAY_ENABLED` |
 | Reverse Proxy | Enabled | **Disabled** | `MCPGATEWAY_REVERSE_PROXY_ENABLED` |
@@ -285,7 +285,7 @@ curl -X GET "http://localhost:4444/users/me/permissions" \
 
 **Before (0.9.x):** ID tokens accepted without signature verification
 
-**After (1.0.0-RC3):** ID tokens verified using provider's JWKS endpoint
+**After (1.0.0):** ID tokens verified using provider's JWKS endpoint
 
 #### Migration Steps
 
@@ -358,7 +358,7 @@ sntp -sS time.nist.gov    # macOS
 
 **Before (0.9.x):** All teams stored `max_members` value in database
 
-**After (1.0.0-RC3):**
+**After (1.0.0):**
 - New teams: `max_members = NULL` (resolved from `MAX_MEMBERS_PER_TEAM` at runtime)
 - Existing teams: Retain baked-in `max_members` value
 
@@ -523,7 +523,7 @@ helm upgrade mcp-stack charts/mcp-stack -n mcp-production -f values.yaml
 **Step 3:** Upgrade from BETA-2 (if applicable)
 
 ```bash
-# BETA-2 to RC3 requires special handling
+# BETA-2 to 1.0.0 requires special handling
 # See: https://github.com/your-org/mcp-context-forge/issues/3684
 
 # 1. Backup database
@@ -549,7 +549,7 @@ kubectl get pods -n mcp-production
 curl http://localhost:4444/health
 
 # Expected response:
-# {"status": "healthy", "version": "1.0.0-RC3"}
+# {"status": "healthy", "version": "1.0.0"}
 ```
 
 ### 2. Test Authentication
@@ -679,7 +679,7 @@ cp plugins/config.yaml.backup plugins/config.yaml
 When reporting upgrade issues, include:
 
 1. Previous version (e.g., 0.9.5)
-2. Target version (1.0.0-RC3)
+2. Target version (1.0.0)
 3. Deployment method (Docker, Kubernetes, local)
 4. Database backend (PostgreSQL, SQLite)
 5. Relevant logs (sanitized)
@@ -691,7 +691,7 @@ When reporting upgrade issues, include:
 
 | Version | Date | Changes |
 |---------|------|---------|
-| 1.0.0-RC3 | 2026-04-14 | Initial release |
+| 1.0.0 | 2026-05-01 | Initial release |
 
 ---
 

--- a/docs/docs/manage/upgrade.md
+++ b/docs/docs/manage/upgrade.md
@@ -14,7 +14,7 @@ ContextForge is under active development, and while we strive for backward compa
 
 **⚠️ IMPORTANT:** Before upgrading, review the version-specific migration guide for your target version:
 
-- **[Upgrading to 1.0.0-RC3](upgrade-to-1.0.0-rc3.md)** - Comprehensive guide covering 8 breaking changes with step-by-step migration instructions
+- **[Upgrading to 1.0.0](upgrade-to-1.0.0.md)** - Comprehensive guide covering 8 breaking changes with step-by-step migration instructions
 
 Each version-specific guide includes:
 - Detailed breaking change descriptions

--- a/docs/docs/media/kit/index.md
+++ b/docs/docs/media/kit/index.md
@@ -66,7 +66,7 @@ And is readily available as open source, published a container image and as a Py
       -e PLATFORM_ADMIN_EMAIL=admin@example.com \
       -e PLATFORM_ADMIN_PASSWORD=changeme \
       -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-      ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+      ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
     Please ⭐ the project on GitHub if you find this useful, it helps us grow!
@@ -86,7 +86,7 @@ And is readily available as open source, published a container image and as a Py
       -e PLATFORM_ADMIN_EMAIL=admin@example.com \
       -e PLATFORM_ADMIN_PASSWORD=changeme \
       -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-      ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+      ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
     **PyPI:**
@@ -127,7 +127,7 @@ And is readily available as open source, published a container image and as a Py
       -e PLATFORM_ADMIN_EMAIL=admin@example.com \
       -e PLATFORM_ADMIN_PASSWORD=changeme \
       -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-      ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+      ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
     **Or install via PyPI:**

--- a/docs/docs/overview/quick_start.md
+++ b/docs/docs/overview/quick_start.md
@@ -122,7 +122,7 @@ Pick an install method below, generate an auth token, then walk through a real t
           -e PLATFORM_ADMIN_EMAIL=admin@example.com \
           -e PLATFORM_ADMIN_PASSWORD=changeme \
           -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-          ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+          ghcr.io/ibm/mcp-context-forge:1.0.0
         ```
 
     2. **(Optional) persist the DB**
@@ -138,7 +138,7 @@ Pick an install method below, generate an auth token, then walk through a real t
               -e PLATFORM_ADMIN_EMAIL=admin@example.com \
               -e PLATFORM_ADMIN_PASSWORD=changeme \
               -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-              ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+              ghcr.io/ibm/mcp-context-forge:1.0.0
             ```
 
         === "PostgreSQL"
@@ -160,7 +160,7 @@ Pick an install method below, generate an auth token, then walk through a real t
               -e PLATFORM_ADMIN_EMAIL=admin@example.com \
               -e PLATFORM_ADMIN_PASSWORD=changeme \
               -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-              ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+              ghcr.io/ibm/mcp-context-forge:1.0.0
             ```
 
     3. **Generate a token inside the container**
@@ -197,7 +197,7 @@ Pick an install method below, generate an auth token, then walk through a real t
     2. **Pull the published image**
 
         ```bash
-        docker pull ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        docker pull ghcr.io/ibm/mcp-context-forge:1.0.0
         ```
 
     3. **Start the stack**

--- a/docs/docs/tutorials/argocd-helm-deployment-ibm-cloud-iks.md
+++ b/docs/docs/tutorials/argocd-helm-deployment-ibm-cloud-iks.md
@@ -103,7 +103,7 @@ podman build -t mcp-context-forge:dev -f Containerfile.lite .
 !!! note "Production deployments"
     Production deployments can pull the signed image directly:
     ```
-    ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    ghcr.io/ibm/mcp-context-forge:1.0.0
     ```
 
 ---
@@ -166,8 +166,8 @@ ibmcloud is subnet-create mcp-subnet-eu-de-3 \
 ibmcloud cr login
 
 # Tag and push the image
-podman tag mcp-context-forge:dev eu.icr.io/mcp-gw/mcpgateway:0.9.0
-podman push eu.icr.io/mcp-gw/mcpgateway:0.9.0
+podman tag mcp-context-forge:dev eu.icr.io/mcp-gw/mcpgateway:1.0.0
+podman push eu.icr.io/mcp-gw/mcpgateway:1.0.0
 
 # Verify the image
 ibmcloud cr images --restrict mcp-gw
@@ -365,7 +365,7 @@ mcpContextForge:
 
   image:
     repository: eu.icr.io/mcp-gw/mcpgateway
-    tag: "0.9.0"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
 
   # Service configuration
@@ -751,11 +751,11 @@ Update the image tag in your values file and commit:
 
 ```bash
 # Update values file
-sed -i 's/tag: "0.7.0"/tag: "0.9.0"/' charts/mcp-stack/envs/iks/values.yaml
+sed -i 's/tag: "0.7.0"/tag: "1.0.0"/' charts/mcp-stack/envs/iks/values.yaml
 
 # Commit and push
 git add charts/mcp-stack/envs/iks/values.yaml
-git commit -m "Upgrade ContextForge to v0.9.0"
+git commit -m "Upgrade ContextForge to v1.0.0"
 git push
 
 # Argo CD will automatically sync the changes

--- a/docs/docs/tutorials/dcr-hyprmcp.md
+++ b/docs/docs/tutorials/dcr-hyprmcp.md
@@ -185,7 +185,7 @@ Add ContextForge service to your compose file (put it in the `services` section)
 
 ```yaml
 context-forge:
-    image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    image: ghcr.io/ibm/mcp-context-forge:1.0.0
     ports:
 
         - 4444:4444
@@ -348,7 +348,7 @@ services:
         network_mode: host
 
     context-forge:
-        image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+        image: ghcr.io/ibm/mcp-context-forge:1.0.0
         ports:
 
             - 4444:4444

--- a/docs/docs/tutorials/openwebui-tutorial.md
+++ b/docs/docs/tutorials/openwebui-tutorial.md
@@ -216,7 +216,7 @@ docker run -d \
   -e AUTH_REQUIRED=true \
   -e PLATFORM_ADMIN_EMAIL=admin@example.com \
   -e PLATFORM_ADMIN_PASSWORD=changeme \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 
 # Generate an API token for later use (expires in 1 week)
 docker exec mcpgateway \
@@ -589,7 +589,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   mcpgateway:
-    image: ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+    image: ghcr.io/ibm/mcp-context-forge:1.0.0
     environment:
       MCPGATEWAY_UI_ENABLED: "true"
       MCPGATEWAY_ADMIN_API_ENABLED: "true"

--- a/docs/docs/using/clients/claude-desktop.md
+++ b/docs/docs/using/clients/claude-desktop.md
@@ -52,7 +52,7 @@ prompt and resource registered in your Gateway.
     "run", "--rm", "--network=host", "-i",
     "-e", "MCP_SERVER_URL=http://localhost:4444/servers/UUID_OF_SERVER_1",
     "-e", "MCP_AUTH=<Bearer YOUR_JWT_TOKEN>",
-    "ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3",
+    "ghcr.io/ibm/mcp-context-forge:1.0.0",
     "python3", "-m", "mcpgateway.wrapper"
   ]
 }

--- a/docs/docs/using/clients/copilot.md
+++ b/docs/docs/using/clients/copilot.md
@@ -117,7 +117,7 @@ That's it - VS Code spawns the stdio process, pipes JSON-RPC, and you're ready t
     "run", "--rm", "--network=host", "-i",
     "-e", "MCP_SERVER_URL=http://localhost:4444/servers/UUID_OF_SERVER_1",
     "-e", "MCP_AUTH=<Bearer YOUR_JWT_TOKEN>",
-    "ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3",
+    "ghcr.io/ibm/mcp-context-forge:1.0.0",
     "python3", "-m", "mcpgateway.wrapper"
   ]
 }

--- a/docs/docs/using/clients/mcp-cli.md
+++ b/docs/docs/using/clients/mcp-cli.md
@@ -111,7 +111,7 @@ Create a `server_config.json` file to define your ContextForge Gateway connectio
         "MCP_AUTH=${MCPGATEWAY_BEARER_TOKEN}",
         "--entrypoint",
         "uv",
-        "ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3",
+        "ghcr.io/ibm/mcp-context-forge:1.0.0",
         "run",
         "--directory",
         "mcpgateway-wrapper",
@@ -494,7 +494,7 @@ docker run -d --name mcpgateway \
   -e PLATFORM_ADMIN_EMAIL=admin@example.com \
   -e PLATFORM_ADMIN_PASSWORD=changeme \
   -e PLATFORM_ADMIN_FULL_NAME="Platform Administrator" \
-  ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3
+  ghcr.io/ibm/mcp-context-forge:1.0.0
 
 # Generate token
 export MCPGATEWAY_BEARER_TOKEN=$(docker exec mcpgateway python3 -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret my-secret-key)

--- a/docs/docs/using/mcpgateway-wrapper.md
+++ b/docs/docs/using/mcpgateway-wrapper.md
@@ -57,7 +57,7 @@ Launching it in your terminal (ex: `python3 -m mcpgateway.wrapper`) is useful fo
     docker run -i --rm --network=host \
       -e MCP_SERVER_URL=$MCP_SERVER_URL \
       -e MCP_AUTH=$MCP_AUTH \
-      ghcr.io/ibm/mcp-context-forge:1.0.0-RC-3 \
+      ghcr.io/ibm/mcp-context-forge:1.0.0 \
       python3 -m mcpgateway.wrapper
     ```
 
@@ -269,7 +269,7 @@ Open two shells or use a tool like `jq -c | nc -U` to pipe messages in and view 
         "resources":{"subscribe":false,"listChanged":false},
         "tools":{"listChanged":false}
       },
-      "serverInfo":{"name":"mcpgateway-wrapper","version":"1.0.0-RC-3"}
+      "serverInfo":{"name":"mcpgateway-wrapper","version":"1.0.0"}
     }}
 
     # Empty tool list


### PR DESCRIPTION
Updates stale public docs and chart examples from 1.0.0 release-candidate tags to the stable 1.0.0 tag.

Renames the 1.0.0 upgrade guide from the RC3-specific path to the stable 1.0.0 path and updates inbound links.

Leaves historical changelog/roadmap entries and release-candidate publishing examples intact.