### PR TITLE
fix: run pre-request hooks for MCP auth

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -70,8 +70,10 @@ from mcpgateway.config import settings
 from mcpgateway.db import Gateway as DbGateway
 from mcpgateway.db import Server as DbServer
 from mcpgateway.db import SessionLocal
+from mcpgateway.middleware.http_auth_middleware import run_pre_request_hooks
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG
 from mcpgateway.observability import create_span
+from mcpgateway.plugins.framework import get_plugin_manager, HttpHookType
 from mcpgateway.plugins.framework.models import UserContext
 from mcpgateway.services.completion_service import CompletionService
 from mcpgateway.services.http_client_service import get_http_client, get_http_limits
@@ -4716,6 +4718,36 @@ class _StreamableHttpAuthHandler:
         self.receive = receive
         self.send = send
 
+    async def _run_http_pre_request_hooks(self, *, path: str, method: str) -> None:
+        """Run HTTP_PRE_REQUEST plugin hooks for mounted MCP routes before auth."""
+        plugin_manager = await get_plugin_manager()
+        if not plugin_manager or not plugin_manager.has_hooks_for(HttpHookType.HTTP_PRE_REQUEST):
+            return
+
+        client_host = None
+        client_port = None
+        client = self.scope.get("client")
+        if isinstance(client, (tuple, list)) and client:
+            client_host = client[0]
+            if len(client) > 1:
+                client_port = client[1]
+
+        merged_headers, global_context, context_table = await run_pre_request_hooks(
+            plugin_manager=plugin_manager,
+            headers=dict(Headers(scope=self.scope)),
+            path=path,
+            method=method,
+            client_host=client_host,
+            client_port=client_port,
+        )
+
+        if global_context:
+            self.scope.setdefault("state", {})["plugin_global_context"] = global_context
+        if context_table:
+            self.scope.setdefault("state", {})["plugin_context_table"] = context_table
+
+        self.scope["headers"] = [(name.lower().encode(), value.encode()) for name, value in merged_headers.items()]
+
     async def _send_error(self, *, detail: str, status_code: int = HTTP_401_UNAUTHORIZED, headers: dict[str, str] | None = None) -> bool:
         """Send an error response and return False (auth rejected).
 
@@ -4763,6 +4795,9 @@ class _StreamableHttpAuthHandler:
             # No auth for non-MCP paths or RFC 9728 metadata endpoints
             return True
 
+        method = self.scope.get("method", "")
+        await self._run_http_pre_request_hooks(path=path, method=method)
+
         # Reject undocumented /mcp/* sub-paths that the Starlette mount would
         # otherwise route to the global MCP handler.  Only /mcp, /mcp/,
         # /mcp/sse, and /mcp/message are valid direct-access endpoints;
@@ -4776,10 +4811,8 @@ class _StreamableHttpAuthHandler:
         # re-evaluate on every request instead of inheriting a stale True.
         _oauth_checked_var.set(False)
 
-        headers = Headers(scope=self.scope)
-
         # CORS preflight (OPTIONS + Origin + Access-Control-Request-Method) cannot carry auth headers
-        method = self.scope.get("method", "")
+        headers = Headers(scope=self.scope)
         if method == "OPTIONS":
             origin = headers.get("origin")
             if origin and headers.get("access-control-request-method"):

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -1852,6 +1852,58 @@ async def test_auth_all_ok(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_streamable_http_auth_runs_pre_request_hooks_before_auth(monkeypatch):
+    """Mounted /mcp auth must run HTTP_PRE_REQUEST hooks before reading Authorization."""
+
+    class DummyPluginManager:
+        def has_hooks_for(self, hook_type):
+            return hook_type == tr.HttpHookType.HTTP_PRE_REQUEST
+
+    marker_global_context = object()
+    marker_context_table = {"plugin": "context"}
+
+    async def fake_get_plugin_manager():
+        return DummyPluginManager()
+
+    async def fake_run_pre_request_hooks(*, plugin_manager, headers, path, method, client_host=None, client_port=None, global_context=None):
+        assert isinstance(plugin_manager, DummyPluginManager)
+        assert headers["x-plugin-token"] == "good-token"
+        assert path == "/servers/1/mcp"
+        assert method == "POST"
+        assert client_host == "127.0.0.1"
+        assert client_port == 12345
+        assert global_context is None
+        return {**headers, "authorization": "Bearer good-token"}, marker_global_context, marker_context_table
+
+    async def fake_verify(token):
+        assert token == "good-token"
+        return {"ok": True}
+
+    monkeypatch.setattr(tr, "get_plugin_manager", fake_get_plugin_manager)
+    monkeypatch.setattr(tr, "run_pre_request_hooks", fake_run_pre_request_hooks)
+    monkeypatch.setattr(tr, "verify_credentials", fake_verify)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", True)
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    scope = _make_scope(
+        "/servers/1/mcp",
+        method="POST",
+        headers=[(b"x-plugin-token", b"good-token")],
+        client=("127.0.0.1", 12345),
+    )
+
+    assert await streamable_http_auth(scope, None, send) is True
+    assert sent == []
+    assert dict(scope["headers"])[b"authorization"] == b"Bearer good-token"
+    assert scope["state"]["plugin_global_context"] is marker_global_context
+    assert scope["state"]["plugin_context_table"] == marker_context_table
+
+
+@pytest.mark.asyncio
 async def test_auth_failure(monkeypatch):
     """When verify_credentials raises and mcp_require_auth=True, auth func responds 401 and returns False."""
 


### PR DESCRIPTION
## Summary
Fixes #4413.

Runs `HTTP_PRE_REQUEST` plugin hooks inside the mounted Streamable HTTP MCP auth path before JWT/proxy authentication reads request headers. This makes `/mcp` behave consistently with normal UI/SSE routes and with the existing internal Rust MCP auth path.

## Reproduction Steps
Configure an `HTTP_PRE_REQUEST` plugin that injects or transforms auth headers, then call a mounted `/mcp` route. Before this change, the mounted app bypassed `HttpAuthMiddleware`, so auth read the original headers and downstream plugin context was missing.

## Root Cause
`/mcp` is mounted as a sub-application, so it does not pass through the parent app middleware where `HttpAuthMiddleware` runs. The Streamable HTTP auth handler did not run the shared `run_pre_request_hooks()` helper before constructing `Headers(scope=...)`.

## Fix Description
- Call the shared `run_pre_request_hooks()` helper in `_StreamableHttpAuthHandler.authenticate()` before reading auth headers.
- Apply modified headers back to the ASGI scope so JWT/proxy auth sees plugin changes.
- Preserve `plugin_global_context` and `plugin_context_table` in `scope["state"]` for downstream request objects.
- Add a regression test proving a plugin-injected Authorization header is honored before auth.

## Verification

| Check | Command | Status |
|---|---|---|
| Targeted auth tests | `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q -k "pre_request_hooks_before_auth or auth_all_ok or auth_failure or proxy_user_with_bearer_header"` | Pass |
| Regression test | `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -q -k "pre_request_hooks_before_auth"` | Pass |
| Transport lint | `uv run ruff check mcpgateway/transports/streamablehttp_transport.py` | Pass |
| Diff hygiene | `git diff --check` | Pass |

Note: a broader ruff run over the whole existing `test_streamablehttp_transport.py` currently reports unrelated pre-existing lint outside this change.

## MCP Compliance
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist
- [x] No secrets/credentials committed
- [x] DCO sign-off included