### PR TITLE
fix(auth): handle OAuth scope claim as both string and list types

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-10T10:18:32Z",
+  "generated_at": "2026-05-10T10:36:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -813,6 +813,15 @@ class OAuthManager:
 
         # Store tokens if storage service is available
         if self.token_storage:
+            # Handle scope as either string or list (OAuth providers vary)
+            scope_value = token_response.get("scope", "")
+            if isinstance(scope_value, list):
+                scopes_list = scope_value
+            elif isinstance(scope_value, str):
+                scopes_list = scope_value.split() if scope_value else []
+            else:
+                scopes_list = []
+
             token_record = await self.token_storage.store_tokens(
                 gateway_id=gateway_id,
                 user_id=user_id,
@@ -820,7 +829,7 @@ class OAuthManager:
                 access_token=token_response["access_token"],
                 refresh_token=token_response.get("refresh_token"),
                 expires_in=parse_expires_in(token_response),
-                scopes=token_response.get("scope", "").split(),
+                scopes=scopes_list,
             )
 
             return {"success": True, "user_id": user_id, "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None, "token_aud": token_aud}

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -816,7 +816,7 @@ class OAuthManager:
             # Handle scope as either string or list (OAuth providers vary)
             scope_value = token_response.get("scope", "")
             if isinstance(scope_value, list):
-                scopes_list = scope_value
+                scopes_list = [s for s in scope_value if isinstance(s, str)]
             elif isinstance(scope_value, str):
                 scopes_list = scope_value.split() if scope_value else []
             else:

--- a/mcpgateway/services/token_validation_service.py
+++ b/mcpgateway/services/token_validation_service.py
@@ -120,7 +120,7 @@ def _derive_issuer_from_token_url(token_url: str) -> Optional[str]:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
-def _normalize_scope(scope_input: Any) -> set:
+def _normalize_scope(scope_input: Any) -> set[str]:
     """Normalize a scope string or list by stripping resource URI prefixes.
 
     IdPs like Entra ID may return scopes as ``api://app-id/Scope.Name``
@@ -136,7 +136,7 @@ def _normalize_scope(scope_input: Any) -> set:
     scopes = set()
     # Handle both string (space-delimited) and list formats
     if isinstance(scope_input, list):
-        scope_list = scope_input
+        scope_list = [s for s in scope_input if isinstance(s, str)]
     elif isinstance(scope_input, str):
         scope_list = scope_input.split()
     else:
@@ -194,12 +194,16 @@ def _validate_scopes(claims: Dict[str, Any], oauth_config: Dict[str, Any], gatew
         return
 
     # Entra ID uses 'scp' claim; standard OAuth uses 'scope'
-    token_scope_str = claims.get("scope") or claims.get("scp") or ""
-    if not token_scope_str:
+    token_scope_value = claims.get("scope")
+    if token_scope_value is None:
+        token_scope_value = claims.get("scp")
+    if token_scope_value is None:
+        token_scope_value = ""
+    if token_scope_value == "":
         logger.debug("OAuth token for gateway %s has no 'scope'/'scp' claim", gateway_name)
         return
 
-    granted_scopes = _normalize_scope(token_scope_str)
+    granted_scopes = _normalize_scope(token_scope_value)
     missing = []
     for cfg_scope in configured_scopes:
         short = cfg_scope.rsplit("/", 1)[-1] if "/" in cfg_scope else cfg_scope

--- a/mcpgateway/services/token_validation_service.py
+++ b/mcpgateway/services/token_validation_service.py
@@ -120,21 +120,29 @@ def _derive_issuer_from_token_url(token_url: str) -> Optional[str]:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
-def _normalize_scope(scope_str: str) -> set:
-    """Normalize a scope string by stripping resource URI prefixes.
+def _normalize_scope(scope_input: Any) -> set:
+    """Normalize a scope string or list by stripping resource URI prefixes.
 
     IdPs like Entra ID may return scopes as ``api://app-id/Scope.Name``
     while the gateway config stores the full URI form.  We compare both
     the full form and the short form (after the last ``/``).
 
     Args:
-        scope_str: Space-delimited scope string from the token.
+        scope_input: Space-delimited scope string or list of scopes from the token.
 
     Returns:
         Set of normalized scope names (both full and short forms).
     """
     scopes = set()
-    for s in scope_str.split():
+    # Handle both string (space-delimited) and list formats
+    if isinstance(scope_input, list):
+        scope_list = scope_input
+    elif isinstance(scope_input, str):
+        scope_list = scope_input.split()
+    else:
+        return scopes
+
+    for s in scope_list:
         scopes.add(s)
         # Also add the short form (after last '/')
         if "/" in s:

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1090,7 +1090,7 @@ async def test_complete_authorization_code_flow_scope_as_list(oauth_manager):
         "scope": ["read", "write", "admin"],  # List format
         "expires_in": 3600
     }
