### PR TITLE
Apply security headers to auth rejection responses

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -2882,9 +2882,6 @@ if settings.compression_enabled:
 else:
     logger.info("🚫 Response compression disabled")
 
-# Add security headers middleware
-app.add_middleware(SecurityHeadersMiddleware)
-
 # Add validation middleware if explicitly enabled
 if settings.validation_middleware_enabled:
     app.add_middleware(ValidationMiddleware)
@@ -2932,6 +2929,10 @@ app.add_middleware(AdminAuthMiddleware)
 
 # Trust all proxies (or lock down with a list of host patterns)
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+
+# Add security headers after auth middlewares so their short-circuit responses
+# receive the same defense-in-depth headers as route-generated responses.
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Add correlation ID middleware if enabled
 # Note: Registered AFTER RequestLoggingMiddleware so correlation ID is available when RequestLoggingMiddleware executes

--- a/tests/security/test_security_headers.py
+++ b/tests/security/test_security_headers.py
@@ -330,13 +330,27 @@ class TestCacheControlHardening:
         SecurityHeadersMiddleware would let a shared cache replay an authenticated
         docs/schema response to unauthenticated viewers — Web Cache Deception.
 
-        This is a unit test of the classifier rather than a request-flow test
-        because DocsAuthMiddleware wraps SecurityHeadersMiddleware and short-
-        circuits unauthenticated requests before they reach the response path.
+        This guards the path classifier used by request-flow tests below.
         """
         middleware = SecurityHeadersMiddleware(app=None)
         for path in ("/docs", "/redoc", "/openapi.json"):
             assert middleware._is_protected_path(path), f"{path} must be treated as protected"  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json", "/admin/tools"])
+    def test_auth_short_circuit_responses_have_security_headers(self, client: TestClient, monkeypatch, path: str):
+        """Auth middleware 401 responses must still receive global security headers."""
+        monkeypatch.setattr(settings, "auth_required", True)
+
+        response = client.get(path, headers={"Accept": "application/json"}, follow_redirects=False)
+
+        assert response.status_code == 401
+        assert response.headers["Cache-Control"] == "no-store, private"
+        assert response.headers["Pragma"] == "no-cache"
+        assert response.headers["Expires"] == "0"
+        assert "Authorization" in response.headers["Vary"]
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert "Content-Security-Policy" in response.headers
 
     def test_protected_endpoints_have_vary_authorization(self, client: TestClient):
         """Test that protected endpoints include Vary: Authorization header."""


### PR DESCRIPTION
## Summary

Moves `SecurityHeadersMiddleware` later in the Starlette middleware registration order so short-circuit responses returned by docs/admin auth middleware still receive the platform security and cache-hardening headers.

This keeps the existing centralized security-header behavior instead of duplicating header logic inside each auth middleware.

Fixes #4484.

## Validation

- `uv run pytest tests/security/test_security_headers.py::TestCacheControlHardening::test_auth_short_circuit_responses_have_security_headers -q`
- `uv run pytest tests/security/test_security_headers.py -q`
- `uv run ruff check mcpgateway/main.py tests/security/test_security_headers.py`
- `git diff --check`
