### PR TITLE
perf(auth): cache get_user_by_email at service level to reduce DB hot-path queries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -5086,7 +5086,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 650,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-06T14:33:38Z",
+  "generated_at": "2026-05-06T10:41:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5086,7 +5086,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 650,
+        "line_number": 672,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7508,7 +7508,7 @@
         "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1504,
+        "line_number": 1505,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7516,7 +7516,7 @@
         "hashed_secret": "addbd3aa5619f2932733104eb8ceef08f6fd2693",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1516,
+        "line_number": 1517,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7524,7 +7524,7 @@
         "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1579,
+        "line_number": 1580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7532,7 +7532,7 @@
         "hashed_secret": "6aa10d711ca6f233cc7d7e9c36a980cbbd6b1ed1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1602,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7540,7 +7540,7 @@
         "hashed_secret": "bdb6e328018a96636bca051255228c0d2a3543b5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1644,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7548,7 +7548,7 @@
         "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1660,
+        "line_number": 1661,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7556,7 +7556,7 @@
         "hashed_secret": "4015d13806dacd6cf5436ce218b7f755ab9ddab3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2176,
+        "line_number": 2177,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7564,7 +7564,7 @@
         "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2261,
+        "line_number": 2262,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -305,9 +305,6 @@ class AuthCache:
                 redis_key = self._get_redis_key("ctx", cache_key)
                 data = await redis.get(redis_key)
                 if data:
-                    # Third-Party
-                    import orjson  # pylint: disable=import-outside-toplevel
-
                     cached = orjson.loads(data)
                     result = CachedAuthContext(
                         user=cached.get("user"),
@@ -377,9 +374,6 @@ class AuthCache:
         redis = await self._get_redis_client()
         if redis:
             try:
-                # Third-Party
-                import orjson  # pylint: disable=import-outside-toplevel
-
                 redis_key = self._get_redis_key("ctx", cache_key)
                 await redis.setex(redis_key, ttl, orjson.dumps(data))
             except Exception as e:
@@ -813,9 +807,6 @@ class AuthCache:
                 if data is not None:
                     self._hit_count += 1
                     self._redis_hit_count += 1
-                    # Third-Party
-                    import orjson  # pylint: disable=import-outside-toplevel
-
                     team_ids = orjson.loads(data)
 
                     # Write-through: populate L1 from Redis hit
@@ -852,9 +843,6 @@ class AuthCache:
         redis = await self._get_redis_client()
         if redis:
             try:
-                # Third-Party
-                import orjson  # pylint: disable=import-outside-toplevel
-
                 redis_key = self._get_redis_key("teams", cache_key)
                 await redis.setex(redis_key, self._teams_list_ttl, orjson.dumps(team_ids))
             except Exception as e:

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -389,6 +389,92 @@ class AuthCache:
                 expiry=time.time() + ttl,
             )
 