-    
+
     mock_token_storage = AsyncMock()
     mock_token_record = MagicMock()
     mock_token_record.expires_at = None
@@ -1125,7 +1125,7 @@ async def test_complete_authorization_code_flow_scope_as_string(oauth_manager):
         "scope": "read write admin",  # String format
         "expires_in": 3600
     }
-    
+
     mock_token_storage = AsyncMock()
     mock_token_record = MagicMock()
     mock_token_record.expires_at = None
@@ -1160,7 +1160,7 @@ async def test_complete_authorization_code_flow_scope_empty_string(oauth_manager
         "scope": "",  # Empty string
         "expires_in": 3600
     }
-    
+
     mock_token_storage = AsyncMock()
     mock_token_record = MagicMock()
     mock_token_record.expires_at = None
@@ -1195,7 +1195,7 @@ async def test_complete_authorization_code_flow_scope_invalid_type(oauth_manager
         "scope": 123,  # Invalid type (number)
         "expires_in": 3600
     }
-    
+
     mock_token_storage = AsyncMock()
     mock_token_record = MagicMock()
     mock_token_record.expires_at = None

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1222,6 +1222,40 @@ async def test_complete_authorization_code_flow_scope_invalid_type(oauth_manager
     assert call_kwargs["scopes"] == []
 
 
+@pytest.mark.asyncio
+async def test_complete_authorization_code_flow_scope_mixed_types(oauth_manager):
+    """Test that complete_authorization_code_flow filters non-string items from list scopes."""
+    mock_token_response = {
+        "access_token": "test-token",
+        "scope": ["read", 123, None, "write"],  # Mixed types
+        "expires_in": 3600
+    }
+
+    mock_token_storage = AsyncMock()
+    mock_token_record = MagicMock()
+    mock_token_record.expires_at = None
+    mock_token_storage.store_tokens.return_value = mock_token_record
+    oauth_manager.token_storage = mock_token_storage
+
+    with (
+        patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+        patch.object(oauth_manager, "_exchange_code_for_tokens", return_value=mock_token_response),
+        patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+        patch.object(oauth_manager, "_extract_token_audience", return_value=None),
+    ):
+        result = await oauth_manager.complete_authorization_code_flow(
+            gateway_id="gw-123",
+            code="auth-code",
+            state="test-state",
+            credentials={"client_id": "cid", "token_url": "https://auth.example.com/token"}
+        )
+
+    assert result["success"] is True
+    # Verify store_tokens was called with only string items
+    mock_token_storage.store_tokens.assert_called_once()
+    call_kwargs = mock_token_storage.store_tokens.call_args[1]
+    assert call_kwargs["scopes"] == ["read", "write"]
+
 
 @pytest.mark.asyncio
 async def test_refresh_token_omits_resource_for_entra_v2_scope_flow(oauth_manager):

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -1082,6 +1082,146 @@ async def test_exchange_code_for_tokens_omits_resource_for_entra_v2_scope_flow(o
     request_data = mock_client.post.call_args[1]["data"]
     assert "resource" not in request_data
 
+@pytest.mark.asyncio
+async def test_complete_authorization_code_flow_scope_as_list(oauth_manager):
+    """Test that complete_authorization_code_flow handles scope returned as list (OAuth providers like Gamma)."""
+    mock_token_response = {
+        "access_token": "test-token",
+        "scope": ["read", "write", "admin"],  # List format
+        "expires_in": 3600
+    }
+    
+    mock_token_storage = AsyncMock()
+    mock_token_record = MagicMock()
+    mock_token_record.expires_at = None
+    mock_token_storage.store_tokens.return_value = mock_token_record
+    oauth_manager.token_storage = mock_token_storage
+
+    with (
+        patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+        patch.object(oauth_manager, "_exchange_code_for_tokens", return_value=mock_token_response),
+        patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+        patch.object(oauth_manager, "_extract_token_audience", return_value=None),
+    ):
+        result = await oauth_manager.complete_authorization_code_flow(
+            gateway_id="gw-123",
+            code="auth-code",
+            state="test-state",
+            credentials={"client_id": "cid", "token_url": "https://auth.example.com/token"}
+        )
+
+    assert result["success"] is True
+    # Verify store_tokens was called with list of scopes
+    mock_token_storage.store_tokens.assert_called_once()
+    call_kwargs = mock_token_storage.store_tokens.call_args[1]
+    assert call_kwargs["scopes"] == ["read", "write", "admin"]
+
+
+@pytest.mark.asyncio
+async def test_complete_authorization_code_flow_scope_as_string(oauth_manager):
+    """Test that complete_authorization_code_flow handles scope as space-separated string (standard OAuth)."""
+    mock_token_response = {
+        "access_token": "test-token",
+        "scope": "read write admin",  # String format
+        "expires_in": 3600
+    }
+    
+    mock_token_storage = AsyncMock()
+    mock_token_record = MagicMock()
+    mock_token_record.expires_at = None
+    mock_token_storage.store_tokens.return_value = mock_token_record
+    oauth_manager.token_storage = mock_token_storage
+
+    with (
+        patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+        patch.object(oauth_manager, "_exchange_code_for_tokens", return_value=mock_token_response),
+        patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+        patch.object(oauth_manager, "_extract_token_audience", return_value=None),
+    ):
+        result = await oauth_manager.complete_authorization_code_flow(
+            gateway_id="gw-123",
+            code="auth-code",
+            state="test-state",
+            credentials={"client_id": "cid", "token_url": "https://auth.example.com/token"}
+        )
+
+    assert result["success"] is True
+    # Verify store_tokens was called with list of scopes
+    mock_token_storage.store_tokens.assert_called_once()
+    call_kwargs = mock_token_storage.store_tokens.call_args[1]
+    assert call_kwargs["scopes"] == ["read", "write", "admin"]
+
+
+@pytest.mark.asyncio
+async def test_complete_authorization_code_flow_scope_empty_string(oauth_manager):
+    """Test that complete_authorization_code_flow handles empty scope string."""
+    mock_token_response = {
+        "access_token": "test-token",
+        "scope": "",  # Empty string
+        "expires_in": 3600
+    }
+    
+    mock_token_storage = AsyncMock()
+    mock_token_record = MagicMock()
+    mock_token_record.expires_at = None
+    mock_token_storage.store_tokens.return_value = mock_token_record
+    oauth_manager.token_storage = mock_token_storage
+
+    with (
+        patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+        patch.object(oauth_manager, "_exchange_code_for_tokens", return_value=mock_token_response),
+        patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+        patch.object(oauth_manager, "_extract_token_audience", return_value=None),
+    ):
+        result = await oauth_manager.complete_authorization_code_flow(
+            gateway_id="gw-123",
+            code="auth-code",
+            state="test-state",
+            credentials={"client_id": "cid", "token_url": "https://auth.example.com/token"}
+        )
+
+    assert result["success"] is True
+    # Verify store_tokens was called with empty list
+    mock_token_storage.store_tokens.assert_called_once()
+    call_kwargs = mock_token_storage.store_tokens.call_args[1]
+    assert call_kwargs["scopes"] == []
+
+
+@pytest.mark.asyncio
+async def test_complete_authorization_code_flow_scope_invalid_type(oauth_manager):
+    """Test that complete_authorization_code_flow handles invalid scope type gracefully."""
+    mock_token_response = {
+        "access_token": "test-token",
+        "scope": 123,  # Invalid type (number)
+        "expires_in": 3600
+    }
+    
+    mock_token_storage = AsyncMock()
+    mock_token_record = MagicMock()
+    mock_token_record.expires_at = None
+    mock_token_storage.store_tokens.return_value = mock_token_record
+    oauth_manager.token_storage = mock_token_storage
+
+    with (
+        patch.object(oauth_manager, "_validate_and_retrieve_state", return_value={"code_verifier": "verifier", "app_user_email": "user@example.com"}),
+        patch.object(oauth_manager, "_exchange_code_for_tokens", return_value=mock_token_response),
+        patch.object(oauth_manager, "_extract_user_id", return_value="user-1"),
+        patch.object(oauth_manager, "_extract_token_audience", return_value=None),
+    ):
+        result = await oauth_manager.complete_authorization_code_flow(
+            gateway_id="gw-123",
+            code="auth-code",
+            state="test-state",
+            credentials={"client_id": "cid", "token_url": "https://auth.example.com/token"}
+        )
+
+    assert result["success"] is True
+    # Verify store_tokens was called with empty list (fallback for invalid type)
+    mock_token_storage.store_tokens.assert_called_once()
+    call_kwargs = mock_token_storage.store_tokens.call_args[1]
+    assert call_kwargs["scopes"] == []
+
+
 
 @pytest.mark.asyncio
 async def test_refresh_token_omits_resource_for_entra_v2_scope_flow(oauth_manager):

--- a/tests/unit/mcpgateway/services/test_token_validation_service.py
+++ b/tests/unit/mcpgateway/services/test_token_validation_service.py
@@ -146,6 +146,38 @@ class TestNormalizeScope:
     def test_empty_string(self):
         assert _normalize_scope("") == set()
 
+    def test_list_input_simple_scopes(self):
+        """Test that _normalize_scope handles list input (OAuth providers like Gamma)."""
+        scopes = _normalize_scope(["read", "write"])
+        assert "read" in scopes
+        assert "write" in scopes
+
+    def test_list_input_uri_prefixed_scopes(self):
+        """Test that _normalize_scope handles list with URI-prefixed scopes."""
+        scopes = _normalize_scope(["api://app-a/Tools.Read", "api://app-a/Tools.Write"])
+        assert "api://app-a/Tools.Read" in scopes
+        assert "Tools.Read" in scopes
+        assert "api://app-a/Tools.Write" in scopes
+        assert "Tools.Write" in scopes
+
+    def test_empty_list(self):
+        """Test that _normalize_scope handles empty list."""
+        assert _normalize_scope([]) == set()
+
+    def test_mixed_list_with_uri_and_simple(self):
+        """Test that _normalize_scope handles mixed list of URI and simple scopes."""
+        scopes = _normalize_scope(["read", "api://app-a/Tools.Write", "admin"])
+        assert "read" in scopes
+        assert "admin" in scopes
+        assert "api://app-a/Tools.Write" in scopes
+        assert "Tools.Write" in scopes
+
+    def test_invalid_input_type(self):
+        """Test that _normalize_scope handles invalid input gracefully."""
+        assert _normalize_scope(None) == set()
+        assert _normalize_scope(123) == set()
+        assert _normalize_scope({}) == set()
+
 
 # ---------- validate_oauth_token_claims ----------
 

--- a/tests/unit/mcpgateway/services/test_token_validation_service.py
+++ b/tests/unit/mcpgateway/services/test_token_validation_service.py
@@ -178,6 +178,14 @@ class TestNormalizeScope:
         assert _normalize_scope(123) == set()
         assert _normalize_scope({}) == set()
 
+    def test_list_with_non_string_elements(self):
+        """Test that _normalize_scope filters out non-string list elements safely."""
+        scopes = _normalize_scope(["read", 123, None, "write"])
+        assert "read" in scopes
+        assert "write" in scopes
+        assert 123 not in scopes
+        assert None not in scopes
+
 
 # ---------- validate_oauth_token_claims ----------
 
@@ -310,6 +318,32 @@ class TestValidateOauthTokenClaims:
 
         # Nothing to compare against
         assert result.scopes_sufficient is None
+
+    def test_empty_list_scope_claim(self):
+        """Empty list scope should be treated as insufficient, not skipped."""
+        token = _make_jwt({"scope": []})
+        oauth_config = {"scopes": ["read"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is False
+        assert any("missing required scopes" in w.lower() for w in result.warnings)
+
+    def test_list_scope_mismatch(self):
+        """List-valued scopes with missing required scopes should be flagged."""
+        token = _make_jwt({"scope": ["read", "admin"]})
+        oauth_config = {"scopes": ["write"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is False
+        assert any("missing required scopes" in w.lower() for w in result.warnings)
+
+    def test_list_scope_match(self):
+        """List-valued scopes that satisfy required scopes should pass."""
+        token = _make_jwt({"scope": ["read", "write"]})
+        oauth_config = {"scopes": ["write"]}
+        result = validate_oauth_token_claims(token, oauth_config, "https://gw.example.com", "test-gw")
+
+        assert result.scopes_sufficient is True
 
     # -- Issuer mismatch --
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4593
**Jira Issue:** https://jsw.ibm.com/browse/ICACF-40

---

## 📝 Summary

Fixed OAuth token scope validation failure that caused "Failed to fetch tools after OAuth: 'list' object has no attribute 'split'" error when connecting to MCP servers (e.g., Gamma) that return OAuth scopes as a list instead of a space-separated string.

**Root Cause:** The code assumed OAuth `scope`/`scp` claims would always be strings, but some OAuth providers return them as lists, which is valid per OAuth 2.0 specifications.

**Solution:** Updated scope handling in two critical locations to accept both string and list formats:
1. JWT token claim validation (`_normalize_scope()`)
2. OAuth token response processing (`exchange_code_for_tokens()`)

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

**Test Results:**
- `test_token_validation_service.py`: 46 tests pass (including 5 new tests for list input)
- `test_oauth_manager.py`: 112 tests pass
- `test_gateway_service_oauth_comprehensive.py`: 29 tests pass

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Files Changed

**1. `mcpgateway/services/token_validation_service.py`**
- Updated `_normalize_scope()` to handle both `str` and `list` inputs
- Added type flexibility: `scope_input: Any` instead of `scope_str: str`
- Gracefully handles invalid types by returning empty set

**2. `mcpgateway/services/oauth_manager.py`**
- Updated `exchange_code_for_tokens()` to handle scope as string or list
- Added explicit type checking before calling `.split()`
- Ensures `store_tokens()` always receives `List[str]`

**3. `tests/unit/mcpgateway/services/test_token_validation_service.py`**
- Added 5 new test cases for list input scenarios:
  - `test_list_input_simple_scopes`
  - `test_list_input_uri_prefixed_scopes`
  - `test_empty_list`
  - `test_mixed_list_with_uri_and_simple`
  - `test_invalid_input_type`

### Impact
- **Before:** OAuth authorization succeeded but tool fetching failed with AttributeError
- **After:** Both string and list scope formats are handled correctly
- **Compatibility:** Maintains backward compatibility with existing OAuth providers that return strings