### PR TITLE
fix: forward task_id from client requests to A2A backend agents

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1395,7 +1395,14 @@ class A2AAgentService(BaseService):
             # Format request based on agent type and endpoint
             if agent_type in ["generic", "jsonrpc"] or agent_endpoint_url.endswith("/"):
                 # Use JSONRPC format for agents that expect it
-                request_data = {"jsonrpc": "2.0", "method": parameters.get("method", "message/send"), "params": parameters.get("params", parameters), "id": 1}
+                # Forward task_id from client parameters to enable multi-turn conversations
+                params_payload = parameters.get("params", parameters)
+                task_id = parameters.get("task_id") or parameters.get("taskId")
+                if task_id and isinstance(params_payload, dict):
+                    msg = params_payload.get("message")
+                    if isinstance(msg, dict) and "task_id" not in msg:
+                        msg["task_id"] = task_id
+                request_data = {"jsonrpc": "2.0", "method": parameters.get("method", "message/send"), "params": params_payload, "id": task_id or 1}
             else:
                 # Use custom A2A format
                 request_data = {"interaction_type": interaction_type, "parameters": parameters, "protocol_version": agent_protocol_version}

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3865,22 +3865,27 @@ class ToolService(BaseService):
                     if a2a_agent_type in ["generic", "jsonrpc"] or endpoint_url.endswith("/"):
                         # JSONRPC agents: Convert flat query to nested message structure
                         params = None
+                        # Extract task_id from arguments if provided (enables multi-turn conversations)
+                        task_id = arguments.get("task_id") or arguments.get("taskId") if isinstance(arguments, dict) else None
                         if isinstance(arguments, dict) and "query" in arguments and isinstance(arguments["query"], str):
-                            message_id = f"admin-test-{int(time.time())}"
+                            message_id = task_id or f"admin-test-{int(time.time())}"
                             # A2A v0.3.x: message.parts use "kind" (not "type").
                             params = {
                                 "message": {
                                     "kind": "message",
                                     "messageId": message_id,
+                                    "task_id": task_id,
                                     "role": "user",
                                     "parts": [{"kind": "text", "text": arguments["query"]}],
                                 }
                             }
+                            if not task_id:
+                                del params["message"]["task_id"]
                             method = arguments.get("method", "message/send")
                         else:
                             params = arguments.get("params", arguments) if isinstance(arguments, dict) else arguments
                             method = arguments.get("method", "message/send") if isinstance(arguments, dict) else "message/send"
-                        request_data = {"jsonrpc": "2.0", "method": method, "params": params, "id": 1}
+                        request_data = {"jsonrpc": "2.0", "method": method, "params": params, "id": task_id or 1}
                     else:
                         # Custom agents: Pass parameters directly
                         params = arguments if isinstance(arguments, dict) else {}
@@ -4942,18 +4947,23 @@ class ToolService(BaseService):
         if agent.agent_type in ["generic", "jsonrpc"] or agent.endpoint_url.endswith("/"):
             # JSONRPC agents: Convert flat query to nested message structure
             params = None
+            # Extract task_id from parameters if provided (enables multi-turn conversations)
+            task_id = parameters.get("task_id") or parameters.get("taskId") if isinstance(parameters, dict) else None
             if isinstance(parameters, dict) and "query" in parameters and isinstance(parameters["query"], str):
                 # Build the nested message object for JSONRPC protocol
-                message_id = f"admin-test-{int(time.time())}"
+                message_id = task_id or f"admin-test-{int(time.time())}"
                 # A2A v0.3.x: message.parts use "kind" (not "type").
                 params = {
                     "message": {
                         "kind": "message",
                         "messageId": message_id,
+                        "task_id": task_id,
                         "role": "user",
                         "parts": [{"kind": "text", "text": parameters["query"]}],
                     }
                 }
+                if not task_id:
+                    del params["message"]["task_id"]
                 method = parameters.get("method", "message/send")
             else:
                 # Already in correct format or unknown, pass through
@@ -4961,7 +4971,7 @@ class ToolService(BaseService):
                 method = parameters.get("method", "message/send")
 
             try:
-                request_data = {"jsonrpc": "2.0", "method": method, "params": params, "id": 1}
+                request_data = {"jsonrpc": "2.0", "method": method, "params": params, "id": task_id or 1}
                 logger.info(f"invoke tool JSONRPC request_data prepared: {request_data}")
             except Exception as e:
                 logger.error(f"Error preparing JSONRPC request data: {e}")


### PR DESCRIPTION
## Summary

Fixes #4589

When ContextForge proxies requests to A2A backend agents, `task_id` is dropped — the gateway uses hardcoded `"id": 1` and timestamp-based `messageId`. This breaks multi-turn conversations for stateful backend agents.

This PR extracts `task_id`/`taskId` from inbound parameters and forwards it to the backend agent:
- In the JSONRPC `id` field (instead of hardcoded `1`)
- In `message.task_id` field (for agents using it as thread identifier)
- As `messageId` (when task_id is provided)

When `task_id` is not provided, behavior is unchanged (backward compatible).

## Changes

- `mcpgateway/services/a2a_service.py` — extract and forward task_id in `invoke_agent()`
- `mcpgateway/services/tool_service.py` — forward task_id in MCP→A2A bridge (both `invoke_tool` and `_call_a2a_agent`)

## Test plan

- [ ] Existing tests pass (no behavior change when task_id absent)
- [ ] A2A agent receives task_id when client provides it
- [ ] Multi-turn conversation works: same task_id → same thread on backend
- [ ] Different task_id → different threads (no cross-contamination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)