### PR TITLE
feat: React Client FastAPI Router

### DIFF
--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -63,12 +63,10 @@ jobs:
 
       - name: 🎭 Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: ./client
         run: npx playwright install --with-deps chromium
 
       - name: 🎭 Install Playwright system deps (cached browsers)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: ./client
         run: npx playwright install-deps chromium
 
       - name: 🧪 Run Playwright tests

--- a/.github/workflows/client-e2e.yml
+++ b/.github/workflows/client-e2e.yml
@@ -63,10 +63,12 @@ jobs:
 
       - name: 🎭 Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: ./client
         run: npx playwright install --with-deps chromium
 
       - name: 🎭 Install Playwright system deps (cached browsers)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: ./client
         run: npx playwright install-deps chromium
 
       - name: 🧪 Run Playwright tests

--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,8 @@ dev:
 	@trap 'echo "🛑 Stopping background processes..."; jobs -p | xargs $(XARGS_FLAGS) kill 2>/dev/null || true' EXIT; \
 	$(MAKE) js-build watch-css & \
 	WATCH_CSS_PID=$$!; \
-	@cd client && npm install --no-audit --no-fund && npm run build:watch > /dev/null 2>&1 & echo $$! > /tmp/mcpgateway-client-watch.pid
+	(cd client && npm install --no-audit --no-fund && npm run build:watch > /dev/null 2>&1) & \
+	echo $$! > /tmp/mcpgateway-client-watch.pid; \
 	TEMPLATES_AUTO_RELOAD=true $(VENV_DIR)/bin/uvicorn mcpgateway.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude='public/' || { kill $$WATCH_CSS_PID 2>/dev/null || true; exit 1; }
 
 .PHONY: dev-echo

--- a/client/README.md
+++ b/client/README.md
@@ -28,17 +28,21 @@ npm install
 The client development workflow requires both the client dev server and the backend gateway:
 
 1. **Build the client assets:**
+
    ```bash
    npm run build
    ```
 
 2. **Start the client development server:**
+
    ```bash
    npm run dev
    ```
+
    This starts the Vite dev server at `http://localhost:5173` with hot module replacement.
 
 3. **In another terminal, start the backend gateway:**
+
    ```bash
    make dev
    ```
@@ -317,7 +321,7 @@ Ensure TypeScript types are properly configured:
 ### MSW Not Intercepting Requests
 
 - Verify handlers are defined in `src/test/mocks/handlers.ts`
-- Check that paths match exactly (e.g., `/auth/login` not `/api/auth/login`)
+- Check that paths match exactly (e.g., `/app/auth/login` not `/api/auth/login`)
 - Ensure MSW server is started in `src/test/setup.ts`
 
 ### window.matchMedia Errors in Tests

--- a/client/e2e/README.md
+++ b/client/e2e/README.md
@@ -58,7 +58,7 @@ Import the `test` and `expect` helpers from the fixture that matches your needs:
 // Unauthenticated / public flows
 import { test, expect } from "../fixtures/api-mock";
 
-// Authenticated flows (token seeded in sessionStorage)
+// Authenticated flows (/app/auth/me mocked as a valid cookie session)
 import { test, expect } from "../fixtures/auth";
 ```
 
@@ -95,5 +95,5 @@ PRs and pushes to `main` / `epic/ui-rewrite` that touch `client/**`.
 - **Tests that pass locally but flake in CI** — add a `page.waitForLoadState`,
   tighten the mock's payload, or widen the retry count in the config for the
   specific test. Do not add arbitrary `waitForTimeout` calls.
-- **Mock not firing** — `page.route()` patterns use glob syntax. `"**/auth/me"`
+- **Mock not firing** — `page.route()` patterns use glob syntax. `"**/app/auth/me"`
   is the supported form; a leading `/` anchors to the origin only.

