### PR TITLE
fix: implement IBM Verify SSO mappings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1161,6 +1161,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # SSO_IBM_VERIFY_CLIENT_ID=your-ibm-verify-client-id
 # SSO_IBM_VERIFY_CLIENT_SECRET=your-ibm-verify-client-secret
 # SSO_IBM_VERIFY_ISSUER=https://your-tenant.verify.ibm.com/oidc/endpoint/default
+# SSO_IBM_VERIFY_SCOPE=openid profile email groups
+# IBM_VERIFY_GROUP_MAPPING={"ContextForge Users": "team-uuid-1", "ContextForge Admins": "team-uuid-2"}
+# IBM_VERIFY_USER_MAPPING={"preferred_username": "username"}
 
 # Okta OIDC Configuration
 # SSO_OKTA_ENABLED=false

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -490,6 +490,9 @@ When `SMTP_ENABLED=false`, reset requests are accepted but no email is delivered
 | `SSO_IBM_VERIFY_CLIENT_ID`    | IBM Security Verify client ID                    | (none)                | string  |
 | `SSO_IBM_VERIFY_CLIENT_SECRET` | IBM Security Verify client secret               | (none)                | string  |
 | `SSO_IBM_VERIFY_ISSUER`       | IBM Security Verify OIDC issuer URL             | (none)                | string  |
+| `SSO_IBM_VERIFY_SCOPE`        | IBM Security Verify OIDC scopes                 | `openid profile email` | string |
+| `IBM_VERIFY_GROUP_MAPPING`    | IBM Security Verify group-to-team mapping       | (none)                | JSON object |
+| `IBM_VERIFY_USER_MAPPING`     | IBM Security Verify claim-to-user-field mapping | (none)                | JSON object |
 
 **Keycloak OIDC:**
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -374,6 +374,9 @@ class Settings(BaseSettings):
     sso_ibm_verify_client_id: Optional[str] = Field(default=None, description="IBM Security Verify client ID")
     sso_ibm_verify_client_secret: Optional[SecretStr] = Field(default=None, description="IBM Security Verify client secret")
     sso_ibm_verify_issuer: Optional[str] = Field(default=None, description="IBM Security Verify OIDC issuer URL")
+    sso_ibm_verify_scope: str = Field(default="openid profile email", description="IBM Security Verify OIDC scopes (space-separated)")
+    ibm_verify_group_mapping: Optional[str] = Field(default=None, description="JSON mapping of IBM Security Verify group names to team UUIDs")
+    ibm_verify_user_mapping: Optional[str] = Field(default=None, description="JSON mapping of IBM Security Verify user claim names to normalized user fields")
 
     sso_okta_enabled: bool = Field(default=False, description="Enable Okta OIDC authentication")
     sso_okta_client_id: Optional[str] = Field(default=None, description="Okta client ID")

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1688,6 +1688,35 @@ class SSOService:
             normalized.update(extra)
         return normalized
 
