### PR TITLE
fix: bound in-memory rate limit storage to prevent memory exhaustion (CWE-400)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -21,7 +21,7 @@ underlying data.
 import asyncio
 import base64
 import binascii
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import csv
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache, wraps
@@ -687,8 +687,10 @@ grpc_service_mgr: Optional[Any] = GrpcService() if (settings.mcpgateway_grpc_ena
 
 # Set up basic authentication
 
-# Rate limiting storage
-rate_limit_storage = defaultdict(list)
+# Rate limiting storage — bounded to prevent memory exhaustion (CWE-400).
+# Uses OrderedDict so oldest entries can be evicted when the cap is reached.
+_RATE_LIMIT_MAX_KEYS: int = 10_000
+rate_limit_storage: OrderedDict[str, list] = OrderedDict()
 
 
 @lru_cache(maxsize=1)
@@ -888,8 +890,8 @@ def rate_limit(requests_per_minute: Optional[int] = None):
         Test rate limit storage structure:
         >>> isinstance(admin.rate_limit_storage, dict)
         True
-        >>> from collections import defaultdict
-        >>> isinstance(admin.rate_limit_storage, defaultdict)
+        >>> from collections import OrderedDict
+        >>> isinstance(admin.rate_limit_storage, OrderedDict)
         True
 
         Test decorator with zero limit:
@@ -938,17 +940,29 @@ def rate_limit(requests_per_minute: Optional[int] = None):
             current_time = time.time()
             minute_ago = current_time - 60
 
-            # prune old timestamps
-            rate_limit_storage[client_ip] = [ts for ts in rate_limit_storage[client_ip] if ts > minute_ago]
+            # prune old timestamps for this IP
+            timestamps = [ts for ts in rate_limit_storage.get(client_ip, []) if ts > minute_ago]
 
             # enforce
-            if len(rate_limit_storage[client_ip]) >= limit:
+            if len(timestamps) >= limit:
                 LOGGER.warning(f"Rate limit exceeded for IP {client_ip} on endpoint {func_to_wrap.__name__}")
                 raise HTTPException(
                     status_code=429,
                     detail=f"Rate limit exceeded. Maximum {limit} requests per minute.",
                 )
-            rate_limit_storage[client_ip].append(current_time)
+            timestamps.append(current_time)
+            rate_limit_storage[client_ip] = timestamps
+            # Move this IP to the end so it's treated as most-recently-used
+            rate_limit_storage.move_to_end(client_ip)
+
+            # Evict oldest IPs when storage exceeds the bounded cap (CWE-400 mitigation)
+            while len(rate_limit_storage) > _RATE_LIMIT_MAX_KEYS:
+                rate_limit_storage.popitem(last=False)
+
+            # Remove keys whose timestamps have all expired (prevents stale key buildup)
+            stale_keys = [k for k, v in rate_limit_storage.items() if not v or v[-1] <= minute_ago]
+            for k in stale_keys:
+                del rate_limit_storage[k]
             if accepts_request:
                 return await func_to_wrap(*args, request=request, **kwargs)
             return await func_to_wrap(*args, **kwargs)

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4765,24 +4765,28 @@ class TestRateLimiting:
         async def test_endpoint(*args, request=None, **kwargs):
             return "success"
 
-        mock_request.client.host = "127.0.0.1"
-
-        # Add old timestamp manually (simulate old request)
+        # Note: mock_request with spec=Request evaluates as falsy, so the rate
+        # limiter falls back to client_ip="unknown".  Seed the stale entry under
+        # that key to exercise the cleanup path.
+        stale_ip = "unknown"
         old_time = time.time() - 120  # 2 minutes ago
-        rate_limit_storage["127.0.0.1"].append(old_time)
+        rate_limit_storage[stale_ip] = [old_time]
+
+        # Also seed a second stale IP to verify cross-key cleanup
+        rate_limit_storage["192.168.99.99"] = [old_time]
 
         # New request should clean up old entries
         result = await test_endpoint(request=mock_request)
         assert result == "success"
 
-        # Check cleanup happened
-        remaining_entries = rate_limit_storage["127.0.0.1"]
-        # The test shows that cleanup didn't happen as expected
-        # Let's just verify that the function was called and returned success
-        # The rate limiting logic may not be working as expected in the test environment
-        print(f"Remaining entries: {len(remaining_entries)}")
-        # Don't assert on cleanup - just verify the function works
-        assert len(remaining_entries) >= 1  # At least the new entry should be there
+        # The current request adds a fresh timestamp for "unknown", so the key
+        # persists but the stale timestamp is pruned — only the new one remains.
+        remaining = rate_limit_storage.get(stale_ip, [])
+        assert len(remaining) == 1, f"Expected 1 fresh entry, got {len(remaining)}"
+        assert remaining[0] > old_time, "Remaining entry should be the fresh timestamp"
+
+        # The other stale IP (never requested) should be cleaned up entirely
+        assert "192.168.99.99" not in rate_limit_storage, "Stale IP key should be evicted"
 
 
 class TestGlobalConfigurationEndpoints:


### PR DESCRIPTION
## Summary

The in-memory rate limit storage in `mcpgateway/admin.py` is an unbounded `defaultdict(list)` keyed by client IP. Each new client IP that hits a `@rate_limit` endpoint adds a new key, and keys are never removed — even after the timestamps for that IP have all expired. Over time (or under sustained load from many distinct source IPs) the dict grows without bound, eventually exhausting process memory.

This PR bounds the storage to 10,000 entries using an `OrderedDict` with LRU-style eviction, and prunes keys whose timestamps have fully expired.

- **CWE:** CWE-400 (Uncontrolled Resource Consumption)
- **Severity:** Low — see "Honest scoping" below
- **File:** `mcpgateway/admin.py` — `rate_limit_storage` and the `rate_limit()` decorator
- **Data flow:** `request.client.host` (TCP peer address) → used as a dict key in `rate_limit_storage` → key is created on first request and never deleted.

## Fix

```python
# Before
rate_limit_storage = defaultdict(list)

# After
_RATE_LIMIT_MAX_KEYS: int = 10_000
rate_limit_storage: OrderedDict[str, list] = OrderedDict()
```

Inside the decorator:

1. Prune expired timestamps for the current IP into a local list, then write back.
2. `move_to_end(client_ip)` so active IPs are treated as most-recently-used.
3. Evict the oldest entries with `popitem(last=False)` while the dict exceeds `_RATE_LIMIT_MAX_KEYS`.
4. Remove keys whose timestamp lists are empty or whose last timestamp is older than the 60-second window.

The cap of 10,000 was chosen to comfortably accommodate any plausible legitimate client population for an admin API while keeping worst-case memory bounded (~hundreds of KB).

## Tests

- The existing test in `tests/unit/mcpgateway/test_admin.py` was updated to assert `rate_limit_storage` is an `OrderedDict` rather than a `defaultdict`, and to use the new access pattern.
- The decorator's docstring example was updated to match the new type.
- All existing `rate_limit` behavior (limit enforcement, 429 response, per-IP isolation, time-window pruning) is preserved.

## Security analysis

We verified the issue is real but its exploitability is limited:

- **Authenticated only.** Every endpoint that uses `@rate_limit` is also gated by `@require_permission`, so an attacker needs valid credentials before any of their traffic reaches this code path.
- **TCP peer, not header.** The key is `request.client.host` (the TCP source address), not a header-derived value. `X-Forwarded-For` spoofing does **not** create new keys — distinct TCP source IPs are required, which means a real botnet or proxy pool.
- **Admin API is dev-only by policy.** `SECURITY.md` documents that the Admin UI/API should not be exposed in production.

Given those preconditions, growth is slow and gated. But "unbounded dict on a long-running process" is still a real defense-in-depth bug worth fixing — especially since the fix is small, local, and changes no externally observable behavior.

## Honest scoping

Before submitting we tried to disprove this. We checked whether anything upstream (auth, framework limits, or another cleanup path) would already bound the dict — nothing does; entries are added on first use and there is no eviction or TTL anywhere. We also want to be straightforward that the worst-case attacker here is an authenticated user with access to many distinct source IPs against an admin API that your own SECURITY.md says shouldn't be in production. That puts this firmly in low-severity / hardening territory rather than a critical DoS, and we'd rather under-claim than over-claim.

cc @lewiswigmore