--- a/client/e2e/auth/login-flow.spec.ts
+++ b/client/e2e/auth/login-flow.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from "../fixtures/api-mock";
 import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
 
 test.describe("Login flow", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, apiMock }) => {
+    await apiMock.mockMe({ status: 401 });
     await page.addInitScript((key) => {
       window.sessionStorage.removeItem(key);
     }, TOKEN_STORAGE_KEY);
@@ -10,7 +11,6 @@ test.describe("Login flow", () => {
 
   test("successful login navigates to the dashboard", async ({ page, apiMock }) => {
     await apiMock.mockLogin();
-    await apiMock.mockMe();
 
     await page.goto(APP.LOGIN);
     await page.getByLabel(/email address/i).fill("test@example.com");
@@ -24,14 +24,10 @@ test.describe("Login flow", () => {
       (key) => window.sessionStorage.getItem(key),
       TOKEN_STORAGE_KEY,
     );
-    expect(token).not.toBeNull();
+    expect(token).toBeNull();
   });
 
   test("401 response keeps user on the login page without a token", async ({ page, apiMock }) => {
-    // A 401 from /auth/login is currently treated as a generic session-expiry
-    // by the API client (clearToken + window.location.replace). That wipes
-    // React state, so the error alert is not observable here — we assert the
-    // outcome the user experiences: stuck on /app/login, no token persisted.
     await apiMock.mockLogin({ status: 401 });
 
     await page.goto(APP.LOGIN);
@@ -40,6 +36,7 @@ test.describe("Login flow", () => {
     await page.getByRole("button", { name: /^sign in$/i }).click();
 
     await expect(page).toHaveURL(new RegExp(`${APP.LOGIN}$`));
+    await expect(page.getByRole("alert")).toHaveText(/invalid/i);
     const token = await page.evaluate(
       (key) => window.sessionStorage.getItem(key),
       TOKEN_STORAGE_KEY,
@@ -58,17 +55,14 @@ test.describe("Login flow", () => {
     await expect(page.getByRole("alert")).toHaveText(/login failed/i);
   });
 
-  test("submit button shows loading state during request", async ({ page, apiMock }) => {
+  test("submit button shows loading state during request", async ({ page }) => {
     // Delay the response so the loading state is observable.
-    await page.route("**/auth/login", async (route) => {
+    await page.route("**/app/auth/login", async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 500));
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
-          access_token: "mock-token-12345",
-          token_type: "bearer",
-          expires_in: 3600,
           user: {
             email: "test@example.com",
             full_name: "Test User",
@@ -78,10 +72,10 @@ test.describe("Login flow", () => {
             email_verified: true,
             password_change_required: false,
           },
+          csrf_token: "mock-csrf-token",
         }),
       });
     });
-    await apiMock.mockMe();
 
     await page.goto(APP.LOGIN);
     await page.getByLabel(/email address/i).fill("test@example.com");

--- a/client/e2e/auth/session.spec.ts
+++ b/client/e2e/auth/session.spec.ts
@@ -2,13 +2,13 @@ import { test, expect } from "../fixtures/auth";
 import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
 
 test.describe("Authenticated session", () => {
-  test("pre-seeded token lets a user reach the dashboard", async ({ page }) => {
+  test("cookie session check lets a user reach the dashboard", async ({ page }) => {
     await page.goto(APP.ROOT);
     await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible();
     const token = await page.evaluate(
       (key) => window.sessionStorage.getItem(key),
       TOKEN_STORAGE_KEY,
     );
-    expect(token).toBe("mock-token-12345");
+    expect(token).toBeNull();
   });
 });

--- a/client/e2e/fixtures/api-mock.ts
+++ b/client/e2e/fixtures/api-mock.ts
@@ -27,15 +27,10 @@ export const DEFAULT_TEST_USER: MockUser = {
   password_change_required: false,
 };
 
-export const MOCK_TOKEN = "mock-token-12345";
+export const MOCK_CSRF_TOKEN = "mock-csrf-token";
 
 export interface ApiMock {
-  mockLogin(options?: {
-    user?: MockUser;
-    status?: number;
-    token?: string;
-    detail?: string;
-  }): Promise<void>;
+  mockLogin(options?: { user?: MockUser; status?: number; detail?: string }): Promise<void>;
   mockMe(options?: { user?: MockUser; status?: number }): Promise<void>;
   mockUnauthorized(urlPattern: string | RegExp): Promise<void>;
 }
@@ -45,19 +40,16 @@ export function createApiMock(page: Page): ApiMock {
     async mockLogin({
       user = DEFAULT_TEST_USER,
       status = 200,
-      token = MOCK_TOKEN,
       detail = "Invalid credentials",
     } = {}) {
-      await page.route("**/auth/login", async (route) => {
+      await page.route("**/app/auth/login", async (route) => {
         if (status === 200) {
           await route.fulfill({
             status,
             contentType: "application/json",
             body: JSON.stringify({
-              access_token: token,
-              token_type: "bearer",
-              expires_in: 3600,
               user,
+              csrf_token: MOCK_CSRF_TOKEN,
             }),
           });
           return;
@@ -71,7 +63,7 @@ export function createApiMock(page: Page): ApiMock {
     },
 
     async mockMe({ user = DEFAULT_TEST_USER, status = 200 } = {}) {
-      await page.route("**/auth/me", async (route) => {
+      await page.route("**/app/auth/me", async (route) => {
         if (status === 200) {
           await route.fulfill({
             status,

--- a/client/e2e/fixtures/auth.ts
+++ b/client/e2e/fixtures/auth.ts
@@ -2,16 +2,14 @@
  * Authenticated-page fixture.
  *
  * Extends the base Playwright test with:
- *   - a `page` that has the bearer token pre-seeded in sessionStorage, and
- *   - an `apiMock` with `/auth/me` + `/auth/login` pre-stubbed.
+ *   - an `apiMock` with `/app/auth/me` + `/app/auth/login` pre-stubbed.
  *
  * Tests import from here when they need to skip the login form and land
  * directly on an authenticated route.
  */
 
 import { test as base } from "@playwright/test";
-import { TOKEN_STORAGE_KEY } from "../utils/paths";
-import { createApiMock, MOCK_TOKEN, type ApiMock } from "./api-mock";
+import { createApiMock, type ApiMock } from "./api-mock";
 
 type AuthFixtures = {
   apiMock: ApiMock;
@@ -19,14 +17,9 @@ type AuthFixtures = {
 
 export const test = base.extend<AuthFixtures>({
   page: async ({ page }, use) => {
-    // Seed token before any page script runs so AuthContext rehydrates
-    // as "authenticated" on first render.
-    await page.addInitScript(
-      ([key, token]) => {
-        window.sessionStorage.setItem(key, token);
-      },
-      [TOKEN_STORAGE_KEY, MOCK_TOKEN],
-    );
+    const mock = createApiMock(page);
+    await mock.mockMe();
+    await mock.mockLogin();
     await use(page);
   },
   apiMock: async ({ page }, use) => {

--- a/client/e2e/smoke/app-loads.spec.ts
+++ b/client/e2e/smoke/app-loads.spec.ts
@@ -3,16 +3,18 @@ import { APP } from "../utils/paths";
 
 test.describe("App loading (smoke)", () => {
   test("loads /app without JavaScript errors", async ({ page, apiMock }) => {
-    // Unauthenticated entry point: auth guard will redirect to /app/login,
-    // which fetches nothing, but mock /auth/me defensively in case a token
-    // sneaks in from a previous worker.
+    // Unauthenticated entry point: auth guard checks /app/auth/me and then
+    // redirects to /app/login when no cookie session exists.
     await apiMock.mockMe({ status: 401 });
 
     const consoleErrors: string[] = [];
     const pageErrors: string[] = [];
 
     page.on("console", (msg) => {
-      if (msg.type() === "error") consoleErrors.push(msg.text());
+      const text = msg.text();
+      if (msg.type() === "error" && !text.includes("401 (Unauthorized)")) {
+        consoleErrors.push(text);
+      }
     });
     page.on("pageerror", (err) => {
       pageErrors.push(`${err.name}: ${err.message}`);

--- a/client/e2e/smoke/team-switcher.spec.ts
+++ b/client/e2e/smoke/team-switcher.spec.ts
@@ -1,16 +1,8 @@
 import { test, expect } from "../fixtures/api-mock";
-import { APP, TOKEN_STORAGE_KEY } from "../utils/paths";
+import { APP } from "../utils/paths";
 
 test.describe("TeamSwitcher component (smoke)", () => {
   test("renders and displays teams from API", async ({ page, apiMock }) => {
-    // Set up authenticated session
-    await page.addInitScript(
-      ({ key, token }) => {
-        window.sessionStorage.setItem(key, token);
-      },
-      { key: TOKEN_STORAGE_KEY, token: "mock-token-12345" },
-    );
-
     // Mock authenticated user
     await apiMock.mockMe();
 
@@ -48,14 +40,6 @@ test.describe("TeamSwitcher component (smoke)", () => {
   });
 
   test("displays error message when teams fail to load", async ({ page, apiMock }) => {
-    // Set up authenticated session
-    await page.addInitScript(
-      ({ key, token }) => {
-        window.sessionStorage.setItem(key, token);
-      },
-      { key: TOKEN_STORAGE_KEY, token: "mock-token-12345" },
-    );
-
     // Mock authenticated user
     await apiMock.mockMe();
 

--- a/client/e2e/utils/paths.ts
+++ b/client/e2e/utils/paths.ts
@@ -36,12 +36,11 @@ export const APP = {
  * so they match regardless of origin (dev vs. reverse-proxied gateway).
  */
 export const API = {
-  LOGIN: "**/auth/login",
-  ME: "**/auth/me",
+  LOGIN: "**/app/auth/login",
+  ME: "**/app/auth/me",
 } as const;
 
 /**
- * sessionStorage key the client uses for the bearer token. Must match
- * `TOKEN_KEY` in `client/src/api/client.ts`.
+ * Legacy sessionStorage key kept so tests can assert cookie auth no longer writes it.
  */
 export const TOKEN_STORAGE_KEY = "mcpgateway_token";

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -2,14 +2,13 @@
  * API client — typed fetch wrapper.
  *
  * Security guarantees:
- *  - JWT is read from sessionStorage; never from a URL query param.
- *  - Authorization: Bearer header is added on every authenticated request.
- *  - Content-Type and X-Requested-With are always set on mutating requests.
+ *  - Authentication uses same-origin httpOnly cookies; JWTs are never stored in web storage.
+ *  - CSRF tokens are read from the non-httpOnly csrf_token cookie and sent on mutating requests.
+ *  - Content-Type and X-Requested-With are always set on JSON requests.
  *  - Non-2xx responses throw a typed ApiError; callers never handle raw text.
- *  - 401 responses clear the stored token and redirect to /app/login.
+ *  - Protected 401 responses redirect to /app/login.
  */
 
-const TOKEN_KEY = "mcpgateway_token";
 const LOGIN_PATH = "/app/login";
 
 export class ApiError extends Error {
@@ -23,20 +22,28 @@ export class ApiError extends Error {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Token helpers — sessionStorage only
-// ---------------------------------------------------------------------------
-
 export function getToken(): string | null {
-  return sessionStorage.getItem(TOKEN_KEY);
+  return null;
 }
 
 export function setToken(token: string): void {
-  sessionStorage.setItem(TOKEN_KEY, token);
+  void token;
+  // Kept for backward-compatible imports; cookie auth does not expose JWTs to JS.
 }
 
 export function clearToken(): void {
-  sessionStorage.removeItem(TOKEN_KEY);
+  // Kept for backward-compatible imports; cookies are cleared by /app/auth/logout.
+}
+
+function getCookie(name: string): string | null {
+  const prefix = `${encodeURIComponent(name)}=`;
+  const cookie = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+
+  if (!cookie) return null;
+  return decodeURIComponent(cookie.slice(prefix.length));
 }
 
 // ---------------------------------------------------------------------------
@@ -71,10 +78,10 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     ...extraHeaders,
   };
 
-  if (!unauthenticated) {
-    const token = getToken();
-    if (token) {
-      headers["Authorization"] = `Bearer ${token}`;
+  if (method !== "GET") {
+    const csrfToken = getCookie("csrf_token");
+    if (csrfToken) {
+      headers["X-CSRF-Token"] = csrfToken;
     }
   }
 
@@ -82,18 +89,16 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
-    // Credentials: omit — auth is via Bearer header, not cookies.  // pragma: allowlist secret
-    // This also means the browser will NOT auto-send cookies cross-origin,
-    // making CSRF attacks structurally impossible for these requests.
-    credentials: "omit", // pragma: allowlist secret
+    credentials: "same-origin",
     signal,
   });
 
   if (response.status === 401) {
-    clearToken();
-    // replace() rather than href= so the failed page is not added to history
-    // (the user can't hit Back into an unauthenticated state).
-    window.location.replace(LOGIN_PATH);
+    if (!unauthenticated && path !== "/app/auth/me") {
+      // replace() rather than href= so the failed page is not added to history
+      // (the user can't hit Back into an unauthenticated state).
+      window.location.replace(LOGIN_PATH);
+    }
     throw new ApiError(401, null, "Session expired — redirecting to login");
   }
 

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -26,8 +26,7 @@ export function getToken(): string | null {
   return null;
 }
 
-export function setToken(token: string): void {
-  void token;
+export function setToken(_token: string): void {
   // Kept for backward-compatible imports; cookie auth does not expose JWTs to JS.
 }
 

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -26,7 +26,7 @@ export function getToken(): string | null {
   return null;
 }
 
-export function setToken(_token: string): void {
+export function setToken(): void {
   // Kept for backward-compatible imports; cookie auth does not expose JWTs to JS.
 }
 

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -45,6 +45,31 @@ function getCookie(name: string): string | null {
   return decodeURIComponent(cookie.slice(prefix.length));
 }
 
+function getRequestUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return new URL(path, window.location.origin).toString();
+  }
+
+  return path;
+}
+
+function canUseSignal(url: string, signal: AbortSignal): boolean {
+  if (typeof Request === "undefined") {
+    return true;
+  }
+
+  try {
+    new Request(url, { signal });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Core request
 // ---------------------------------------------------------------------------
@@ -84,13 +109,19 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     }
   }
 
-  const response = await fetch(path, {
+  const requestUrl = getRequestUrl(path);
+  const requestOptions: RequestInit = {
     method,
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
     credentials: "same-origin",
-    signal,
-  });
+  };
+
+  if (signal && canUseSignal(requestUrl, signal)) {
+    requestOptions.signal = signal;
+  }
+
+  const response = await fetch(requestUrl, requestOptions);
 
   if (response.status === 401) {
     if (!unauthenticated && path !== "/app/auth/me") {

--- a/client/src/auth/AuthContext.tsx
+++ b/client/src/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
-import { createContext, useCallback, useContext, useState, useEffect } from "react";
+import { createContext, useCallback, useContext, useState, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
-import { api, setToken, clearToken, ApiError } from "../api/client";
+import { api, ApiError } from "../api/client";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -17,20 +17,19 @@ export interface User {
 }
 
 interface LoginResponse {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
   user: User;
+  csrf_token: string;
 }
 
 interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
+  isLoading: boolean;
 }
 
 interface AuthContextValue extends AuthState {
   login: (email: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -40,44 +39,38 @@ interface AuthContextValue extends AuthState {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const authVersion = useRef(0);
   const [state, setState] = useState<AuthState>({
-    // Restore session: if a token exists in sessionStorage we treat the user
-    // as authenticated until the first API call proves otherwise (401 clears it).
     user: null,
-    isAuthenticated: sessionStorage.getItem("mcpgateway_token") !== null,
+    isAuthenticated: false,
+    isLoading: true,
   });
 
-  // Rehydrate user on mount if token exists
   useEffect(() => {
-    const token = sessionStorage.getItem("mcpgateway_token");
-    if (token && !state.user) {
-      // Try new endpoint first, fallback to legacy endpoint for backward compatibility
-      const fetchUser = async () => {
-        try {
-          return await api.get<User>("/auth/email/me");
-        } catch (err) {
-          // Fallback to old endpoint if new one doesn't exist
-          if (err instanceof ApiError && err.status === 404) {
-            console.warn("Falling back to legacy auth endpoint");
-            return await api.get<User>("/auth/me");
-          }
-          throw err;
-        }
-      };
+    let cancelled = false;
+    const version = authVersion.current;
 
-      fetchUser()
-        .then((user) => {
-          setState({ user, isAuthenticated: true });
-        })
-        .catch((err) => {
-          // Token invalid or expired - clear auth state
+    api
+      .get<User>("/app/auth/me")
+      .then((user) => {
+        if (!cancelled && version === authVersion.current) {
+          setState({ user, isAuthenticated: true, isLoading: false });
+        }
+      })
+      .catch((err) => {
+        if (!cancelled && version === authVersion.current) {
           if (err instanceof ApiError && err.status === 401) {
-            clearToken();
-            setState({ user: null, isAuthenticated: false });
+            setState({ user: null, isAuthenticated: false, isLoading: false });
+            return;
           }
-        });
-    }
-  }, [state.user]);
+          setState({ user: null, isAuthenticated: false, isLoading: false });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const login = useCallback(
     async (
@@ -85,21 +78,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       password: string, // pragma: allowlist secret
     ): Promise<void> => {
       const data = await api.post<LoginResponse>(
-        "/auth/login",
+        "/app/auth/login",
         { email, password },
         { unauthenticated: true },
       );
 
-      setToken(data.access_token);
-      setState({ user: data.user, isAuthenticated: true });
+      authVersion.current += 1;
+      setState({ user: data.user, isAuthenticated: true, isLoading: false });
     },
     [],
   );
 
-  const logout = useCallback((): void => {
-    clearToken();
-    setState({ user: null, isAuthenticated: false });
-    window.location.href = "/app/login";
+  const logout = useCallback(async (): Promise<void> => {
+    try {
+      await api.post<{ message: string }>("/app/auth/logout");
+    } catch {
+      // Client-side logout should still complete if the server-side session is already gone
+      // or the CSRF cookie has expired.
+    } finally {
+      authVersion.current += 1;
+      setState({ user: null, isAuthenticated: false, isLoading: false });
+      window.location.href = "/app/login";
+    }
   }, []);
 
   return (

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { useAuth } from "../auth/useAuth";
 import { useRouter } from "../router";
@@ -6,12 +6,18 @@ import { ApiError } from "../api/client";
 
 export function Login() {
   const intl = useIntl();
-  const { login } = useAuth();
+  const { isAuthenticated, login } = useAuth();
   const { navigate } = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate("/app/");
+    }
+  }, [isAuthenticated, navigate]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/client/src/router/index.tsx
+++ b/client/src/router/index.tsx
@@ -243,6 +243,28 @@ export function AuthGuard({
     }
   }, [isAuthenticated, isLoading, isPublic, navigate]);
 
-  if (isPublic || isLoading || !isAuthenticated) return null;
+  // Public routes: render immediately
+  if (isPublic) return <>{children}</>;
+
+  // Loading state: show loading indicator instead of blank page
+  if (isLoading) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        fontSize: '14px',
+        color: '#666'
+      }}>
+        Loading...
+      </div>
+    );
+  }
+
+  // Not authenticated: return null (redirect will happen via useEffect)
+  if (!isAuthenticated) return null;
+
+  // Authenticated: render protected content
   return <>{children}</>;
 }

--- a/client/src/router/index.tsx
+++ b/client/src/router/index.tsx
@@ -249,14 +249,16 @@ export function AuthGuard({
   // Loading state: show loading indicator instead of blank page
   if (isLoading) {
     return (
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100vh',
-        fontSize: '14px',
-        color: '#666'
-      }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          fontSize: "14px",
+          color: "#666",
+        }}
+      >
         Loading...
       </div>
     );

--- a/client/src/router/index.tsx
+++ b/client/src/router/index.tsx
@@ -24,7 +24,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { ComponentType, ReactNode } from "react";
-import { getToken } from "../api/client";
+import { useAuthContext } from "../auth/AuthContext";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -231,17 +231,18 @@ export function AuthGuard({
   publicPrefixes = DEFAULT_PUBLIC_PREFIXES,
 }: AuthGuardProps) {
   const { navigate, path } = useRouter();
-  const authenticated = getToken() !== null;
+  const { isAuthenticated, isLoading } = useAuthContext();
+  const pathname = path.split("?")[0];
 
   const isPublic =
-    publicPaths.includes(path) || publicPrefixes.some((prefix) => path.startsWith(prefix));
+    publicPaths.includes(pathname) || publicPrefixes.some((prefix) => pathname.startsWith(prefix));
 
   useEffect(() => {
-    if (!authenticated && !isPublic) {
+    if (!isLoading && !isAuthenticated && !isPublic) {
       navigate("/app/login");
     }
-  }, [authenticated, isPublic, navigate]);
+  }, [isAuthenticated, isLoading, isPublic, navigate]);
 
-  if (isPublic || !authenticated) return null;
+  if (isPublic || isLoading || !isAuthenticated) return null;
   return <>{children}</>;
 }

--- a/client/src/test/mocks/handlers.ts
+++ b/client/src/test/mocks/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 
 export const handlers = [
   // Mock login endpoint
-  http.post("/auth/login", async ({ request }) => {
+  http.post("/app/auth/login", async ({ request }) => {
     const body = await request.json();
     const { email, password } = body as { email: string; password: string };
 
@@ -12,9 +12,6 @@ export const handlers = [
       password === "password123" // pragma: allowlist secret
     ) {
       return HttpResponse.json({
-        access_token: "mock-token-12345",
-        token_type: "bearer",
-        expires_in: 3600,
         user: {
           email: "test@example.com",
           full_name: "Test User",
@@ -24,6 +21,7 @@ export const handlers = [
           email_verified: true,
           password_change_required: false,
         },
+        csrf_token: "mock-csrf-token",
       });
     }
 
@@ -31,16 +29,8 @@ export const handlers = [
   }),
 
   // Mock auth check endpoint
-  http.get("/auth/me", () => {
-    return HttpResponse.json({
-      email: "test@example.com",
-      full_name: "Test User",
-      is_admin: true,
-      is_active: true,
-      auth_provider: "local",
-      email_verified: true,
-      password_change_required: false,
-    });
+  http.get("/app/auth/me", () => {
+    return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
   }),
 
   // Mock gateways endpoint with cursor pagination

--- a/client/src/test/mocks/handlers.ts
+++ b/client/src/test/mocks/handlers.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 
 export const handlers = [
   // Mock login endpoint
-  http.post("/app/auth/login", async ({ request }) => {
+  http.post("*/app/auth/login", async ({ request }) => {
     const body = await request.json();
     const { email, password } = body as { email: string; password: string };
 
@@ -29,12 +29,12 @@ export const handlers = [
   }),
 
   // Mock auth check endpoint
-  http.get("/app/auth/me", () => {
+  http.get("*/app/auth/me", () => {
     return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
   }),
 
   // Mock gateways endpoint with cursor pagination
-  http.get("/gateways", ({ request }) => {
+  http.get("*/gateways", ({ request }) => {
     const url = new URL(request.url);
     const cursor = url.searchParams.get("cursor");
     const limit = parseInt(url.searchParams.get("limit") || "25", 10);
@@ -64,12 +64,12 @@ export const handlers = [
   }),
 
   // Mock gateway delete endpoint
-  http.delete("/gateways/:id", () => {
+  http.delete("*/gateways/:id", () => {
     return HttpResponse.json({ success: true });
   }),
 
   // Mock gateway test endpoint
-  http.post("/gateways/:id/test", () => {
+  http.post("*/gateways/:id/test", () => {
     return HttpResponse.json({
       success: true,
       message: "Connection successful",
@@ -77,7 +77,7 @@ export const handlers = [
   }),
 
   // Mock create gateway endpoint
-  http.post("/gateways", async ({ request }) => {
+  http.post("*/gateways", async ({ request }) => {
     const body = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json(
       {
@@ -90,7 +90,7 @@ export const handlers = [
   }),
 
   // Mock update gateway endpoint
-  http.put("/gateways/:gatewayId", async ({ request, params }) => {
+  http.put("*/gateways/:gatewayId", async ({ request, params }) => {
     const body = (await request.json()) as Record<string, unknown>;
     const { gatewayId } = params;
     return HttpResponse.json({

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,6 +7,12 @@ import path from "path";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
 
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -6,6 +6,11 @@ import path from "path";
 
 export default defineConfig({
   plugins: [react()] as any,
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -1560,6 +1560,128 @@ done
 echo "Done!"
 ```
 
+## React App Authentication
+
+The React client uses cookie-based authentication with CSRF protection for secure session management.
+
+### Login
+
+```bash
+# Login with email and password
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "password": "your-password"
+  }' \
+  $BASE_URL/app/auth/login | jq '.'
+```
+
+**Response:**
+```json
+{
+  "user": {
+    "email": "user@example.com",
+    "is_admin": false,
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:00:00Z"
+  },
+  "csrf_token": "abc123...xyz"
+}
+```
+
+**Cookies Set:**
+- `jwt_token` - httpOnly JWT token (XSS protection)
+- `csrf_token` - non-httpOnly CSRF token (path=/app, readable by JS for double-submit pattern)
+
+### Get Current User
+
+```bash
+# Get current user from session cookie
+curl -s -H "Cookie: jwt_token=<token>" \
+  $BASE_URL/app/auth/me | jq '.'
+```
+
+**Response:**
+```json
+{
+  "email": "user@example.com",
+  "is_admin": false,
+  "created_at": "2024-01-01T00:00:00Z",
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+### Logout
+
+```bash
+# Logout (requires CSRF token from login response)
+curl -s -X POST \
+  -H "Cookie: jwt_token=<token>; csrf_token=<csrf>" \
+  -H "X-CSRF-Token: <csrf-token-from-login>" \
+  $BASE_URL/app/auth/logout | jq '.'
+```
+
+**Response:**
+```json
+{
+  "message": "Logged out successfully"
+}
+```
+
+### Security Features
+
+**httpOnly Cookies:**
+- JWT token stored in httpOnly cookie (not accessible via JavaScript)
+- Protects against XSS attacks
+
+**CSRF Protection:**
+- Synchronizer token pattern
+- CSRF token in non-httpOnly cookie + X-CSRF-Token header (double-submit pattern; JS reads the cookie value)
+- Required for state-changing operations (logout)
+
+**Cookie Configuration:**
+- `httpOnly=true` - Prevents JavaScript access
+- `secure=true` - HTTPS only (production)
+- `samesite=strict` - CSRF cookie (prevents cross-site requests)
+- `samesite=lax` - JWT cookie (allows navigation)
+- `path=/app` - CSRF cookie scoped to app namespace
+
+### Cross-Tab Session Persistence
+
+Sessions are shared across browser tabs via cookies:
+
+```bash
+# Tab 1: Login — save cookies to jar (-c) so jwt_token is preserved (it's httpOnly)
+LOGIN_RESPONSE=$(curl -s -c /tmp/cookiejar -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "password"}' \
+  $BASE_URL/app/auth/login)
+
+# Extract CSRF token from response body (jwt_token is httpOnly — not in body, only in cookie jar)
+CSRF_TOKEN=$(echo $LOGIN_RESPONSE | jq -r '.csrf_token')
+
+# Tab 2: Use same cookie jar (browser shares cookies automatically across tabs)
+curl -s -b /tmp/cookiejar \
+  $BASE_URL/app/auth/me | jq '.'
+```
+
+### Error Responses
+
+**401 Unauthorized:**
+```json
+{
+  "detail": "Invalid email or password"
+}
+```
+
+**403 Forbidden (CSRF):**
+```json
+{
+  "detail": "CSRF token missing from header"
+}
+```
+
 ## Related Documentation
 
 - [Configuration Guide](configuration.md) - Environment variables and settings

--- a/docs/docs/manage/securing.md
+++ b/docs/docs/manage/securing.md
@@ -148,6 +148,90 @@ make certs-all                   # Generates both TLS certificates and JWT RSA k
 **Security Requirements:**
 
 - [ ] **Never commit private keys** to version control
+- [ ] **Rotate keys regularly** (recommended: every 90 days for production)
+- [ ] **Use secrets management** (Vault, AWS Secrets Manager, etc.) in production
+- [ ] **Implement rate limiting** at the reverse proxy/load balancer level
+
+### 3. Rate Limiting for Authentication Endpoints
+
+The React app authentication endpoints (`/app/auth/login`, `/app/auth/logout`) implement **per-IP rate limiting** (10 requests/minute per IP address) and **per-user account lockout**. Additional infrastructure-level rate limiting is recommended for defense-in-depth protection.
+
+#### Built-in Protection
+
+The application provides:
+
+- **Per-IP Rate Limiting**: 10 requests/minute per IP address via `@rate_limit(10)` decorator on login endpoint
+- **Per-User Account Lockout**: Tracks failed attempts per email address (see below)
+
+#### Infrastructure Rate Limiting (Recommended)
+
+While the application provides per-IP rate limiting, configuring additional rate limiting at your reverse proxy (nginx, Traefik, Envoy) or load balancer provides defense-in-depth protection:
+
+```nginx
+# nginx example - limit login attempts across all accounts
+limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/m;
+
+location /app/auth/login {
+    limit_req zone=login_limit burst=3 nodelay;
+    proxy_pass http://contextforge:4444;
+}
+```
+
+**Recommended thresholds:**
+- **Login endpoint**: 5 requests/minute per IP (burst: 3)
+- **Logout endpoint**: 10 requests/minute per IP (burst: 5)
+- **Token refresh**: 20 requests/minute per IP (burst: 10)
+
+#### Per-User Account Lockout
+
+The application provides built-in per-user lockout via `EmailAuthService`:
+- Tracks failed login attempts per email address
+- Locks account after configurable threshold (default: 5 attempts)
+- Automatic unlock after configurable duration (default: 15 minutes)
+- Prevents credential stuffing against individual accounts
+
+**Configuration:**
+```bash
+# Per-user lockout settings (handled by EmailAuthService)
+MAX_LOGIN_ATTEMPTS=5           # Failed attempts before lockout
+LOCKOUT_DURATION=900           # Lockout duration in seconds (15 minutes)
+```
+
+#### Production Deployment Pattern
+
+```yaml
+# Example: Traefik middleware for rate limiting
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: auth-rate-limit
+spec:
+  rateLimit:
+    average: 5
+    period: 1m
+    burst: 3
+    sourceCriterion:
+      ipStrategy:
+        depth: 1
+```
+
+Apply to ingress routes:
+```yaml
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: contextforge-auth
+spec:
+  routes:
+    - match: PathPrefix(`/app/auth/login`)
+      middlewares:
+        - name: auth-rate-limit
+      services:
+        - name: contextforge
+          port: 4444
+```
+
+See [Reverse Proxy Configuration](../using/reverse-proxy.md) for additional examples.
 - [ ] **Store private keys** in secure, encrypted storage
 - [ ] **Use strong file permissions** (600) on private keys
 - [ ] **Implement key rotation** procedures (recommend 90-day rotation)
@@ -296,6 +380,30 @@ Tokens with a `jti` (JWT ID) claim are tracked and can be revoked before expirat
 # Enable token tracking (required for revocation)
 REQUIRE_JTI=true
 ```
+
+##### Logout Token Revocation (Best-Effort Pattern)
+
+The `/app/auth/logout` endpoint uses a **best-effort revocation pattern** that prioritizes user experience and availability:
+
+**Success Case:**
+- Token added to blocklist (Redis/DB)
+- Auth cookies cleared immediately
+- Token rejected on subsequent requests
+
+**Failure Case (Redis/DB unavailable):**
+- Revocation fails but logout succeeds
+- Auth cookies still cleared (immediate client-side protection)
+- Token remains valid until natural expiry (`TOKEN_EXPIRY`, default: 20 minutes)
+- Failure logged with correlation ID for monitoring
+- Metric recorded: `auth.token_revocation_failure`
+
+**Security Considerations:**
+- Short `TOKEN_EXPIRY` (5-20 minutes recommended) limits exposure window
+- Monitor `auth.token_revocation_failure` metric for blocklist health
+- Consider `TOKEN_IDLE_TIMEOUT` for additional protection
+- Tokens without `jti` cannot be revoked (logged as warning)
+
+**Rationale:** Logout must always succeed from the user's perspective. Cookie clearing provides immediate client-side protection, while token TTL bounds the exposure window if server-side revocation fails.
 
 #### Token Validation Settings
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -19908,36 +19908,3 @@ async def get_performance_history(
     )
 
     return history.model_dump()
-
-
-# ---------------------------------------------------------------------------
-# React SPA — /app catch-all
-#
-# Served on a SEPARATE router (no /admin prefix, no CSRF dependency) so that
-# /app/login and all other client-side routes are reachable at their intended
-# paths.  Auth is NOT enforced here: the HTML is public; access control is
-# handled by the React AuthGuard (client-side) and by each API endpoint
-# (server-side).  This follows the standard SPA deployment pattern.
-# ---------------------------------------------------------------------------
-
-app_spa_router = APIRouter(tags=["App UI"])
-
-
-@app_spa_router.get("/app", include_in_schema=False)
-@app_spa_router.get("/app/{path:path}", include_in_schema=False)
-async def app_spa(_request: Request) -> FileResponse:
-    """Serve the React SPA for all /app/* routes.
-
-    Returns:
-        FileResponse: The compiled React index.html
-
-    Raises:
-        HTTPException: 404 when the SPA has not been built yet
-    """
-    index = settings.static_dir / "app" / "index.html"
-    if not index.exists():
-        raise HTTPException(
-            status_code=404,
-            detail="React UI not built. Run: cd client && npm run build",
-        )
-    return FileResponse(str(index))

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -92,6 +92,7 @@ from mcpgateway.utils.trace_context import (
     set_trace_user_email,
     set_trace_user_is_admin,
 )
+from mcpgateway.utils.auth_errors import raise_auth_error
 from mcpgateway.utils.verify_credentials import (
     ConfigurableHTTPBearer,
     security,
@@ -106,6 +107,7 @@ __all__ = [
     "normalize_token_teams",
     "resolve_session_teams",
 ]
+logger = logging.getLogger(__name__)
 
 # Module-level sync Redis client for rate-limiting (lazy-initialized)
 _SYNC_REDIS_CLIENT = None  # pylint: disable=invalid-name
@@ -1910,3 +1912,42 @@ def _inject_userinfo_instate(request: Optional[object] = None, user: Optional[Em
 
     if request and global_context:
         request.state.plugin_global_context = global_context
+
+
+async def get_current_user_from_cookie(
+    request: Request,
+) -> tuple[EmailUser, Optional[str]]:
+    """FastAPI dependency: validate JWT cookie and return (user, jti) tuple.
+
+    Returns:
+        Tuple of (EmailUser ORM instance, jti claim or None)
+    Raises:
+        HTTPException: 401 with structured ErrorResponse if cookie missing, invalid, revoked, or user inactive
+    """
+    token = request.cookies.get("jwt_token")
+    if not token:
+        raise_auth_error("not_authenticated", "Not authenticated")
+
+    try:
+        payload = await verify_jwt_token_cached(token, request)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.debug("JWT cookie validation failed: %s", e)
+        raise_auth_error("invalid_token", "Invalid or expired token")
+
+    email = payload.get("sub")
+    if not email:
+        raise_auth_error("invalid_token", "Invalid token: missing subject")
+
+    jti = payload.get("jti")
+    if jti:
+        is_revoked = await asyncio.to_thread(_check_token_revoked_sync, jti)
+        if is_revoked:
+            raise_auth_error("token_revoked", "Token has been revoked")
+
+    user = await asyncio.to_thread(_get_user_by_email_sync, email)
+    if user is None or not user.is_active:
+        raise_auth_error("not_authenticated", "Not authenticated")
+
+    return user, jti

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -75,7 +75,7 @@ from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
 # Import the admin routes from the new module
 from mcpgateway import __version__
 from mcpgateway import version as version_module
-from mcpgateway.admin import admin_router, app_spa_router, set_logging_service
+from mcpgateway.admin import admin_router, set_logging_service
 from mcpgateway.auth import _check_token_revoked_sync, _lookup_api_token_sync, get_current_user, get_user_team_roles, normalize_token_teams, resolve_session_teams
 from mcpgateway.auth_context import (
     decode_internal_mcp_auth_context,
@@ -1313,6 +1313,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Initialize logging service FIRST to ensure all logging goes to dual output
     await logging_service.initialize()
     logger.info("Starting ContextForge services")
+
+    # Token expiry validation now runs at module import time in mcpgateway.routers.app
+    # (fail-fast before any initialization). This log confirms it passed during import.
+    logger.info("Token expiry validation passed at import time (CSRF and JWT tokens synchronized)")
 
     # Wait for the database to be ready, then run bootstrap (alembic + seed).
     # This used to run at module-import time, which made every test that
@@ -12367,6 +12371,12 @@ app.mount("/_internal/mcp/transport", app=internal_trusted_mcp_transport.handle_
 
 # Conditional static files mounting and root redirect
 if UI_ENABLED:
+    # React App auth API and SPA routes (only when UI is enabled)
+    from mcpgateway.routers.app import app_router, app_spa_router  # pylint: disable=import-outside-toplevel
+
+    app.include_router(app_router)  # /app/auth/* JSON API endpoints
+    app.include_router(app_spa_router)  # /app/* SPA catch-all
+
     # Mount static files for UI
     logger.info("Mounting static files - UI enabled")
     try:
@@ -12386,10 +12396,6 @@ if UI_ENABLED:
             settings.static_dir,
             exc,
         )
-    
-    # Mount React SPA router (requires static files to be available)
-    app.include_router(app_spa_router)  # React SPA at /app/* (no prefix, no CSRF)
-    logger.info("React SPA router mounted at /app/*")
 
     # Redirect root path to admin UI
     @app.get("/")

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -17,6 +17,7 @@ import functools
 from functools import wraps
 import logging
 from typing import Any, Callable, Generator, List, Optional
+from urllib.parse import urlparse
 import uuid
 import warnings
 
@@ -355,17 +356,19 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     sec_fetch_mode = request.headers.get("sec-fetch-mode", "")
     sec_fetch_site = request.headers.get("sec-fetch-site", "")
     is_admin_ui_request = "/admin" in referer
+    request_path = request.url.path
     # SPA shell/document navigations — path == "/app" covers navigations without text/html Accept.
-    is_spa_document_request = request.url.path == "/app"
-    # First-party React fetches to /app/auth/* — Sec-Fetch-* are forbidden request headers
-    # (https://fetch.spec.whatwg.org/#forbidden-request-header) set only by browsers, making
-    # them a reliable browser signal. Origin is intentionally excluded: it can be set by any
-    # HTTP client (curl, scripts) and does not prove browser origin.
-    is_first_party_app_fetch = request.url.path.startswith("/app/auth/") and (sec_fetch_site in {"same-origin", "same-site"} or sec_fetch_mode in {"cors", "same-origin"})
+    is_spa_document_request = request_path == "/app"
+    referer_path = urlparse(referer).path if referer else ""
+    is_app_referer = referer_path == "/app" or referer_path.startswith("/app/")
+    # First-party React fetches from the SPA. Sec-Fetch-* are forbidden request
+    # headers in browsers, and the /app referer ties the request to the client UI
+    # instead of allowing arbitrary cookie-authenticated API calls.
+    is_first_party_app_fetch = is_app_referer and sec_fetch_site == "same-origin" and sec_fetch_mode in {"cors", "same-origin"}
     is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request or is_spa_document_request or is_first_party_app_fetch
 
     # SECURITY: Reject cookie-only authentication for API requests
-    # Cookies should only be used for browser/HTML requests (including admin UI and React SPA fetch calls)
+    # Cookies should only be used for browser/HTML requests and same-origin UI fetches.
     if token_from_cookie and not is_browser_request:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -374,6 +377,9 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
         )
 
     if not token:
+        if is_first_party_app_fetch:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authorization token required")
+
         # For browser requests (HTML Accept header or HTMX), redirect to login
         if is_browser_request:
             raise HTTPException(status_code=status.HTTP_302_FOUND, detail="Authentication required", headers={"Location": f"{settings.app_root_path}/admin/login"})

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -352,11 +352,20 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     accept_header = request.headers.get("accept", "")
     is_htmx = request.headers.get("hx-request") == "true"
     referer = request.headers.get("referer", "")
+    sec_fetch_mode = request.headers.get("sec-fetch-mode", "")
+    sec_fetch_site = request.headers.get("sec-fetch-site", "")
     is_admin_ui_request = "/admin" in referer
-    is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request
+    # SPA shell/document navigations — path == "/app" covers navigations without text/html Accept.
+    is_spa_document_request = request.url.path == "/app"
+    # First-party React fetches to /app/auth/* — Sec-Fetch-* are forbidden request headers
+    # (https://fetch.spec.whatwg.org/#forbidden-request-header) set only by browsers, making
+    # them a reliable browser signal. Origin is intentionally excluded: it can be set by any
+    # HTTP client (curl, scripts) and does not prove browser origin.
+    is_first_party_app_fetch = request.url.path.startswith("/app/auth/") and (sec_fetch_site in {"same-origin", "same-site"} or sec_fetch_mode in {"cors", "same-origin"})
+    is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request or is_spa_document_request or is_first_party_app_fetch
 
     # SECURITY: Reject cookie-only authentication for API requests
-    # Cookies should only be used for browser/HTML requests (including admin UI fetch calls)
+    # Cookies should only be used for browser/HTML requests (including admin UI and React SPA fetch calls)
     if token_from_cookie and not is_browser_request:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/mcpgateway/routers/app.py
+++ b/mcpgateway/routers/app.py
@@ -1,0 +1,296 @@
+"""React App API Router.
+
+This module provides JSON API endpoints for the React client application,
+including cookie-based authentication with CSRF protection and SPA serving.
+
+Endpoints:
+- POST /app/auth/login - Authenticate and set httpOnly cookie
+- GET /app/auth/me - Get current user info from cookie
+- POST /app/auth/logout - Clear authentication cookie
+- GET /app/* - Serve React SPA (catch-all)
+"""
+
+import asyncio
+import logging
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy.orm import Session
+
+from mcpgateway.admin import rate_limit
+from mcpgateway.auth import get_current_user_from_cookie
+from mcpgateway.config import settings
+from mcpgateway.db import EmailUser, get_db
+from mcpgateway.routers.email_auth import create_access_token
+from mcpgateway.schemas import EmailUserResponse
+from mcpgateway.services.email_auth_service import EmailAuthService
+from mcpgateway.services.observability_service import ObservabilityService
+from mcpgateway.services.token_blocklist_service import get_token_blocklist_service
+from mcpgateway.utils.auth_errors import raise_auth_error
+from mcpgateway.utils.csrf import clear_csrf_cookie, generate_csrf_token, require_csrf, set_csrf_cookie
+from mcpgateway.utils.security_cookies import clear_auth_cookie, set_auth_cookie
+
+logger = logging.getLogger(__name__)
+
+# Module-level constants
+APP_COOKIE_PATH = "/app"
+
+
+def _validate_token_expiry_sync() -> None:
+    """Validate that CSRF and JWT tokens have synchronized expiry times.
+
+    This is a critical security check performed at application startup to ensure
+    that CSRF tokens and JWT session tokens expire simultaneously. Mismatched
+    expiry times can lead to auth/CSRF desynchronization vulnerabilities.
+
+    Both token types use settings.token_expiry as their single source of truth:
+    - JWT expiry: Set via exp claim in create_access_token() (email_auth.py)
+    - CSRF expiry: Set via max_age in set_csrf_cookie() (csrf.py)
+
+    Raises:
+        ValueError: If token expiry configuration is invalid or mismatched.
+            This will cause application startup to fail (intentional fail-fast).
+
+    Examples:
+        >>> # Called during application startup in main.py
+        >>> _validate_token_expiry_sync()  # Passes if config is valid
+        >>> # If TOKEN_EXPIRY is misconfigured, raises ValueError
+    """
+    # Verify both modules reference the same config value
+    # This is a compile-time check - both modules import settings.token_expiry
+    # If either module hardcoded a different value, this would catch it
+    from mcpgateway.routers.email_auth import TOKEN_EXPIRY_MINUTES
+    from mcpgateway.utils.csrf import CSRF_TOKEN_LENGTH
+
+    if TOKEN_EXPIRY_MINUTES != settings.token_expiry:
+        raise ValueError(
+            f"JWT token expiry mismatch: email_auth.TOKEN_EXPIRY_MINUTES={TOKEN_EXPIRY_MINUTES} "
+            f"but settings.token_expiry={settings.token_expiry}. "
+            f"Both must use the same value to prevent auth/CSRF desynchronization."
+        )
+
+    # CSRF token length validation (security check)
+    expected_csrf_length = 43  # 32 bytes base64url = 43 chars
+    if CSRF_TOKEN_LENGTH != expected_csrf_length:
+        raise ValueError(f"CSRF token length mismatch: expected {expected_csrf_length} chars, " f"got {CSRF_TOKEN_LENGTH}. This indicates a configuration error in csrf.py")
+
+    logger.debug(
+        "Token expiry validation passed: JWT and CSRF tokens synchronized at %d minutes",
+        settings.token_expiry,
+    )
+
+
+# Run validation at module import time (fail-fast before app startup)
+_validate_token_expiry_sync()
+
+# Main app router for auth endpoints
+app_router = APIRouter(prefix="/app", tags=["app"])
+
+# Separate router for SPA serving (no prefix, to handle /app/*)
+app_spa_router = APIRouter(tags=["App UI"])
+
+
+class LoginRequest(BaseModel):
+    """Login request payload."""
+
+    email: EmailStr
+    password: str = Field(..., min_length=settings.password_min_length, max_length=256)
+
+
+class LoginResponse(BaseModel):
+    """Login response payload."""
+
+    user: EmailUserResponse
+    csrf_token: str
+
+
+@app_router.post("/auth/login", response_model=LoginResponse)
+@rate_limit(10)  # 10 requests per minute to prevent credential stuffing
+async def auth_login(
+    request: Request,
+    response: Response,
+    login_data: LoginRequest,
+    db: Annotated[Session, Depends(get_db)],
+) -> LoginResponse:
+    """Authenticate user and set httpOnly JWT cookie plus CSRF token.
+
+    Rate limited to 10 requests per minute per IP to prevent credential stuffing attacks.
+    Per-user account lockout is handled by EmailAuthService.
+
+    Args:
+        request: FastAPI request object
+        response: FastAPI response object for setting cookies
+        login_data: Login credentials (email and password)
+        db: Database session
+
+    Returns:
+        LoginResponse: User profile and CSRF token
+
+    Raises:
+        HTTPException: 401 if authentication fails
+        HTTPException: 429 if rate limit exceeded
+        HTTPException: 500 if internal error occurs
+    """
+    try:
+        auth_service = EmailAuthService(db)
+
+        user = await auth_service.authenticate_user(login_data.email, login_data.password)
+
+        if not user:
+            raise_auth_error("authentication_failed", "Invalid email or password")
+
+        token, _ = await create_access_token(user)
+        set_auth_cookie(response, token, path=APP_COOKIE_PATH)
+
+        csrf_token = generate_csrf_token()
+        set_csrf_cookie(response, csrf_token)
+
+        logger.debug("User authenticated via cookie auth")
+
+        return LoginResponse(
+            user=EmailUserResponse.from_email_user(user),
+            csrf_token=csrf_token,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        correlation_id = str(uuid.uuid4())
+        logger.error("Login failed [%s]: %s", correlation_id, e, exc_info=True)
+        raise_auth_error("internal_error", "Authentication failed", status_code=500, correlation_id=correlation_id)
+
+
+@app_router.get("/auth/me", response_model=EmailUserResponse)
+async def get_me(
+    user_ctx: Annotated[tuple[EmailUser, str | None], Depends(get_current_user_from_cookie)],
+) -> EmailUserResponse:
+    """Return current authenticated user from cookie.
+
+    Returns:
+        EmailUserResponse: Current user profile data
+
+    Raises:
+        HTTPException: 401 if authentication fails (no valid cookie)
+        HTTPException: 500 if internal error occurs
+    """
+    user, _ = user_ctx
+    return EmailUserResponse.from_email_user(user)
+
+
+@app_router.post("/auth/logout")
+async def logout(
+    response: Response,
+    _csrf: Annotated[None, Depends(require_csrf)],
+    user_ctx: Annotated[tuple[EmailUser, str | None], Depends(get_current_user_from_cookie)],
+) -> dict[str, str]:
+    """Revoke JWT server-side and clear auth cookies.
+
+    Security Flow:
+        1. CSRF validation (via Depends) - prevents cross-site logout attacks
+        2. Authentication check (via get_current_user_from_cookie)
+        3. Server-side token revocation (best-effort)
+        4. Cookie clearing (always succeeds)
+
+    Token Revocation Pattern (Best-Effort):
+        Token revocation is attempted but not required for logout success. This design
+        prioritizes user experience and availability over strict revocation guarantees:
+
+        Success Case:
+            - Token added to blocklist (Redis/DB)
+            - User immediately logged out client-side (cookies cleared)
+            - Token rejected on subsequent requests (blocklist check)
+
+        Failure Case (Redis/DB unavailable):
+            - Revocation fails but logout succeeds (cookies still cleared)
+            - User immediately logged out client-side
+            - Token remains valid until natural expiry (settings.token_expiry)
+            - Failure logged with correlation ID for monitoring/alerting
+            - Metric recorded for observability (auth.token_revocation_failure)
+
+        Rationale:
+            - Logout must always succeed from user perspective (UX requirement)
+            - Cookie clearing provides immediate client-side protection
+            - Token TTL bounds exposure window (default: 20 minutes)
+            - Monitoring/alerting enables operational response to blocklist outages
+            - Alternative: Fail logout on revocation failure (poor UX, availability impact)
+
+        Security Considerations:
+            - Tokens without JTI cannot be revoked (logged as warning)
+            - Short token_expiry (5-20 min recommended) limits exposure
+            - Monitor auth.token_revocation_failure metric for blocklist health
+            - Consider token_idle_timeout for additional protection
+
+    Returns:
+        dict: Success message with "message" key
+
+    Raises:
+        HTTPException: 401 if authentication fails
+        HTTPException: 403 if CSRF validation fails
+        HTTPException: 500 if internal error occurs
+    """
+    try:
+        user, jti = user_ctx
+        if jti:
+            try:
+                blocklist_service = get_token_blocklist_service()
+                await asyncio.to_thread(blocklist_service.revoke_token, jti, user.email, "logout")
+            except Exception as e:
+                # Best-effort revocation: log but don't fail logout if blocklist is unavailable
+                correlation_id = str(uuid.uuid4())
+                logger.warning("Token revocation failed [%s]: %s", correlation_id, e, extra={"user_id": user.id})
+
+                # Record metric for monitoring/alerting (only when observability is enabled)
+                if settings.observability_enabled:
+                    try:
+                        _svc = ObservabilityService()
+                        await asyncio.to_thread(
+                            _svc.record_metric,
+                            "auth.token_revocation_failure",
+                            1,
+                            metric_type="counter",
+                            attributes={"user_id": str(user.id), "correlation_id": correlation_id, "error_type": type(e).__name__},
+                        )
+                    except Exception as metric_error:
+                        logger.debug("Failed to record token revocation failure metric: %s", metric_error)
+        else:
+            logger.warning("Logout: token missing jti — server-side revocation skipped", extra={"user_id": user.id})
+
+        clear_auth_cookie(response, path=APP_COOKIE_PATH)
+        clear_csrf_cookie(response)
+
+        logger.debug("User logged out via cookie auth")
+
+        return {"message": "Logged out successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        correlation_id = str(uuid.uuid4())
+        logger.error("Logout failed [%s]: %s", correlation_id, e, exc_info=True)
+        raise_auth_error("internal_error", "Logout failed", status_code=500, correlation_id=correlation_id)
+
+
+# ---------------------------------------------------------------------------
+# React SPA — /app catch-all
+#
+# Served on a SEPARATE router (no /admin prefix, no CSRF dependency) so that
+# /app/login and all other client-side routes are reachable at their intended
+# paths.  Auth is NOT enforced here: the HTML is public; access control is
+# handled by the React AuthGuard (client-side) and by each API endpoint
+# (server-side).  This follows the standard SPA deployment pattern.
+# ---------------------------------------------------------------------------
+
+
+@app_spa_router.get("/app", include_in_schema=False)
+@app_spa_router.get("/app/{path:path}", include_in_schema=False)
+async def app_spa(_request: Request) -> FileResponse:
+    """Serve the React SPA for all /app/* routes."""
+    index = settings.static_dir / "app" / "index.html"
+    if not index.exists():
+        raise HTTPException(
+            status_code=404,
+            detail="React UI not built. Run: cd client && npm run build",
+        )
+    return FileResponse(str(index))

--- a/mcpgateway/routers/app.py
+++ b/mcpgateway/routers/app.py
@@ -36,7 +36,7 @@ from mcpgateway.utils.security_cookies import clear_auth_cookie, set_auth_cookie
 logger = logging.getLogger(__name__)
 
 # Module-level constants
-APP_COOKIE_PATH = "/app"
+APP_COOKIE_PATH = "/"
 
 
 def _validate_token_expiry_sync() -> None:

--- a/mcpgateway/routers/app.py
+++ b/mcpgateway/routers/app.py
@@ -36,55 +36,38 @@ from mcpgateway.utils.security_cookies import clear_auth_cookie, set_auth_cookie
 logger = logging.getLogger(__name__)
 
 # Module-level constants
-APP_COOKIE_PATH = "/"
+JWT_COOKIE_PATH = "/"
 
 
-def _validate_token_expiry_sync() -> None:
-    """Validate that CSRF and JWT tokens have synchronized expiry times.
+def _validate_csrf_token_length() -> None:
+    """Validate CSRF token length at startup.
 
-    This is a critical security check performed at application startup to ensure
-    that CSRF tokens and JWT session tokens expire simultaneously. Mismatched
-    expiry times can lead to auth/CSRF desynchronization vulnerabilities.
+    This is a security check performed at application startup to ensure
+    CSRF tokens are generated with the correct length (32 bytes = 43 chars base64url).
 
-    Both token types use settings.token_expiry as their single source of truth:
-    - JWT expiry: Set via exp claim in create_access_token() (email_auth.py)
-    - CSRF expiry: Set via max_age in set_csrf_cookie() (csrf.py)
+    Token expiry synchronization between JWT and CSRF is validated by E2E tests
+    (test_app_auth_token_expiry.py) which verify that both cookies have identical
+    max_age values derived from settings.token_expiry.
 
     Raises:
-        ValueError: If token expiry configuration is invalid or mismatched.
+        ValueError: If CSRF token length is misconfigured.
             This will cause application startup to fail (intentional fail-fast).
-
-    Examples:
-        >>> # Called during application startup in main.py
-        >>> _validate_token_expiry_sync()  # Passes if config is valid
-        >>> # If TOKEN_EXPIRY is misconfigured, raises ValueError
     """
-    # Verify both modules reference the same config value
-    # This is a compile-time check - both modules import settings.token_expiry
-    # If either module hardcoded a different value, this would catch it
-    from mcpgateway.routers.email_auth import TOKEN_EXPIRY_MINUTES
     from mcpgateway.utils.csrf import CSRF_TOKEN_LENGTH
-
-    if TOKEN_EXPIRY_MINUTES != settings.token_expiry:
-        raise ValueError(
-            f"JWT token expiry mismatch: email_auth.TOKEN_EXPIRY_MINUTES={TOKEN_EXPIRY_MINUTES} "
-            f"but settings.token_expiry={settings.token_expiry}. "
-            f"Both must use the same value to prevent auth/CSRF desynchronization."
-        )
 
     # CSRF token length validation (security check)
     expected_csrf_length = 43  # 32 bytes base64url = 43 chars
     if CSRF_TOKEN_LENGTH != expected_csrf_length:
-        raise ValueError(f"CSRF token length mismatch: expected {expected_csrf_length} chars, " f"got {CSRF_TOKEN_LENGTH}. This indicates a configuration error in csrf.py")
+        raise ValueError(
+            f"CSRF token length mismatch: expected {expected_csrf_length} chars, "
+            f"got {CSRF_TOKEN_LENGTH}. This indicates a configuration error in csrf.py"
+        )
 
-    logger.debug(
-        "Token expiry validation passed: JWT and CSRF tokens synchronized at %d minutes",
-        settings.token_expiry,
-    )
+    logger.debug("CSRF token length validation passed: %d chars", CSRF_TOKEN_LENGTH)
 
 
 # Run validation at module import time (fail-fast before app startup)
-_validate_token_expiry_sync()
+_validate_csrf_token_length()
 
 # Main app router for auth endpoints
 app_router = APIRouter(prefix="/app", tags=["app"])
@@ -143,7 +126,7 @@ async def auth_login(
             raise_auth_error("authentication_failed", "Invalid email or password")
 
         token, _ = await create_access_token(user)
-        set_auth_cookie(response, token, path=APP_COOKIE_PATH)
+        set_auth_cookie(response, token, path=JWT_COOKIE_PATH)
 
         csrf_token = generate_csrf_token()
         set_csrf_cookie(response, csrf_token)
@@ -258,7 +241,7 @@ async def logout(
         else:
             logger.warning("Logout: token missing jti — server-side revocation skipped", extra={"user_id": user.id})
 
-        clear_auth_cookie(response, path=APP_COOKIE_PATH)
+        clear_auth_cookie(response, path=JWT_COOKIE_PATH)
         clear_csrf_cookie(response)
 
         logger.debug("User logged out via cookie auth")

--- a/mcpgateway/routers/app.py
+++ b/mcpgateway/routers/app.py
@@ -36,7 +36,7 @@ from mcpgateway.utils.security_cookies import clear_auth_cookie, set_auth_cookie
 logger = logging.getLogger(__name__)
 
 # Module-level constants
-JWT_COOKIE_PATH = "/"
+JWT_COOKIE_PATH = "/app"
 
 
 def _validate_csrf_token_length() -> None:

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -63,6 +63,9 @@ email_auth_router = APIRouter()
 # Security scheme
 bearer_scheme = HTTPBearer(auto_error=False)
 
+# Exported for startup token-expiry synchronization check in _validate_token_expiry_sync
+TOKEN_EXPIRY_MINUTES = settings.token_expiry
+
 
 def get_db():
     """Database dependency.

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -5950,6 +5950,7 @@ class EmailUserResponse(BaseModel):
     is_active: bool = Field(..., description="Whether account is active")
     auth_provider: str = Field(..., description="Authentication provider")
     created_at: datetime = Field(..., description="Account creation timestamp")
+    updated_at: Optional[datetime] = Field(None, description="Last account update timestamp")
     last_login: Optional[datetime] = Field(None, description="Last successful login")
     email_verified: bool = Field(False, description="Whether email is verified")
     password_change_required: bool = Field(False, description="Whether user must change password on next login")
@@ -5982,6 +5983,7 @@ class EmailUserResponse(BaseModel):
             is_active=user.is_active,
             auth_provider=user.auth_provider,
             created_at=user.created_at,
+            updated_at=getattr(user, "updated_at", None),
             last_login=user.last_login,
             email_verified=user.is_email_verified(),
             password_change_required=user.password_change_required,

--- a/mcpgateway/utils/auth_errors.py
+++ b/mcpgateway/utils/auth_errors.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Shared auth error helpers.
+
+Centralises ErrorResponse and raise_auth_error so both mcpgateway.auth and
+mcpgateway.routers.app can import from a leaf module, breaking the circular
+dependency that would arise if auth.py imported from routers/.
+"""
+
+from typing import NoReturn, Optional
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """Structured error response payload."""
+
+    error: str
+    message: str
+    correlation_id: Optional[str] = None
+
+
+def raise_auth_error(
+    error: str,
+    message: str,
+    status_code: int = 401,
+    correlation_id: Optional[str] = None,
+) -> NoReturn:
+    """Raise HTTPException with a structured ErrorResponse detail.
+
+    Args:
+        error: Machine-readable error code (e.g. 'not_authenticated', 'csrf_mismatch')
+        message: Human-readable description
+        status_code: HTTP status code (default 401)
+        correlation_id: Optional tracing identifier
+
+    Raises:
+        HTTPException: Always raised; never returns.
+    """
+    raise HTTPException(
+        status_code=status_code,
+        detail=ErrorResponse(
+            error=error,
+            message=message,
+            correlation_id=correlation_id,
+        ).model_dump(),
+    )

--- a/mcpgateway/utils/csrf.py
+++ b/mcpgateway/utils/csrf.py
@@ -1,0 +1,119 @@
+"""CSRF protection utilities for cookie-based authentication.
+
+Implements double-submit cookie pattern: CSRF token set in a non-httpOnly
+cookie (so JS can read it after page refresh) and validated against the
+X-CSRF-Token request header. The JWT session cookie remains httpOnly.
+
+Token Expiry Coupling:
+    CSRF and JWT tokens share the same expiry (settings.token_expiry * 60 seconds).
+    This coupling is intentional to prevent auth/CSRF desynchronization:
+
+    - Both cookies expire simultaneously
+    - Token refresh (if implemented) must renew both cookies together
+    - Prevents edge case: valid JWT with expired CSRF (or vice versa)
+
+    Implementation notes:
+    - JWT expiry: Set in create_access_token() via exp claim
+    - CSRF expiry: Set in set_csrf_cookie() via max_age parameter
+    - Both use settings.token_expiry as single source of truth
+    - Default: 60 minutes (configurable via TOKEN_EXPIRY env var)
+"""
+
+import math
+import secrets
+from typing import Optional
+
+from fastapi import Request, Response
+
+from mcpgateway.config import settings
+from mcpgateway.utils.auth_errors import raise_auth_error
+
+# CSRF token generation constants
+CSRF_TOKEN_BYTES = 32  # 32 bytes = 256 bits (OWASP recommendation)
+CSRF_TOKEN_LENGTH = math.ceil(CSRF_TOKEN_BYTES * 4 / 3)  # URL-safe base64 without padding
+
+
+def generate_csrf_token() -> str:
+    """Generate cryptographically secure CSRF token.
+
+    Returns:
+        str: URL-safe random token (32 bytes = 43 characters base64)
+    """
+    return secrets.token_urlsafe(CSRF_TOKEN_BYTES)
+
+
+def set_csrf_cookie(response: Response, token: str) -> None:
+    """Set CSRF token in a non-httpOnly cookie so JS can read it after page refresh.
+
+    Expiry matches token_expiry so CSRF and JWT cookies stay in sync. If a
+    token-refresh endpoint is added later, both cookies must be renewed together.
+
+    Security properties:
+    - max_age: Synchronized with JWT expiry (settings.token_expiry * 60)
+    - httponly: False (JS must read token for X-CSRF-Token header)
+    - secure: True in production (HTTPS only)
+    - samesite: strict (prevents CSRF attacks)
+    - path: /app (scoped to React client routes)
+    """
+    response.set_cookie(
+        key="csrf_token",
+        value=token,
+        httponly=False,  # JS must read for X-CSRF-Token header (double-submit pattern)
+        secure=(settings.environment == "production") or settings.secure_cookies,  # HTTPS only in prod
+        samesite="strict",  # Prevents CSRF attacks (no cross-site requests)
+        path="/app",  # Scoped to React client routes only
+        max_age=settings.token_expiry * 60,  # Synchronized with JWT expiry
+    )
+
+
+def get_csrf_token_from_cookie(request: Request) -> Optional[str]:
+    """Extract CSRF token from cookie."""
+    return request.cookies.get("csrf_token")
+
+
+def get_csrf_token_from_header(request: Request) -> Optional[str]:
+    """Extract CSRF token from X-CSRF-Token header."""
+    return request.headers.get("X-CSRF-Token")
+
+
+def validate_csrf_token(request: Request) -> None:
+    """Validate CSRF token: cookie value must match X-CSRF-Token header.
+
+    Cross-origin attackers cannot set custom headers, so a matching
+    cookie+header pair proves the request originates from the same site.
+
+    Security: Validates token length before comparison to prevent DoS via oversized tokens.
+    """
+    cookie_token = get_csrf_token_from_cookie(request)
+    header_token = get_csrf_token_from_header(request)
+
+    if not cookie_token:
+        raise_auth_error("csrf_missing_cookie", "CSRF token missing from cookie", status_code=403)
+
+    if not header_token:
+        raise_auth_error("csrf_missing_header", "CSRF token missing from header", status_code=403)
+
+    # Validate token format and length to prevent DoS
+    if len(cookie_token) != CSRF_TOKEN_LENGTH:
+        raise_auth_error("csrf_invalid_format", "Invalid CSRF token format", status_code=403)
+
+    if len(header_token) != CSRF_TOKEN_LENGTH:
+        raise_auth_error("csrf_invalid_format", "Invalid CSRF token format", status_code=403)
+
+    if not secrets.compare_digest(cookie_token, header_token):
+        raise_auth_error("csrf_mismatch", "CSRF token mismatch", status_code=403)
+
+
+def require_csrf(request: Request) -> None:
+    """FastAPI dependency: validate CSRF token before handler body executes."""
+    validate_csrf_token(request)
+
+
+def clear_csrf_cookie(response: Response) -> None:
+    """Clear CSRF token cookie."""
+    response.delete_cookie(
+        key="csrf_token",
+        path="/app",
+        samesite="strict",
+        secure=(settings.environment == "production") or settings.secure_cookies,
+    )

--- a/mcpgateway/utils/security_cookies.py
+++ b/mcpgateway/utils/security_cookies.py
@@ -41,7 +41,7 @@ class CookieTooLargeError(Exception):
         super().__init__(f"Cookie size {cookie_size} bytes exceeds browser limit of {limit} bytes")
 
 
-def set_auth_cookie(response: Response, token: str, remember_me: bool = False) -> None:
+def set_auth_cookie(response: Response, token: str, remember_me: bool = False, path: str | None = None) -> None:
     """
     Set authentication cookie with security flags and size validation.
 
@@ -51,7 +51,10 @@ def set_auth_cookie(response: Response, token: str, remember_me: bool = False) -
     Args:
         response: FastAPI response object to set the cookie on
         token: JWT token to store in the cookie
-        remember_me: If True, sets longer expiration time (30 days vs 1 hour)
+        remember_me: If True, sets longer expiration time (30 days)
+        path: Cookie path scope. Defaults to settings.app_root_path or "/".
+              Use "/app" for the React client so the cookie is not sent to
+              unrelated endpoints (/admin, /api, etc.).
 
     Raises:
         CookieTooLargeError: If the cookie would exceed 4096 bytes
@@ -79,14 +82,16 @@ def set_auth_cookie(response: Response, token: str, remember_me: bool = False) -
         >>> 'Max-Age=2592000' in resp2.headers.get('set-cookie')  # 30 days
         True
     """
-    # Set expiration based on remember_me preference
-    max_age = 30 * 24 * 3600 if remember_me else 3600  # 30 days or 1 hour
+    # Set expiration based on remember_me preference.
+    # Non-remember-me uses settings.token_expiry to stay in sync with the CSRF cookie
+    # (set by set_csrf_cookie, which also uses settings.token_expiry * 60).
+    max_age = 30 * 24 * 3600 if remember_me else settings.token_expiry * 60
 
     # Determine if we should use secure flag
     # In production or when explicitly configured, require HTTPS
     use_secure = (settings.environment == "production") or settings.secure_cookies
     samesite = settings.cookie_samesite
-    path = settings.app_root_path or "/"
+    path = path if path is not None else (settings.app_root_path or "/")
 
     # Estimate cookie size in bytes (Set-Cookie header format)
     # The cookie name, value, and attributes all count toward the limit
@@ -128,7 +133,7 @@ def set_auth_cookie(response: Response, token: str, remember_me: bool = False) -
     )
 
 
-def clear_auth_cookie(response: Response) -> None:
+def clear_auth_cookie(response: Response, path: str | None = None) -> None:
     """
     Clear authentication cookie securely.
 
@@ -137,6 +142,8 @@ def clear_auth_cookie(response: Response) -> None:
 
     Args:
         response: FastAPI response object to clear the cookie from
+        path: Must match the path used in set_auth_cookie. Defaults to
+              settings.app_root_path or "/".
 
     Examples:
         >>> from fastapi import Response
@@ -147,12 +154,12 @@ def clear_auth_cookie(response: Response) -> None:
         >>> 'jwt_token=' in resp.headers.get('set-cookie')
         True
     """
-    # Use same security settings as when setting the cookie
     use_secure = (settings.environment == "production") or settings.secure_cookies
+    effective_path = path if path is not None else (settings.app_root_path or "/")
 
     response.delete_cookie(
         key="jwt_token",
-        path=settings.app_root_path or "/",
+        path=effective_path,
         secure=use_secure,
         httponly=True,
         samesite=settings.cookie_samesite,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,11 +238,13 @@ def app():
     # Also patch security_logger and auth_middleware's SessionLocal
     # First-Party
     import mcpgateway.middleware.auth_middleware as auth_middleware_mod
+    import mcpgateway.auth as auth_mod
     import mcpgateway.services.security_logger as sec_logger_mod
     import mcpgateway.services.structured_logger as struct_logger_mod
     import mcpgateway.services.audit_trail_service as audit_trail_mod
     import mcpgateway.services.log_aggregator as log_aggregator_mod
 
+    mp.setattr(auth_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(auth_middleware_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(sec_logger_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(struct_logger_mod, "SessionLocal", TestSessionLocal, raising=False)
@@ -314,11 +316,13 @@ def app_with_temp_db():
     # Also patch security_logger and auth_middleware's SessionLocal
     # First-Party
     import mcpgateway.middleware.auth_middleware as auth_middleware_mod
+    import mcpgateway.auth as auth_mod
     import mcpgateway.services.security_logger as sec_logger_mod
     import mcpgateway.services.structured_logger as struct_logger_mod
     import mcpgateway.services.audit_trail_service as audit_trail_mod
     import mcpgateway.services.log_aggregator as log_aggregator_mod
 
+    mp.setattr(auth_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(auth_middleware_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(sec_logger_mod, "SessionLocal", TestSessionLocal, raising=False)
     mp.setattr(struct_logger_mod, "SessionLocal", TestSessionLocal, raising=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,14 @@ Authors: Mihai Criveti
 """
 
 # Standard
+import asyncio
 import os
 import socket
 import sys
 import tempfile
+import uuid
 import warnings
+from typing import Dict, Generator
 from unittest.mock import AsyncMock
 
 # Third-Party
@@ -112,6 +115,8 @@ _force_minimal_main_app_features()
 # First-Party
 import mcpgateway.db as db_mod  # noqa: E402  # must load after test DB env hardening
 from mcpgateway.config import Settings  # noqa: E402  # must load after test DB env hardening
+from mcpgateway.db import EmailUser  # noqa: E402
+from mcpgateway.services.email_auth_service import EmailAuthService  # noqa: E402
 
 # Local
 
@@ -618,3 +623,63 @@ def clear_jwt_cache_between_tests():
         clear_jwt_caches()
     except ImportError:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Shared E2E fixtures for app authentication tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_user_credentials() -> Dict[str, str]:
+    """Test user credentials for E2E authentication tests.
+
+    Generates unique email addresses to avoid conflicts between parallel tests.
+    Used by test_app_auth.py, test_app_auth_rate_limiting.py, and
+    test_app_auth_token_expiry.py.
+    """
+    return {
+        "email": f"e2e-test-{uuid.uuid4().hex[:8]}@example.com",
+        "password": "TestPassword123!",  # pragma: allowlist secret
+    }
+
+
+@pytest.fixture
+def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
+    """Create test user in database for E2E authentication tests.
+
+    Handles cleanup of existing users and ensures proper teardown.
+    Used by test_app_auth.py, test_app_auth_rate_limiting.py, and
+    test_app_auth_token_expiry.py.
+    """
+    db = db_mod.SessionLocal()
+    user = None
+    try:
+        # Clean up any existing test user
+        existing = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+        if existing:
+            db.delete(existing)
+            db.commit()
+
+        # Create test user
+        auth_service = EmailAuthService(db)
+        user = asyncio.run(
+            auth_service.create_user(
+                email=test_user_credentials["email"],
+                password=test_user_credentials["password"],
+            )
+        )
+        db.commit()
+        yield user
+    finally:
+        # Cleanup — separate try/except so a test failure inside yield doesn't
+        # skip the delete and leave orphaned rows in the test database.
+        try:
+            if user is not None:
+                user_to_delete = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+                if user_to_delete:
+                    db.delete(user_to_delete)
+                    db.commit()
+        except Exception:
+            db.rollback()
+        db.close()

--- a/tests/e2e/test_app_auth.py
+++ b/tests/e2e/test_app_auth.py
@@ -1,0 +1,437 @@
+"""E2E tests for React App authentication flow.
+
+Tests the complete authentication flow including:
+- Login with cookie and CSRF token
+- Session validation via /app/auth/me
+- CSRF protection on logout
+- Cookie security flags
+- Cross-tab session persistence
+"""
+
+import os
+import re
+import time
+import uuid
+from typing import Dict, Generator
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from mcpgateway.main import app
+from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway.services.email_auth_service import EmailAuthService
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("MCPGATEWAY_UI_ENABLED", "").lower() not in ("1", "true"),
+        reason="MCPGATEWAY_UI_ENABLED is not set — /app routes not registered",
+    ),
+]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def test_user_credentials() -> Dict[str, str]:
+    """Test user credentials."""
+    return {
+        "email": f"e2e-test-{uuid.uuid4().hex[:8]}@example.com",
+        "password": "TestPassword123!",  # pragma: allowlist secret
+    }
+
+
+@pytest.fixture
+def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
+    """Create test user in database."""
+    db = SessionLocal()
+    try:
+        # Clean up any existing test user
+        existing = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+        if existing:
+            db.delete(existing)
+            db.commit()
+
+        # Create test user
+        auth_service = EmailAuthService(db)
+        user = auth_service.create_user(
+            email=test_user_credentials["email"],
+            password=test_user_credentials["password"],
+        )
+        db.commit()
+        yield user
+    finally:
+        # Cleanup — separate try/except so a test failure inside yield doesn't
+        # skip the delete and leave orphaned rows in the test database.
+        try:
+            user_to_delete = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+            if user_to_delete:
+                db.delete(user_to_delete)
+                db.commit()
+        except Exception:
+            db.rollback()
+        finally:
+            db.close()
+
+
+class TestFullLoginFlow:
+    """Test complete login flow with cookies and CSRF."""
+
+    def test_login_sets_cookies_and_returns_user(self, client, setup_test_user, test_user_credentials):
+        """Test POST /app/auth/login sets JWT and CSRF cookies."""
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+
+        # Verify response
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["user"]["email"] == test_user_credentials["email"]
+        assert "csrf_token" in data
+        assert len(data["csrf_token"]) == 43  # URL-safe base64 of 32 bytes
+
+        # Verify cookies set
+        assert "jwt_token" in response.cookies
+        assert "csrf_token" in response.cookies
+
+        # Verify cookie values match
+        assert response.cookies["csrf_token"] == data["csrf_token"]
+
+    def test_login_then_get_me(self, client, setup_test_user, test_user_credentials):
+        """Test login followed by GET /app/auth/me validates session."""
+        # Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        assert login_response.status_code == status.HTTP_200_OK
+
+        # Extract cookies
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token = login_response.cookies.get("csrf_token")
+
+        # Get current user
+        me_response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token},
+        )
+
+        # Verify response
+        assert me_response.status_code == status.HTTP_200_OK
+        data = me_response.json()
+        assert data["email"] == test_user_credentials["email"]
+
+    def test_login_then_logout(self, client, setup_test_user, test_user_credentials):
+        """Test full login/logout flow with CSRF validation."""
+        # Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        assert login_response.status_code == status.HTTP_200_OK
+
+        # Extract cookies and CSRF token
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token_cookie = login_response.cookies.get("csrf_token")
+        csrf_token_header = login_response.json()["csrf_token"]
+
+        # Logout with CSRF token
+        logout_response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+            headers={"X-CSRF-Token": csrf_token_header},
+        )
+
+        # Verify logout success
+        assert logout_response.status_code == status.HTTP_200_OK
+        assert logout_response.json()["message"] == "Logged out successfully"
+
+        # Verify cookies are cleared in the HTTP response
+        set_cookie_headers = [v for k, v in logout_response.headers.items() if k.lower() == "set-cookie"]
+        jwt_clear = next((c for c in set_cookie_headers if "jwt_token=" in c), "")
+        csrf_clear = next((c for c in set_cookie_headers if "csrf_token=" in c), "")
+        assert jwt_clear, "jwt_token Set-Cookie header missing from logout response"
+        assert csrf_clear, "csrf_token Set-Cookie header missing from logout response"
+        assert "max-age=0" in jwt_clear.lower(), "jwt_token cookie not cleared (max-age=0 missing)"
+        assert "max-age=0" in csrf_clear.lower(), "csrf_token cookie not cleared (max-age=0 missing)"
+
+        # Verify session invalidated - GET /app/auth/me should fail
+        me_response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+        )
+        assert me_response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+class TestCSRFProtection:
+    """Test CSRF protection on state-changing operations."""
+
+    def test_logout_without_csrf_token_fails(self, client, setup_test_user, test_user_credentials):
+        """Test logout without CSRF token returns 403."""
+        # Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token_cookie = login_response.cookies.get("csrf_token")
+
+        # Attempt logout without CSRF header
+        logout_response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+            # No X-CSRF-Token header
+        )
+
+        # Verify CSRF protection
+        assert logout_response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF token" in logout_response.json()["detail"]["message"]
+
+    def test_logout_with_invalid_csrf_token_fails(self, client, setup_test_user, test_user_credentials):
+        """Test logout with mismatched CSRF token returns 403."""
+        # Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token_cookie = login_response.cookies.get("csrf_token")
+
+        # Attempt logout with wrong CSRF header
+        logout_response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+            headers={"X-CSRF-Token": "wrong-csrf-token"},
+        )
+
+        # Verify CSRF protection
+        assert logout_response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF token" in logout_response.json()["detail"]["message"]
+
+    def test_logout_with_valid_csrf_token_succeeds(self, client, setup_test_user, test_user_credentials):
+        """Test logout with valid CSRF token succeeds."""
+        # Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token_cookie = login_response.cookies.get("csrf_token")
+        csrf_token_header = login_response.json()["csrf_token"]
+
+        # Logout with matching CSRF tokens
+        logout_response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+            headers={"X-CSRF-Token": csrf_token_header},
+        )
+
+        # Verify success
+        assert logout_response.status_code == status.HTTP_200_OK
+
+
+class TestCrossTabSessionPersistence:
+    """Test session persistence across multiple tabs (simulated)."""
+
+    def test_session_shared_across_tabs(self, client, setup_test_user, test_user_credentials):
+        """Test that JWT cookie enables session sharing across tabs."""
+        # Tab 1: Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token = login_response.cookies.get("csrf_token")
+
+        # Tab 2: Use same cookies (simulates browser sharing cookies)
+        tab2_response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token},
+        )
+
+        # Verify Tab 2 is authenticated without re-login
+        assert tab2_response.status_code == status.HTTP_200_OK
+        assert tab2_response.json()["email"] == test_user_credentials["email"]
+
+    def test_logout_in_one_tab_affects_all_tabs(self, client, setup_test_user, test_user_credentials):
+        """Test that logout in one tab invalidates session in all tabs."""
+        # Tab 1: Login
+        login_response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        jwt_token = login_response.cookies.get("jwt_token")
+        csrf_token_cookie = login_response.cookies.get("csrf_token")
+        csrf_token_header = login_response.json()["csrf_token"]
+
+        # Tab 1: Logout
+        logout_response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+            headers={"X-CSRF-Token": csrf_token_header},
+        )
+        assert logout_response.status_code == status.HTTP_200_OK
+
+        # Tab 2: Try to use same cookies (should fail)
+        tab2_response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": jwt_token, "csrf_token": csrf_token_cookie},
+        )
+
+        # Verify Tab 2 is logged out
+        assert tab2_response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+class TestCookieSecurityFlags:
+    """Test cookie security configuration."""
+
+    def test_jwt_cookie_security_flags(self, client, setup_test_user, test_user_credentials):
+        """Test JWT cookie has httpOnly and samesite flags set."""
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), "")
+
+        assert jwt_cookie, "jwt_token cookie not found in Set-Cookie headers"
+        assert "httponly" in jwt_cookie.lower()
+        assert "samesite=lax" in jwt_cookie.lower()
+
+    def test_csrf_cookie_security_flags(self, client, setup_test_user, test_user_credentials):
+        """Test CSRF cookie has samesite=strict and is scoped to /app."""
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": test_user_credentials["password"],
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        csrf_cookie = next((c for c in set_cookies if "csrf_token=" in c), "")
+
+        assert csrf_cookie, "csrf_token cookie not found in Set-Cookie headers"
+        assert "samesite=strict" in csrf_cookie.lower()
+        assert "path=/app" in csrf_cookie.lower()
+        assert "httponly" not in csrf_cookie.lower(), "CSRF cookie must not be httpOnly — JS needs to read it"
+
+
+class TestInvalidCredentials:
+    """Test authentication with invalid credentials."""
+
+    def test_login_with_wrong_password(self, client, setup_test_user, test_user_credentials):
+        """Test login with wrong password returns 401."""
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": test_user_credentials["email"],
+                "password": "WrongPassword123!",  # pragma: allowlist secret
+            },
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "Invalid email or password" in response.json()["detail"]["message"]
+
+    def test_login_with_nonexistent_user(self, client):
+        """Test login with non-existent user returns 401."""
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": "nonexistent@example.com",
+                "password": "Password123!",  # pragma: allowlist secret
+            },
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "Invalid email or password" in response.json()["detail"]["message"]
+
+    def test_get_me_without_authentication(self, client):
+        """Test GET /app/auth/me without authentication returns 401."""
+        response = client.get("/app/auth/me")
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+class TestLockedAccount:
+    """Test that locked accounts cannot authenticate."""
+
+    def test_login_with_locked_account_fails(self, client, setup_test_user, test_user_credentials):
+        """Locked account login returns 401."""
+        db = SessionLocal()
+        try:
+            user = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+            user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=30)
+            db.commit()
+        finally:
+            db.close()
+
+        response = client.post(
+            "/app/auth/login",
+            json=test_user_credentials,
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_login_after_lock_expires_succeeds(self, client, setup_test_user, test_user_credentials):
+        """Login succeeds once lock expiry has passed."""
+        db = SessionLocal()
+        try:
+            user = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+            user.locked_until = datetime.now(timezone.utc) - timedelta(minutes=5)
+            db.commit()
+        finally:
+            db.close()
+
+        response = client.post(
+            "/app/auth/login",
+            json=test_user_credentials,
+        )
+
+        assert response.status_code == status.HTTP_200_OK

--- a/tests/e2e/test_app_auth.py
+++ b/tests/e2e/test_app_auth.py
@@ -8,6 +8,8 @@ Tests the complete authentication flow including:
 - Cross-tab session persistence
 """
 
+import asyncio
+from datetime import datetime, timedelta, timezone
 import os
 import re
 import time
@@ -15,12 +17,12 @@ import uuid
 from typing import Dict, Generator
 
 import pytest
-from datetime import datetime, timedelta, timezone
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from mcpgateway.main import app
-from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway import db as db_mod
+from mcpgateway.admin import rate_limit_storage
+from mcpgateway.db import EmailUser
 from mcpgateway.services.email_auth_service import EmailAuthService
 
 pytestmark = [
@@ -32,10 +34,23 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limits() -> Generator[None, None, None]:
+    """Keep auth rate limiting isolated between tests."""
+    rate_limit_storage.clear()
+    yield
+    rate_limit_storage.clear()
+
+
+def _set_cookie_headers(response) -> list[str]:
+    """Return separate Set-Cookie headers from an httpx response."""
+    return response.headers.get_list("set-cookie")
+
+
 @pytest.fixture
-def client() -> TestClient:
+def client(app_with_temp_db) -> TestClient:
     """Create test client."""
-    return TestClient(app)
+    return TestClient(app_with_temp_db)
 
 
 @pytest.fixture
@@ -50,7 +65,7 @@ def test_user_credentials() -> Dict[str, str]:
 @pytest.fixture
 def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
     """Create test user in database."""
-    db = SessionLocal()
+    db = db_mod.SessionLocal()
     try:
         # Clean up any existing test user
         existing = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
@@ -60,9 +75,11 @@ def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUse
 
         # Create test user
         auth_service = EmailAuthService(db)
-        user = auth_service.create_user(
-            email=test_user_credentials["email"],
-            password=test_user_credentials["password"],
+        user = asyncio.run(
+            auth_service.create_user(
+                email=test_user_credentials["email"],
+                password=test_user_credentials["password"],
+            )
         )
         db.commit()
         yield user
@@ -163,7 +180,7 @@ class TestFullLoginFlow:
         assert logout_response.json()["message"] == "Logged out successfully"
 
         # Verify cookies are cleared in the HTTP response
-        set_cookie_headers = [v for k, v in logout_response.headers.items() if k.lower() == "set-cookie"]
+        set_cookie_headers = _set_cookie_headers(logout_response)
         jwt_clear = next((c for c in set_cookie_headers if "jwt_token=" in c), "")
         csrf_clear = next((c for c in set_cookie_headers if "csrf_token=" in c), "")
         assert jwt_clear, "jwt_token Set-Cookie header missing from logout response"
@@ -333,7 +350,7 @@ class TestCookieSecurityFlags:
         )
         assert response.status_code == status.HTTP_200_OK
 
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
         jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), "")
 
         assert jwt_cookie, "jwt_token cookie not found in Set-Cookie headers"
@@ -351,7 +368,7 @@ class TestCookieSecurityFlags:
         )
         assert response.status_code == status.HTTP_200_OK
 
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
         csrf_cookie = next((c for c in set_cookies if "csrf_token=" in c), "")
 
         assert csrf_cookie, "csrf_token cookie not found in Set-Cookie headers"
@@ -404,7 +421,7 @@ class TestLockedAccount:
 
     def test_login_with_locked_account_fails(self, client, setup_test_user, test_user_credentials):
         """Locked account login returns 401."""
-        db = SessionLocal()
+        db = db_mod.SessionLocal()
         try:
             user = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
             user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=30)
@@ -421,7 +438,7 @@ class TestLockedAccount:
 
     def test_login_after_lock_expires_succeeds(self, client, setup_test_user, test_user_credentials):
         """Login succeeds once lock expiry has passed."""
-        db = SessionLocal()
+        db = db_mod.SessionLocal()
         try:
             user = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
             user.locked_until = datetime.now(timezone.utc) - timedelta(minutes=5)

--- a/tests/e2e/test_app_auth.py
+++ b/tests/e2e/test_app_auth.py
@@ -356,6 +356,7 @@ class TestCookieSecurityFlags:
         assert jwt_cookie, "jwt_token cookie not found in Set-Cookie headers"
         assert "httponly" in jwt_cookie.lower()
         assert "samesite=lax" in jwt_cookie.lower()
+        assert "path=/app" in jwt_cookie.lower()
 
     def test_csrf_cookie_security_flags(self, client, setup_test_user, test_user_credentials):
         """Test CSRF cookie has samesite=strict and is scoped to /app."""

--- a/tests/e2e/test_app_auth_rate_limiting.py
+++ b/tests/e2e/test_app_auth_rate_limiting.py
@@ -3,6 +3,7 @@
 Tests rate limiting on authentication endpoints to prevent credential stuffing attacks.
 """
 
+import asyncio
 import os
 import time
 import uuid
@@ -12,8 +13,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from mcpgateway.main import app
-from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway import db as db_mod
+from mcpgateway.admin import rate_limit_storage
+from mcpgateway.db import EmailUser
 from mcpgateway.services.email_auth_service import EmailAuthService
 
 pytestmark = [
@@ -25,10 +27,18 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limits() -> Generator[None, None, None]:
+    """Keep auth rate limiting isolated between tests."""
+    rate_limit_storage.clear()
+    yield
+    rate_limit_storage.clear()
+
+
 @pytest.fixture
-def client() -> TestClient:
+def client(app_with_temp_db) -> TestClient:
     """Create test client."""
-    return TestClient(app)
+    return TestClient(app_with_temp_db)
 
 
 @pytest.fixture
@@ -43,7 +53,7 @@ def test_user_credentials() -> Dict[str, str]:
 @pytest.fixture
 def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
     """Create test user in database."""
-    db = SessionLocal()
+    db = db_mod.SessionLocal()
     user = None
     try:
         # Clean up any existing test user
@@ -54,9 +64,11 @@ def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUse
 
         # Create test user
         auth_service = EmailAuthService(db)
-        user = auth_service.create_user(
-            email=test_user_credentials["email"],
-            password=test_user_credentials["password"],
+        user = asyncio.run(
+            auth_service.create_user(
+                email=test_user_credentials["email"],
+                password=test_user_credentials["password"],
+            )
         )
         db.commit()
         yield user

--- a/tests/e2e/test_app_auth_rate_limiting.py
+++ b/tests/e2e/test_app_auth_rate_limiting.py
@@ -98,18 +98,22 @@ class TestRateLimiting:
         assert "rate limit" in response.json()["detail"].lower()
 
     def test_rate_limit_is_per_ip(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
-        """Test rate limit is enforced per IP address."""
+        """Test rate limit is enforced per IP address.
+        
+        Note: TestClient doesn't support changing client IP in headers, so this test
+        verifies that rate limiting is active for a single IP. In production, different
+        IPs would have separate rate limit buckets.
+        """
         # Exhaust rate limit for default IP
         for _ in range(10):
-            client.post("/app/auth/login", json=test_user_credentials)
+            response = client.post("/app/auth/login", json=test_user_credentials)
+            # First 10 requests should succeed or fail with 401 (wrong password after user creation)
+            assert response.status_code in (200, 401), f"Request should not be rate limited yet, got {response.status_code}"
 
-        # Verify rate limit is active
+        # Verify rate limit is active after 10 requests
         response = client.post("/app/auth/login", json=test_user_credentials)
-        assert response.status_code == 429
-
-        # Note: TestClient doesn't support changing client IP in headers
-        # In production, different IPs would have separate rate limit buckets
-        # This test documents the expected behavior
+        assert response.status_code == 429, f"11th request should be rate limited, got {response.status_code}"
+        assert "rate limit" in response.json()["detail"].lower(), "Error message should mention rate limit"
 
     @pytest.mark.slow
     def test_rate_limit_resets_after_window(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:

--- a/tests/e2e/test_app_auth_rate_limiting.py
+++ b/tests/e2e/test_app_auth_rate_limiting.py
@@ -1,0 +1,152 @@
+"""E2E tests for authentication rate limiting.
+
+Tests rate limiting on authentication endpoints to prevent credential stuffing attacks.
+"""
+
+import os
+import time
+import uuid
+from typing import Dict, Generator
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from mcpgateway.main import app
+from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway.services.email_auth_service import EmailAuthService
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("MCPGATEWAY_UI_ENABLED", "").lower() not in ("1", "true"),
+        reason="MCPGATEWAY_UI_ENABLED is not set — /app routes not registered",
+    ),
+]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def test_user_credentials() -> Dict[str, str]:
+    """Test user credentials."""
+    return {
+        "email": f"rate-limit-test-{uuid.uuid4().hex[:8]}@example.com",
+        "password": "TestPassword123!",  # pragma: allowlist secret
+    }
+
+
+@pytest.fixture
+def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
+    """Create test user in database."""
+    db = SessionLocal()
+    user = None
+    try:
+        # Clean up any existing test user
+        existing = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+        if existing:
+            db.delete(existing)
+            db.commit()
+
+        # Create test user
+        auth_service = EmailAuthService(db)
+        user = auth_service.create_user(
+            email=test_user_credentials["email"],
+            password=test_user_credentials["password"],
+        )
+        db.commit()
+        yield user
+    finally:
+        try:
+            if user is not None:
+                db.delete(user)
+                db.commit()
+        except Exception:
+            db.rollback()
+        db.close()
+
+
+class TestRateLimiting:
+    """Test rate limiting on authentication endpoints."""
+
+    def test_login_rate_limit_blocks_after_threshold(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test login endpoint blocks after 10 requests per minute."""
+        # Make 10 requests (should succeed or fail based on credentials, but not be rate limited)
+        for i in range(10):
+            response = client.post("/app/auth/login", json=test_user_credentials)
+            assert response.status_code in [200, 401], f"Request {i+1} should not be rate limited"
+
+        # 11th request should be rate limited
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 429, "11th request should be rate limited"
+        assert "rate limit" in response.json()["detail"].lower()
+
+    def test_rate_limit_is_per_ip(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test rate limit is enforced per IP address."""
+        # Exhaust rate limit for default IP
+        for _ in range(10):
+            client.post("/app/auth/login", json=test_user_credentials)
+
+        # Verify rate limit is active
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 429
+
+        # Note: TestClient doesn't support changing client IP in headers
+        # In production, different IPs would have separate rate limit buckets
+        # This test documents the expected behavior
+
+    @pytest.mark.slow
+    def test_rate_limit_resets_after_window(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test rate limit resets after time window expires.
+
+        Note: This test is marked as slow because it requires waiting 61 seconds.
+        Run with: pytest -m slow
+        """
+        # Exhaust rate limit
+        for _ in range(10):
+            client.post("/app/auth/login", json=test_user_credentials)
+
+        # Verify rate limit is active
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 429
+
+        # Wait for rate limit window to reset (61 seconds)
+        time.sleep(61)
+
+        # Should succeed after reset (or fail with 401 if credentials wrong, but not 429)
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code in [200, 401], "Request should not be rate limited after window reset"
+        assert response.status_code != 429
+
+    def test_successful_login_counts_toward_rate_limit(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test that successful logins also count toward rate limit."""
+        # Make 10 successful login requests
+        for i in range(10):
+            response = client.post("/app/auth/login", json=test_user_credentials)
+            assert response.status_code == 200, f"Request {i+1} should succeed"
+
+        # 11th request should be rate limited even with valid credentials
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 429
+        assert "rate limit" in response.json()["detail"].lower()
+
+    def test_failed_login_counts_toward_rate_limit(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test that failed logins count toward rate limit."""
+        wrong_credentials = {
+            "email": test_user_credentials["email"],
+            "password": "WrongPassword123!",  # pragma: allowlist secret
+        }
+
+        # Make 10 failed login attempts
+        for i in range(10):
+            response = client.post("/app/auth/login", json=wrong_credentials)
+            assert response.status_code == 401, f"Request {i+1} should fail with wrong password"
+
+        # 11th request should be rate limited
+        response = client.post("/app/auth/login", json=wrong_credentials)
+        assert response.status_code == 429
+        assert "rate limit" in response.json()["detail"].lower()

--- a/tests/e2e/test_app_auth_token_expiry.py
+++ b/tests/e2e/test_app_auth_token_expiry.py
@@ -171,4 +171,4 @@ class TestTokenExpirySynchronization:
         # Verify security flags
         assert "httponly" in jwt_cookie.lower(), "JWT cookie must be httpOnly (prevent XSS)"
         assert "samesite=lax" in jwt_cookie.lower(), "JWT cookie should have SameSite=Lax"
-        assert "path=/" in jwt_cookie.lower(), "JWT cookie should be scoped to root path"
+        assert "path=/app" in jwt_cookie.lower(), "JWT cookie should be scoped to /app path"

--- a/tests/e2e/test_app_auth_token_expiry.py
+++ b/tests/e2e/test_app_auth_token_expiry.py
@@ -1,0 +1,157 @@
+"""E2E tests for token expiry synchronization.
+
+Tests that CSRF and JWT tokens expire simultaneously to prevent auth/CSRF desynchronization.
+"""
+
+import os
+import re
+import uuid
+from typing import Dict, Generator
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from mcpgateway.main import app
+from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway.services.email_auth_service import EmailAuthService
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        os.environ.get("MCPGATEWAY_UI_ENABLED", "").lower() not in ("1", "true"),
+        reason="MCPGATEWAY_UI_ENABLED is not set — /app routes not registered",
+    ),
+]
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def test_user_credentials() -> Dict[str, str]:
+    """Test user credentials."""
+    return {
+        "email": f"expiry-test-{uuid.uuid4().hex[:8]}@example.com",
+        "password": "TestPassword123!",  # pragma: allowlist secret
+    }
+
+
+@pytest.fixture
+def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
+    """Create test user in database."""
+    db = SessionLocal()
+    user = None
+    try:
+        # Clean up any existing test user
+        existing = db.query(EmailUser).filter_by(email=test_user_credentials["email"]).first()
+        if existing:
+            db.delete(existing)
+            db.commit()
+
+        # Create test user
+        auth_service = EmailAuthService(db)
+        user = auth_service.create_user(
+            email=test_user_credentials["email"],
+            password=test_user_credentials["password"],
+        )
+        db.commit()
+        yield user
+    finally:
+        try:
+            if user is not None:
+                db.delete(user)
+                db.commit()
+        except Exception:
+            db.rollback()
+        db.close()
+
+
+class TestTokenExpirySynchronization:
+    """Test CSRF and JWT token expiry synchronization."""
+
+    def test_csrf_and_jwt_cookies_expire_simultaneously(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test CSRF and JWT cookies have identical max_age values."""
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 200
+
+        # Extract Set-Cookie headers
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+
+        # Find JWT and CSRF cookies
+        jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
+        csrf_cookie = next((c for c in set_cookies if "csrf_token=" in c), None)
+
+        assert jwt_cookie is not None, "JWT cookie should be set"
+        assert csrf_cookie is not None, "CSRF cookie should be set"
+
+        # Extract max-age from both cookies
+        jwt_max_age_match = re.search(r"max-age=(\d+)", jwt_cookie, re.I)
+        csrf_max_age_match = re.search(r"max-age=(\d+)", csrf_cookie, re.I)
+
+        assert jwt_max_age_match is not None, "JWT cookie should have max-age"
+        assert csrf_max_age_match is not None, "CSRF cookie should have max-age"
+
+        jwt_max_age = int(jwt_max_age_match.group(1))
+        csrf_max_age = int(csrf_max_age_match.group(1))
+
+        # Verify synchronization
+        assert jwt_max_age == csrf_max_age, f"JWT and CSRF cookies must expire simultaneously: " f"jwt_max_age={jwt_max_age}, csrf_max_age={csrf_max_age}"
+
+    def test_token_expiry_matches_config(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test token expiry matches settings.token_expiry configuration."""
+        from mcpgateway.config import settings
+
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 200
+
+        # Extract Set-Cookie headers
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
+
+        assert jwt_cookie is not None, "JWT cookie should be set"
+
+        # Extract max-age
+        jwt_max_age_match = re.search(r"max-age=(\d+)", jwt_cookie, re.I)
+        assert jwt_max_age_match is not None, "JWT cookie should have max-age"
+
+        jwt_max_age = int(jwt_max_age_match.group(1))
+        expected_max_age = settings.token_expiry * 60  # Convert minutes to seconds
+
+        # Verify cookie expiry matches config
+        assert jwt_max_age == expected_max_age, f"JWT cookie max-age should match settings.token_expiry: " f"jwt_max_age={jwt_max_age}, expected={expected_max_age}"
+
+    def test_csrf_cookie_security_flags(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test CSRF cookie has correct security flags."""
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 200
+
+        # Extract CSRF cookie
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        csrf_cookie = next((c for c in set_cookies if "csrf_token=" in c), None)
+
+        assert csrf_cookie is not None, "CSRF cookie should be set"
+
+        # Verify security flags
+        assert "httponly" not in csrf_cookie.lower() or "httponly=false" in csrf_cookie.lower(), "CSRF cookie must NOT be httpOnly (JS needs to read it for X-CSRF-Token header)"
+        assert "samesite=strict" in csrf_cookie.lower(), "CSRF cookie must have SameSite=Strict"
+        assert "path=/app" in csrf_cookie.lower(), "CSRF cookie must be scoped to /app path"
+
+    def test_jwt_cookie_security_flags(self, client: TestClient, setup_test_user: EmailUser, test_user_credentials: Dict[str, str]) -> None:
+        """Test JWT cookie has correct security flags."""
+        response = client.post("/app/auth/login", json=test_user_credentials)
+        assert response.status_code == 200
+
+        # Extract JWT cookie
+        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
+
+        assert jwt_cookie is not None, "JWT cookie should be set"
+
+        # Verify security flags
+        assert "httponly" in jwt_cookie.lower(), "JWT cookie must be httpOnly (prevent XSS)"
+        assert "samesite=lax" in jwt_cookie.lower(), "JWT cookie should have SameSite=Lax"
+        assert "path=/" in jwt_cookie.lower(), "JWT cookie should be scoped to root path"

--- a/tests/e2e/test_app_auth_token_expiry.py
+++ b/tests/e2e/test_app_auth_token_expiry.py
@@ -3,6 +3,7 @@
 Tests that CSRF and JWT tokens expire simultaneously to prevent auth/CSRF desynchronization.
 """
 
+import asyncio
 import os
 import re
 import uuid
@@ -12,8 +13,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from mcpgateway.main import app
-from mcpgateway.db import SessionLocal, EmailUser
+from mcpgateway import db as db_mod
+from mcpgateway.admin import rate_limit_storage
+from mcpgateway.db import EmailUser
 from mcpgateway.services.email_auth_service import EmailAuthService
 
 pytestmark = [
@@ -25,10 +27,23 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def clear_auth_rate_limits() -> Generator[None, None, None]:
+    """Keep auth rate limiting isolated between tests."""
+    rate_limit_storage.clear()
+    yield
+    rate_limit_storage.clear()
+
+
+def _set_cookie_headers(response) -> list[str]:
+    """Return separate Set-Cookie headers from an httpx response."""
+    return response.headers.get_list("set-cookie")
+
+
 @pytest.fixture
-def client() -> TestClient:
+def client(app_with_temp_db) -> TestClient:
     """Create test client."""
-    return TestClient(app)
+    return TestClient(app_with_temp_db)
 
 
 @pytest.fixture
@@ -43,7 +58,7 @@ def test_user_credentials() -> Dict[str, str]:
 @pytest.fixture
 def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUser, None, None]:
     """Create test user in database."""
-    db = SessionLocal()
+    db = db_mod.SessionLocal()
     user = None
     try:
         # Clean up any existing test user
@@ -54,9 +69,11 @@ def setup_test_user(test_user_credentials: Dict[str, str]) -> Generator[EmailUse
 
         # Create test user
         auth_service = EmailAuthService(db)
-        user = auth_service.create_user(
-            email=test_user_credentials["email"],
-            password=test_user_credentials["password"],
+        user = asyncio.run(
+            auth_service.create_user(
+                email=test_user_credentials["email"],
+                password=test_user_credentials["password"],
+            )
         )
         db.commit()
         yield user
@@ -79,7 +96,7 @@ class TestTokenExpirySynchronization:
         assert response.status_code == 200
 
         # Extract Set-Cookie headers
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
 
         # Find JWT and CSRF cookies
         jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
@@ -109,7 +126,7 @@ class TestTokenExpirySynchronization:
         assert response.status_code == 200
 
         # Extract Set-Cookie headers
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
         jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
 
         assert jwt_cookie is not None, "JWT cookie should be set"
@@ -130,7 +147,7 @@ class TestTokenExpirySynchronization:
         assert response.status_code == 200
 
         # Extract CSRF cookie
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
         csrf_cookie = next((c for c in set_cookies if "csrf_token=" in c), None)
 
         assert csrf_cookie is not None, "CSRF cookie should be set"
@@ -146,7 +163,7 @@ class TestTokenExpirySynchronization:
         assert response.status_code == 200
 
         # Extract JWT cookie
-        set_cookies = [v for k, v in response.headers.items() if k.lower() == "set-cookie"]
+        set_cookies = _set_cookie_headers(response)
         jwt_cookie = next((c for c in set_cookies if "jwt_token=" in c), None)
 
         assert jwt_cookie is not None, "JWT cookie should be set"

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -141,6 +141,72 @@ async def test_cookie_auth_allowed_with_accept_text_html():
 
 
 @pytest.mark.asyncio
+async def test_cookie_auth_allowed_for_same_origin_react_app_fetch():
+    """Same-origin React SPA fetches may use cookie auth for API requests."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.url = SimpleNamespace(path="/gateways")
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "http://localhost:4444/app/gateways",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+    }
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-react", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.middleware.rbac.get_current_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_for_same_site_react_app_fetch():
+    """Same-site is not enough for React API cookie auth; require same-origin."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.url = SimpleNamespace(path="/gateways")
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "http://localhost:4444/app/gateways",
+        "sec-fetch-site": "same-site",
+        "sec-fetch-mode": "cors",
+    }
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-react")
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Cookie authentication not allowed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_missing_react_app_cookie_returns_401_not_admin_redirect():
+    """React fetches without a cookie should receive JSON-style 401, not an admin redirect."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.url = SimpleNamespace(path="/gateways")
+    mock_request.cookies = {}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "http://localhost:4444/app/gateways",
+        "sec-fetch-site": "same-origin",
+        "sec-fetch-mode": "cors",
+    }
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc.value.detail == "Authorization token required"
+
+
+@pytest.mark.asyncio
 async def test_cookie_auth_rejected_with_cross_origin_oauth_referer():
     """Cross-origin /oauth/ referer without browser headers must NOT grant cookie auth."""
     mock_request = MagicMock(spec=Request)

--- a/tests/unit/mcpgateway/routers/test_app.py
+++ b/tests/unit/mcpgateway/routers/test_app.py
@@ -1,0 +1,459 @@
+"""Unit tests for React App API router (/app/auth/* endpoints)."""
+
+import os
+import pytest
+from collections.abc import Callable, Generator
+from datetime import datetime
+from typing import Any
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcpgateway.auth import get_current_user_from_cookie
+from mcpgateway.main import app
+from mcpgateway.utils.csrf import CSRF_TOKEN_LENGTH, require_csrf
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MCPGATEWAY_UI_ENABLED", "").lower() not in ("1", "true"),
+    reason="MCPGATEWAY_UI_ENABLED is not set — /app routes not registered",
+)
+
+
+def _make_mock_user(email: str = "test@example.com") -> MagicMock:
+    """Build a MagicMock that quacks like an EmailUser ORM object."""
+    user = MagicMock()
+    user.email = email
+    user.full_name = None
+    user.is_admin = False
+    user.is_active = True
+    user.auth_provider = "local"
+    user.password_change_required = False
+    user.is_email_verified.return_value = True
+    user.failed_login_attempts = 0
+    user.locked_until = None
+    user.is_account_locked.return_value = False
+    user.last_login = None
+    user.created_at = datetime(2024, 1, 1)
+    user.updated_at = datetime(2024, 1, 1)
+    return user
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def dep_override() -> Generator[Callable[..., None], Any, None]:
+    """Set FastAPI dependency overrides and clean up after each test."""
+    overrides_set: dict[Any, Any] = {}
+
+    def _set(dep: Any, fn: Any) -> None:
+        overrides_set[dep] = fn
+        app.dependency_overrides[dep] = fn
+
+    yield _set
+
+    for dep in overrides_set:
+        app.dependency_overrides.pop(dep, None)
+
+
+def _raise_invalid_token():
+    raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def _raise_expired_token():
+    raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+
+def _raise_csrf_missing_header():
+    raise HTTPException(status_code=403, detail="CSRF token missing from header")
+
+
+def _raise_csrf_mismatch():
+    raise HTTPException(status_code=403, detail="CSRF token mismatch")
+
+
+def _raise_csrf_missing_cookie():
+    raise HTTPException(status_code=403, detail="CSRF token missing from cookie")
+
+
+class TestAuthLogin:
+    """Tests for POST /app/auth/login endpoint."""
+
+    # Successful login is covered by tests/e2e/test_app_auth.py::TestFullLoginFlow
+    # which runs the full stack against a real DB. Unit-testing it here would require
+    # mocking create_access_token and generate_csrf_token (internal functions), which
+    # tests routing plumbing rather than real behavior.
+
+    @patch("mcpgateway.routers.app.EmailAuthService")
+    def test_login_invalid_credentials(self, mock_auth_service, client):
+        """Test login with invalid credentials returns 401."""
+        # Setup mock to return None (authentication failed)
+        mock_auth_instance = AsyncMock()
+        mock_auth_instance.authenticate_user = AsyncMock(return_value=None)
+        mock_auth_service.return_value = mock_auth_instance
+
+        # Make request
+        response = client.post(
+            "/app/auth/login",
+            json={"email": "test@example.com", "password": "wrongpassword"},  # pragma: allowlist secret
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        detail = response.json()["detail"]
+        if isinstance(detail, dict):
+            assert detail["message"] == "Invalid email or password"
+        else:
+            assert "Invalid email or password" in detail
+
+        # Verify no cookies set
+        assert "jwt_token" not in response.cookies
+        assert "csrf_token" not in response.cookies
+
+    def test_login_missing_email(self, client):
+        """Test login without email returns 422."""
+        response = client.post(
+            "/app/auth/login",
+            json={"password": "password123"},  # pragma: allowlist secret
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_login_missing_password(self, client):
+        """Test login without password returns 422."""
+        response = client.post(
+            "/app/auth/login",
+            json={"email": "test@example.com"},
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_login_invalid_email_format(self, client):
+        """Test login with invalid email format returns 422."""
+        response = client.post(
+            "/app/auth/login",
+            json={"email": "not-an-email", "password": "password123"},  # pragma: allowlist secret
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @patch("mcpgateway.routers.app.EmailAuthService")
+    def test_login_service_error(self, mock_auth_service, client):
+        """Test login handles service errors gracefully."""
+        # Setup mock to raise exception
+        mock_auth_instance = AsyncMock()
+        mock_auth_instance.authenticate_user = AsyncMock(side_effect=Exception("Database error"))
+        mock_auth_service.return_value = mock_auth_instance
+
+        # Make request
+        response = client.post(
+            "/app/auth/login",
+            json={"email": "test@example.com", "password": "password123"},  # pragma: allowlist secret
+        )
+
+        # Assertions
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        detail = response.json()["detail"]
+        if isinstance(detail, dict):
+            assert detail["message"] == "Authentication failed"
+        else:
+            assert "Authentication failed" in detail
+
+
+class TestGetCurrentUser:
+    """Tests for GET /app/auth/me endpoint."""
+
+    def test_get_me_without_cookie(self, client):
+        """Test GET /app/auth/me without cookie returns 401."""
+        response = client.get("/app/auth/me")
+
+        # Should return 401 or 403 depending on auth middleware
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    def test_get_me_with_invalid_cookie(self, client, dep_override):
+        """Test GET /app/auth/me with invalid JWT cookie returns 401."""
+        dep_override(get_current_user_from_cookie, _raise_invalid_token)
+
+        response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": "invalid-jwt-token"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_get_me_with_expired_token(self, client, dep_override):
+        """Test GET /app/auth/me with expired JWT cookie returns 401."""
+        dep_override(get_current_user_from_cookie, _raise_expired_token)
+
+        response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": "expired-jwt-token"},
+        )
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "expired" in response.json()["detail"].lower()
+
+
+class TestLogout:
+    """Tests for POST /app/auth/logout endpoint."""
+
+    def test_logout_missing_csrf_token(self, client, dep_override):
+        """Test logout without CSRF token returns 403."""
+        dep_override(get_current_user_from_cookie, lambda: (_make_mock_user(), None))
+        dep_override(require_csrf, _raise_csrf_missing_header)
+
+        response = client.post(
+            "/app/auth/logout",
+            cookies={
+                "jwt_token": "valid-jwt-token",
+                "csrf_token": "valid-csrf-token",
+            },
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF token" in response.json()["detail"]
+
+    def test_logout_invalid_csrf_token(self, client, dep_override):
+        """Test logout with mismatched CSRF token returns 403."""
+        dep_override(get_current_user_from_cookie, lambda: (_make_mock_user(), None))
+        dep_override(require_csrf, _raise_csrf_mismatch)
+
+        response = client.post(
+            "/app/auth/logout",
+            cookies={
+                "jwt_token": "valid-jwt-token",
+                "csrf_token": "cookie-csrf-token",
+            },
+            headers={"X-CSRF-Token": "different-csrf-token"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF token" in response.json()["detail"]
+
+    def test_logout_without_authentication(self, client):
+        """Test logout without authentication returns 401."""
+        response = client.post("/app/auth/logout")
+
+        # Should return 401 or 403 depending on auth middleware
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+class TestCSRFProtection:
+    """Tests for CSRF protection utilities."""
+
+    def test_csrf_token_generation(self):
+        """Test CSRF token generation produces unique tokens."""
+        from mcpgateway.utils.csrf import generate_csrf_token
+
+        token1 = generate_csrf_token()
+        token2 = generate_csrf_token()
+
+        # Tokens should be different
+        assert token1 != token2
+
+        assert len(token1) == CSRF_TOKEN_LENGTH
+        assert len(token2) == CSRF_TOKEN_LENGTH
+
+    def test_csrf_cookie_security_flags(self):
+        """Test CSRF cookie has samesite=strict, non-httpOnly, and path=/app (not /app/auth)."""
+        from fastapi import Response
+        from mcpgateway.utils.csrf import set_csrf_cookie
+
+        response = Response()
+        set_csrf_cookie(response, "test-token")
+
+        set_cookie_headers = [v.decode() if isinstance(v, bytes) else v for k, v in response.raw_headers if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"]
+        assert set_cookie_headers, "No Set-Cookie header found"
+        csrf_cookie = next((h for h in set_cookie_headers if "csrf_token=" in h), "")
+        assert csrf_cookie, "csrf_token cookie not found in Set-Cookie"
+        assert "samesite=strict" in csrf_cookie.lower()
+        assert "httponly" not in csrf_cookie.lower(), "CSRF cookie must not be httpOnly — JS needs to read it"
+        assert "path=/app" in csrf_cookie.lower()
+
+
+class TestSecurityVectors:
+    """Test security attack vectors."""
+
+    @patch("mcpgateway.routers.app.EmailAuthService")
+    def test_login_sql_injection_attempt(self, mock_auth_service, client):
+        """Test SQL injection in email field is safely handled."""
+        # Mock auth service to return None (authentication failed)
+        mock_auth_instance = AsyncMock()
+        mock_auth_instance.authenticate_user = AsyncMock(return_value=None)
+        mock_auth_service.return_value = mock_auth_instance
+
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": "admin'--@example.com",
+                "password": "password123",  # pragma: allowlist secret
+            },
+        )
+        # Should fail safely with 401 or 422 (validation error)
+        assert response.status_code in [401, 422]
+
+    @patch("mcpgateway.routers.app.EmailAuthService")
+    def test_login_xss_payload_in_password(self, mock_auth_service, client):
+        """Test XSS payload in password field is safely handled."""
+        # Mock auth service to return None (authentication failed)
+        mock_auth_instance = AsyncMock()
+        mock_auth_instance.authenticate_user = AsyncMock(return_value=None)
+        mock_auth_service.return_value = mock_auth_instance
+
+        response = client.post(
+            "/app/auth/login",
+            json={
+                "email": "test@example.com",
+                "password": "<script>alert('xss')</script>",  # pragma: allowlist secret
+            },
+        )
+        # Should fail safely with 401 (invalid credentials)
+        assert response.status_code == 401
+
+    def test_csrf_token_wrong_length_rejected(self, client):
+        """Test CSRF validation rejects tokens that are not 43 characters."""
+        short_token = "token-with-wrong-len"  # 20 chars, not 43
+        response = client.post(
+            "/app/auth/logout",
+            cookies={
+                "jwt_token": "valid-jwt-token",
+                "csrf_token": short_token,
+            },
+            headers={"X-CSRF-Token": short_token},
+        )
+        # Fails due to token length check (not XSS — JSON body is never reflected)
+        assert response.status_code in [401, 403]
+
+    def test_csrf_token_length_validation_oversized(self, client):
+        """Test CSRF validation rejects oversized tokens."""
+        oversized_token = "x" * 1000
+        response = client.post(
+            "/app/auth/logout",
+            cookies={
+                "jwt_token": "valid-jwt-token",
+                "csrf_token": oversized_token,
+            },
+            headers={"X-CSRF-Token": oversized_token},
+        )
+        # Should fail with 403 (invalid token format)
+        assert response.status_code in [401, 403]
+        if response.status_code == 403:
+            assert response.json()["detail"]["message"] == "Invalid CSRF token format"
+
+    def test_csrf_token_length_validation_undersized(self, client):
+        """Test CSRF validation rejects undersized tokens."""
+        undersized_token = "short"
+        response = client.post(
+            "/app/auth/logout",
+            cookies={
+                "jwt_token": "valid-jwt-token",
+                "csrf_token": undersized_token,
+            },
+            headers={"X-CSRF-Token": undersized_token},
+        )
+        # Should fail with 403 (invalid token format)
+        assert response.status_code in [401, 403]
+        if response.status_code == 403:
+            assert response.json()["detail"]["message"] == "Invalid CSRF token format"
+
+
+class TestRBACMiddleware:
+    """Tests for Sec-Fetch-* based RBAC cookie rejection.
+
+    /app/auth/* endpoints use get_current_user_from_cookie (cookie-only by design) and
+    bypass the RBAC Sec-Fetch-* check. The check in get_current_user_with_permissions
+    guards admin/API endpoints when accessed from the React SPA via cookie.
+    """
+
+    def test_app_auth_endpoints_accept_cookie_without_sec_fetch_headers(self, client, dep_override):
+        """/app/auth/* accepts cookie auth without Sec-Fetch-* — these endpoints are cookie-only by design."""
+        dep_override(get_current_user_from_cookie, _raise_invalid_token)
+
+        response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": "any-token"},
+            # No Sec-Fetch-* headers — still reaches auth layer (not blocked by RBAC)
+        )
+        # Auth layer rejects the invalid token — not RBAC
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        detail = response.json()["detail"]
+        assert detail != "Cookie authentication not allowed for API requests. Use Authorization header."
+
+    def test_cookie_auth_passes_rbac_with_sec_fetch_same_origin(self, client, dep_override):
+        """Browser fetch with Sec-Fetch-Site: same-origin reaches the auth layer."""
+        dep_override(get_current_user_from_cookie, _raise_invalid_token)
+
+        response = client.get(
+            "/app/auth/me",
+            cookies={"jwt_token": "invalid-but-reaches-auth"},
+            headers={"Sec-Fetch-Site": "same-origin", "Sec-Fetch-Mode": "cors"},
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        detail = response.json()["detail"]
+        assert detail != "Cookie authentication not allowed for API requests. Use Authorization header."
+
+
+class TestSPAServing:
+    """Tests for React SPA serving."""
+
+    @patch("mcpgateway.routers.app.settings")
+    def test_spa_returns_404_when_not_built(self, mock_settings, client: TestClient, tmp_path):
+        """Test /app returns 404 with helpful message when React app is not built."""
+        mock_settings.static_dir = tmp_path  # tmp_path has no app/index.html
+        response = client.get("/app")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "not built" in response.json()["detail"]
+
+    @patch("mcpgateway.routers.app.FileResponse")
+    @patch("mcpgateway.routers.app.settings")
+    def test_spa_serves_index_when_built(self, mock_settings, mock_file_response, client: TestClient, tmp_path):
+        """Test /app serves index.html when React app is built."""
+        import os
+        from fastapi.responses import HTMLResponse
+
+        os.makedirs(tmp_path / "app")
+        (tmp_path / "app" / "index.html").write_text("<html/>")
+        mock_settings.static_dir = tmp_path
+        mock_file_response.return_value = HTMLResponse(content="<html/>", status_code=200)
+
+        response = client.get("/app")
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch("mcpgateway.routers.app.settings")
+    def test_spa_nested_route_returns_404_when_not_built(self, mock_settings, client: TestClient, tmp_path):
+        """Test /app/nested/route returns 404 when React app is not built."""
+        mock_settings.static_dir = tmp_path
+        response = client.get("/app/nested/route")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestTokenExpiry:
+    """Tests for token expiry behavior."""
+
+    def test_csrf_token_expiry_synchronized_with_jwt(self, client: TestClient, dep_override: Callable[..., None]):
+        """Test that CSRF failure blocks logout even when JWT auth would succeed.
+
+        Verifies the coupling documented in csrf.py: both tokens must expire
+        simultaneously to prevent auth/CSRF desynchronization.
+        """
+        # Auth would succeed, but CSRF cookie is missing (simulates simultaneous expiry)
+        dep_override(get_current_user_from_cookie, lambda: (_make_mock_user(), "valid-jti"))
+        dep_override(require_csrf, _raise_csrf_missing_cookie)
+
+        response = client.post(
+            "/app/auth/logout",
+            cookies={"jwt_token": "valid-jwt"},
+            headers={"X-CSRF-Token": "some-token"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF token" in response.json()["detail"]


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Relates to #4269

---

## 🚀 Summary (1-2 sentences)
Adds new endpoints to handle the react client authentication

---

## 🧪 Checks

- [X] `make lint` passes
- [X] `make test` passes
- [X] CHANGELOG updated (if user-facing)

---

## 📓 Notes (optional)
Moves the react client routes to a separate file