+    async def get_user(self, email: str) -> Optional[Dict[str, Any]]:
+        """Get cached user dict for a given email (L1 → L2 lookup).
+
+        Args:
+            email: Normalised user email address.
+
+        Returns:
+            Cached user dict or None on cache miss.
+
+        Examples:
+            >>> import asyncio
+            >>> cache = AuthCache()
+            >>> result = asyncio.run(cache.get_user("test@example.com"))
+            >>> result is None  # Cache miss on fresh cache
+            True
+        """
+        if not self._enabled:
+            return None
+
+        # L1 check
+        entry = self._user_cache.get(email)
+        if entry and not entry.is_expired():
+            self._hit_count += 1
+            return entry.value
+
+        # L2 check
+        redis = await self._get_redis_client()
+        if redis:
+            try:
+                redis_key = self._get_redis_key("user", email)
+                data = await redis.get(redis_key)
+                if data is not None:
+                    # Third-Party
+                    import orjson  # pylint: disable=import-outside-toplevel
+
+                    user_dict = orjson.loads(data)
+                    self._hit_count += 1
+                    self._redis_hit_count += 1
+                    # Write-through to L1
+                    with self._lock:
+                        self._user_cache[email] = CacheEntry(
+                            value=user_dict,
+                            expiry=time.time() + self._user_ttl,
+                        )
+                    return user_dict
+                self._redis_miss_count += 1
+            except Exception as e:
+                logger.warning(f"AuthCache Redis get_user failed: {e}")
+
+        self._miss_count += 1
+        return None
+
+    async def set_user(self, email: str, user_dict: Dict[str, Any]) -> None:
+        """Store user dict in cache (L2 then L1).
+
+        Args:
+            email: Normalised user email address.
+            user_dict: Serialisable user data dict.
+
+        Examples:
+            >>> import asyncio
+            >>> cache = AuthCache()
+            >>> asyncio.run(cache.set_user("test@example.com", {"email": "test@example.com"}))
+        """
+        if not self._enabled:
+            return
+
+        # Store in Redis
+        redis = await self._get_redis_client()
+        if redis:
+            try:
+                # Third-Party
+                import orjson  # pylint: disable=import-outside-toplevel
+
+                redis_key = self._get_redis_key("user", email)
+                await redis.setex(redis_key, self._user_ttl, orjson.dumps(user_dict))
+            except Exception as e:
+                logger.warning(f"AuthCache Redis set_user failed: {e}")
+
+        # Store in L1
+        with self._lock:
+            self._user_cache[email] = CacheEntry(
+                value=user_dict,
+                expiry=time.time() + self._user_ttl,
+            )
+
     async def invalidate_user(self, email: str) -> None:
         """Invalidate cached data for a user.
 
@@ -1180,6 +1266,7 @@ class AuthCache:
             "redis_hit_rate": self._redis_hit_count / redis_total if redis_total > 0 else 0.0,
             "redis_available": self._redis_available,
             "revoked_tokens_cached": len(self._revoked_jtis),
+            "user_cache_size": len(self._user_cache),
             "context_cache_size": len(self._context_cache),
             "role_cache_size": len(self._role_cache),
             "teams_list_cache_size": len(self._teams_list_cache),

--- a/mcpgateway/cache/auth_cache.py
+++ b/mcpgateway/cache/auth_cache.py
@@ -37,6 +37,9 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Set
 
+# Third-Party
+import orjson
+
 logger = logging.getLogger(__name__)
 
 # Sentinel value to represent "user is not a member" in Redis cache
@@ -409,7 +412,8 @@ class AuthCache:
             return None
 
         # L1 check
-        entry = self._user_cache.get(email)
+        with self._lock:
+            entry = self._user_cache.get(email)
         if entry and not entry.is_expired():
             self._hit_count += 1
             return entry.value
@@ -421,9 +425,6 @@ class AuthCache:
                 redis_key = self._get_redis_key("user", email)
                 data = await redis.get(redis_key)
                 if data is not None:
-                    # Third-Party
-                    import orjson  # pylint: disable=import-outside-toplevel
-
                     user_dict = orjson.loads(data)
                     self._hit_count += 1
                     self._redis_hit_count += 1
@@ -460,9 +461,6 @@ class AuthCache:
         redis = await self._get_redis_client()
         if redis:
             try:
-                # Third-Party
-                import orjson  # pylint: disable=import-outside-toplevel
-
                 redis_key = self._get_redis_key("user", email)
                 await redis.setex(redis_key, self._user_ttl, orjson.dumps(user_dict))
             except Exception as e:

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -74,6 +74,62 @@ _GET_ALL_USERS_LIMIT = 10000
 _DUMMY_ARGON2_HASH = "$argon2id$v=19$m=65536,t=3,p=1$9x/nTs9D0R97+BI7BWP2Tg$V/40qCuaGh4i+94HpGpxJESEVs3IDpLzUqtNqRPuty4"
 
 
+def _user_obj_to_dict(user: EmailUser) -> dict:
+    """Serialise an EmailUser ORM object to a plain dict safe for caching."""
+
+    def _iso(v: Optional[datetime]) -> Optional[str]:
+        return v.isoformat() if v is not None else None
+
+    return {
+        "email": user.email,
+        "password_hash": user.password_hash,
+        "full_name": user.full_name,
+        "is_admin": user.is_admin,
+        "is_active": user.is_active,
+        "auth_provider": user.auth_provider,
+        "password_hash_type": user.password_hash_type,
+        "password_change_required": user.password_change_required,
+        "failed_login_attempts": user.failed_login_attempts,
+        "locked_until": _iso(user.locked_until),
+        "email_verified_at": _iso(user.email_verified_at),
+        "created_at": _iso(user.created_at),
+        "updated_at": _iso(user.updated_at),
+        "last_login": _iso(user.last_login),
+        "admin_origin": user.admin_origin,
+        "password_changed_at": _iso(user.password_changed_at),
+    }
+
+
+def _user_dict_to_obj(d: dict) -> EmailUser:
+    """Reconstruct a detached EmailUser from a cached dict."""
+
+    def _dt(v: Optional[str]) -> Optional[datetime]:
+        if v is None:
+            return None
+        if isinstance(v, datetime):
+            return v
+        return datetime.fromisoformat(v)
+
+    return EmailUser(
+        email=d["email"],
+        password_hash=d.get("password_hash", ""),
+        full_name=d.get("full_name"),
+        is_admin=d.get("is_admin", False),
+        is_active=d.get("is_active", True),
+        auth_provider=d.get("auth_provider", "local"),
+        password_hash_type=d.get("password_hash_type", "argon2id"),
+        password_change_required=d.get("password_change_required", False),
+        failed_login_attempts=d.get("failed_login_attempts", 0),
+        locked_until=_dt(d.get("locked_until")),
+        email_verified_at=_dt(d.get("email_verified_at")),
+        created_at=_dt(d.get("created_at")) or datetime.now(timezone.utc),
+        updated_at=_dt(d.get("updated_at")) or datetime.now(timezone.utc),
+        last_login=_dt(d.get("last_login")),
+        admin_origin=d.get("admin_origin"),
+        password_changed_at=_dt(d.get("password_changed_at")),
+    )
+
+
 @dataclass(frozen=True)
 class UsersListResult:
     """Result for list_users queries."""
@@ -507,6 +563,8 @@ class EmailAuthService:
     async def get_user_by_email(self, email: str) -> Optional[EmailUser]:
         """Get user by email address.
 
+        Checks the auth cache (L1 → L2) before hitting the DB.
+
         Args:
             email: Email address to look up
 
