### PR TITLE
fix(tools): add missing REST passthrough field assignments to the update_tool method

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6407,6 +6407,27 @@ class ToolService(BaseService):
             if tool_update.tags is not None:
                 tool.tags = tool_update.tags
 
+            # Update REST-specific fields if applicable
+            if tool_update.integration_type == "REST" or (tool_update.integration_type is None and tool.integration_type == "REST"):
+                if tool_update.base_url is not None:
+                    tool.base_url = tool_update.base_url
+                if tool_update.path_template is not None:
+                    tool.path_template = tool_update.path_template
+                if tool_update.query_mapping is not None:
+                    tool.query_mapping = tool_update.query_mapping
+                if tool_update.header_mapping is not None:
+                    tool.header_mapping = tool_update.header_mapping
+                if tool_update.timeout_ms is not None:
+                    tool.timeout_ms = tool_update.timeout_ms
+                if tool_update.expose_passthrough is not None:
+                    tool.expose_passthrough = tool_update.expose_passthrough
+                if tool_update.allowlist is not None:
+                    tool.allowlist = tool_update.allowlist
+                if tool_update.plugin_chain_pre is not None:
+                    tool.plugin_chain_pre = tool_update.plugin_chain_pre
+                if tool_update.plugin_chain_post is not None:
+                    tool.plugin_chain_post = tool_update.plugin_chain_post
+
             # Update modification metadata
             if modified_by is not None:
                 tool.modified_by = modified_by

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -5594,6 +5594,132 @@ class TestUpdateToolBranches:
         assert tool.version == 1
 
     @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_fields(self, tool_service):
+        """Test updating REST passthrough fields (base_url, path_template, query_mapping, header_mapping, etc.)."""
+        tool = MagicMock(spec=DbTool)
+        tool.id = "t1"
+        tool.name = "rest_tool"
+        tool.custom_name = "rest_tool"
+        tool.integration_type = "REST"
+        tool.version = 1
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.base_url = "https://old.example.com"
+        tool.path_template = "/old/path"
+        tool.query_mapping = {"old": "param"}
+        tool.header_mapping = {"Old-Header": "old_value"}
+        tool.timeout_ms = 10000
+        tool.expose_passthrough = False
+        tool.allowlist = ["old.example.com"]
+        tool.plugin_chain_pre = ["old_pre"]
+        tool.plugin_chain_post = ["old_post"]
+
+        tool_update = MagicMock(spec=ToolUpdate)
+        tool_update.name = None
+        tool_update.custom_name = None
+        tool_update.displayName = None
+        tool_update.title = None
+        tool_update.url = None
+        tool_update.description = None
+        tool_update.integration_type = "REST"
+        tool_update.request_type = None
+        tool_update.headers = None
+        tool_update.input_schema = None
+        tool_update.output_schema = None
+        tool_update.annotations = None
+        tool_update.jsonpath_filter = None
+        tool_update.visibility = None
+        tool_update.auth = None
+        tool_update.tags = None
+        # REST passthrough fields
+        tool_update.base_url = "https://new.example.com"
+        tool_update.path_template = "/new/path"
+        tool_update.query_mapping = {"new": "param"}
+        tool_update.header_mapping = {"New-Header": "new_value"}
+        tool_update.timeout_ms = 20000
+        tool_update.expose_passthrough = True
+        tool_update.allowlist = ["new.example.com"]
+        tool_update.plugin_chain_pre = ["new_pre"]
+        tool_update.plugin_chain_post = ["new_post"]
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.base_url == "https://new.example.com"
+        assert tool.path_template == "/new/path"
+        assert tool.query_mapping == {"new": "param"}
+        assert tool.header_mapping == {"New-Header": "new_value"}
+        assert tool.timeout_ms == 20000
+        assert tool.expose_passthrough is True
+        assert tool.allowlist == ["new.example.com"]
+        assert tool.plugin_chain_pre == ["new_pre"]
+        assert tool.plugin_chain_post == ["new_post"]
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_fields_existing_rest_tool(self, tool_service):
+        """Test updating REST passthrough fields when integration_type is not changing but tool is already REST."""
+        tool = MagicMock(spec=DbTool)
+        tool.id = "t2"
+        tool.name = "existing_rest"
+        tool.custom_name = "existing_rest"
+        tool.integration_type = "REST"
+        tool.version = 5
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.base_url = None
+        tool.query_mapping = None
+        tool.header_mapping = None
+
+        tool_update = MagicMock(spec=ToolUpdate)
+        tool_update.name = None
+        tool_update.custom_name = None
+        tool_update.displayName = None
+        tool_update.title = None
+        tool_update.url = None
+        tool_update.description = None
+        tool_update.integration_type = None  # Not changing integration_type
+        tool_update.request_type = None
+        tool_update.headers = None
+        tool_update.input_schema = None
+        tool_update.output_schema = None
+        tool_update.annotations = None
+        tool_update.jsonpath_filter = None
+        tool_update.visibility = None
+        tool_update.auth = None
+        tool_update.tags = None
+        # REST passthrough fields
+        tool_update.base_url = "https://api.example.com"
+        tool_update.path_template = None
+        tool_update.query_mapping = {"filter": "name"}
+        tool_update.header_mapping = {"X-API-Key": "secret"}
+        tool_update.timeout_ms = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t2"}),
+        ):
+            result = await tool_service.update_tool(db, "t2", tool_update)
+
+        assert result is not None
+        assert tool.base_url == "https://api.example.com"
+        assert tool.query_mapping == {"filter": "name"}
+        assert tool.header_mapping == {"X-API-Key": "secret"}
+        assert tool.version == 6
+
+    @pytest.mark.asyncio
     async def test_team_name_conflict_on_update(self, tool_service):
         """Raises ToolNameConflictError when team tool name conflicts on rename."""
         tool = MagicMock(spec=DbTool)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4578

---

## 📝 Summary

Fixed a bug where `ToolService.update_tool()` silently dropped REST passthrough fields during tool updates. The PUT `/tools/{id}` endpoint would accept fields like `query_mapping`, `header_mapping`, `base_url`, `path_template`, `timeout_ms`, `expose_passthrough`, `allowlist`, `plugin_chain_pre`, and `plugin_chain_post`, return HTTP 200 with the new values reflected in the response body, but the underlying database row remained unchanged.

**Changes:**
- Added REST passthrough field assignments to [`update_tool()`](mcpgateway/services/tool_service.py:6258-6277)
- Logic mirrors the existing create-with-conflict-rename path at lines 2417-2427
- Fields are updated when `integration_type` is "REST" (either being set or already set)
- Added comprehensive unit tests covering both scenarios (changing to REST and updating existing REST tool)

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

**New tests added:**
- `test_update_tool_rest_passthrough_fields` - Verifies all 9 REST fields are persisted when updating a tool
- `test_update_tool_rest_passthrough_fields_existing_rest_tool` - Verifies fields update when tool is already REST type

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Impact:** This fix is particularly important for users with pre-existing tools who want to add `query_mapping` (which was effectively dead-on-arrival until #3369 wired it to apply at runtime in v1.0.0). Previously, they would need to either delete-and-recreate the tool (blocked by FK constraint issues) or modify the DB directly.

**Implementation details:**
- Conditional at line 6259 checks if the update is changing `integration_type` to "REST" OR if the existing tool is already "REST"
- Each field is only updated if provided in the `ToolUpdate` payload (preserves partial update semantics)
- Follows the same pattern as other field updates in the method