### PR TITLE
fix(auth): set request.state.token_teams for proxy authentication flow to resolve admin status

### DIFF
--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -605,6 +605,11 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                 # rather than treating the proxy payload as an API-token payload with embedded teams.
                 "token_use": "session",  # nosec B105 - Not a password; JWT claim type
             }
+
+            # Set request.state.token_teams so get_token_teams_from_request() can find it.
+            # This matches the pattern in auth.py:1403 where get_current_user() sets it
+            # after resolving teams for session tokens.
+            request.state.token_teams = token_teams
         else:
             # User not in DB - handle based on REQUIRE_USER_IN_DB setting
             platform_admin_email = getattr(settings, "platform_admin_email", "admin@example.com")
@@ -619,6 +624,8 @@ async def _authenticate_proxy_user(request: Request, proxy_user: str) -> dict:
                     "email": proxy_user,
                     "token_use": "session",  # nosec B105 - Not a password; JWT claim type
                 }
+                # Set request.state.token_teams for bootstrap admin as well
+                request.state.token_teams = None
             else:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4587

---

## 📝 Summary

Fixes proxy-authenticated admin users being unable to access private/team-scoped tools despite having `is_admin=true` in the database.

**Root Cause:** The `_authenticate_proxy_user()` function correctly resolved admin status and teams from the database but failed to set `request.state.token_teams`. This caused downstream code in `get_token_teams_from_request()` to fall back to `normalize_token_teams()` instead of using the pre-resolved value, breaking admin bypass for proxy-authenticated requests.

**Solution:** Added `request.state.token_teams` assignment in both proxy authentication paths (DB user lookup and platform admin bootstrap), matching the pattern used by `get_current_user()` for JWT session tokens.

**Impact:** Admin users authenticated via proxy headers (when `TRUST_PROXY_AUTH=true`) now correctly receive admin bypass (`token_teams=None`) and can access all tools (public + team + private).

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Changes Made

**File:** `mcpgateway/utils/verify_credentials.py`

1. **Line 473** (DB user path): Added `request.state.token_teams = token_teams` after resolving teams via `_resolve_teams_from_db()`
2. **Line 489** (bootstrap admin path): Added `request.state.token_teams = None` for platform admin bootstrap when `REQUIRE_USER_IN_DB=false`

### Why This Works

The fix ensures proxy-authenticated requests follow the same state-setting pattern as JWT session tokens:

- **JWT path** ([`auth.py:1403`](mcpgateway/auth.py:1403)): `get_current_user()` sets `request.state.token_teams` after calling `resolve_session_teams()`
- **Proxy path** (now fixed): `_authenticate_proxy_user()` sets `request.state.token_teams` after calling `_resolve_teams_from_db()`

This makes `get_token_teams_from_request()` find the pre-resolved value immediately instead of falling back to `normalize_token_teams()`, ensuring consistent admin bypass behavior.