### PR TITLE
fix(admin-ui): namespace onsubmit handlers in LLM provider/model forms

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2078,7 +2078,7 @@
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="Admin.closeLLMProviderModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
             <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-              <form id="llm-provider-form" onsubmit="saveLLMProvider(event)">
+              <form id="llm-provider-form" onsubmit="Admin.saveLLMProvider(event)">
                 <input type="hidden" id="llm-provider-id" name="provider_id" value="">
                 <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4" id="llm-provider-modal-title">
@@ -2176,7 +2176,7 @@
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="Admin.closeLLMModelModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
             <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-              <form id="llm-model-form" onsubmit="saveLLMModel(event)">
+              <form id="llm-model-form" onsubmit="Admin.saveLLMModel(event)">
                 <input type="hidden" id="llm-model-id" name="model_id" value="">
                 <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4" id="llm-model-modal-title">


### PR DESCRIPTION
## Summary

Closes #4619.

The "Add LLM Provider" and "Add LLM Model" modals at `/admin/#llm-settings` silently fail when clicking the Save button: the modal closes, no entity is created, no error toast, no log line.

Root cause: the two forms' inline `onsubmit` attributes reference bare globals (`saveLLMProvider` / `saveLLMModel`), but `admin.js` registers those handlers only on the `Admin` namespace (`Admin.saveLLMProvider`, `Admin.saveLLMModel`) — they are never exposed on `window`. The bare references therefore raise `ReferenceError`, and with no `return false`/`preventDefault` the browser falls back to a default form submit (no `action`/`method` set), which silently re-renders the page and dismisses the modal — no POST is ever sent.

The selects right next to the broken forms already use the correct namespaced form: `onchange="Admin.onLLMProviderTypeChange()"` (line 2095) and `onchange="Admin.onModelProviderChange()"` (line 2193). Only the two `onsubmit` calls were missed.

A scan of all other inline handlers in `admin.html` confirms these are the only two cases — every other `onclick`/`onchange`/`onsubmit` references a real `window` global. The fix is therefore safe to apply minimally.

## Changes

`mcpgateway/templates/admin.html`:

```diff
-              <form id="llm-provider-form" onsubmit="saveLLMProvider(event)">
+              <form id="llm-provider-form" onsubmit="Admin.saveLLMProvider(event)">
...
-              <form id="llm-model-form" onsubmit="saveLLMModel(event)">
+              <form id="llm-model-form" onsubmit="Admin.saveLLMModel(event)">
```

## Verification

Verified locally against `ghcr.io/ibm/mcp-context-forge:1.0.0` by bind-mounting the patched template:

- **Add Provider** flow now fires `POST /llm/providers → 201 Created`; provider appears in the list.
- **Add Model** flow now fires `POST /llm/models → 201 Created`; model appears in the list.

DevTools state confirms the namespacing is the only thing that changed:
```
typeof window.saveLLMProvider          // "undefined" (still)
typeof window.Admin.saveLLMProvider    // "function"
typeof window.saveLLMModel             // "undefined" (still)
typeof window.Admin.saveLLMModel       // "function"
```

## Test plan
- [ ] Pull this branch, run the gateway, sign in as the platform admin, navigate to `/admin/#llm-settings`.
- [ ] Click **Add Provider** → fill name/type/key → **Save Provider** → confirm 201 + provider appears in list.
- [ ] Switch to **Models** tab → click **Add Model** → pick provider, fill model id + display name → **Save Model** → confirm 201 + model appears in list.