@@ -518,10 +576,27 @@ class EmailAuthService:
             # user = await service.get_user_by_email("test@example.com")
             # user.email if user else None  # Returns: 'test@example.com'
         """
+        normalized = email.lower().strip()
         try:
-            stmt = select(EmailUser).where(EmailUser.email == email.lower())
+            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+            cached = await auth_cache.get_user(normalized)
+            if cached is not None:
+                return _user_dict_to_obj(cached)
+        except Exception:
+            pass  # graceful fallback to DB
+
+        try:
+            stmt = select(EmailUser).where(EmailUser.email == normalized)
             result = self.db.execute(stmt)
             user = result.scalar_one_or_none()
+            if user is not None:
+                try:
+                    from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                    await auth_cache.set_user(normalized, _user_obj_to_dict(user))
+                except Exception:
+                    pass
             return user
         except Exception as e:
             logger.error(f"Error getting user by email {SecurityValidator.sanitize_log_message(email)}: {e}")
@@ -1757,6 +1832,7 @@ class EmailAuthService:
             user.updated_at = datetime.now(timezone.utc)
 
             self.db.commit()
+            await self._invalidate_user_auth_cache(email)
 
             return user
 
@@ -1789,6 +1865,7 @@ class EmailAuthService:
             user.updated_at = datetime.now(timezone.utc)
 
             self.db.commit()
+            await self._invalidate_user_auth_cache(email)
 
             logger.info(f"User {SecurityValidator.sanitize_log_message(email)} activated")
             return user
@@ -1822,6 +1899,7 @@ class EmailAuthService:
             user.updated_at = datetime.now(timezone.utc)
 
             self.db.commit()
+            await self._invalidate_user_auth_cache(email)
 
             logger.info(f"User {SecurityValidator.sanitize_log_message(email)} deactivated")
             return user

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -584,8 +584,8 @@ class EmailAuthService:
             cached = await auth_cache.get_user(normalized)
             if cached is not None:
                 return _user_dict_to_obj(cached)
-        except Exception:
-            pass  # graceful fallback to DB
+        except Exception as e:
+            logger.debug("Cache read failed for user %s, falling back to DB: %s", normalized, e)
 
         try:
             stmt = select(EmailUser).where(EmailUser.email == normalized)
@@ -597,8 +597,8 @@ class EmailAuthService:
                     from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
 
                     await auth_cache.set_user(normalized, _user_obj_to_dict(user))
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Cache write failed for user %s: %s", normalized, e)
             return user
         except Exception as e:
             logger.error(f"Error getting user by email {SecurityValidator.sanitize_log_message(email)}: {e}")

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -578,6 +578,7 @@ class EmailAuthService:
         """
         normalized = email.lower().strip()
         try:
+            # First-Party
             from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
 
             cached = await auth_cache.get_user(normalized)
@@ -592,6 +593,7 @@ class EmailAuthService:
             user = result.scalar_one_or_none()
             if user is not None:
                 try:
+                    # First-Party
                     from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
 
                     await auth_cache.set_user(normalized, _user_obj_to_dict(user))

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -75,14 +75,19 @@ _DUMMY_ARGON2_HASH = "$argon2id$v=19$m=65536,t=3,p=1$9x/nTs9D0R97+BI7BWP2Tg$V/40
 
 
 def _user_obj_to_dict(user: EmailUser) -> dict:
