### PR TITLE
Fix empty database bootstrap to use Alembic

### DIFF
--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -53,7 +53,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
-from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, Gateway, Prompt, Resource, Server, Tool
+from mcpgateway.db import A2AAgent, Base, EmailTeam, EmailUser, Gateway, Prompt, Resource, Server, Tool  # noqa: F401
 from mcpgateway.services.logging_service import LoggingService
 
 # Migration lock to prevent concurrent migrations from multiple workers
@@ -688,8 +688,8 @@ async def main() -> None:
     """
     Bootstrap or upgrade the database schema, then log readiness.
 
-    Runs `create_all()` + `alembic stamp head` on an empty DB, otherwise just
-    executes `alembic upgrade head`, leaving application data intact.
+    Runs `alembic upgrade head` for empty and existing databases, leaving
+    application data intact.
     Also creates the platform admin user if email authentication is enabled.
 
     Uses distributed advisory locks (PG) or file locking (SQLite)
@@ -727,9 +727,8 @@ async def main() -> None:
                 table_names = insp.get_table_names()
 
                 if "gateways" not in table_names:
-                    logger.info("Empty DB detected - creating baseline schema")
-                    Base.metadata.create_all(bind=conn)
-                    command.stamp(cfg, "head")
+                    logger.info("Empty DB detected - running Alembic migrations to create baseline schema")
+                    command.upgrade(cfg, "head")
                 else:
                     versions: list[str] = []
                     if "alembic_version" in table_names:

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -1446,10 +1446,10 @@ class TestMain:
                                                     with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
                                                         await main()
 
-                                                        mock_base.metadata.create_all.assert_called_once_with(bind=mock_conn)
-                                                        mock_command.stamp.assert_called_once_with(mock_config, "head")
-                                                        mock_command.upgrade.assert_not_called()
-                                                        mock_logger.info.assert_any_call("Empty DB detected - creating baseline schema")
+                                                        mock_base.metadata.create_all.assert_not_called()
+                                                        mock_command.stamp.assert_not_called()
+                                                        mock_command.upgrade.assert_called_once_with(mock_config, "head")
+                                                        mock_logger.info.assert_any_call("Empty DB detected - running Alembic migrations to create baseline schema")
 
     @pytest.mark.asyncio
     async def test_main_existing_database(self, mock_settings):


### PR DESCRIPTION
## Summary
- run `alembic upgrade head` for empty databases instead of creating ORM metadata directly and then stamping head
- keep the existing baseline-stamp compatibility path for already-created schemas
- update bootstrap unit coverage so empty databases assert migrations run and `Base.metadata.create_all()` is not called

Fixes #4555.

## Validation
- `uv run ruff check mcpgateway/bootstrap_db.py`
- `uv run pytest tests/unit/mcpgateway/test_bootstrap_db.py -q`