+    @staticmethod
+    def _resolve_user_mapping_overrides(user_data: Dict[str, Any], user_mapping: Any) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Resolve configured IdP claim mappings into normalized-user overrides."""
+        if not isinstance(user_mapping, dict) or not user_mapping:
+            return {}, {}
+
+        normalized_field_aliases = {
+            "name": "full_name",
+            "picture": "avatar_url",
+            "sub": "provider_id",
+        }
+        supported_normalized_fields = {"email", "full_name", "avatar_url", "provider_id", "username"}
+        overrides: Dict[str, Any] = {}
+        extra: Dict[str, Any] = {}
+
+        for source_claim, target_field in user_mapping.items():
+            if not isinstance(source_claim, str) or not source_claim.strip() or not isinstance(target_field, str) or not target_field.strip():
+                continue
+            if source_claim not in user_data:
+                continue
+
+            normalized_target = normalized_field_aliases.get(target_field.strip(), target_field.strip())
+            if normalized_target in supported_normalized_fields:
+                overrides[normalized_target] = user_data.get(source_claim)
+            else:
+                extra[normalized_target] = user_data.get(source_claim)
+
+        return overrides, extra
+
     def _normalize_user_info(self, provider: SSOProvider, user_data: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize user info from different providers to common format.
 
@@ -1734,7 +1763,14 @@ class SSOService:
         # Handle IBM Verify provider
         if provider.id == "ibm_verify":
             groups = self._extract_groups_and_roles(user_data, groups_claim)
-            return self._build_normalized_user_info(user_data, "ibm_verify", groups)
+            user_overrides, extra = self._resolve_user_mapping_overrides(user_data, metadata.get("user_mapping"))
+            return self._build_normalized_user_info(
+                user_data,
+                "ibm_verify",
+                groups,
+                extra=extra or None,
+                **user_overrides,
+            )
 
         # Handle Okta provider
         if provider.id == "okta":

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -22,6 +22,39 @@ from mcpgateway.services.sso_service import ADFS_PROVIDER_ID
 logger = logging.getLogger(__name__)
 
 
+def _parse_json_object_mapping(raw_mapping: Any, env_var_name: str) -> Dict[str, Any]:
+    """Parse a JSON object mapping from an optional environment setting."""
+    if not raw_mapping:
+        return {}
+
+    try:
+        parsed = json.loads(raw_mapping)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse %s as JSON; using empty mapping", env_var_name)
+        return {}
+
+    if not isinstance(parsed, dict):
+        logger.warning("%s must be a JSON object (got %s); using empty mapping", env_var_name, type(parsed).__name__)
+        return {}
+
+    return parsed
+
+
+def _ibm_verify_issuer_url(configured_issuer: Any) -> str:
+    """Return the IBM Verify issuer endpoint from a tenant base, issuer, or discovery URL."""
+    issuer_url = str(configured_issuer).strip() if configured_issuer else "https://tenant.verify.ibm.com"
+    issuer_url = issuer_url.rstrip("/")
+
+    well_known_suffix = "/.well-known/openid-configuration"
+    if issuer_url.endswith(well_known_suffix):
+        issuer_url = issuer_url[: -len(well_known_suffix)].rstrip("/")
+
+    if "/oidc/endpoint/" in issuer_url:
+        return issuer_url
+
+    return f"{issuer_url}/oidc/endpoint/default"
+
+
 def get_predefined_sso_providers() -> List[Dict]:
     """Get list of predefined SSO providers based on environment configuration.
 
@@ -154,39 +187,33 @@ def get_predefined_sso_providers() -> List[Dict]:
 
     # IBM Security Verify Provider
     if settings.sso_ibm_verify_enabled and settings.sso_ibm_verify_client_id:
-        base_url = settings.sso_ibm_verify_issuer or "https://tenant.verify.ibm.com"
-        providers.append(
-            {
-                "id": "ibm_verify",
-                "name": "ibm_verify",
-                "display_name": "IBM Security Verify",
-                "provider_type": "oidc",
-                "client_id": settings.sso_ibm_verify_client_id,
-                "client_secret": settings.sso_ibm_verify_client_secret.get_secret_value() if settings.sso_ibm_verify_client_secret else "",
-                "authorization_url": f"{base_url}/oidc/endpoint/default/authorize",
-                "token_url": f"{base_url}/oidc/endpoint/default/token",
-                "userinfo_url": f"{base_url}/oidc/endpoint/default/userinfo",
-                "issuer": f"{base_url}/oidc/endpoint/default",
-                "scope": "openid profile email",
-                "trusted_domains": settings.sso_trusted_domains,
-                "auto_create_users": settings.sso_auto_create_users,
-                "team_mapping": {},
-            }
-        )
+        issuer_url = _ibm_verify_issuer_url(settings.sso_ibm_verify_issuer)
+        ibm_user_mapping = _parse_json_object_mapping(settings.ibm_verify_user_mapping, "IBM_VERIFY_USER_MAPPING")
+        ibm_provider_config: Dict[str, Any] = {
+            "id": "ibm_verify",
+            "name": "ibm_verify",
+            "display_name": "IBM Security Verify",
+            "provider_type": "oidc",
+            "client_id": settings.sso_ibm_verify_client_id,
+            "client_secret": settings.sso_ibm_verify_client_secret.get_secret_value() if settings.sso_ibm_verify_client_secret else "",
+            "authorization_url": f"{issuer_url}/authorize",
+            "token_url": f"{issuer_url}/token",
+            "userinfo_url": f"{issuer_url}/userinfo",
+            "issuer": issuer_url,
+            "scope": settings.sso_ibm_verify_scope,
+            "trusted_domains": settings.sso_trusted_domains,
+            "auto_create_users": settings.sso_auto_create_users,
+            "team_mapping": _parse_json_object_mapping(settings.ibm_verify_group_mapping, "IBM_VERIFY_GROUP_MAPPING"),
+        }
+        if ibm_user_mapping:
+            ibm_provider_config["provider_metadata"] = {"user_mapping": ibm_user_mapping}
+
+        providers.append(ibm_provider_config)
 
     # Okta Provider
     if settings.sso_okta_enabled and settings.sso_okta_client_id:
         base_url = settings.sso_okta_issuer or "https://company.okta.com"