-    """Serialise an EmailUser ORM object to a plain dict safe for caching."""
+    """Serialise an EmailUser ORM object to a plain dict safe for caching.
+
+    password_hash is intentionally excluded — same reasoning as JWT payloads
+    (per module docstring): storing credential material in Redis risks exposure
+    on a Redis compromise.  Mutation paths (authenticate_user, unlock_user_account)
+    always fetch session-attached objects directly from the DB.
+    """
 
     def _iso(v: Optional[datetime]) -> Optional[str]:
         return v.isoformat() if v is not None else None
 
     return {
         "email": user.email,
-        "password_hash": user.password_hash,
         "full_name": user.full_name,
         "is_admin": user.is_admin,
         "is_active": user.is_active,
@@ -101,7 +106,12 @@ def _user_obj_to_dict(user: EmailUser) -> dict:
 
 
 def _user_dict_to_obj(d: dict) -> EmailUser:
-    """Reconstruct a detached EmailUser from a cached dict."""
+    """Reconstruct a detached EmailUser from a cached dict.
+
+    The returned object is NOT tracked by any SQLAlchemy session.  Use only
+    for read-only lookups.  Mutation paths must use session-attached objects
+    fetched directly from the DB.
+    """
 
     def _dt(v: Optional[str]) -> Optional[datetime]:
         if v is None:
@@ -112,10 +122,10 @@ def _user_dict_to_obj(d: dict) -> EmailUser:
 
     return EmailUser(
         email=d["email"],
-        password_hash=d.get("password_hash", ""),
+        password_hash=d.get("password_hash", ""),  # not cached; empty for read-only paths
         full_name=d.get("full_name"),
         is_admin=d.get("is_admin", False),
-        is_active=d.get("is_active", True),
+        is_active=d.get("is_active", False),  # fail-closed: missing key → inactive
         auth_provider=d.get("auth_provider", "local"),
         password_hash_type=d.get("password_hash_type", "argon2id"),
         password_change_required=d.get("password_change_required", False),
@@ -577,10 +587,10 @@ class EmailAuthService:
             # user.email if user else None  # Returns: 'test@example.com'
         """
         normalized = email.lower().strip()
-        try:
-            # First-Party
-            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+        # First-Party
+        from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
 
+        try:
             cached = await auth_cache.get_user(normalized)
             if cached is not None:
                 return _user_dict_to_obj(cached)
@@ -593,15 +603,27 @@ class EmailAuthService:
             user = result.scalar_one_or_none()
             if user is not None:
                 try:
-                    # First-Party
-                    from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
-
                     await auth_cache.set_user(normalized, _user_obj_to_dict(user))
                 except Exception as e:
                     logger.debug("Cache write failed for user %s: %s", normalized, e)
             return user
         except Exception as e:
             logger.error(f"Error getting user by email {SecurityValidator.sanitize_log_message(email)}: {e}")
+            return None
+
+    def _fetch_user_from_db(self, email: str) -> Optional[EmailUser]:
+        """Fetch a session-attached EmailUser directly from the DB, bypassing cache.
+
+        Required for mutation paths (authenticate_user, unlock_user_account) where
+        the returned object must be tracked by self.db so that ORM mutations and
+        self.db.commit() are durable.  Never use the cached detached object for writes.
+        """
+        try:
+            stmt = select(EmailUser).where(EmailUser.email == email)
+            result = self.db.execute(stmt)
+            return result.scalar_one_or_none()
+        except Exception as e:
+            logger.error(f"Error fetching user from DB {SecurityValidator.sanitize_log_message(email)}: {e}")
             return None
 
     async def create_user(
@@ -852,8 +874,10 @@ class EmailAuthService:
         email = email.lower().strip()
         start_time = time.monotonic()
 
-        # Get user from database
-        user = await self.get_user_by_email(email)
+        # Fetch session-attached object from DB — mutations (increment_failed_attempts,
+        # reset_failed_attempts) must be tracked by self.db; a cached detached object
+        # would silently discard those writes (CWE-307 brute-force bypass).
+        user = self._fetch_user_from_db(email)
 
         # Track authentication attempt
         auth_success = False
@@ -1156,7 +1180,9 @@ class EmailAuthService:
             ValueError: If the target user cannot be found.
         """
         normalized_email = email.lower().strip()
-        user = await self.get_user_by_email(normalized_email)
+        # Fetch session-attached object — mutations must be tracked by self.db;
+        # a cached detached object would silently discard the unlock (CWE-613).
+        user = self._fetch_user_from_db(normalized_email)
         if not user:
             raise ValueError(f"User {normalized_email} not found")
 
@@ -1164,6 +1190,7 @@ class EmailAuthService:
         user.locked_until = None
         user.updated_at = utc_now()
         self.db.commit()
+        await self._invalidate_user_auth_cache(normalized_email)
         self._log_auth_event(
             event_type="ACCOUNT_UNLOCKED",
             success=True,

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -1120,7 +1120,11 @@ class EmailAuthService:
             PasswordValidationError: If new password violates policy or reuse checks.
         """
         reset_token = await self.validate_password_reset_token(token, ip_address=ip_address, user_agent=user_agent)
-        user = await self.get_user_by_email(reset_token.user_email)
+        # Use _fetch_user_from_db to get a session-attached object — mutations
+        # (password_hash, password_changed_at, failed_login_attempts) must be
+        # tracked by self.db so self.db.commit() is durable.  Also ensures the
+        # real password_hash is present for the reuse check (cached objects store "").
+        user = self._fetch_user_from_db(reset_token.user_email)
         if not user or not user.is_active:
             password_reset_completions_counter.labels(outcome="invalid_user").inc()
             raise AuthenticationError("This reset link is invalid")

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -876,7 +876,7 @@ class EmailAuthService:
 
         # Fetch session-attached object from DB — mutations (increment_failed_attempts,
         # reset_failed_attempts) must be tracked by self.db; a cached detached object
-        # would silently discard those writes (CWE-307 brute-force bypass).
+        # would silently discard those writes.
         user = self._fetch_user_from_db(email)
 
         # Track authentication attempt
@@ -1181,7 +1181,7 @@ class EmailAuthService:
         """
         normalized_email = email.lower().strip()
         # Fetch session-attached object — mutations must be tracked by self.db;
-        # a cached detached object would silently discard the unlock (CWE-613).
+        # a cached detached object would silently discard the unlock.
         user = self._fetch_user_from_db(normalized_email)
         if not user:
             raise ValueError(f"User {normalized_email} not found")

--- a/tests/unit/mcpgateway/cache/test_auth_cache_user.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_user.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/cache/test_auth_cache_user.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for AuthCache.get_user() / set_user() (Issue #3061).
+"""
+
+# Standard
+import time
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.cache.auth_cache import AuthCache, CacheEntry
+
+
+@pytest.fixture
+def cache():
+    """AuthCache with caching enabled, Redis disabled."""
+    c = AuthCache(enabled=True, user_ttl=60)
+    c._redis_checked = True
+    c._redis_available = False
+    return c
+
+
+@pytest.fixture
+def mock_redis():
+    r = AsyncMock()
+    r.get = AsyncMock(return_value=None)
+    r.setex = AsyncMock()
+    r.delete = AsyncMock()
+    r.scan_iter = AsyncMock(return_value=aiter([]))
+    r.publish = AsyncMock()
+    return r
+
+
+async def aiter(items):
+    for item in items:
+        yield item
+
+
+_USER_DICT = {
+    "email": "test@example.com",
+    "password_hash": "$argon2id$...",
+    "full_name": "Test User",
+    "is_admin": False,
+    "is_active": True,
+    "auth_provider": "local",
+    "password_hash_type": "argon2id",
+    "password_change_required": False,
+    "failed_login_attempts": 0,
+    "locked_until": None,
+    "email_verified_at": None,
+    "created_at": "2025-01-01T00:00:00+00:00",
+    "updated_at": "2025-01-01T00:00:00+00:00",
+    "last_login": None,
+    "admin_origin": None,
+    "password_changed_at": None,
+}
+
+
+class TestGetUser:
+    @pytest.mark.asyncio
+    async def test_cache_miss_returns_none(self, cache):
+        result = await cache.get_user("test@example.com")
+        assert result is None
+        assert cache._miss_count == 1
+
+    @pytest.mark.asyncio
+    async def test_set_then_get_returns_dict(self, cache):
+        await cache.set_user("test@example.com", _USER_DICT)
+        result = await cache.get_user("test@example.com")
+        assert result is not None
+        assert result["email"] == "test@example.com"
+        assert result["is_admin"] is False
+        assert cache._hit_count == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_entry_returns_none(self, cache):
+        # Insert an already-expired entry
+        cache._user_cache["test@example.com"] = CacheEntry(
+            value=_USER_DICT,
+            expiry=time.time() - 1,  # already expired
+        )
+        result = await cache.get_user("test@example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalidate_user_clears_user_cache(self, cache):
+        await cache.set_user("test@example.com", _USER_DICT)
+        assert await cache.get_user("test@example.com") is not None
+
+        await cache.invalidate_user("test@example.com")
+
+        assert await cache.get_user("test@example.com") is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_cache_get_returns_none(self):
+        c = AuthCache(enabled=False)
+        await c.set_user("test@example.com", _USER_DICT)
+        result = await c.get_user("test@example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_redis_hit_populates_l1(self, cache, mock_redis):
+        import orjson
+
+        mock_redis.get = AsyncMock(return_value=orjson.dumps(_USER_DICT))
+
+        with patch.object(cache, "_get_redis_client", return_value=mock_redis):
+            result = await cache.get_user("test@example.com")
+
+        assert result is not None
+        assert result["email"] == "test@example.com"
+        # L1 should now be populated
+        assert "test@example.com" in cache._user_cache
+
+    @pytest.mark.asyncio
+    async def test_stats_includes_user_cache_size(self, cache):
+        await cache.set_user("test@example.com", _USER_DICT)
+        stats = cache.stats()
+        assert "user_cache_size" in stats
+        assert stats["user_cache_size"] == 1

--- a/tests/unit/mcpgateway/cache/test_auth_cache_user.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_user.py
@@ -44,7 +44,6 @@ async def aiter(items):
 
 _USER_DICT = {
     "email": "test@example.com",
-    "password_hash": "$argon2id$...",
     "full_name": "Test User",
     "is_admin": False,
     "is_active": True,

--- a/tests/unit/mcpgateway/cache/test_auth_cache_user.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_user.py
@@ -118,8 +118,20 @@ class TestGetUser:
         assert "test@example.com" in cache._user_cache
 
     @pytest.mark.asyncio
+    async def test_redis_miss_increments_redis_miss_count(self, cache, mock_redis):
+        """Line 438: redis.get() returns None → _redis_miss_count increments."""
+        mock_redis.get = AsyncMock(return_value=None)
+
+        with patch.object(cache, "_get_redis_client", return_value=mock_redis):
+            result = await cache.get_user("test@example.com")
+
+        assert result is None
+        assert cache._redis_miss_count == 1
+        assert cache._miss_count == 1
+
+    @pytest.mark.asyncio
     async def test_redis_get_error_logs_warning_and_returns_none(self, cache, mock_redis):
-        """Line 438: except block in get_user when redis.get() raises."""
+        """except block in get_user when redis.get() raises."""
         mock_redis.get = AsyncMock(side_effect=RuntimeError("Redis connection lost"))
 
         with patch.object(cache, "_get_redis_client", return_value=mock_redis):

--- a/tests/unit/mcpgateway/cache/test_auth_cache_user.py
+++ b/tests/unit/mcpgateway/cache/test_auth_cache_user.py
@@ -119,6 +119,36 @@ class TestGetUser:
         assert "test@example.com" in cache._user_cache
 
     @pytest.mark.asyncio
+    async def test_redis_get_error_logs_warning_and_returns_none(self, cache, mock_redis):
+        """Line 438: except block in get_user when redis.get() raises."""
+        mock_redis.get = AsyncMock(side_effect=RuntimeError("Redis connection lost"))
+
+        with patch.object(cache, "_get_redis_client", return_value=mock_redis):
+            result = await cache.get_user("test@example.com")
+
+        assert result is None
+        assert cache._miss_count == 1
+
+    @pytest.mark.asyncio
+    async def test_set_user_with_redis_stores_in_both_tiers(self, cache, mock_redis):
+        """Lines 463/466: import orjson and setex inside set_user try block."""
+        with patch.object(cache, "_get_redis_client", return_value=mock_redis):
+            await cache.set_user("test@example.com", _USER_DICT)
+
+        mock_redis.setex.assert_awaited_once()
+        assert "test@example.com" in cache._user_cache
+
+    @pytest.mark.asyncio
+    async def test_set_user_redis_error_still_populates_l1(self, cache, mock_redis):
+        """Line 468: except block in set_user when redis.setex() raises."""
+        mock_redis.setex = AsyncMock(side_effect=RuntimeError("Redis write failed"))
+
+        with patch.object(cache, "_get_redis_client", return_value=mock_redis):
+            await cache.set_user("test@example.com", _USER_DICT)
+
+        assert "test@example.com" in cache._user_cache
+
+    @pytest.mark.asyncio
     async def test_stats_includes_user_cache_size(self, cache):
         await cache.set_user("test@example.com", _USER_DICT)
         stats = cache.stats()

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -1233,7 +1233,7 @@ class TestEmailAuthServiceUserManagement:
             mock_settings.password_reset_invalidate_sessions = True
 
             with patch.object(service, "validate_password_reset_token", new=AsyncMock(return_value=reset_token)):
-                with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=user)):
+                with patch.object(service, "_fetch_user_from_db", return_value=user):
                     with patch.object(service, "_invalidate_user_auth_cache", new=AsyncMock(return_value=None)):
                         with patch.object(service.email_notification_service, "send_password_reset_confirmation_email", new=AsyncMock(return_value=True)):
                             result = await service.reset_password_with_token(token="token", new_password="NewPassword123!")
@@ -1253,7 +1253,7 @@ class TestEmailAuthServiceUserManagement:
         reset_token.user_email = "user@example.com"
 
         with patch.object(service, "validate_password_reset_token", new=AsyncMock(return_value=reset_token)):
-            with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=None)):
+            with patch.object(service, "_fetch_user_from_db", return_value=None):
                 with pytest.raises(AuthenticationError, match="invalid"):
                     await service.reset_password_with_token(token="token", new_password="NewPassword123!")
 
@@ -1275,7 +1275,7 @@ class TestEmailAuthServiceUserManagement:
             mock_settings.password_policy_enabled = False
             mock_settings.password_prevent_reuse = True
             with patch.object(service, "validate_password_reset_token", new=AsyncMock(return_value=reset_token)):
-                with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=user)):
+                with patch.object(service, "_fetch_user_from_db", return_value=user):
                     with pytest.raises(PasswordValidationError, match="different"):
                         await service.reset_password_with_token(token="token", new_password="same-password")
 
@@ -1309,7 +1309,7 @@ class TestEmailAuthServiceUserManagement:
             mock_settings.password_reset_invalidate_sessions = False
 
             with patch.object(service, "validate_password_reset_token", new=AsyncMock(return_value=reset_token)):
-                with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=user)):
+                with patch.object(service, "_fetch_user_from_db", return_value=user):
                     with patch.object(service.email_notification_service, "send_password_reset_confirmation_email", new=AsyncMock(side_effect=RuntimeError("smtp"))):
                         result = await service.reset_password_with_token(token="token", new_password="NewPassword123!")
 

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -1319,7 +1319,7 @@ class TestEmailAuthServiceUserManagement:
     @pytest.mark.asyncio
     async def test_unlock_user_account_not_found(self, service):
         """Unlock raises ValueError for unknown users."""
-        with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=None)):
+        with patch.object(service, "_fetch_user_from_db", return_value=None):
             with pytest.raises(ValueError, match="not found"):
                 await service.unlock_user_account("missing@example.com")
 
@@ -1331,8 +1331,9 @@ class TestEmailAuthServiceUserManagement:
         user.failed_login_attempts = 3
         user.locked_until = datetime.now(timezone.utc) + timedelta(minutes=5)
 
-        with patch.object(service, "get_user_by_email", new=AsyncMock(return_value=user)):
-            result = await service.unlock_user_account("user@example.com", unlocked_by="admin@example.com")
+        with patch.object(service, "_fetch_user_from_db", return_value=user):
+            with patch.object(service, "_invalidate_user_auth_cache", new_callable=AsyncMock):
+                result = await service.unlock_user_account("user@example.com", unlocked_by="admin@example.com")
 
         assert result is user
         assert user.failed_login_attempts == 0

--- a/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
@@ -94,6 +94,16 @@ def test_user_dict_to_obj_round_trip():
     assert obj.created_at.tzinfo is not None
 
 
+def test_user_dict_to_obj_accepts_datetime_objects():
+    """Line 110: _dt() returns v directly when v is already a datetime."""
+    d = dict(_USER_DICT)
+    d["created_at"] = _NOW
+    d["updated_at"] = _NOW
+    obj = _user_dict_to_obj(d)
+    assert obj.created_at == _NOW
+    assert obj.updated_at == _NOW
+
+
 # ---------- get_user_by_email cache hit ----------
 
 
@@ -188,3 +198,20 @@ async def test_deactivate_user_invalidates_cache(service, mock_db):
         await service.deactivate_user("test@example.com")
 
     mock_inv.assert_awaited_once_with("test@example.com")
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_email_set_cache_error_still_returns_user(service, mock_db):
+    """Line 598: except block when auth_cache.set_user() raises."""
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    mock_cache = AsyncMock()
+    mock_cache.get_user = AsyncMock(return_value=None)
+    mock_cache.set_user = AsyncMock(side_effect=RuntimeError("Cache write failed"))
+
+    with patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache):
+        result = await service.get_user_by_email("test@example.com")
+
+    assert result is not None
+    assert result.email == "test@example.com"

--- a/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Tests for get_user_by_email() cache integration and mutation invalidation (Issue #3061).
+"""
+
+# Standard
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import EmailUser
+from mcpgateway.services.email_auth_service import EmailAuthService, _user_dict_to_obj, _user_obj_to_dict
+
+_NOW = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+_USER_DICT = {
+    "email": "test@example.com",
+    "password_hash": "$argon2id$...",
+    "full_name": "Test User",
+    "is_admin": False,
+    "is_active": True,
+    "auth_provider": "local",
+    "password_hash_type": "argon2id",
+    "password_change_required": False,
+    "failed_login_attempts": 0,
+    "locked_until": None,
+    "email_verified_at": None,
+    "created_at": "2025-01-01T00:00:00+00:00",
+    "updated_at": "2025-01-01T00:00:00+00:00",
+    "last_login": None,
+    "admin_origin": None,
+    "password_changed_at": None,
+}
+
+
+def _make_email_user(email="test@example.com"):
+    return EmailUser(
+        email=email,
+        password_hash="$argon2id$...",
+        full_name="Test User",
+        is_admin=False,
+        is_active=True,
+        auth_provider="local",
+        password_hash_type="argon2id",
+        password_change_required=False,
+        failed_login_attempts=0,
+        locked_until=None,
+        email_verified_at=None,
+        created_at=_NOW,
+        updated_at=_NOW,
+        last_login=None,
+        admin_origin=None,
+        password_changed_at=None,
+    )
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+    db.execute.return_value.scalars.return_value.all.return_value = []
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    with patch("mcpgateway.services.email_auth_service.Argon2PasswordService"):
+        svc = EmailAuthService(mock_db)
+        return svc
+
+
+# ---------- Helper serialisation round-trip ----------
+
+
+def test_user_obj_to_dict_round_trip():
+    user = _make_email_user()
+    d = _user_obj_to_dict(user)
+    assert d["email"] == "test@example.com"
+    assert d["is_admin"] is False
+    assert d["locked_until"] is None
+    assert isinstance(d["created_at"], str)
+
+
+def test_user_dict_to_obj_round_trip():
+    obj = _user_dict_to_obj(_USER_DICT)
+    assert obj.email == "test@example.com"
+    assert obj.is_admin is False
+    assert obj.created_at.tzinfo is not None
+
+
+# ---------- get_user_by_email cache hit ----------
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_email_cache_hit_skips_db(service, mock_db):
+    mock_cache = AsyncMock()
+    mock_cache.get_user = AsyncMock(return_value=_USER_DICT)
+
+    with patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache):
+        result = await service.get_user_by_email("test@example.com")
+
+    assert result is not None
+    assert result.email == "test@example.com"
+    mock_db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_email_cache_miss_populates_cache(service, mock_db):
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    mock_cache = AsyncMock()
+    mock_cache.get_user = AsyncMock(return_value=None)
+    mock_cache.set_user = AsyncMock()
+
+    with patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache):
+        result = await service.get_user_by_email("test@example.com")
+
+    assert result is not None
+    assert result.email == "test@example.com"
+    mock_cache.set_user.assert_awaited_once()
+    call_args = mock_cache.set_user.call_args
+    assert call_args[0][0] == "test@example.com"
+    assert call_args[0][1]["email"] == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_email_cache_error_falls_back_to_db(service, mock_db):
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    mock_cache = AsyncMock()
+    mock_cache.get_user = AsyncMock(side_effect=RuntimeError("Redis down"))
+
+    with patch("mcpgateway.cache.auth_cache.auth_cache", mock_cache):
+        result = await service.get_user_by_email("test@example.com")
+
+    assert result is not None
+    assert result.email == "test@example.com"
+    mock_db.execute.assert_called_once()
+
+
+# ---------- Mutation invalidation ----------
+
+
+@pytest.mark.asyncio
+async def test_update_user_invalidates_cache(service, mock_db):
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    with patch.object(service, "_invalidate_user_auth_cache", new_callable=AsyncMock) as mock_inv:
+        with patch("mcpgateway.services.email_auth_service.settings") as mock_settings:
+            mock_settings.password_min_length = 8
+            mock_settings.password_require_uppercase = False
+            mock_settings.password_require_lowercase = False
+            mock_settings.password_require_numbers = False
+            mock_settings.password_require_special = False
+            mock_settings.admin_role_name = "platform_admin"
+            mock_settings.user_role_name = "developer"
+            await service.update_user("test@example.com", full_name="Updated Name")
+
+    mock_inv.assert_awaited_once_with("test@example.com")
+
+
+@pytest.mark.asyncio
+async def test_activate_user_invalidates_cache(service, mock_db):
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    with patch.object(service, "_invalidate_user_auth_cache", new_callable=AsyncMock) as mock_inv:
+        await service.activate_user("test@example.com")
+
+    mock_inv.assert_awaited_once_with("test@example.com")
+
+
+@pytest.mark.asyncio
+async def test_deactivate_user_invalidates_cache(service, mock_db):
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    with patch.object(service, "_invalidate_user_auth_cache", new_callable=AsyncMock) as mock_inv:
+        await service.deactivate_user("test@example.com")
+
+    mock_inv.assert_awaited_once_with("test@example.com")

--- a/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py
@@ -21,7 +21,6 @@ _NOW = datetime(2025, 1, 1, tzinfo=timezone.utc)
 
 _USER_DICT = {
     "email": "test@example.com",
-    "password_hash": "$argon2id$...",
     "full_name": "Test User",
     "is_admin": False,
     "is_active": True,
@@ -215,3 +214,53 @@ async def test_get_user_by_email_set_cache_error_still_returns_user(service, moc
 
     assert result is not None
     assert result.email == "test@example.com"
+
+
+# ---------- Mutation paths bypass cache (CWE-307 / CWE-613 regression) ----------
+
+
+def test_user_obj_to_dict_excludes_password_hash():
+    """password_hash must not be serialised into Redis (CWE-312)."""
+    user = _make_email_user()
+    d = _user_obj_to_dict(user)
+    assert "password_hash" not in d
+
+
+def test_user_dict_to_obj_is_active_fails_closed():
+    """is_active missing from cache dict must default to False, not True (CWE-20)."""
+    d = dict(_USER_DICT)
+    d.pop("is_active", None)
+    obj = _user_dict_to_obj(d)
+    assert obj.is_active is False
+
+
+def test_fetch_user_from_db_queries_db_directly(service, mock_db):
+    """_fetch_user_from_db must hit DB, not cache — ensures ORM tracking for mutations."""
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    result = service._fetch_user_from_db("test@example.com")
+
+    assert result is db_user
+    mock_db.execute.assert_called_once()
+
+
+def test_fetch_user_from_db_returns_none_on_error(service, mock_db):
+    mock_db.execute.side_effect = RuntimeError("DB down")
+
+    result = service._fetch_user_from_db("test@example.com")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unlock_user_account_invalidates_cache(service, mock_db):
+    """unlock_user_account must invalidate cache after DB commit (CWE-613)."""
+    db_user = _make_email_user()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = db_user
+
+    with patch.object(service, "_invalidate_user_auth_cache", new_callable=AsyncMock) as mock_inv:
+        with patch.object(service, "_log_auth_event"):
+            await service.unlock_user_account("test@example.com", unlocked_by="admin@example.com")
+
+    mock_inv.assert_awaited_once_with("test@example.com")


### PR DESCRIPTION
## Summary

`EmailAuthService.get_user_by_email()` is called on every service operation that reads or verifies a user (login, password change, SSO upsert, OAuth token introspection, profile fetch, admin bootstrap, and more — 12+ internal call sites). Each call issued a synchronous `SELECT … WHERE email = ?` with no caching, even though the existing `AuthCache` already had an allocated `_user_cache` dict and the Redis key `mcpgw:auth:user:{email}` wired into `invalidate_user()` but never populated.

- Adds `get_user()` / `set_user()` to `AuthCache` using the same L1 (in-memory) → L2 (Redis) write-through pattern as `get_user_role()` / `set_user_role()`
- Wires those methods into `EmailAuthService.get_user_by_email()` so every call checks cache first and populates on a DB hit
- Adds missing cache invalidation to `update_user()`, `activate_user()`, and `deactivate_user()` — three mutation methods that previously committed user changes without busting the cache
- Exposes `user_cache_size` in `AuthCache.stats()` (was always 0 because the cache was never written)
- All cache operations wrapped in `try/except`; Redis outage falls through to DB transparently

No new config knobs. Existing `auth_cache_user_ttl` (default 60 s) and `auth_cache_enabled` govern this path.

Closes #3061
Sub-issue of #2692 (DB query hot-path optimisations)

## Files Changed

| File | What changed |
|------|-------------|
| `mcpgateway/cache/auth_cache.py` | Added `get_user()` and `set_user()` methods; added `user_cache_size` to `stats()` |
| `mcpgateway/services/email_auth_service.py` | Added `_user_obj_to_dict()` / `_user_dict_to_obj()` helpers; updated `get_user_by_email()` to use cache; added `_invalidate_user_auth_cache()` calls in `update_user()`, `activate_user()`, `deactivate_user()` |
| `tests/unit/mcpgateway/cache/test_auth_cache_user.py` | 7 new unit tests for cache hit, miss, expiry, invalidation, Redis write-through, disabled cache, and stats |
| `tests/unit/mcpgateway/services/test_email_auth_get_user_cache.py` | 8 new unit tests for helper round-trips, cache hit skips DB, cache miss populates cache, error fallback to DB, and all three mutation invalidations |

## Invalidation Coverage After This PR

| Mutation path | Method | Invalidation |
|--------------|--------|-------------|
| Password reset | `reset_password()` | existing |
| Password change | `change_password()` | existing |
| User update (name, admin flag, etc.) | `update_user()` | **added here** |
| Activate user | `activate_user()` | **added here** |
| Deactivate user | `deactivate_user()` | **added here** |
| User deletion | `delete_user()` | existing |
| User creation | `create_user()` | not needed |