### PR TITLE
chore(plugins): align rate-limiter config with gateway convention

### DIFF
--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -286,8 +286,8 @@ plugins:
     conditions: []
     config:
       backend: "redis"
-      # Sourced from the gateway's REDIS_URL env. When run
-      # externally (separate container or WASM sandbox), extra wiring may be needed.
+      # Sourced from the gateway's REDIS_URL env; when the plugin runs in a
+      # separate container, ensure that host is reachable from within it.
       redis_url: '{{ env.REDIS_URL | default("redis://redis:6379/0") }}'
       redis_key_prefix: "rl"
       redis_fallback: true

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -288,7 +288,7 @@ plugins:
       backend: "redis"
       # Sourced from the gateway's REDIS_URL env. When run
       # externally (separate container or WASM sandbox), extra wiring may be needed.
-      redis_url: "{{ env.REDIS_URL }}"
+      redis_url: '{{ env.REDIS_URL | default("redis://redis:6379/0") }}'
       redis_key_prefix: "rl"
       redis_fallback: true
       algorithm: "fixed_window"

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -286,7 +286,9 @@ plugins:
     conditions: []
     config:
       backend: "redis"
-      redis_url: "redis://redis:6379/0"
+      # Sourced from the gateway's REDIS_URL env. When run
+      # externally (separate container or WASM sandbox), extra wiring may be needed.
+      redis_url: "{{ env.REDIS_URL }}"
       redis_key_prefix: "rl"
       redis_fallback: true
       algorithm: "fixed_window"

--- a/tests/integration/test_rate_limiter_redis_url_from_yaml.py
+++ b/tests/integration/test_rate_limiter_redis_url_from_yaml.py
@@ -20,6 +20,7 @@ runners without a Redis service available.
 """
 
 # Standard
+import pathlib
 import socket
 
 # Third-Party
@@ -28,6 +29,11 @@ import redis
 
 # First-Party
 from mcpgateway.plugins.framework.loader.config import ConfigLoader
+
+# Anchor the plugins/config.yaml path to this file's location so the test
+# works regardless of where pytest is invoked from (repo root, tests/, etc.).
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_CONFIG_YAML = str(_REPO_ROOT / "plugins" / "config.yaml")
 
 
 def _redis_reachable(host: str = "127.0.0.1", port: int = 6379, timeout: float = 0.2) -> bool:
@@ -50,7 +56,7 @@ def test_rate_limiter_redis_url_resolves_and_connects(monkeypatch):
     """
     monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
 
-    cfg = ConfigLoader.load_config("plugins/config.yaml")
+    cfg = ConfigLoader.load_config(_CONFIG_YAML)
     rl = next(p for p in cfg.plugins if p.name == "RateLimiterPlugin")
     resolved = rl.config.get("redis_url")
 
@@ -66,3 +72,20 @@ def test_rate_limiter_redis_url_resolves_and_connects(monkeypatch):
         assert client.ping() is True
     finally:
         client.close()
+
+
+def test_rate_limiter_redis_url_uses_default_when_env_unset(monkeypatch):
+    """When REDIS_URL is unset, the Jinja ``default(...)`` filter must
+    resolve to the literal fallback baked into ``plugins/config.yaml``.
+
+    Pins the contract that the loader's Jinja env applies the ``default``
+    filter (not just plain env-var substitution) — a regression here would
+    silently leave operators on a broken redis_url whenever the env var
+    isn't injected.  Runs without Redis.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+
+    cfg = ConfigLoader.load_config(_CONFIG_YAML)
+    rl = next(p for p in cfg.plugins if p.name == "RateLimiterPlugin")
+
+    assert rl.config.get("redis_url") == "redis://redis:6379/0"

--- a/tests/integration/test_rate_limiter_redis_url_from_yaml.py
+++ b/tests/integration/test_rate_limiter_redis_url_from_yaml.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Smoke test for the rate-limiter's env-sourced redis_url.
+
+Pins the contract that ``plugins/config.yaml`` resolves the rate-limiter's
+``redis_url`` from the gateway's ``REDIS_URL`` environment variable via the
+plugin loader's Jinja substitution AND that the resolved URL points at a
+live Redis (not just a parseable string).
+
+Companion to issue IBM/mcp-context-forge#4581 — guards against three
+classes of regression:
+
+  1. The yaml stops Jinja-substituting ``{{ env.REDIS_URL }}`` (e.g. loader
+     change drops the env render context).
+  2. The ``REDIS_URL`` env var isn't honored at config-load time.
+  3. The resolved URL points at a broken endpoint (e.g. someone hard-codes
+     a stale literal back into the yaml without realising it).
+
+Skips cleanly when Redis isn't reachable, so the suite stays green on
+runners without a Redis service available.
+"""
+
+# Standard
+import socket
+
+# Third-Party
+import pytest
+import redis
+
+# First-Party
+from mcpgateway.plugins.framework.loader.config import ConfigLoader
+
+
+def _redis_reachable(host: str = "127.0.0.1", port: int = 6379, timeout: float = 0.2) -> bool:
+    """Return True if a TCP connection to host:port succeeds."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _redis_reachable(),
+    reason="Redis not reachable on 127.0.0.1:6379",
+)
+def test_rate_limiter_redis_url_resolves_and_connects(monkeypatch):
+    """The rate-limiter's redis_url, sourced from the REDIS_URL env via the
+    plugin loader's Jinja substitution, must resolve to a non-empty string
+    AND the resolved URL must reach a live Redis (PING -> PONG).
+    """
+    monkeypatch.setenv("REDIS_URL", "redis://127.0.0.1:6379/0")
+
+    cfg = ConfigLoader.load_config("plugins/config.yaml")
+    rl = next(p for p in cfg.plugins if p.name == "RateLimiterPlugin")
+    resolved = rl.config.get("redis_url")
+
+    assert resolved, (
+        "redis_url must resolve to a non-empty string after Jinja substitution"
+    )
+    assert "{{" not in resolved, (
+        f"Jinja placeholder leaked through unrendered: {resolved!r}"
+    )
+
+    client = redis.from_url(resolved, socket_connect_timeout=2, socket_timeout=2)
+    try:
+        assert client.ping() is True
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

Align the rate-limiter plugin's `redis_url` in `plugins/config.yaml` with the gateway's existing convention of sourcing Redis URLs from the `REDIS_URL` env via the plugin loader's Jinja substitution. Operators set `REDIS_URL` once and the rate-limiter picks it up — no more hand-editing the yaml or templating it in deployment tooling.

Companion to #4581.

## Changes

- `plugins/config.yaml`: `redis_url: "redis://redis:6379/0"` → `redis_url: '{{ env.REDIS_URL | default("redis://redis:6379/0") }}'` plus a short comment about the env-source. Outer single / inner double quotes survive `yaml.safe_dump` round-trips cleanly.
- `tests/integration/test_rate_limiter_redis_url_from_yaml.py`: new test — env-var substitution flows through the plugin loader cleanly and the resolved URL reaches a live Redis (PING → PONG). Skips when Redis isn't reachable.

## Test plan

- [x] `pytest tests/integration/test_rate_limiter_redis_url_from_yaml.py` green locally with Redis running
- [x] Skips cleanly without Redis
- [ ] CI green

The schema-regression test and `redis_fallback` cleanup originally bundled here are now tracked as #4603.