-        okta_team_mapping: Dict[str, Any] = {}
-        if settings.okta_group_mapping:
-            try:
-                parsed = json.loads(settings.okta_group_mapping)
-                if isinstance(parsed, dict):
-                    okta_team_mapping = parsed
-                else:
-                    logger.warning("OKTA_GROUP_MAPPING must be a JSON object (got %s); using empty team mapping", type(parsed).__name__)
-            except (json.JSONDecodeError, TypeError):
-                logger.warning("Failed to parse OKTA_GROUP_MAPPING as JSON; using empty team mapping")
+        okta_team_mapping = _parse_json_object_mapping(settings.okta_group_mapping, "OKTA_GROUP_MAPPING")
         providers.append(
             {
                 "id": "okta",

--- a/tests/unit/mcpgateway/services/test_sso_user_normalization.py
+++ b/tests/unit/mcpgateway/services/test_sso_user_normalization.py
@@ -813,6 +813,32 @@ class TestIBMVerifyNormalization:
 
         assert sorted(normalized["groups"]) == ["Engineering", "Platform"]
 
+    def test_ibm_verify_user_mapping_overrides_normalized_fields(self, sso_service):
+        """IBM Verify user_mapping maps source claims to normalized user fields."""
+        ibm_provider = SSOProvider(
+            id="ibm_verify",
+            name="ibm_verify",
+            display_name="IBM Security Verify",
+            provider_type="oidc",
+            provider_metadata={"user_mapping": {"preferred_username": "username", "uid": "provider_id", "display_name": "full_name", "family_name": "last_name"}},
+        )
+        user_data = {
+            "email": "user@company.com",
+            "name": "Default Name",
+            "sub": "default-sub",
+            "preferred_username": "mapped-user",
+            "uid": "ibm-uid-123",
+            "display_name": "Mapped Name",
+            "family_name": "MappedFamily",
+        }
+
+        normalized = sso_service._normalize_user_info(ibm_provider, user_data)
+
+        assert normalized["username"] == "mapped-user"
+        assert normalized["provider_id"] == "ibm-uid-123"
+        assert normalized["full_name"] == "Mapped Name"
+        assert normalized["last_name"] == "MappedFamily"
+
     def test_ibm_verify_roles_single_string(self, sso_service):
         """A single string roles value is included in groups for IBM Verify."""
         ibm_provider = SSOProvider(id="ibm_verify", name="ibm_verify", display_name="IBM Security Verify", provider_type="oidc")

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -41,6 +41,9 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
         sso_ibm_verify_client_id="ibm-client",
         sso_ibm_verify_client_secret=secret,
         sso_ibm_verify_issuer="https://tenant.verify.ibm.com",
+        sso_ibm_verify_scope="openid profile email groups",
+        ibm_verify_group_mapping='{"CN=Developers,OU=Groups": "dev-team-uuid"}',
+        ibm_verify_user_mapping='{"preferred_username": "username", "uid": "provider_id"}',
         sso_okta_enabled=True,
         sso_okta_client_id="okta-client",
         sso_okta_client_secret=secret,
@@ -103,6 +106,13 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
 
     assert {"github", "google", "ibm_verify", "okta", "entra", "keycloak", "authentik"} <= provider_ids
 
+    ibm_provider = next(provider for provider in providers if provider["id"] == "ibm_verify")
+    assert ibm_provider["scope"] == "openid profile email groups"
+    assert ibm_provider["team_mapping"] == {"CN=Developers,OU=Groups": "dev-team-uuid"}
+    assert ibm_provider["provider_metadata"] == {"user_mapping": {"preferred_username": "username", "uid": "provider_id"}}
+    assert ibm_provider["authorization_url"] == "https://tenant.verify.ibm.com/oidc/endpoint/default/authorize"
+    assert ibm_provider["issuer"] == "https://tenant.verify.ibm.com/oidc/endpoint/default"
+
     okta_provider = next(provider for provider in providers if provider["id"] == "okta")
     assert okta_provider["scope"] == "openid profile email groups"
     assert okta_provider["team_mapping"] == {"Engineering": "team-uuid-1"}
@@ -115,7 +125,6 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
     assert entra_metadata["graph_api_max_groups"] == 777
 
     keycloak_provider = next(provider for provider in providers if provider["id"] == "keycloak")
-    metadata = keycloak_provider["provider_metadata"]
     assert keycloak_provider["jwks_uri"] == "https://keycloak.example.com/jwks"
 
 
@@ -938,6 +947,103 @@ def test_okta_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
     assert len(providers) == 1
     assert providers[0]["team_mapping"] == {}
     assert any("Failed to parse OKTA_GROUP_MAPPING" in record.message for record in caplog.records)
+
+
+def test_ibm_verify_invalid_mappings_use_empty(monkeypatch, caplog):
+    """Invalid IBM Verify mapping JSON should log warnings and use empty mappings."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_github_client_id=None,
+        sso_github_client_secret=None,
+        sso_google_enabled=False,
+        sso_google_client_id=None,
+        sso_google_client_secret=None,
+        sso_ibm_verify_enabled=True,
+        sso_ibm_verify_client_id="ibm-client",
+        sso_ibm_verify_client_secret=secret,
+        sso_ibm_verify_issuer="https://tenant.verify.ibm.com",
+        sso_ibm_verify_scope="openid profile email",
+        ibm_verify_group_mapping="not-valid-json{",
+        ibm_verify_user_mapping='["not", "a", "dict"]',
+        sso_okta_enabled=False,
+        sso_okta_client_id=None,
+        sso_okta_client_secret=None,
+        sso_okta_issuer=None,
+        sso_entra_enabled=False,
+        sso_entra_client_id=None,
+        sso_entra_client_secret=None,
+        sso_entra_tenant_id=None,
+        sso_keycloak_enabled=False,
+        sso_keycloak_base_url=None,
+        sso_keycloak_client_id=None,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=False,
+        sso_generic_provider_id=None,
+        sso_generic_client_id=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.sso_bootstrap"):
+        providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    assert providers[0]["team_mapping"] == {}
+    assert "provider_metadata" not in providers[0]
+    assert any("Failed to parse IBM_VERIFY_GROUP_MAPPING" in record.message for record in caplog.records)
+    assert any("IBM_VERIFY_USER_MAPPING must be a JSON object" in record.message for record in caplog.records)
+
+
+def test_ibm_verify_issuer_accepts_documented_endpoint(monkeypatch):
+    """IBM Verify issuer should accept the documented /oidc/endpoint/default value."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("secret-value")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False,
+        sso_github_client_id=None,
+        sso_github_client_secret=None,
+        sso_google_enabled=False,
+        sso_google_client_id=None,
+        sso_google_client_secret=None,
+        sso_ibm_verify_enabled=True,
+        sso_ibm_verify_client_id="ibm-client",
+        sso_ibm_verify_client_secret=secret,
+        sso_ibm_verify_issuer="https://tenant.verify.ibm.com/oidc/endpoint/default",
+        sso_ibm_verify_scope="openid profile email",
+        ibm_verify_group_mapping=None,
+        ibm_verify_user_mapping=None,
+        sso_okta_enabled=False,
+        sso_okta_client_id=None,
+        sso_okta_client_secret=None,
+        sso_okta_issuer=None,
+        sso_entra_enabled=False,
+        sso_entra_client_id=None,
+        sso_entra_client_secret=None,
+        sso_entra_tenant_id=None,
+        sso_keycloak_enabled=False,
+        sso_keycloak_base_url=None,
+        sso_keycloak_client_id=None,
+        sso_adfs_enabled=False,
+        sso_generic_enabled=False,
+        sso_generic_provider_id=None,
+        sso_generic_client_id=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    providers = get_predefined_sso_providers()
+
+    assert providers[0]["authorization_url"] == "https://tenant.verify.ibm.com/oidc/endpoint/default/authorize"
+    assert providers[0]["token_url"] == "https://tenant.verify.ibm.com/oidc/endpoint/default/token"
+    assert providers[0]["issuer"] == "https://tenant.verify.ibm.com/oidc/endpoint/default"
 
 
 class TestBootstrapPreservesDBValues:


### PR DESCRIPTION
## Summary
Fixes #4510.

Implements the documented IBM Verify SSO environment variables for group-to-team mapping, user claim mapping, and custom scopes. This also accepts the documented `SSO_IBM_VERIFY_ISSUER=https://tenant.verify.ibm.com/oidc/endpoint/default` form without double-appending the IBM Verify endpoint path.

## Reproduction Steps
Set IBM Verify SSO env vars with `IBM_VERIFY_GROUP_MAPPING` and `IBM_VERIFY_USER_MAPPING`, then bootstrap/login through the built-in IBM Verify provider. Previously the provider was created with an empty `team_mapping`, the user mapping was never applied, and the documented issuer endpoint form produced malformed authorize/token/userinfo URLs.

## Root Cause
The settings model did not expose the documented IBM Verify mapping or scope fields. The SSO bootstrap code hard-coded the IBM Verify scope, always used an empty team mapping, and assumed `SSO_IBM_VERIFY_ISSUER` was a tenant root rather than the documented issuer endpoint. IBM Verify user normalization also had no path to consume claim mappings.

## Fix Description
- Add `SSO_IBM_VERIFY_SCOPE`, `IBM_VERIFY_GROUP_MAPPING`, and `IBM_VERIFY_USER_MAPPING` settings.
- Parse IBM Verify mapping JSON with the same defensive behavior used for Okta mappings.
- Store IBM Verify group mappings in `team_mapping` and user mappings in provider metadata.
- Apply IBM Verify user mappings during normalization, including passthrough for extra mapped attributes.
- Normalize IBM Verify tenant-root, issuer, and discovery URLs into the correct issuer endpoint.
- Update `.env.example` and configuration docs for the now-supported variables.

## Verification

| Check | Command | Status |
|---|---|---|
| Unit tests | `uv run pytest tests/unit/mcpgateway/utils/test_sso_bootstrap.py tests/unit/mcpgateway/services/test_sso_user_normalization.py -q` | Pass |
| Targeted SSO regressions | `uv run pytest tests/unit/mcpgateway/utils/test_sso_bootstrap.py tests/unit/mcpgateway/services/test_sso_user_normalization.py tests/unit/mcpgateway/services/test_sso_service.py -q -k "ibm_verify or okta_invalid_group_mapping_json_uses_empty or okta_non_dict_group_mapping_uses_empty or get_predefined_sso_providers_multiple"` | Pass |
| Lint | `uv run ruff check mcpgateway/config.py mcpgateway/utils/sso_bootstrap.py mcpgateway/services/sso_service.py tests/unit/mcpgateway/utils/test_sso_bootstrap.py tests/unit/mcpgateway/services/test_sso_user_normalization.py` | Pass |
| Diff hygiene | `git diff --check` | Pass |

## MCP Compliance
- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist
- [x] No secrets/credentials committed
- [x] Updated relevant documentation
- [x] DCO sign-off included