### PR TITLE
feat(oauth): allow operator-defined multi-audience for virtual servers

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2878,6 +2878,7 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
             authorization_server = str(form.get("oauth_authorization_server", "")).strip()
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
+            oauth_resource_raw = str(form.get("oauth_resource", "")).strip()
 
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
@@ -2886,6 +2887,19 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+                if oauth_resource_raw:
+                    try:
+                        parsed_resource = json.loads(oauth_resource_raw)
+                    except (json.JSONDecodeError, ValueError):
+                        parsed_resource = None
+                    if isinstance(parsed_resource, list):
+                        cleaned = [r.strip() for r in parsed_resource if isinstance(r, str) and r.strip()]
+                        if len(cleaned) == 1:
+                            oauth_config["resource"] = cleaned[0]
+                        elif len(cleaned) > 1:
+                            oauth_config["resource"] = cleaned
+                    elif isinstance(parsed_resource, str) and parsed_resource.strip():
+                        oauth_config["resource"] = parsed_resource.strip()
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(
@@ -3035,6 +3049,7 @@ async def admin_edit_server(
             authorization_server = str(form.get("oauth_authorization_server", "")).strip()
             scopes_str = str(form.get("oauth_scopes", "")).strip()
             token_endpoint = str(form.get("oauth_token_endpoint", "")).strip()
+            oauth_resource_raw = str(form.get("oauth_resource", "")).strip()
 
             if authorization_server:
                 oauth_config = {"authorization_servers": [authorization_server]}
@@ -3043,6 +3058,19 @@ async def admin_edit_server(
                     oauth_config["scopes_supported"] = scopes_str.split()
                 if token_endpoint:
                     oauth_config["token_endpoint"] = token_endpoint
+                if oauth_resource_raw:
+                    try:
+                        parsed_resource = json.loads(oauth_resource_raw)
+                    except (json.JSONDecodeError, ValueError):
+                        parsed_resource = None
+                    if isinstance(parsed_resource, list):
+                        cleaned = [r.strip() for r in parsed_resource if isinstance(r, str) and r.strip()]
+                        if len(cleaned) == 1:
+                            oauth_config["resource"] = cleaned[0]
+                        elif len(cleaned) > 1:
+                            oauth_config["resource"] = cleaned
+                    elif isinstance(parsed_resource, str) and parsed_resource.strip():
+                        oauth_config["resource"] = parsed_resource.strip()
             else:
                 # Invalid or incomplete OAuth configuration; disable OAuth to avoid inconsistent state
                 LOGGER.warning(

--- a/mcpgateway/admin_ui/admin.js
+++ b/mcpgateway/admin_ui/admin.js
@@ -426,10 +426,11 @@ Admin.resetImportSelection = resetImportSelection;
 Admin.handleSelectiveImport = handleSelectiveImport;
 
 // Servers
-import { viewServer, editServer } from "./servers.js";
+import { viewServer, editServer, addOauthResource } from "./servers.js";
 
 Admin.viewServer = viewServer;
 Admin.editServer = editServer;
+Admin.addOauthResource = addOauthResource;
 
 // Tabs
 import { showTab } from "./tabs.js";

--- a/mcpgateway/admin_ui/servers.js
+++ b/mcpgateway/admin_ui/servers.js
@@ -17,6 +17,111 @@ import {
   makeCopyIdButton,
 } from "./utils.js";
 
+let _oauthResourceCounter = 0;
+
+/**
+ * Add a new OAuth resource (audience) row to the specified container.
+ * @param {string} containerId - ID of the container div
+ * @param {string} [value=""] - Pre-populated audience value
+ * @param {boolean} [focus=true] - Whether to focus the value input
+ */
+export function addOauthResource(containerId, value = "", focus = true) {
+  const container = safeGetElement(containerId);
+  if (!container) {
+    console.error(`Container with ID ${containerId} not found`);
+    return;
+  }
+
+  const rowId = `oauth-resource-row-${++_oauthResourceCounter}`;
+  const row = document.createElement("div");
+  row.id = rowId;
+  row.className = "flex items-center space-x-2";
+
+  row.innerHTML = `
+    <div class="flex-1">
+      <input
+        type="text"
+        placeholder="https://api.example.com or your-client-id"
+        class="oauth-resource-value block w-full px-3 py-2 rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300 text-sm"
+      />
+    </div>
+    <button
+      type="button"
+      class="inline-flex items-center px-2 py-1 border border-transparent text-sm leading-4 font-medium rounded-md text-red-700 bg-red-100 hover:bg-red-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 dark:bg-red-900 dark:text-red-300 dark:hover:bg-red-800"
+      title="Remove audience"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+      </svg>
+    </button>
+  `;
+
+  const valueInput = row.querySelector(".oauth-resource-value");
+  const removeBtn = row.querySelector("button");
+
+  valueInput.value = value;
+
+  valueInput.addEventListener("input", () => updateOauthResourceJSON(containerId));
+  removeBtn.addEventListener("click", () => {
+    row.remove();
+    updateOauthResourceJSON(containerId);
+  });
+
+  container.appendChild(row);
+  updateOauthResourceJSON(containerId);
+
+  if (focus && valueInput) {
+    valueInput.focus();
+  }
+}
+
+/**
+ * Sync all OAuth resource rows into the hidden JSON input.
+ * @param {string} containerId - ID of the container div
+ */
+export function updateOauthResourceJSON(containerId) {
+  const container = safeGetElement(containerId);
+  if (!container) return;
+
+  const values = [];
+  const rows = container.querySelectorAll('[id^="oauth-resource-row-"]');
+  rows.forEach((row) => {
+    const v = row.querySelector(".oauth-resource-value")?.value?.trim();
+    if (v) values.push(v);
+  });
+
+  const hiddenId = containerId.replace("-container", "-json");
+  const hiddenInput = safeGetElement(hiddenId);
+  if (hiddenInput) {
+    hiddenInput.value = values.length > 0 ? JSON.stringify(values) : "";
+  }
+}
+
+/**
+ * Populate OAuth resource rows from an existing string or list value.
+ * @param {string} containerId - ID of the container div
+ * @param {string|string[]|null|undefined} resource - Stored ``oauth_config.resource`` value
+ */
+export function loadOauthResources(containerId, resource) {
+  const container = safeGetElement(containerId);
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  let values = [];
+  if (Array.isArray(resource)) {
+    values = resource.filter((v) => typeof v === "string" && v.trim());
+  } else if (typeof resource === "string" && resource.trim()) {
+    values = [resource.trim()];
+  }
+
+  values.forEach((v) => {
+    addOauthResource(containerId, v, false);
+  });
+
+  updateOauthResourceJSON(containerId);
+}
+
 /**
  * SECURE: View Server function
  */
@@ -855,11 +960,17 @@ export const editServer = async function (serverId) {
       if (oauthTokenEndpointField) {
         oauthTokenEndpointField.value = server.oauthConfig.token_endpoint || "";
       }
+
+      loadOauthResources(
+        "edit-server-oauth-resource-container",
+        server.oauthConfig.resource
+      );
     } else {
       // Clear OAuth config fields when no config exists
       if (oauthAuthServerField) oauthAuthServerField.value = "";
       if (oauthScopesField) oauthScopesField.value = "";
       if (oauthTokenEndpointField) oauthTokenEndpointField.value = "";
+      loadOauthResources("edit-server-oauth-resource-container", []);
     }
 
     // Store server data for modal population

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3377,6 +3377,29 @@
                     Leave blank to use standard discovery from authorization server
                   </p>
                 </div>
+                <div>
+                  <label
+                    class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                    >Resource (Audience) (optional)</label
+                  >
+                  <div id="server-oauth-resource-container" class="mt-1 space-y-2"></div>
+                  <button
+                    type="button"
+                    onclick="Admin.addOauthResource('server-oauth-resource-container')"
+                    class="mt-2 inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-700 shadow-sm text-sm leading-4 font-medium rounded-md text-indigo-700 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-gray-900 dark:text-indigo-300 dark:hover:bg-gray-800"
+                  >
+                    + Add Audience
+                  </button>
+                  <input
+                    type="hidden"
+                    name="oauth_resource"
+                    id="server-oauth-resource-json"
+                    value=""
+                  />
+                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Allowed <code>aud</code> values. Leave empty to auto-learn from the first verified token.
+                  </p>
+                </div>
               </div>
             </div>
 
@@ -11705,6 +11728,29 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                       />
                       <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         Leave blank to use standard discovery from authorization server
+                      </p>
+                    </div>
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                        >Resource (Audience) (optional)</label
+                      >
+                      <div id="edit-server-oauth-resource-container" class="mt-1 space-y-2"></div>
+                      <button
+                        type="button"
+                        onclick="Admin.addOauthResource('edit-server-oauth-resource-container')"
+                        class="mt-2 inline-flex items-center px-3 py-1.5 border border-gray-300 dark:border-gray-700 shadow-sm text-sm leading-4 font-medium rounded-md text-indigo-700 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:bg-gray-900 dark:text-indigo-300 dark:hover:bg-gray-800"
+                      >
+                        + Add Audience
+                      </button>
+                      <input
+                        type="hidden"
+                        name="oauth_resource"
+                        id="edit-server-oauth-resource-json"
+                        value=""
+                      />
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Allowed <code>aud</code> values. Leave empty to auto-learn from the first verified token.
                       </p>
                     </div>
                   </div>

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -5415,10 +5415,15 @@ class _StreamableHttpAuthHandler:
         #    enabling cross-resource token confusion in shared-IdP
         #    deployments.
         configured_resource = server.oauth_config.get("resource")
-        expected_audience: Optional[Union[str, list[str]]]
-        if configured_resource:
-            expected_audience = configured_resource
-        else:
+        expected_audience: Optional[Union[str, list[str]]] = None
+        if isinstance(configured_resource, str) and configured_resource.strip():
+            expected_audience = configured_resource.strip()
+        elif isinstance(configured_resource, list):
+            cleaned_resources = [r.strip() for r in configured_resource if isinstance(r, str) and r.strip()]
+            if cleaned_resources:
+                expected_audience = cleaned_resources[0] if len(cleaned_resources) == 1 else cleaned_resources
+
+        if expected_audience is None:
             fallback_audiences: list[str] = []
             canonical_url = _build_server_resource_url(self.scope, server_id)
             if canonical_url:

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -342,6 +342,82 @@ class TestAdminServerAPIs:
         response = await client.post(f"/admin/servers/{server_id}/delete", headers=TEST_AUTH_HEADER, follow_redirects=False)
         assert response.status_code == 303
 
+    async def test_admin_server_oauth_resource_multi_audience(self, client: AsyncClient, mock_settings):
+        """Multi-audience oauth_resource round-trips through create / read / edit."""
+        # Standard
+        import json as _json
+
+        unique_name = f"test_admin_server_oauth_{uuid.uuid4().hex[:8]}"
+        create = {
+            "name": unique_name,
+            "description": "OAuth multi-aud server",
+            "associatedTools": "",
+            "associatedResources": "",
+            "associatedPrompts": "",
+            "visibility": "public",
+            "oauth_enabled": "on",
+            "oauth_authorization_server": "https://idp.example.com",
+            "oauth_resource": _json.dumps(["aud-a", "aud-b"]),
+        }
+        response = await client.post("/admin/servers", data=create, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        assert response.status_code == 200
+
+        listing = await client.get("/admin/servers", headers=TEST_AUTH_HEADER)
+        servers = listing.json()
+        servers = servers["data"] if isinstance(servers, dict) else servers
+        server = next((s for s in servers if s["name"] == unique_name), None)
+        assert server is not None
+        server_id = server["id"]
+
+        detail = await client.get(f"/admin/servers/{server_id}", headers=TEST_AUTH_HEADER)
+        assert detail.status_code == 200
+        oauth_config = detail.json().get("oauthConfig") or detail.json().get("oauth_config")
+        assert oauth_config is not None
+        assert oauth_config["resource"] == ["aud-a", "aud-b"]
+
+        edit = dict(create)
+        edit["oauth_resource"] = _json.dumps(["aud-only"])
+        response = await client.post(f"/admin/servers/{server_id}/edit", data=edit, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        assert response.status_code == 200
+
+        detail = await client.get(f"/admin/servers/{server_id}", headers=TEST_AUTH_HEADER)
+        oauth_config = detail.json().get("oauthConfig") or detail.json().get("oauth_config")
+        assert oauth_config["resource"] == "aud-only"
+
+        await client.post(f"/admin/servers/{server_id}/delete", headers=TEST_AUTH_HEADER, follow_redirects=False)
+
+    async def test_admin_server_oauth_resource_backward_compat_string(self, client: AsyncClient, mock_settings):
+        """Existing single-string callers (no JSON) still create cleanly via the form."""
+        # Standard
+        import json as _json
+
+        unique_name = f"test_admin_server_oauth_compat_{uuid.uuid4().hex[:8]}"
+        create = {
+            "name": unique_name,
+            "description": "OAuth single-aud server",
+            "associatedTools": "",
+            "associatedResources": "",
+            "associatedPrompts": "",
+            "visibility": "public",
+            "oauth_enabled": "on",
+            "oauth_authorization_server": "https://idp.example.com",
+            "oauth_resource": _json.dumps("legacy-string-aud"),
+        }
+        response = await client.post("/admin/servers", data=create, headers=TEST_AUTH_HEADER, follow_redirects=False)
+        assert response.status_code == 200
+
+        listing = await client.get("/admin/servers", headers=TEST_AUTH_HEADER)
+        servers = listing.json()
+        servers = servers["data"] if isinstance(servers, dict) else servers
+        server = next((s for s in servers if s["name"] == unique_name), None)
+        assert server is not None
+
+        detail = await client.get(f"/admin/servers/{server['id']}", headers=TEST_AUTH_HEADER)
+        oauth_config = detail.json().get("oauthConfig") or detail.json().get("oauth_config")
+        assert oauth_config["resource"] == "legacy-string-aud"
+
+        await client.post(f"/admin/servers/{server['id']}/delete", headers=TEST_AUTH_HEADER, follow_redirects=False)
+
 
 # -------------------------
 # Test Tool Admin APIs

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1260,6 +1260,146 @@ class TestAdminServerRoutes:
         assert "include_inactive=true" in location
         assert "nope" in location
 
+    # ------------------------------------------------------------------
+    # oauth_resource (Resource / Audience) form parsing — multi-audience
+    # ------------------------------------------------------------------
+
+    def _oauth_form(self, **overrides):
+        base = {
+            "id": "00000000-0000-0000-0000-0000000000ff",
+            "name": "S",
+            "oauth_enabled": "on",
+            "oauth_authorization_server": "https://idp.example.com",
+            "visibility": "public",
+            "associatedTools": [],
+            "associatedResources": [],
+            "associatedPrompts": [],
+        }
+        base.update(overrides)
+        return FakeForm(base)
+
+    def _setup_team_and_metadata(self, monkeypatch):
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            lambda *_args, **_kwargs: {
+                "created_by": "u@example.com",
+                "created_from_ip": None,
+                "created_via": "ui",
+                "created_user_agent": None,
+                "import_batch_id": None,
+                "federation_source": None,
+            },
+        )
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_json_array_single(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """JSON array with a single value is stored as a string."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource=json.dumps(["https://api.example.com"])))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert oauth_config["resource"] == "https://api.example.com"
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_json_array_multi(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """JSON array with 2+ values is stored as a list."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource=json.dumps(["a", "b"])))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert oauth_config["resource"] == ["a", "b"]
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_json_array_empty(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """An empty JSON array does not set the resource key at all."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource=json.dumps([])))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert "resource" not in oauth_config
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_json_string(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """A bare JSON-encoded string is stored as a string."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource=json.dumps("solo-aud")))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert oauth_config["resource"] == "solo-aud"
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_invalid_json_ignored(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """Malformed JSON is silently ignored; the rest of oauth_config still saves."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource="{not json"))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert "resource" not in oauth_config
+        assert oauth_config["authorization_servers"] == ["https://idp.example.com"]
+
+    @patch.object(ServerService, "register_server")
+    async def test_admin_add_server_oauth_resource_trims_whitespace(self, mock_register_server, mock_request, mock_db, monkeypatch):
+        """Whitespace inside array entries is trimmed and empty strings dropped."""
+        mock_request.form = AsyncMock(return_value=self._oauth_form(oauth_resource=json.dumps(["  a  ", "", "b"])))
+        self._setup_team_and_metadata(monkeypatch)
+
+        result = await admin_add_server(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        oauth_config = mock_register_server.call_args.args[1].oauth_config
+        assert oauth_config["resource"] == ["a", "b"]
+
+    @patch.object(ServerService, "update_server")
+    async def test_admin_edit_server_oauth_resource_json_array_single(self, mock_update_server, mock_request, mock_db):
+        """admin_edit_server: single-element array → string."""
+        server_id = "00000000-0000-0000-0000-000000000010"
+        mock_request.form = AsyncMock(return_value=self._oauth_form(id=server_id, oauth_resource=json.dumps(["one"])))
+        mock_request.scope = {"root_path": ""}
+        mock_update_server.return_value = MagicMock(model_dump=lambda: {})
+
+        result = await admin_edit_server(server_id, mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        server_update = mock_update_server.call_args[0][2]
+        assert server_update.oauth_config["resource"] == "one"
+
+    @patch.object(ServerService, "update_server")
+    async def test_admin_edit_server_oauth_resource_json_array_multi(self, mock_update_server, mock_request, mock_db):
+        """admin_edit_server: multi-element array → list."""
+        server_id = "00000000-0000-0000-0000-000000000011"
+        mock_request.form = AsyncMock(return_value=self._oauth_form(id=server_id, oauth_resource=json.dumps(["x", "y"])))
+        mock_request.scope = {"root_path": ""}
+        mock_update_server.return_value = MagicMock(model_dump=lambda: {})
+
+        result = await admin_edit_server(server_id, mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        server_update = mock_update_server.call_args[0][2]
+        assert server_update.oauth_config["resource"] == ["x", "y"]
+
+    @patch.object(ServerService, "update_server")
+    async def test_admin_edit_server_oauth_resource_invalid_json_ignored(self, mock_update_server, mock_request, mock_db):
+        """admin_edit_server: malformed JSON is silently ignored."""
+        server_id = "00000000-0000-0000-0000-000000000012"
+        mock_request.form = AsyncMock(return_value=self._oauth_form(id=server_id, oauth_resource="???"))
+        mock_request.scope = {"root_path": ""}
+        mock_update_server.return_value = MagicMock(model_dump=lambda: {})
+
+        result = await admin_edit_server(server_id, mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert result.status_code == 200
+        server_update = mock_update_server.call_args[0][2]
+        assert "resource" not in server_update.oauth_config
+
 
 class TestAdminToolRoutes:
     """Test admin routes for tool management with enhanced coverage."""

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -17025,3 +17025,176 @@ async def test_list_tools_sso_admin_gets_admin_bypass_at_service_layer(monkeypat
     await list_tools()
 
     assert called["args"] == (None, None)
+# Multi-audience resource (oauth_config["resource"] str | list[str])
+# ---------------------------------------------------------------------------
+
+
+def _make_oauth_handler(server_oauth_config, monkeypatch, *, verify_return=None, verify_capture=None, patch_persist=True, app_domain="https://gateway.example"):
+    """Wire ``_try_oauth_access_token`` end-to-end.
+
+    Returns ``(handler, captured, mock_db, mock_server)``. ``captured["expected_audience"]``
+    is filled by the patched ``verify_oauth_access_token``. When ``patch_persist`` is
+    False the real prod ``_persist_learned_server_audience`` runs against ``mock_db``
+    so callers can assert side effects (or the absence of them).
+    """
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler
+
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+    mock_server.oauth_config = server_oauth_config
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _make_fake_get_db(mock_db))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.app_domain", app_domain)
+
+    captured: dict = {}
+
+    async def _fake_verify(token, auth_servers, *, expected_audience=None):
+        captured["expected_audience"] = expected_audience
+        captured["token"] = token
+        if verify_capture is not None:
+            verify_capture(token, auth_servers, expected_audience)
+        return verify_return
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", _fake_verify)
+    if patch_persist:
+        monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", MagicMock())
+
+    user_record = SimpleNamespace(is_admin=False, is_active=True, email="user@example.com")
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", lambda _e: user_record)
+    monkeypatch.setattr("mcpgateway.auth._resolve_teams_from_db", AsyncMock(return_value=[]))
+
+    scope = _make_scope("/servers/abc123/mcp", headers=[(b"host", b"gateway.example")])
+    handler = _StreamableHttpAuthHandler(scope=scope, receive=AsyncMock(), send=AsyncMock())
+    return handler, captured, mock_db, mock_server
+
+
+_CANONICAL_AUD = "https://gateway.example/servers/abc123/mcp"
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_string_resource_passed_through(monkeypatch):
+    """String resource is forwarded as-is (after strip)."""
+    claims = {"iss": "https://idp.example.com", "aud": "https://api.example.com", "email": "user@example.com"}
+    handler, captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": "  https://api.example.com  "},
+        monkeypatch,
+        verify_return=claims,
+    )
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert captured["expected_audience"] == "https://api.example.com"
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_list_resource_multiple_passed_as_list(monkeypatch):
+    """A list with 2+ entries is forwarded as a list (any-element semantics)."""
+    claims = {"iss": "https://idp.example.com", "aud": "client-b", "email": "user@example.com"}
+    handler, captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": ["client-a", "client-b"]},
+        monkeypatch,
+        verify_return=claims,
+    )
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert captured["expected_audience"] == ["client-a", "client-b"]
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_list_resource_single_unwrapped(monkeypatch):
+    """A list with 1 entry collapses to a string."""
+    claims = {"iss": "https://idp.example.com", "aud": "only-one", "email": "user@example.com"}
+    handler, captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": ["only-one"]},
+        monkeypatch,
+        verify_return=claims,
+    )
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert captured["expected_audience"] == "only-one"
+    assert isinstance(captured["expected_audience"], str)
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_list_resource_mismatch_returns_failed(monkeypatch):
+    """When verify returns None (PyJWT InvalidAudience) the handler returns FAILED."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import _StreamableHttpAuthHandler
+
+    monkeypatch.setattr(_StreamableHttpAuthHandler, "_send_error", AsyncMock(return_value=False))
+    handler, _captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": ["a", "b"]},
+        monkeypatch,
+        verify_return=None,
+    )
+    unverified = {"iss": "https://idp.example.com"}
+
+    result = await handler._try_oauth_access_token("tok", unverified)
+    assert result is tr.OAuthAuthResult.FAILED
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_empty_list_resource_uses_fallback(monkeypatch):
+    """An empty list (or list of empty strings) falls through to the canonical-URL fallback."""
+    claims = {"iss": "https://idp.example.com", "aud": _CANONICAL_AUD, "email": "user@example.com"}
+    handler, captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": ["", "   "]},
+        monkeypatch,
+        verify_return=claims,
+    )
+
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert captured["expected_audience"] == _CANONICAL_AUD
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_malformed_resource_uses_fallback(monkeypatch):
+    """A list of non-strings is treated as unset; fallback resolves to the canonical URL."""
+    claims = {"iss": "https://idp.example.com", "aud": _CANONICAL_AUD, "email": "user@example.com"}
+    handler, captured, _db, _srv = _make_oauth_handler(
+        {"authorization_servers": ["https://idp.example.com"], "resource": [1, 2, {"x": "y"}]},
+        monkeypatch,
+        verify_return=claims,
+    )
+
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert captured["expected_audience"] == _CANONICAL_AUD
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_list_resource_does_not_overwrite_existing_resource(monkeypatch):
+    """A truthy list resource hits the first-write-only guard inside _persist_learned_server_audience.
+
+    Asserts the real prod helper is invoked (so the guard is actually exercised)
+    AND that no DB write side-effects occur: ``db.flush`` is not called and
+    ``server.oauth_config`` is not mutated.
+    """
+    original_config = {"authorization_servers": ["https://idp.example.com"], "resource": ["client-a", "client-b"]}
+    claims = {"iss": "https://idp.example.com", "aud": "client-a", "email": "user@example.com"}
+    handler, _captured, mock_db, mock_server = _make_oauth_handler(
+        original_config,
+        monkeypatch,
+        verify_return=claims,
+        patch_persist=False,
+    )
+
+    unverified = {"iss": "https://idp.example.com"}
+    result = await handler._try_oauth_access_token("tok", unverified)
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    mock_db.flush.assert_not_called()
+    assert mock_server.oauth_config == original_config


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4609 

---

## 📝 Summary
Virtual servers with `oauth_enabled=true` cannot complete inbound OAuth verification on IdPs that don't honor RFC 8707 (e.g. Authentik), because such IdPs mint tokens with `aud == client_id`. Auto-learn (#4404, #4410, #4475) is supposed to handle this, but the fallback path it depends on never matches before learning can fire — so the audience can't be bootstrapped, and authentication fails on every request.

This PR adds an explicit operator-defined audience list to the virtual-server OAuth config: `oauth_config.resource` accepts a string or `list[str]`, with a small "+ Add Audience" UI on the server create/edit forms. The primary goal is to unblock the cold-start case, and as a side benefit it also supports multi-client setups where a single virtual server needs to accept tokens from multiple OAuth clients (not the main motivation, but covered naturally).

Auto-learn behavior is unchanged — the existing first-write-only guard means an operator-defined value is preserved, and leaving the field empty falls back to auto-learn.

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |   pass     |
| Coverage ≥ 80%            | `make coverage` |   pass  |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Tests added: 7 transport-layer (str / list 2+ / single-list unwrap / list mismatch / empty / malformed / first-write-only no-op), 9 admin form parser (JSON array shapes / bare string / invalid JSON / whitespace), 2 admin API e2e (multi-audience round-trip, single-string backward compatibility).

Backward compatible: existing single-string `oauth_config.resource` values continue to work; no schema migration.

<img width="1035" height="574" alt="스크린샷 2026-05-06 오후 1 55 35" src="https://github.com/user-attachments/assets/ca0f852e-5434-41f5-8df1-aa44a5bdca7f" />

