### PR TITLE
fix(chore): centralize Layer-1 visibility filter across REST endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-07T10:14:38Z",
+  "generated_at": "2026-08-07T13:52:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -216,7 +216,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -224,7 +224,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 302,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +232,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 304,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 366,
+        "line_number": 376,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 367,
+        "line_number": 377,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2032,
+        "line_number": 2039,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2120,
+        "line_number": 2127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2470,
+        "line_number": 2477,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3835,
+        "line_number": 3842,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3926,
+        "line_number": 3933,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3969,
+        "line_number": 3976,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3974,
+        "line_number": 3981,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3979,
+        "line_number": 3986,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,16 @@ ContextForge implements a **two-layer security model**:
 - **Layer 1 only**: Token scoping controls visibility (what you can see). RBAC (Layer 2) is evaluated independently — session-token narrowing does not restrict which team roles are checked for permissions.
 - **External IdP tokens**: identities provisioned from trusted external SSO providers (see `SSO_API_TOKEN_AUTH_ENABLED`) are dispatched through the session-token table above (`resolve_session_teams()`), not the API/legacy table — `is_admin`/`teams` come from the persisted local user record, never from the external token's claims.
 
+### Implementation Helpers
+
+Layer-1 derivation is centralized in `mcpgateway/auth_context.py`. Route handlers must call these rather than re-deriving the rule inline:
+
+- `get_scoped_resource_access_context(request, user)` → `(user_email, token_teams)` — the visibility scope to pass into service fetch/list/read calls. Admin bypass is signalled by `token_teams=None` while `user_email` is **kept**, so the service can still owner-match the admin's own private rows. Public-only is `(email, [])`.
+- `get_request_identity(request, user)` → `(user_email, is_admin)` — the requester's own identity, for audit capture and header masking. Use when you need the identity independent of the visibility scope.
+- `get_rpc_filter_context(request, user)` → `(user_email, token_teams, is_admin)` — the raw pre-rule triple. Reserved for the few sites that genuinely need `is_admin` or the un-normalized teams (auth-context forwarding, run-ownership capture, tool-execution authorization); these carry a `Layer-1 exception` comment naming the reason.
+
+The derived triple is memoized on `request.state` per principal, so calling the scope and identity helpers together costs one derivation rather than two.
+
 ### Security Invariants (Required)
 
 - Treat `public` as platform-public scope, not internet-anonymous scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **Admins see more rows from visibility-filtered endpoints** ([#4451](https://github.com/IBM/mcp-context-forge/issues/4451)) - Layer-1 visibility derivation in `main.py` is now centralized on `get_scoped_resource_access_context()` instead of being re-implemented inline at each call site. Response shapes, error codes, and non-admin visibility are unchanged; what changes is how many rows an **admin** token sees. No configuration or migration step is required, and the boundary that hides *other* users' private rows is unchanged and covered by deny-path tests. Two distinct changes are bundled here:
+
+    - **Basic-auth and dev-mode admins gain admin bypass across every migrated call site** (27 in this change). The superseded inline derivation read `is_admin` only from a verified JWT payload, so an admin authenticating without one - basic auth, or `AUTH_REQUIRED=false` local setups - was narrowed to public-only. Such callers now receive the intended bypass: public + team + their own private rows. This is the wider-reaching of the two changes and affects an entire authentication mode.
+    - **JWT-authenticated admins now see their own private rows on 10 endpoints** that previously discarded the caller's email when granting bypass, which dropped *every* private row including the admin's own: `GET /tags`, `GET /tags/{tag}/entities`, the JSON-RPC `completion/complete` method, the internal MCP `tools/list`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, and `completion/complete` handlers, and `POST /appbridge/sessions`. On the AppBridge endpoint the effect was a hard failure rather than a short list: an admin opening a session against a `ui://` resource they own received `404 Resource not found`.
+
 ## [1.0.7] - 2026-08-04 - Security Hardening, Unified Search, OAuth Improvements, Dataplane Enhancements, and Operational Reliability
 
 ### Overview

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -784,7 +784,9 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
     cached = getattr(request.state, "_jwt_verified_payload", None)
     if cached and isinstance(cached, tuple) and len(cached) == 2:
         _, payload = cached
-        if payload:
+        # A malformed (non-dict) cached payload carries no usable admin claim; fall through
+        # with is_admin unchanged so the caller defers to RBAC instead of raising.
+        if isinstance(payload, dict):
             # Session tokens ignore JWT is_admin claim — DB is the authority.
             # An old/stale session JWT carrying is_admin=true must not influence
             # the boolean admin decision; only DB-resolved token_teams=None can

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -103,11 +103,14 @@ policy. The key invariants that this module enforces:
 2. ``get_rpc_filter_context`` derives ``is_admin`` from the verified JWT
    payload or the trusted internal MCP auth context - NOT from the DB user -
    so a scoped token (``teams=[]``) cannot inherit admin bypass.
-3. ``get_scoped_resource_access_context`` returns ``(None, None)`` *only* for
-   genuine admin bypass (verified JWT ``is_admin=true`` + ``teams=null``, or
-   non-JWT dev-mode admin). Public-only tokens get ``(email, [])``.
-   Downstream services MUST treat ``(None, None)`` as "admin bypass; still
-   deny private resources" per PR #4341.
+3. ``get_scoped_resource_access_context`` signals admin bypass with
+   ``token_teams=None``, and *only* for genuine admin bypass (verified JWT
+   ``is_admin=true`` + ``teams=null``, or non-JWT dev-mode admin). It keeps
+   ``user_email`` set on that path so the service can owner-match the admin's
+   own private rows; ``(None, None)`` therefore means bypass for a caller with
+   no resolvable email. Public-only tokens get ``(email, [])``. Downstream
+   services MUST treat ``token_teams=None`` as "admin bypass; still deny other
+   users' private resources" per PR #4341.
 4. Non-JWT admin callers (basic-auth / dev mode) keep unrestricted visibility
    via the fallback-admin branch; this carve-out is intentional and documented
    in ``AGENTS.md``.
@@ -720,6 +723,62 @@ def get_token_teams_from_request(request: Request) -> Optional[List[str]]:
     return []
 
 
+# Attribute used to memoize the derived filter context for the life of one request.
+# Handlers that need both the visibility scope and the requester identity call
+# get_scoped_resource_access_context() and get_request_identity() back to back, and
+# both derive via get_rpc_filter_context(); for session tokens that derivation can
+# issue a live EmailUser lookup, so without memoization those handlers pay the query
+# twice per request.
+_RPC_FILTER_CONTEXT_CACHE_ATTR = "_rpc_filter_context_cache"
+
+
+def _get_cached_rpc_filter_context(request: Request, user) -> Optional[tuple[Optional[str], Optional[List[str]], bool]]:
+    """Return the memoized filter context for ``user`` on ``request``, if present.
+
+    The entry is keyed on the identity of the ``user`` object, not just the request:
+    a single request may derive context for more than one principal (for example the
+    synthetic forwarded user built for trusted internal A2A calls), and those must not
+    read each other's cached result.
+
+    Args:
+        request: Incoming request context.
+        user: Authenticated user context the caller is deriving for.
+
+    Returns:
+        The cached ``(user_email, token_teams, is_admin)`` triple, or ``None`` on miss.
+    """
+    state = getattr(request, "state", None)
+    if state is None:
+        return None
+    entry = getattr(state, _RPC_FILTER_CONTEXT_CACHE_ATTR, None)
+    # Guard the shape explicitly: request.state is frequently a MagicMock in tests,
+    # where a plain truthiness check would return a mock instead of missing.
+    if isinstance(entry, tuple) and len(entry) == 2 and entry[0] is user and isinstance(entry[1], tuple) and len(entry[1]) == 3:
+        return entry[1]
+    return None
+
+
+def _cache_rpc_filter_context(request: Request, user, context: tuple[Optional[str], Optional[List[str]], bool]) -> tuple[Optional[str], Optional[List[str]], bool]:
+    """Memoize ``context`` for ``user`` on ``request`` and return it unchanged.
+
+    Args:
+        request: Incoming request context.
+        user: Authenticated user context the result was derived for.
+        context: The ``(user_email, token_teams, is_admin)`` triple to cache.
+
+    Returns:
+        ``context``, so callers can ``return _cache_rpc_filter_context(...)`` directly.
+    """
+    state = getattr(request, "state", None)
+    if state is not None:
+        try:
+            setattr(state, _RPC_FILTER_CONTEXT_CACHE_ATTR, (user, context))
+        except (AttributeError, TypeError):
+            # A read-only or exotic state object is not fatal; skip memoization.
+            pass
+    return context
+
+
 def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optional[List[str]], bool]:
     """Extract ``(user_email, token_teams, is_admin)`` for RPC filtering.
 
@@ -751,6 +810,10 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
         >>> is_admin
         True
     """
+    cached_context = _get_cached_rpc_filter_context(request, user)
+    if cached_context is not None:
+        return cached_context
+
     # Use existing get_user_email() helper for consistent email extraction
     user_email = get_user_email(user)
     # get_user_email() guarantees a string return, but may return "unknown"
@@ -779,13 +842,19 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
         is_admin = bool(internal_auth_context.get("is_admin", False))
         if token_teams is not None and len(token_teams) == 0:
             is_admin = False
-        return user_email, token_teams, is_admin
+        return _cache_rpc_filter_context(request, user, (user_email, token_teams, is_admin))
 
     cached = getattr(request.state, "_jwt_verified_payload", None)
     if cached and isinstance(cached, tuple) and len(cached) == 2:
         _, payload = cached
         # A malformed (non-dict) cached payload carries no usable admin claim; fall through
         # with is_admin unchanged so the caller defers to RBAC instead of raising.
+        if payload is not None and not isinstance(payload, dict):
+            logger.warning(
+                "get_rpc_filter_context: verified JWT payload non-dict type=%s path=%s; treating caller as non-admin",
+                type(payload).__name__,
+                getattr(getattr(request, "url", None), "path", "unknown"),
+            )
         if isinstance(payload, dict):
             # Session tokens ignore JWT is_admin claim — DB is the authority.
             # An old/stale session JWT carrying is_admin=true must not influence
@@ -831,7 +900,7 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
                 db_user_is_admin,
             )
 
-    return user_email, token_teams, is_admin
+    return _cache_rpc_filter_context(request, user, (user_email, token_teams, is_admin))
 
 
 async def is_unrestricted_platform_admin(request: Request, user: Any, db: Session) -> bool:
@@ -931,9 +1000,13 @@ def get_scoped_resource_access_context(request: Request, user) -> tuple[Optional
     the canonical ``(user_email, token_teams)`` input shape for service-layer
     visibility checks:
 
-    - ``(None, None)``: admin bypass. The service still applies the post-PR
-      #4341 rule "admin bypass may see public + team, never another user's
-      private".
+    - ``(email, None)``: admin bypass. ``user_email`` is deliberately preserved
+      so the service can still owner-match the admin's own private rows. The
+      service applies the rule "admin bypass may see public + team + own
+      private, never another user's private".
+    - ``(None, None)``: admin bypass for a caller with no resolvable email
+      (anonymous / dev-mode). The service returns public + team and no private
+      rows at all, since there is no owner to match against.
     - ``(email, [])``: public-only token. Service returns public rows only.
     - ``(email, ["team-a", ...])``: team-scoped token. Service returns
       public rows + team-scoped rows for the listed teams + the caller's own

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -471,6 +471,9 @@ def _build_internal_mcp_auth_context_for_rpc(request: Request, user: Any) -> Dic
     Returns:
         Encodable auth-context dict for ``encode_internal_mcp_auth_context``.
     """
+    # Layer-1 exception: this builds an auth context to forward, it does not derive
+    # visibility scope. It needs the raw pre-rule triple (including is_admin) rather
+    # than the post-rule (user_email, token_teams) from get_scoped_resource_access_context.
     email, token_teams, is_admin = get_rpc_filter_context(request, user)
     # Genuine anonymous / MCP_REQUIRE_AUTH=false public-only callers have no email.
     is_authenticated = email is not None
@@ -1019,6 +1022,9 @@ async def _authorize_run_cancellation(request: Request, user, request_id: str, *
         JSONRPCError: When ``as_jsonrpc_error`` is True and cancellation is not authorized.
         HTTPException: When ``as_jsonrpc_error`` is False and cancellation is not authorized.
     """
+    # Layer-1 exception: run-cancellation authorization compares the requester against the
+    # run owner. It needs the raw token teams and is_admin flag, not the post-rule visibility
+    # scope, so the admin-bypass normalization in get_scoped_resource_access_context does not apply.
     requester_email, requester_token_teams, requester_is_admin = get_rpc_filter_context(request, user)
     requester_teams = [] if requester_token_teams is None else list(requester_token_teams)
     run_status = await cancellation_service.get_status(request_id)
@@ -4876,13 +4882,7 @@ async def get_a2a_agent(
             raise HTTPException(status_code=503, detail="A2A service not available")
 
         # Get filtering context from token (respects token scope)
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-        # Admin bypass - only when token has NO team restrictions
-        if is_admin and token_teams is None:
-            token_teams = None  # Admin unrestricted
-        elif token_teams is None:
-            token_teams = []  # Non-admin without teams = public-only
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         return await a2a_service.get_agent(
             db,
@@ -5188,13 +5188,7 @@ def _extract_a2a_request_context(
         - request_headers: Dict[str, str]
     """
     # Get filtering context from token (respects token scope)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-    # Admin bypass - only when token has NO team restrictions
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     # Extract user ID
     user_id = None
@@ -8534,11 +8528,7 @@ async def handle_internal_mcp_resources_read(request: Request):
                 },
             )
 
-        auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-        if auth_is_admin and auth_token_teams is None:
-            auth_user_email = None
-        elif auth_token_teams is None:
-            auth_token_teams = []
+        auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
 
         plugin_context_table = getattr(request.state, "plugin_context_table", None)
         plugin_global_context = getattr(request.state, "plugin_global_context", None)
@@ -9331,11 +9321,7 @@ async def handle_internal_mcp_prompts_get(request: Request):
                 },
             )
 
-        auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-        if auth_is_admin and auth_token_teams is None:
-            auth_user_email = None
-        elif auth_token_teams is None:
-            auth_token_teams = []
+        auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
 
         plugin_context_table = getattr(request.state, "plugin_context_table", None)
         plugin_global_context = getattr(request.state, "plugin_global_context", None)
@@ -9652,13 +9638,7 @@ async def _authorize_internal_a2a_method(
 def _get_internal_a2a_scope_context(request: Request) -> tuple[Optional[str], Optional[List[str]]]:
     """Return scoped visibility context for trusted internal A2A requests."""
     user = _build_internal_mcp_forwarded_user(request)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-    if is_admin and token_teams is None:
-        return user_email, None
-    if token_teams is None:
-        return user_email, []
-    return user_email, token_teams
+    return get_scoped_resource_access_context(request, user)
 
 
 @utility_router.post("/_internal/a2a/invoke/authz/")
@@ -10267,9 +10247,7 @@ async def _mcp_apps_initialize_authorized(request: Request, db: Session, user, s
     if not server_id:
         return True
 
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    if not (is_admin and token_teams is None) and token_teams is None:
-        token_teams = []
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     try:
         await server_service.get_server(db, server_id, user_email=user_email, token_teams=token_teams)
@@ -10372,6 +10350,9 @@ async def _execute_rpc_tools_call(
     if not name:
         raise JSONRPCError(-32602, "Missing tool name in parameters", params)
 
+    # Layer-1 exception: run ownership (run_owner_email / run_owner_team_ids) must be captured
+    # from the raw pre-rule context before the admin-bypass normalization is applied, so this
+    # site cannot collapse to get_scoped_resource_access_context.
     auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
     run_owner_email = auth_user_email
     run_owner_team_ids = [] if auth_token_teams is None else list(auth_token_teams)
@@ -10487,6 +10468,10 @@ async def create_mcp_app_session(request: Request, db: Session = Depends(get_db)
     server_id = body.get("serverId") or body.get("server_id") or request.headers.get("x-contextforge-server-id")
     if not server_id or not isinstance(server_id, str):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="serverId is required for MCP Apps sessions")
+    # Layer-1 exception: this site keeps user_email and the resource-scope email as separate
+    # values (resource_user_email is nulled for admin bypass while user_email is retained for
+    # the session record), which is not the single-value contract of
+    # get_scoped_resource_access_context. See the tool-execution follow-up noted in issue #4451.
     user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
     if is_admin and token_teams is None:
         resource_user_email = None
@@ -10963,6 +10948,9 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         if (get_internal_mcp_auth_context(request) or {}).get("is_authenticated", True) is True:
             await _ensure_rpc_permission(user, db, "tools.execute", "tools/call", request=request)
 
+        # Layer-1 exception: tool-execution authorization, not resource visibility. Migrating this
+        # to get_scoped_resource_access_context would widen admin execution scope to the admin's own
+        # private tools, which is a behavior change outside the scope of issue #4451.
         auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
         if auth_is_admin and auth_token_teams is None:
             auth_user_email = None
@@ -11169,16 +11157,9 @@ async def _handle_tools_list_rpc(
     Raises:
         HTTPException: If permission check fails
     """
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    _req_email, _req_is_admin = user_email, is_admin
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
+    _req_email, _req_is_admin = get_request_identity(request, user)
     _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
-
-    # Admin bypass - only when token has NO team restrictions
-    if is_admin and token_teams is None:
-        # user_email stays as-is (not None) for owner matching (PR #4341 / issue #4694)
-        token_teams = None  # Admin unrestricted
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
 
     if server_id:
         tools = await tool_svc.list_server_tools(
@@ -11419,12 +11400,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 raise JSONRPCError(-32602, "Missing resource URI in parameters", params)
 
             # Get authorization context (same as resources/list)
-            auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-            if auth_is_admin and auth_token_teams is None:
-                # Keep auth_user_email set for owner matching on the admin's own private rows (PR #4341 / issue #4694)
-                pass  # auth_token_teams stays None (unrestricted)
-            elif auth_token_teams is None:
-                auth_token_teams = []  # Non-admin without teams = public-only
+            auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
 
             # Get user email for OAuth token selection
             oauth_user_email = get_user_email(user)
@@ -11510,12 +11486,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 raise JSONRPCError(-32602, "Missing prompt name in parameters", params)
 
             # Get authorization context (same as prompts/list)
-            auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
-            if auth_is_admin and auth_token_teams is None:
-                # Keep auth_user_email set for owner matching on the admin's own private rows (PR #4341 / issue #4694)
-                pass  # auth_token_teams stays None (unrestricted)
-            elif auth_token_teams is None:
-                auth_token_teams = []  # Non-admin without teams = public-only
+            auth_user_email, auth_token_teams = get_scoped_resource_access_context(request, user)
 
             # Get plugin contexts from request.state for cross-hook sharing
             plugin_context_table = getattr(request.state, "plugin_context_table", None)
@@ -11744,6 +11715,8 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             await _ensure_rpc_permission(user, db, "tools.execute", method, request=request)
 
             # Get authorization context (same as tools/call)
+            # Layer-1 exception: tool-execution authorization, not resource visibility. Kept in sync
+            # with _execute_rpc_tools_call / handle_internal_mcp_tools_call_resolve; see issue #4451.
             auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
             if auth_is_admin and auth_token_teams is None:
                 auth_user_email = None

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -471,9 +471,8 @@ def _build_internal_mcp_auth_context_for_rpc(request: Request, user: Any) -> Dic
     Returns:
         Encodable auth-context dict for ``encode_internal_mcp_auth_context``.
     """
-    # Layer-1 exception: this builds an auth context to forward, it does not derive
-    # visibility scope. It needs the raw pre-rule triple (including is_admin) rather
-    # than the post-rule (user_email, token_teams) from get_scoped_resource_access_context.
+    # Layer-1 exception: forwards an auth context, does not derive visibility scope.
+    # Needs the raw is_admin flag.
     email, token_teams, is_admin = get_rpc_filter_context(request, user)
     # Genuine anonymous / MCP_REQUIRE_AUTH=false public-only callers have no email.
     is_authenticated = email is not None
@@ -1022,9 +1021,8 @@ async def _authorize_run_cancellation(request: Request, user, request_id: str, *
         JSONRPCError: When ``as_jsonrpc_error`` is True and cancellation is not authorized.
         HTTPException: When ``as_jsonrpc_error`` is False and cancellation is not authorized.
     """
-    # Layer-1 exception: run-cancellation authorization compares the requester against the
-    # run owner. It needs the raw token teams and is_admin flag, not the post-rule visibility
-    # scope, so the admin-bypass normalization in get_scoped_resource_access_context does not apply.
+    # Layer-1 exception: compares requester against run owner, so it needs the raw
+    # token teams and is_admin flag rather than the normalized visibility scope.
     requester_email, requester_token_teams, requester_is_admin = get_rpc_filter_context(request, user)
     requester_teams = [] if requester_token_teams is None else list(requester_token_teams)
     run_status = await cancellation_service.get_status(request_id)
@@ -10350,9 +10348,8 @@ async def _execute_rpc_tools_call(
     if not name:
         raise JSONRPCError(-32602, "Missing tool name in parameters", params)
 
-    # Layer-1 exception: run ownership (run_owner_email / run_owner_team_ids) must be captured
-    # from the raw pre-rule context before the admin-bypass normalization is applied, so this
-    # site cannot collapse to get_scoped_resource_access_context.
+    # Layer-1 exception: run ownership is captured below from the raw context,
+    # before admin-bypass normalization is applied.
     auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
     run_owner_email = auth_user_email
     run_owner_team_ids = [] if auth_token_teams is None else list(auth_token_teams)
@@ -10468,10 +10465,8 @@ async def create_mcp_app_session(request: Request, db: Session = Depends(get_db)
     server_id = body.get("serverId") or body.get("server_id") or request.headers.get("x-contextforge-server-id")
     if not server_id or not isinstance(server_id, str):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="serverId is required for MCP Apps sessions")
-    # Layer-1 exception: this site keeps user_email and the resource-scope email as separate
-    # values (resource_user_email is nulled for admin bypass while user_email is retained for
-    # the session record), which is not the single-value contract of
-    # get_scoped_resource_access_context. See the tool-execution follow-up noted in issue #4451.
+    # Layer-1 exception: keeps the resource-scope email separate from user_email,
+    # which the single-value helper contract cannot express.
     user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
     if is_admin and token_teams is None:
         resource_user_email = None
@@ -10948,9 +10943,8 @@ async def handle_internal_mcp_tools_call_resolve(request: Request):
         if (get_internal_mcp_auth_context(request) or {}).get("is_authenticated", True) is True:
             await _ensure_rpc_permission(user, db, "tools.execute", "tools/call", request=request)
 
-        # Layer-1 exception: tool-execution authorization, not resource visibility. Migrating this
-        # to get_scoped_resource_access_context would widen admin execution scope to the admin's own
-        # private tools, which is a behavior change outside the scope of issue #4451.
+        # Layer-1 exception: tool-execution authorization, not resource visibility.
+        # Centralizing here would widen admin execution scope to their own private tools.
         auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
         if auth_is_admin and auth_token_teams is None:
             auth_user_email = None
@@ -11715,8 +11709,8 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             await _ensure_rpc_permission(user, db, "tools.execute", method, request=request)
 
             # Get authorization context (same as tools/call)
-            # Layer-1 exception: tool-execution authorization, not resource visibility. Kept in sync
-            # with _execute_rpc_tools_call / handle_internal_mcp_tools_call_resolve; see issue #4451.
+            # Layer-1 exception: tool-execution authorization, not resource visibility.
+            # Kept in sync with _execute_rpc_tools_call.
             auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
             if auth_is_admin and auth_token_teams is None:
                 auth_user_email = None

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -4057,12 +4057,7 @@ async def handle_completion(request: Request, db: Session = Depends(get_db), use
     """
     body = await _read_request_json(request)
     logger.debug(f"User {SecurityValidator.sanitize_log_message(user['email'])} sent a completion request")
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
     try:
         return await completion_service.handle_completion(db, body, user_email=user_email, token_teams=token_teams)
     except CompletionError as exc:
@@ -4682,16 +4677,9 @@ async def server_get_tools(
         List[ToolRead]: A list of tool records formatted with by_alias=True.
     """
     logger.debug(f"User: {safe_log_user(user)} has listed tools for the server_id: {server_id}")
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    _req_email, _req_is_admin = user_email, is_admin
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
+    _req_email, _req_is_admin = get_request_identity(request, user)
     _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even empty [] for public-only), respect it
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
     tools = await tool_service.list_server_tools(
         db,
         server_id=server_id,
@@ -4735,14 +4723,7 @@ async def server_get_resources(
         List[ResourceRead]: A list of resource records formatted with by_alias=True.
     """
     logger.debug(f"User: {safe_log_user(user)} has listed resources for the server_id: {server_id}")
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even empty [] for public-only), respect it
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
     resources = await resource_service.list_server_resources(
         db, server_id=server_id, include_inactive=include_inactive, include_metrics=include_metrics, user_email=user_email, token_teams=token_teams
     )
@@ -4778,14 +4759,7 @@ async def server_get_prompts(
         List[PromptRead]: A list of prompt records formatted with by_alias=True.
     """
     logger.debug(f"User: {safe_log_user(user)} has listed prompts for the server_id: {server_id}")
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even empty [] for public-only), respect it
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
     prompts = await prompt_service.list_server_prompts(db, server_id=server_id, include_inactive=include_inactive, include_metrics=include_metrics, user_email=user_email, token_teams=token_teams)
     return [prompt.model_dump(by_alias=True) for prompt in prompts]
 
@@ -4838,15 +4812,7 @@ async def list_a2a_agents(
         raise HTTPException(status_code=503, detail="A2A service not available")
 
     # Get filtering context from token (respects token scope)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even for admins), respect it for least-privilege
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     # Check team_id from request.state (set during auth)
     token_team_id = getattr(request.state, "team_id", None)
@@ -5662,17 +5628,9 @@ async def list_tools(
         tags_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
 
     # Get filtering context from token (respects token scope)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
     # Capture original identity for header masking (before admin bypass modifies user_email)
-    _req_email, _req_is_admin = user_email, is_admin
-
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even for admins), respect it for least-privilege
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    _req_email, _req_is_admin = get_request_identity(request, user)
 
     # Check team_id from request.state (set during auth)
     token_team_id = getattr(request.state, "team_id", None)
@@ -6230,15 +6188,7 @@ async def list_resources(
         tags_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
 
     # Get filtering context from token (respects token scope)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even for admins), respect it for least-privilege
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     # Check team_id from request.state (set during auth)
     token_team_id = getattr(request.state, "team_id", None)
@@ -6802,15 +6752,7 @@ async def list_prompts(
         tags_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
 
     # Get filtering context from token (respects token scope)
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-
-    # Admin bypass - only when token has NO team restrictions (token_teams is None)
-    # If token has explicit team scope (even for admins), respect it for least-privilege
-    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
-    if is_admin and token_teams is None:
-        token_teams = None  # Admin unrestricted - sees all public+team resources + own private
-    elif token_teams is None:
-        token_teams = []  # Non-admin without teams = public-only (secure default)
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     # Check team_id from request.state (set during auth)
     token_team_id = getattr(request.state, "team_id", None)
@@ -8392,12 +8334,7 @@ async def handle_internal_mcp_tools_list(request: Request):
             method="tools/list",
             server_id=server_id,
         )
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-            token_teams = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         tools = await tool_service.list_server_mcp_tool_definitions(
             db,
@@ -8487,12 +8424,7 @@ async def handle_internal_mcp_resources_list(request: Request):
             server_id=server_id,
         )
 
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-            token_teams = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         if server_id:
             resources = await resource_service.list_server_resources(
@@ -9063,12 +8995,7 @@ async def handle_internal_mcp_completion_complete(request: Request):
             server_id=server_id,
         )
 
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-            token_teams = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         payload = await completion_service.handle_completion(
             db,
@@ -9290,12 +9217,7 @@ async def handle_internal_mcp_prompts_list(request: Request):
             server_id=server_id,
         )
 
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-            token_teams = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         if server_id:
             prompts = await prompt_service.list_server_prompts(
@@ -11460,13 +11382,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             )
         elif method == "list_gateways":
             await _ensure_rpc_permission(user, db, "gateways.read", method, request=request)
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            # Admin bypass - only when token has NO team restrictions
-            if is_admin and token_teams is None:
-                # Keep user_email set for owner matching on the admin's own private rows (PR #4341 / issue #4694)
-                token_teams = None  # Admin unrestricted
-            elif token_teams is None:
-                token_teams = []  # Non-admin without teams = public-only (secure default)
+            user_email, token_teams = get_scoped_resource_access_context(request, user)
             gateways, next_cursor = await gateway_service.list_gateways(db, include_inactive=False, user_email=user_email, token_teams=token_teams)
             db.commit()
             db.close()
@@ -11481,13 +11397,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             result = {"roots": [r.model_dump(by_alias=True, exclude_none=True) for r in roots]}
         elif method == "resources/list":
             await _ensure_rpc_permission(user, db, "resources.read", method, request=request)
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            # Admin bypass - only when token has NO team restrictions
-            if is_admin and token_teams is None:
-                # Keep user_email set for owner matching on the admin's own private rows (PR #4341 / issue #4694)
-                token_teams = None  # Admin unrestricted
-            elif token_teams is None:
-                token_teams = []  # Non-admin without teams = public-only (secure default)
+            user_email, token_teams = get_scoped_resource_access_context(request, user)
             if server_id:
                 resources = await resource_service.list_server_resources(db, server_id, user_email=user_email, token_teams=token_teams)
                 db.commit()
@@ -11578,13 +11488,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             result = {}
         elif method == "prompts/list":
             await _ensure_rpc_permission(user, db, "prompts.read", method, request=request)
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            # Admin bypass - only when token has NO team restrictions
-            if is_admin and token_teams is None:
-                # Keep user_email set for owner matching on the admin's own private rows (PR #4341 / issue #4694)
-                token_teams = None  # Admin unrestricted
-            elif token_teams is None:
-                token_teams = []  # Non-admin without teams = public-only (secure default)
+            user_email, token_teams = get_scoped_resource_access_context(request, user)
             if server_id:
                 prompts = await prompt_service.list_server_prompts(db, server_id, cursor=cursor, user_email=user_email, token_teams=token_teams)
                 db.commit()
@@ -11812,11 +11716,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
         elif method == "completion/complete":
             await _ensure_rpc_permission(user, db, "tools.read", method, request=request)
             # MCP spec-compliant completion endpoint
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            if is_admin and token_teams is None:
-                user_email = None
-            elif token_teams is None:
-                token_teams = []
+            user_email, token_teams = get_scoped_resource_access_context(request, user)
             try:
                 result = await completion_service.handle_completion(db, params, user_email=user_email, token_teams=token_teams)
             except CompletionError as e:
@@ -12555,11 +12455,7 @@ async def list_tags(
     logger.debug(f"User {safe_log_user(user)} is retrieving tags for entity types: {entity_types_list}, include_entities: {include_entities}")
 
     try:
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         tags = await tag_service.get_all_tags(
             db,
@@ -12609,11 +12505,7 @@ async def get_entities_by_tag(
     logger.debug(f"User {safe_log_user(user)} is retrieving entities for tag '{tag_name}' with entity types: {entity_types_list}")
 
     try:
-        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-        if is_admin and token_teams is None:
-            user_email = None
-        elif token_teams is None:
-            token_teams = []
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
 
         entities = await tag_service.get_entities_by_tag(
             db,

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10465,15 +10465,7 @@ async def create_mcp_app_session(request: Request, db: Session = Depends(get_db)
     server_id = body.get("serverId") or body.get("server_id") or request.headers.get("x-contextforge-server-id")
     if not server_id or not isinstance(server_id, str):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="serverId is required for MCP Apps sessions")
-    # Layer-1 exception: keeps the resource-scope email separate from user_email,
-    # which the single-value helper contract cannot express.
-    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-    if is_admin and token_teams is None:
-        resource_user_email = None
-    else:
-        resource_user_email = user_email
-        if token_teams is None:
-            token_teams = []
+    resource_user_email, token_teams = get_scoped_resource_access_context(request, user)
 
     try:
         await resource_service.read_resource(

--- a/tests/integration/test_admin_bypass_owner_visibility.py
+++ b/tests/integration/test_admin_bypass_owner_visibility.py
@@ -53,6 +53,34 @@ PUBLIC_TAG = "owner-vis-public"
 ADMIN_PRIVATE_PROMPT = "owner-vis-admin-private-prompt"
 OTHER_PRIVATE_PROMPT = "owner-vis-other-private-prompt"
 
+ADMIN_PRIVATE_RESOURCE = "owner-vis://admin-private"
+OTHER_PRIVATE_RESOURCE = "owner-vis://other-private"
+
+
+def _make_resource(owner_email: str, uri: str, visibility: str):
+    """Build a Resource row owned by ``owner_email``.
+
+    Args:
+        owner_email: Email recorded as the resource owner.
+        uri: Unique resource URI.
+        visibility: One of ``public`` / ``team`` / ``private``.
+
+    Returns:
+        An unpersisted ``db_mod.Resource`` instance.
+    """
+    return db_mod.Resource(
+        id=uuid.uuid4().hex,
+        uri=uri,
+        name=uri.rsplit("/", 1)[-1],
+        mime_type="text/plain",
+        text_content="hello",
+        owner_email=owner_email,
+        visibility=visibility,
+        enabled=True,
+        created_by=owner_email,
+        tags=[],
+    )
+
 
 def _make_prompt(owner_email: str, name: str, visibility: str):
     """Build a Prompt row owned by ``owner_email`` with a single completable argument.
@@ -220,6 +248,8 @@ def client_and_db():
     db.add(_make_tool(OTHER_EMAIL, "owner-vis-public-tool", "public", PUBLIC_TAG))
     db.add(_make_prompt(ADMIN_EMAIL, ADMIN_PRIVATE_PROMPT, "private"))
     db.add(_make_prompt(OTHER_EMAIL, OTHER_PRIVATE_PROMPT, "private"))
+    db.add(_make_resource(ADMIN_EMAIL, ADMIN_PRIVATE_RESOURCE, "private"))
+    db.add(_make_resource(OTHER_EMAIL, OTHER_PRIVATE_RESOURCE, "private"))
     db.commit()
 
     # Grant the non-admin caller Layer-2 tags.read so the request reaches the Layer-1
@@ -464,3 +494,44 @@ class TestAdminBypassOwnerVisibilityInternalMcp:
 
         assert ADMIN_PRIVATE_PROMPT not in names
         assert OTHER_PRIVATE_PROMPT not in names
+
+    @staticmethod
+    def _post_resources_list(test_client, monkeypatch, *, email, is_admin, teams):
+        """Call the internal resources/list endpoint with a forged trusted auth context.
+
+        Args:
+            test_client: Client bound to the temp-DB app.
+            monkeypatch: Fixture used to stub the runtime trust gate.
+            email: Email carried in the forwarded auth context.
+            is_admin: Admin flag carried in the forwarded auth context.
+            teams: Team scope carried in the forwarded context (``None`` = unrestricted).
+
+        Returns:
+            The set of resource URIs in the response.
+        """
+        # First-Party
+        from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+        monkeypatch.setattr(main_mod, "_is_trusted_internal_mcp_runtime_request", lambda _request: True)
+        header = encode_internal_mcp_auth_context(
+            {"email": email, "teams": teams, "is_admin": is_admin, "is_authenticated": True}
+        )
+        resp = test_client.post(
+            "/_internal/mcp/resources/list",
+            json={"jsonrpc": "2.0", "id": "owner-vis-res", "method": "resources/list", "params": {}},
+            headers={"x-contextforge-auth-context": header},
+        )
+        assert resp.status_code == 200, resp.text
+        return {r.get("uri") for r in resp.json().get("resources", [])}
+
+    def test_admin_sees_own_private_resource(self, client_and_db, monkeypatch):
+        """resources/list is a second internal-MCP surface with the same behavior change."""
+        uris = self._post_resources_list(client_and_db, monkeypatch, email=ADMIN_EMAIL, is_admin=True, teams=None)
+
+        assert ADMIN_PRIVATE_RESOURCE in uris
+
+    def test_admin_does_not_see_another_users_private_resource(self, client_and_db, monkeypatch):
+        """Admin bypass on resources/list still excludes another user's private resource."""
+        uris = self._post_resources_list(client_and_db, monkeypatch, email=ADMIN_EMAIL, is_admin=True, teams=None)
+
+        assert OTHER_PRIVATE_RESOURCE not in uris

--- a/tests/integration/test_admin_bypass_owner_visibility.py
+++ b/tests/integration/test_admin_bypass_owner_visibility.py
@@ -1,0 +1,309 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_admin_bypass_owner_visibility.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for admin-bypass owner matching on endpoints that centralized
+Layer-1 visibility derivation.
+
+Several endpoints previously nulled ``user_email`` when granting admin bypass and
+now forward the caller's email instead. Against the real service layer
+(``BaseService._apply_visibility_scope``) that difference decides whether a
+DB-admin's *own* private rows are returned:
+
+- ``token_teams=None, user_email=None``  -> public + team, no private rows at all
+- ``token_teams=None, user_email=admin`` -> public + team + the admin's own private rows
+
+These tests exercise the real auth pipeline against a real database rather than
+mocking the Layer-1 helper, so they prove the row actually becomes visible and,
+critically, that another user's private row still does not.
+"""
+
+# Standard
+from datetime import datetime, timezone
+import os
+import tempfile
+import uuid
+
+# Third-Party
+from fastapi import Depends, Request as FastAPIRequest
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+import mcpgateway.db as db_mod
+import mcpgateway.main as main_mod
+from mcpgateway.auth import get_current_user
+from mcpgateway.config import settings
+from mcpgateway.db import Base, EmailUser
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+
+ADMIN_EMAIL = "owner-vis-admin@example.com"
+OTHER_EMAIL = "owner-vis-other@example.com"
+ADMIN_PASSWORD = "TestPass123!"  # pragma: allowlist secret
+OTHER_PASSWORD = "OtherPass123!"  # pragma: allowlist secret
+
+ADMIN_PRIVATE_TAG = "owner-vis-admin-private"
+OTHER_PRIVATE_TAG = "owner-vis-other-private"
+PUBLIC_TAG = "owner-vis-public"
+
+
+def _make_tool(owner_email: str, name: str, visibility: str, tag: str):
+    """Build a Tool row owned by ``owner_email`` carrying a single ``tag``.
+
+    Args:
+        owner_email: Email recorded as the tool owner.
+        name: Unique original name for the tool.
+        visibility: One of ``public`` / ``team`` / ``private``.
+        tag: Single tag applied to the tool.
+
+    Returns:
+        An unpersisted ``db_mod.Tool`` instance.
+    """
+    return db_mod.Tool(
+        id=uuid.uuid4().hex,
+        original_name=name,
+        url="http://example.com/tool",
+        owner_email=owner_email,
+        visibility=visibility,
+        integration_type="REST",
+        request_type="GET",
+        input_schema={},
+        output_schema={},
+        enabled=True,
+        deprecated=False,
+        created_by=owner_email,
+        tags=[tag],
+    )
+
+
+@pytest.fixture
+def client_and_db():
+    """Provision a temp-DB app with an admin, a second user, and three tagged tools.
+
+    Uses the real auth pipeline so ``request.state.token_use`` / ``token_teams`` are
+    populated the way production sets them; only RBAC permission resolution is
+    stubbed, since these tests target Layer-1 visibility rather than Layer-2.
+
+    Yields:
+        The configured ``TestClient``.
+    """
+    # Third-Party
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    url = f"sqlite:///{path}"
+
+    mp.setattr(settings, "database_url", url, raising=False)
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+
+    # First-Party
+    import mcpgateway.middleware.auth_middleware as auth_middleware_mod
+    import mcpgateway.services.audit_trail_service as audit_trail_mod
+    import mcpgateway.services.log_aggregator as log_aggregator_mod
+    import mcpgateway.services.security_logger as sec_logger_mod
+    import mcpgateway.services.structured_logger as struct_logger_mod
+
+    for mod in (auth_middleware_mod, sec_logger_mod, struct_logger_mod, audit_trail_mod, log_aggregator_mod):
+        mp.setattr(mod, "SessionLocal", TestSessionLocal, raising=False)
+
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        """Yield a session bound to the temp database.
+
+        Yields:
+            A SQLAlchemy session.
+        """
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # First-Party
+    from mcpgateway.db import get_db as mcpgateway_get_db
+    from mcpgateway.middleware.rbac import get_db as rbac_get_db
+    from mcpgateway.routers.auth import get_db as auth_get_db
+
+    main_mod.app.dependency_overrides[mcpgateway_get_db] = override_get_db
+    main_mod.app.dependency_overrides[auth_get_db] = override_get_db
+    main_mod.app.dependency_overrides[rbac_get_db] = override_get_db
+
+    async def mock_user_with_permissions(request: FastAPIRequest, user=Depends(get_current_user)):
+        """Return the authenticated user without running Layer-2 permission checks.
+
+        Args:
+            request: Incoming request (unused; keeps the real dependency signature).
+            user: User resolved by the real auth pipeline.
+
+        Returns:
+            The user context dict handlers expect.
+        """
+        return {
+            "email": user.email,
+            "full_name": user.full_name,
+            "is_admin": user.is_admin,
+            "ip_address": "127.0.0.1",
+            "user_agent": "test-client",
+        }
+
+    main_mod.app.dependency_overrides[get_current_user_with_permissions] = mock_user_with_permissions
+
+    # First-Party
+    from mcpgateway.services.argon2_service import Argon2PasswordService
+
+    argon2 = Argon2PasswordService()
+    db = TestSessionLocal()
+    for email, password, is_admin in ((ADMIN_EMAIL, ADMIN_PASSWORD, True), (OTHER_EMAIL, OTHER_PASSWORD, False)):
+        db.add(
+            EmailUser(
+                id=str(uuid.uuid4()),
+                email=email,
+                password_hash=argon2.hash_password(password),
+                full_name=f"Owner Vis {email}",
+                is_admin=is_admin,
+                is_active=True,
+                auth_provider="local",
+                email_verified_at=datetime.now(timezone.utc),
+            )
+        )
+    db.commit()
+
+    db.add(_make_tool(ADMIN_EMAIL, "owner-vis-admin-private-tool", "private", ADMIN_PRIVATE_TAG))
+    db.add(_make_tool(OTHER_EMAIL, "owner-vis-other-private-tool", "private", OTHER_PRIVATE_TAG))
+    db.add(_make_tool(OTHER_EMAIL, "owner-vis-public-tool", "public", PUBLIC_TAG))
+    db.commit()
+
+    # Grant the non-admin caller Layer-2 tags.read so the request reaches the Layer-1
+    # filter under test; without it RBAC rejects with 403 before visibility is derived.
+    reader_role = db_mod.Role(
+        id=str(uuid.uuid4()),
+        name="owner-vis-tag-reader",
+        scope="global",
+        permissions=["tags.read"],
+        created_by=ADMIN_EMAIL,
+        is_active=True,
+    )
+    db.add(reader_role)
+    db.commit()
+    db.add(
+        db_mod.UserRole(
+            id=str(uuid.uuid4()),
+            user_email=OTHER_EMAIL,
+            role_id=reader_role.id,
+            scope="global",
+            granted_by=ADMIN_EMAIL,
+            is_active=True,
+        )
+    )
+    db.commit()
+    db.close()
+
+    test_client = TestClient(main_mod.app, raise_server_exceptions=False)
+    try:
+        yield test_client
+    finally:
+        main_mod.app.dependency_overrides.clear()
+        mp.undo()
+        engine.dispose()
+        os.unlink(path)
+
+
+def _auth_headers(test_client: TestClient, email: str, password: str) -> dict:
+    """Authenticate via the real session-login route and return a bearer header.
+
+    Logging in for real (rather than minting a token by hand) is the point: it is what
+    populates ``request.state.token_use`` and ``token_teams``, which drive the Layer-1
+    derivation under test.
+
+    Args:
+        test_client: Client used to perform the login.
+        email: Account email.
+        password: Account password.
+
+    Returns:
+        An ``Authorization`` header dict carrying the issued session token.
+    """
+    resp = test_client.post("/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200, f"Login failed for {email}: {resp.text}"
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _tag_names(resp) -> set:
+    """Extract the set of tag names from a ``/tags`` response.
+
+    Args:
+        resp: The HTTP response returned by the tags endpoint.
+
+    Returns:
+        Set of tag name strings.
+    """
+    assert resp.status_code == 200, resp.text
+    return {entry["name"] for entry in resp.json()}
+
+
+class TestAdminBypassOwnerVisibility:
+    """End-to-end Layer-1 behavior on the tag endpoints, against a real database."""
+
+    def test_admin_sees_own_private_tag(self, client_and_db):
+        """A DB-admin with an unrestricted token sees tags from their own private rows.
+
+        This is the behavior change: the superseded inline derivation nulled the admin's
+        email, which excluded every private row including the admin's own.
+        """
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        names = _tag_names(client_and_db.get("/tags", headers=headers))
+
+        assert ADMIN_PRIVATE_TAG in names
+        assert PUBLIC_TAG in names
+
+    def test_admin_does_not_see_another_users_private_tag(self, client_and_db):
+        """Admin bypass must not widen visibility to another user's private rows.
+
+        This is the invariant that makes preserving the email safe; if it ever fails,
+        forwarding the email has become a data leak rather than owner matching.
+        """
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        names = _tag_names(client_and_db.get("/tags", headers=headers))
+
+        assert OTHER_PRIVATE_TAG not in names
+
+    def test_non_admin_sees_only_public_tags(self, client_and_db):
+        """A non-admin caller is unaffected and still sees public rows only."""
+        headers = _auth_headers(client_and_db, OTHER_EMAIL, OTHER_PASSWORD)
+
+        names = _tag_names(client_and_db.get("/tags", headers=headers))
+
+        assert PUBLIC_TAG in names
+        assert ADMIN_PRIVATE_TAG not in names
+
+    def test_admin_lists_own_private_entity_by_tag(self, client_and_db):
+        """The entity lookup resolves the admin's own private tool for its tag."""
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        resp = client_and_db.get(f"/tags/{ADMIN_PRIVATE_TAG}/entities", headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert any(entity.get("name") == "owner-vis-admin-private-tool" for entity in resp.json())
+
+    def test_admin_cannot_list_another_users_private_entity_by_tag(self, client_and_db):
+        """The entity lookup does not resolve another user's private tool, even for an admin."""
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        resp = client_and_db.get(f"/tags/{OTHER_PRIVATE_TAG}/entities", headers=headers)
+
+        assert resp.status_code == 200, resp.text
+        assert not [entity for entity in resp.json() if entity.get("name") == "owner-vis-other-private-tool"]

--- a/tests/integration/test_admin_bypass_owner_visibility.py
+++ b/tests/integration/test_admin_bypass_owner_visibility.py
@@ -50,6 +50,41 @@ ADMIN_PRIVATE_TAG = "owner-vis-admin-private"
 OTHER_PRIVATE_TAG = "owner-vis-other-private"
 PUBLIC_TAG = "owner-vis-public"
 
+ADMIN_PRIVATE_PROMPT = "owner-vis-admin-private-prompt"
+OTHER_PRIVATE_PROMPT = "owner-vis-other-private-prompt"
+
+
+def _make_prompt(owner_email: str, name: str, visibility: str):
+    """Build a Prompt row owned by ``owner_email`` with a single completable argument.
+
+    Args:
+        owner_email: Email recorded as the prompt owner.
+        name: Unique prompt name.
+        visibility: One of ``public`` / ``team`` / ``private``.
+
+    Returns:
+        An unpersisted ``db_mod.Prompt`` instance.
+    """
+    return db_mod.Prompt(
+        id=uuid.uuid4().hex,
+        original_name=name,
+        custom_name=name,
+        custom_name_slug=name,
+        name=name,
+        template="Hello {{ topic }}",
+        argument_schema={
+            "type": "object",
+            # The completion service matches on each property's own "name" key and
+            # returns its enum values, so both are required for a resolvable completion.
+            "properties": {"topic": {"name": "topic", "type": "string", "enum": ["alpha", "beta"]}},
+        },
+        owner_email=owner_email,
+        visibility=visibility,
+        enabled=True,
+        created_by=owner_email,
+        tags=[],
+    )
+
 
 def _make_tool(owner_email: str, name: str, visibility: str, tag: str):
     """Build a Tool row owned by ``owner_email`` carrying a single ``tag``.
@@ -183,6 +218,8 @@ def client_and_db():
     db.add(_make_tool(ADMIN_EMAIL, "owner-vis-admin-private-tool", "private", ADMIN_PRIVATE_TAG))
     db.add(_make_tool(OTHER_EMAIL, "owner-vis-other-private-tool", "private", OTHER_PRIVATE_TAG))
     db.add(_make_tool(OTHER_EMAIL, "owner-vis-public-tool", "public", PUBLIC_TAG))
+    db.add(_make_prompt(ADMIN_EMAIL, ADMIN_PRIVATE_PROMPT, "private"))
+    db.add(_make_prompt(OTHER_EMAIL, OTHER_PRIVATE_PROMPT, "private"))
     db.commit()
 
     # Grant the non-admin caller Layer-2 tags.read so the request reaches the Layer-1
@@ -191,7 +228,7 @@ def client_and_db():
         id=str(uuid.uuid4()),
         name="owner-vis-tag-reader",
         scope="global",
-        permissions=["tags.read"],
+        permissions=["tags.read", "prompts.read"],
         created_by=ADMIN_EMAIL,
         is_active=True,
     )
@@ -307,3 +344,123 @@ class TestAdminBypassOwnerVisibility:
 
         assert resp.status_code == 200, resp.text
         assert not [entity for entity in resp.json() if entity.get("name") == "owner-vis-other-private-tool"]
+
+
+class TestAdminBypassOwnerVisibilityRpcCompletion:
+    """Same Layer-1 change, exercised through the JSON-RPC dispatcher.
+
+    ``completion/complete`` is a second affected surface: it also used to null
+    ``user_email`` on admin bypass. The completion service resolves the referenced
+    prompt through ``BaseService._apply_visibility_scope``, so an admin's own private
+    prompt is only reachable when the email survives the derivation.
+    """
+
+    @staticmethod
+    def _complete(test_client, headers, prompt_name):
+        """Issue a ``completion/complete`` JSON-RPC call for ``prompt_name``.
+
+        Args:
+            test_client: Authenticated client.
+            headers: Authorization header dict.
+            prompt_name: Name of the prompt to complete against.
+
+        Returns:
+            The parsed JSON-RPC response body.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "id": "owner-vis-1",
+            "method": "completion/complete",
+            "params": {
+                "ref": {"type": "ref/prompt", "name": prompt_name},
+                "argument": {"name": "topic", "value": ""},
+            },
+        }
+        resp = test_client.post("/rpc/", json=payload, headers=headers)
+        assert resp.status_code == 200, resp.text
+        return resp.json()
+
+    def test_admin_completes_against_own_private_prompt(self, client_and_db):
+        """The admin's own private prompt resolves through the RPC completion branch.
+
+        When the email is nulled the visibility scope drops every private row, and the
+        service reports "Prompt not found" instead of returning completions.
+        """
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        body = self._complete(client_and_db, headers, ADMIN_PRIVATE_PROMPT)
+
+        assert "error" not in body, body
+        assert body["result"]["completion"]["values"] == ["alpha", "beta"]
+
+    def test_admin_cannot_complete_against_another_users_private_prompt(self, client_and_db):
+        """Another user's private prompt stays invisible even under admin bypass."""
+        headers = _auth_headers(client_and_db, ADMIN_EMAIL, ADMIN_PASSWORD)
+
+        body = self._complete(client_and_db, headers, OTHER_PRIVATE_PROMPT)
+
+        assert "result" not in body, body
+        assert "not found" in body["error"]["message"].lower(), body
+
+
+class TestAdminBypassOwnerVisibilityInternalMcp:
+    """Same Layer-1 change on the trusted internal MCP dispatch path.
+
+    The six ``handle_internal_mcp_*`` handlers previously nulled ``user_email`` too.
+    They are reachable only from the local Rust runtime, so the trust gate is stubbed;
+    everything below it - the forwarded auth context, the Layer-1 derivation, the
+    service and the database - is real.
+    """
+
+    @staticmethod
+    def _post_prompts_list(test_client, monkeypatch, *, email, is_admin, teams):
+        """Call the internal prompts/list endpoint with a forged trusted auth context.
+
+        Args:
+            test_client: Client bound to the temp-DB app.
+            monkeypatch: Fixture used to stub the runtime trust gate.
+            email: Email carried in the forwarded auth context.
+            is_admin: Admin flag carried in the forwarded auth context.
+            teams: Team scope carried in the forwarded context (``None`` = unrestricted).
+
+        Returns:
+            The set of prompt names in the response.
+        """
+        # First-Party
+        from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+        monkeypatch.setattr(main_mod, "_is_trusted_internal_mcp_runtime_request", lambda _request: True)
+        header = encode_internal_mcp_auth_context(
+            {
+                "email": email,
+                "teams": teams,
+                "is_admin": is_admin,
+                "is_authenticated": True,
+            }
+        )
+        resp = test_client.post(
+            "/_internal/mcp/prompts/list",
+            json={"jsonrpc": "2.0", "id": "owner-vis-mcp", "method": "prompts/list", "params": {}},
+            headers={"x-contextforge-auth-context": header},
+        )
+        assert resp.status_code == 200, resp.text
+        return {p.get("name") for p in resp.json().get("prompts", [])}
+
+    def test_admin_sees_own_private_prompt(self, client_and_db, monkeypatch):
+        """An unrestricted admin context lists the admin's own private prompt."""
+        names = self._post_prompts_list(client_and_db, monkeypatch, email=ADMIN_EMAIL, is_admin=True, teams=None)
+
+        assert ADMIN_PRIVATE_PROMPT in names
+
+    def test_admin_does_not_see_another_users_private_prompt(self, client_and_db, monkeypatch):
+        """Admin bypass on the internal path still excludes another user's private prompt."""
+        names = self._post_prompts_list(client_and_db, monkeypatch, email=ADMIN_EMAIL, is_admin=True, teams=None)
+
+        assert OTHER_PRIVATE_PROMPT not in names
+
+    def test_non_admin_context_sees_no_private_prompts(self, client_and_db, monkeypatch):
+        """A non-admin forwarded context is held to public-only visibility."""
+        names = self._post_prompts_list(client_and_db, monkeypatch, email=OTHER_EMAIL, is_admin=False, teams=[])
+
+        assert ADMIN_PRIVATE_PROMPT not in names
+        assert OTHER_PRIVATE_PROMPT not in names

--- a/tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py
+++ b/tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py
@@ -498,11 +498,11 @@ class TestJSONRPCPassthroughErrorHandling:
 class TestJSONRPCPassthroughGovernance:
     """Test that governance features are applied."""
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_admin_unrestricted_token_teams(self, mock_get_filter_context, mock_a2a_service, mock_auth, auth_headers):
         """Test admin with no team restrictions (line 5385)."""
         # Admin with token_teams=None should stay None (unrestricted)
-        mock_get_filter_context.return_value = ("admin@example.com", None, True)
+        mock_get_filter_context.return_value = ("admin@example.com", None)
         mock_a2a_service.invoke_agent = AsyncMock(return_value={"jsonrpc": "2.0", "result": {}, "id": 1})
 
         client = TestClient(app)
@@ -523,11 +523,11 @@ class TestJSONRPCPassthroughGovernance:
         assert call_args is not None
         assert call_args.kwargs["token_teams"] is None
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_non_admin_public_only_token_teams(self, mock_get_filter_context, mock_a2a_service, mock_auth, auth_headers):
         """Test non-admin without teams gets public-only access (line 5387)."""
         # Non-admin with token_teams=None should get [] (public-only)
-        mock_get_filter_context.return_value = ("user@example.com", None, False)
+        mock_get_filter_context.return_value = ("user@example.com", [])
         mock_a2a_service.invoke_agent = AsyncMock(return_value={"jsonrpc": "2.0", "result": {}, "id": 1})
 
         client = TestClient(app)
@@ -548,10 +548,10 @@ class TestJSONRPCPassthroughGovernance:
         assert call_args is not None
         assert call_args.kwargs["token_teams"] == []
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_applies_token_scoping(self, mock_get_filter_context, mock_a2a_service, mock_auth, auth_headers):
         """Test that token scoping is applied."""
-        mock_get_filter_context.return_value = ("user@example.com", ["team1"], False)
+        mock_get_filter_context.return_value = ("user@example.com", ["team1"])
         mock_a2a_service.invoke_agent = AsyncMock(return_value={"jsonrpc": "2.0", "result": {}, "id": 1})
 
         client = TestClient(app)
@@ -1375,9 +1375,9 @@ class TestRequestContextTokenScoping:
 
     def test_admin_with_no_team_restrictions_unrestricted(self, mock_request_for_context, mock_user_dict_for_context):
         """Test admin with token_teams=None gets unrestricted access (admin bypass)."""
-        with patch("mcpgateway.main.get_rpc_filter_context") as mock_get_filter:
+        with patch("mcpgateway.main.get_scoped_resource_access_context") as mock_get_filter:
             # Admin with token_teams=None should remain None (unrestricted)
-            mock_get_filter.return_value = ("admin@example.com", None, True)
+            mock_get_filter.return_value = ("admin@example.com", None)
 
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
@@ -1388,9 +1388,9 @@ class TestRequestContextTokenScoping:
 
     def test_non_admin_with_no_teams_gets_public_only(self, mock_request_for_context, mock_user_dict_for_context):
         """Test non-admin without teams gets public-only access (empty list)."""
-        with patch("mcpgateway.main.get_rpc_filter_context") as mock_get_filter:
+        with patch("mcpgateway.main.get_scoped_resource_access_context") as mock_get_filter:
             # Non-admin with token_teams=None should get [] (public-only)
-            mock_get_filter.return_value = ("user@example.com", None, False)
+            mock_get_filter.return_value = ("user@example.com", [])
 
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
@@ -1401,9 +1401,9 @@ class TestRequestContextTokenScoping:
 
     def test_non_admin_with_teams_preserves_teams(self, mock_request_for_context, mock_user_dict_for_context):
         """Test non-admin with specific teams preserves team list."""
-        with patch("mcpgateway.main.get_rpc_filter_context") as mock_get_filter:
+        with patch("mcpgateway.main.get_scoped_resource_access_context") as mock_get_filter:
             # Non-admin with specific teams
-            mock_get_filter.return_value = ("user@example.com", ["team1", "team2"], False)
+            mock_get_filter.return_value = ("user@example.com", ["team1", "team2"])
 
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
@@ -1414,9 +1414,9 @@ class TestRequestContextTokenScoping:
 
     def test_admin_with_specific_teams_preserves_teams(self, mock_request_for_context, mock_user_dict_for_context):
         """Test admin with specific team restrictions preserves those restrictions."""
-        with patch("mcpgateway.main.get_rpc_filter_context") as mock_get_filter:
+        with patch("mcpgateway.main.get_scoped_resource_access_context") as mock_get_filter:
             # Admin with specific team restrictions (narrowed token)
-            mock_get_filter.return_value = ("admin@example.com", ["team1"], True)
+            mock_get_filter.return_value = ("admin@example.com", ["team1"])
 
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
@@ -1433,7 +1433,7 @@ class TestRequestContextUserIdentityExtraction:
         """Test user identity extracted from dict with 'sub' field."""
         user = {"sub": "user123", "email": "user@example.com"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, user)
@@ -1445,7 +1445,7 @@ class TestRequestContextUserIdentityExtraction:
         """Test user identity extracted from dict with 'id' field."""
         user = {"id": "user456", "email": "user@example.com"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, user)
@@ -1457,7 +1457,7 @@ class TestRequestContextUserIdentityExtraction:
         """Test user identity falls back to email when id/sub missing."""
         user = {"email": "user@example.com"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, user)
@@ -1469,7 +1469,7 @@ class TestRequestContextUserIdentityExtraction:
         """Test user identity when user is a string (non-dict format)."""
         user = "user@example.com"
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, user)
@@ -1487,7 +1487,7 @@ class TestRequestContextBearerTokenExtraction:
         jwt_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"  # pragma: allowlist secret
         mock_request_for_context.state.bearer_token = jwt_token
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1500,7 +1500,7 @@ class TestRequestContextBearerTokenExtraction:
         mock_request_for_context.state.bearer_token = None  # Not set by middleware
         mock_request_for_context.headers = {"authorization": f"Bearer {jwt_token}"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1513,7 +1513,7 @@ class TestRequestContextBearerTokenExtraction:
         mock_request_for_context.state.bearer_token = None
         mock_request_for_context.headers = {"authorization": f"bearer {jwt_token}"}  # lowercase 'bearer'
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1525,7 +1525,7 @@ class TestRequestContextBearerTokenExtraction:
         opaque_token = "local-opaque-token-12345"  # pragma: allowlist secret
         mock_request_for_context.state.bearer_token = opaque_token
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 with patch("mcpgateway.main._is_jwt_token", return_value=False):
                     from mcpgateway.main import _extract_a2a_request_context
@@ -1538,7 +1538,7 @@ class TestRequestContextBearerTokenExtraction:
         jwt_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U"  # pragma: allowlist secret
         mock_request_for_context.state.bearer_token = jwt_token
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 with patch("mcpgateway.main._is_jwt_token", return_value=True):
                     from mcpgateway.main import _extract_a2a_request_context
@@ -1551,7 +1551,7 @@ class TestRequestContextBearerTokenExtraction:
         mock_request_for_context.state.bearer_token = None
         mock_request_for_context.headers = {}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1564,7 +1564,7 @@ class TestRequestContextHopCountReading:
 
     def test_hop_count_zero_for_new_request(self, mock_request_for_context, mock_user_dict_for_context):
         """Test hop count is 0 for non-federated request."""
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1575,7 +1575,7 @@ class TestRequestContextHopCountReading:
         """Test hop count is read from X-UAID-Hop-Count header."""
         mock_request_for_context.headers = {"X-UAID-Hop-Count": "2"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=2):
                 from mcpgateway.main import _extract_a2a_request_context
                 context = _extract_a2a_request_context(mock_request_for_context, mock_user_dict_for_context)
@@ -1584,7 +1584,7 @@ class TestRequestContextHopCountReading:
 
     def test_hop_count_extraction_delegates_to_uaid_utils(self, mock_request_for_context, mock_user_dict_for_context):
         """Test hop count extraction delegates to uaid_utils.read_hop_count."""
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count") as mock_read_hop:
                 mock_read_hop.return_value = 5
                 from mcpgateway.main import _extract_a2a_request_context
@@ -1601,7 +1601,7 @@ class TestRequestContextMetadataExtraction:
         """Test content-type header is extracted."""
         mock_request_for_context.headers = {"content-type": "application/json"}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 with patch("mcpgateway.main._prepare_request_headers", return_value={"content-type": "application/json"}):
                     from mcpgateway.main import _extract_a2a_request_context
@@ -1623,7 +1623,7 @@ class TestRequestContextMetadataExtraction:
             # authorization removed by filter
         }
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 with patch("mcpgateway.main._prepare_request_headers", return_value=filtered_headers) as mock_prepare:
                     from mcpgateway.main import _extract_a2a_request_context
@@ -1636,7 +1636,7 @@ class TestRequestContextMetadataExtraction:
         """Test content-type is None when header missing."""
         mock_request_for_context.headers = {}
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=0):
                 with patch("mcpgateway.main._prepare_request_headers", return_value={}):
                     from mcpgateway.main import _extract_a2a_request_context
@@ -1657,7 +1657,7 @@ class TestRequestContextCompleteContext:
             "X-UAID-Hop-Count": "1",
         }
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", ["team1"], False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", ["team1"])):
             with patch("mcpgateway.main.uaid_utils.read_hop_count", return_value=1):
                 with patch("mcpgateway.main._prepare_request_headers", return_value={"content-type": "application/json"}):
                     with patch("mcpgateway.main._is_jwt_token", return_value=True):

--- a/tests/unit/mcpgateway/test_auth_context.py
+++ b/tests/unit/mcpgateway/test_auth_context.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_auth_context.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the centralized Layer-1 visibility helpers in ``mcpgateway.auth_context``.
+
+``get_scoped_resource_access_context`` is the single derivation point for the Layer-1
+admin-bypass + public-only-secure-default rule that route handlers in ``main.py`` used to
+copy inline (issue #4451). These tests pin the rule itself, so endpoint tests are free to
+mock the helper and assert only that the handler passes the context through verbatim.
+
+Contract under test:
+
+- ``(email, None)``  - admin bypass. ``user_email`` is deliberately preserved so the service
+  layer can still owner-match the admin's own private rows (PR #4341 / issue #4694).
+- ``(email, [])``    - public-only token (also the secure default for non-admins).
+- ``(email, [...])`` - team-scoped token, passed through unchanged.
+"""
+
+# Standard
+from unittest.mock import MagicMock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.auth_context import get_rpc_filter_context, get_scoped_resource_access_context
+
+
+def _request(*, jwt_payload=None, token_teams=None, token_use=None):
+    """Build a request stub with the auth state the Layer-1 helpers read.
+
+    Args:
+        jwt_payload: Value cached at ``request.state._jwt_verified_payload[1]``. ``None``
+            simulates a non-JWT context (basic-auth / dev-mode).
+        token_teams: Value cached at ``request.state.token_teams``.
+        token_use: Value cached at ``request.state.token_use``.
+
+    Returns:
+        A ``MagicMock`` request whose ``state`` exposes the attributes above.
+    """
+    request = MagicMock()
+    request.state = MagicMock()
+    request.state._jwt_verified_payload = ("token", jwt_payload) if jwt_payload is not None else None
+    request.state.token_teams = token_teams
+    request.state.token_use = token_use
+    request.state.internal_auth_context = None
+    return request
+
+
+class TestScopedResourceAccessContext:
+    """Layer-1 rule applied by ``get_scoped_resource_access_context``."""
+
+    def test_jwt_admin_bypass_preserves_email(self):
+        """Issue #4694: admin bypass must keep user_email for owner matching, not null it.
+
+        Nulling the email would hand the service ``(None, None)``, which resolves to
+        "public + team, but no private rows at all" - silently hiding the admin's own
+        private resources. This is the regression the inline copies kept reintroducing.
+        """
+        request = _request(jwt_payload={"is_admin": True, "teams": None}, token_teams=None)
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+
+        assert user_email == "admin@example.com"
+        assert token_teams is None
+
+    def test_non_admin_without_teams_defaults_to_public_only(self):
+        """Secure default: a non-admin with no team scope sees public rows only."""
+        request = _request(jwt_payload={"is_admin": False, "teams": None}, token_teams=None)
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "viewer@example.com"})
+
+        assert user_email == "viewer@example.com"
+        assert token_teams == []
+
+    def test_team_scoped_token_passes_through(self):
+        """An explicit team scope is forwarded unchanged."""
+        request = _request(jwt_payload={"is_admin": False, "teams": ["team-a"]}, token_teams=["team-a"])
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "member@example.com"})
+
+        assert user_email == "member@example.com"
+        assert token_teams == ["team-a"]
+
+    def test_admin_with_explicit_team_scope_is_not_widened(self):
+        """Least privilege: an admin token carrying an explicit team scope keeps that scope."""
+        request = _request(jwt_payload={"is_admin": True, "teams": ["team-a"]}, token_teams=["team-a"])
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+
+        assert token_teams == ["team-a"]
+
+    def test_admin_with_public_only_token_is_not_widened(self):
+        """An explicit empty team scope means public-only, even for an admin."""
+        request = _request(jwt_payload={"is_admin": True, "teams": []}, token_teams=[])
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+
+        assert token_teams == []
+
+    def test_basic_auth_admin_gets_bypass(self):
+        """Issue #4451: non-JWT (basic-auth / dev-mode) admins get Layer-1 admin bypass.
+
+        The superseded inline derivation only consulted the JWT ``is_admin`` claim, so an
+        admin authenticating without a JWT was silently narrowed to public-only.
+        """
+        request = _request(jwt_payload=None, token_teams=None)
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+
+        assert user_email == "admin@example.com"
+        assert token_teams is None
+
+    def test_basic_auth_non_admin_stays_public_only(self):
+        """The secure default still applies to non-admins in non-JWT contexts."""
+        request = _request(jwt_payload=None, token_teams=None)
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "user@example.com", "is_admin": False})
+
+        assert user_email == "user@example.com"
+        assert token_teams == []
+
+    def test_returns_two_tuple(self):
+        """The helper's contract is a 2-tuple; callers must not unpack an is_admin flag."""
+        request = _request(jwt_payload={"is_admin": False, "teams": []}, token_teams=[])
+
+        result = get_scoped_resource_access_context(request, {"email": "user@example.com"})
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+class TestMalformedJwtPayload:
+    """A malformed cached JWT payload must not crash Layer-1 derivation."""
+
+    @pytest.mark.parametrize("payload", ["not-a-dict", 42, ["teams"]])
+    def test_non_dict_payload_defers_to_rbac(self, payload):
+        """A non-dict payload carries no usable admin claim, so treat the caller as non-admin.
+
+        Route handlers reach this through ``get_scoped_resource_access_context``; raising here
+        would surface as a JSON-RPC -32603 Internal error instead of a normal RBAC decision.
+        """
+        request = _request(jwt_payload=payload, token_teams=None)
+
+        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "user@example.com"})
+
+        assert user_email == "user@example.com"
+        assert token_teams == []
+
+    def test_non_dict_payload_reports_non_admin(self):
+        """The lower-level helper reports is_admin=False rather than raising."""
+        request = _request(jwt_payload="not-a-dict", token_teams=None)
+
+        _email, _teams, is_admin = get_rpc_filter_context(request, {"email": "user@example.com"})
+
+        assert is_admin is False

--- a/tests/unit/mcpgateway/test_auth_context.py
+++ b/tests/unit/mcpgateway/test_auth_context.py
@@ -25,7 +25,8 @@ from unittest.mock import MagicMock
 import pytest
 
 # First-Party
-from mcpgateway.auth_context import get_rpc_filter_context, get_scoped_resource_access_context
+from mcpgateway import auth_context
+from mcpgateway.auth_context import get_request_identity, get_rpc_filter_context, get_scoped_resource_access_context
 
 
 def _request(*, jwt_payload=None, token_teams=None, token_use=None):
@@ -147,3 +148,78 @@ class TestMalformedJwtPayload:
         _email, _teams, is_admin = get_rpc_filter_context(request, {"email": "user@example.com"})
 
         assert is_admin is False
+
+
+class TestRequestScopedMemoization:
+    """The derived triple is cached per request, per principal.
+
+    Handlers that need both the visibility scope and the requester identity call
+    ``get_scoped_resource_access_context`` and ``get_request_identity`` back to back.
+    Both derive through ``get_rpc_filter_context``, which can issue a live ``EmailUser``
+    lookup for session tokens, so without memoization those handlers pay it twice.
+    """
+
+    @staticmethod
+    def _counting_teams_reader(monkeypatch):
+        """Count how many times a full derivation runs.
+
+        ``get_token_teams_from_request`` is called exactly once per uncached derivation,
+        which makes it a faithful proxy for "how many times did we derive".
+
+        Args:
+            monkeypatch: Fixture used to install the counting wrapper.
+
+        Returns:
+            A single-element list whose value is the derivation count.
+        """
+        calls = []
+        real = auth_context.get_token_teams_from_request
+
+        def counting(request):
+            calls.append(1)
+            return real(request)
+
+        monkeypatch.setattr(auth_context, "get_token_teams_from_request", counting)
+        return calls
+
+    def test_scope_and_identity_derive_once_for_same_user(self, monkeypatch):
+        """Asking for the scope and then the identity costs one derivation, not two."""
+        calls = self._counting_teams_reader(monkeypatch)
+        request = _request(jwt_payload={"is_admin": True, "teams": None}, token_teams=None)
+        user = {"email": "admin@example.com", "is_admin": True}
+
+        scope = get_scoped_resource_access_context(request, user)
+        identity = get_request_identity(request, user)
+
+        assert len(calls) == 1
+        assert scope == ("admin@example.com", None)
+        assert identity == ("admin@example.com", True)
+
+    def test_repeated_calls_reuse_the_cached_triple(self, monkeypatch):
+        """Repeated derivations for the same principal on one request stay at one."""
+        calls = self._counting_teams_reader(monkeypatch)
+        request = _request(jwt_payload={"is_admin": False, "teams": ["team-a"]}, token_teams=["team-a"])
+        user = {"email": "member@example.com"}
+
+        first = get_rpc_filter_context(request, user)
+        second = get_rpc_filter_context(request, user)
+
+        assert len(calls) == 1
+        assert first == second
+
+    def test_a_different_principal_is_not_served_from_cache(self, monkeypatch):
+        """A second principal on the same request derives separately.
+
+        Trusted internal A2A dispatch builds a synthetic forwarded user and derives with it
+        on a request that may already have derived for the real caller. Keying the cache on
+        the request alone would hand the synthetic user the real caller's context.
+        """
+        calls = self._counting_teams_reader(monkeypatch)
+        request = _request(jwt_payload={"is_admin": False, "teams": ["team-a"]}, token_teams=["team-a"])
+
+        real_caller = get_rpc_filter_context(request, {"email": "caller@example.com"})
+        forwarded = get_rpc_filter_context(request, {"email": "forwarded@example.com"})
+
+        assert len(calls) == 2
+        assert real_caller[0] == "caller@example.com"
+        assert forwarded[0] == "forwarded@example.com"

--- a/tests/unit/mcpgateway/test_auth_context.py
+++ b/tests/unit/mcpgateway/test_auth_context.py
@@ -7,13 +7,13 @@ Unit tests for the centralized Layer-1 visibility helpers in ``mcpgateway.auth_c
 
 ``get_scoped_resource_access_context`` is the single derivation point for the Layer-1
 admin-bypass + public-only-secure-default rule that route handlers in ``main.py`` used to
-copy inline (issue #4451). These tests pin the rule itself, so endpoint tests are free to
-mock the helper and assert only that the handler passes the context through verbatim.
+copy inline. Endpoint tests mock this helper and assert only that the handler forwards its
+result, so the rule itself is pinned here.
 
 Contract under test:
 
 - ``(email, None)``  - admin bypass. ``user_email`` is deliberately preserved so the service
-  layer can still owner-match the admin's own private rows (PR #4341 / issue #4694).
+  layer can still owner-match the admin's own private rows.
 - ``(email, [])``    - public-only token (also the secure default for non-admins).
 - ``(email, [...])`` - team-scoped token, passed through unchanged.
 """
@@ -53,11 +53,11 @@ class TestScopedResourceAccessContext:
     """Layer-1 rule applied by ``get_scoped_resource_access_context``."""
 
     def test_jwt_admin_bypass_preserves_email(self):
-        """Issue #4694: admin bypass must keep user_email for owner matching, not null it.
+        """Admin bypass must keep user_email for owner matching, not null it.
 
-        Nulling the email would hand the service ``(None, None)``, which resolves to
-        "public + team, but no private rows at all" - silently hiding the admin's own
-        private resources. This is the regression the inline copies kept reintroducing.
+        Nulling the email hands the service ``(None, None)``, which resolves to "public +
+        team, but no private rows at all" - silently hiding the admin's own private
+        resources. This is the regression the inline copies kept reintroducing.
         """
         request = _request(jwt_payload={"is_admin": True, "teams": None}, token_teams=None)
 
@@ -88,7 +88,7 @@ class TestScopedResourceAccessContext:
         """Least privilege: an admin token carrying an explicit team scope keeps that scope."""
         request = _request(jwt_payload={"is_admin": True, "teams": ["team-a"]}, token_teams=["team-a"])
 
-        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+        _user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
 
         assert token_teams == ["team-a"]
 
@@ -96,12 +96,12 @@ class TestScopedResourceAccessContext:
         """An explicit empty team scope means public-only, even for an admin."""
         request = _request(jwt_payload={"is_admin": True, "teams": []}, token_teams=[])
 
-        user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
+        _user_email, token_teams = get_scoped_resource_access_context(request, {"email": "admin@example.com", "is_admin": True})
 
         assert token_teams == []
 
     def test_basic_auth_admin_gets_bypass(self):
-        """Issue #4451: non-JWT (basic-auth / dev-mode) admins get Layer-1 admin bypass.
+        """Non-JWT (basic-auth / dev-mode) admins get Layer-1 admin bypass.
 
         The superseded inline derivation only consulted the JWT ``is_admin`` claim, so an
         admin authenticating without a JWT was silently narrowed to public-only.
@@ -121,15 +121,6 @@ class TestScopedResourceAccessContext:
 
         assert user_email == "user@example.com"
         assert token_teams == []
-
-    def test_returns_two_tuple(self):
-        """The helper's contract is a 2-tuple; callers must not unpack an is_admin flag."""
-        request = _request(jwt_payload={"is_admin": False, "teams": []}, token_teams=[])
-
-        result = get_scoped_resource_access_context(request, {"email": "user@example.com"})
-
-        assert isinstance(result, tuple)
-        assert len(result) == 2
 
 
 class TestMalformedJwtPayload:

--- a/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
+++ b/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
@@ -172,17 +172,18 @@ class TestInternalA2AAuthzTrusted:
 
 
 class TestInternalA2AScopeContext:
-    # Patch ``mcpgateway.main.get_rpc_filter_context`` (the binding inside
-    # main's namespace), not ``mcpgateway.auth_context.get_rpc_filter_context``,
+    # Patch ``mcpgateway.main.get_scoped_resource_access_context`` (the binding inside
+    # main's namespace), not ``mcpgateway.auth_context.get_scoped_resource_access_context``,
     # because ``_get_internal_a2a_scope_context`` is defined in main.py and
-    # resolves the name against main's own namespace.
+    # resolves the name against main's own namespace. The helper returns the post-rule
+    # 2-tuple, so these mocks supply already-derived (user_email, token_teams) values.
     @patch("mcpgateway.main._build_internal_mcp_forwarded_user", return_value={"email": "admin@test.com"})
-    @patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@test.com", None, True))
+    @patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@test.com", None))
     def test_admin_with_null_teams_keeps_bypass(self, _mock_scope, _mock_user):
         assert _get_internal_a2a_scope_context(MagicMock()) == ("admin@test.com", None)
 
     @patch("mcpgateway.main._build_internal_mcp_forwarded_user", return_value={"email": "user@test.com"})
-    @patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@test.com", None, False))
+    @patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@test.com", []))
     def test_non_admin_with_null_teams_becomes_public_only(self, _mock_scope, _mock_user):
         assert _get_internal_a2a_scope_context(MagicMock()) == ("user@test.com", [])
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -2390,8 +2390,12 @@ class TestTagEndpoints:
     @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_all_tags", new_callable=AsyncMock)
     def test_list_tags_admin_bypass_passes_unrestricted_scope(self, mock_get_tags, mock_filter_context, test_client, auth_headers):
-        """Explicit admin bypass token should pass unrestricted scope to tag service."""
-        mock_filter_context.return_value = (None, None)
+        """Explicit admin bypass token should pass unrestricted scope to tag service.
+
+        Issue #4694: admin bypass keeps user_email set so the service can still match the
+        admin's own private rows. The endpoint passes the scoped context through verbatim.
+        """
+        mock_filter_context.return_value = ("admin@example.com", None)
         mock_get_tags.return_value = []
 
         response = test_client.get("/tags", headers=auth_headers)
@@ -2401,7 +2405,7 @@ class TestTagEndpoints:
             ANY,
             entity_types=None,
             include_entities=False,
-            user_email=None,
+            user_email="admin@example.com",
             token_teams=None,
         )
 
@@ -2426,8 +2430,12 @@ class TestTagEndpoints:
     @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_entities_by_tag", new_callable=AsyncMock)
     def test_get_entities_by_tag_admin_bypass_passes_unrestricted_scope(self, mock_get_entities, mock_filter_context, test_client, auth_headers):
-        """Admin bypass context should pass unrestricted scope to tag entity lookup."""
-        mock_filter_context.return_value = (None, None)
+        """Admin bypass context should pass unrestricted scope to tag entity lookup.
+
+        Issue #4694: admin bypass keeps user_email set so the service can still match the
+        admin's own private rows. The endpoint passes the scoped context through verbatim.
+        """
+        mock_filter_context.return_value = ("admin@example.com", None)
         mock_get_entities.return_value = []
 
         response = test_client.get("/tags/test/entities", headers=auth_headers)
@@ -2437,7 +2445,7 @@ class TestTagEndpoints:
             ANY,
             tag_name="test",
             entity_types=None,
-            user_email=None,
+            user_email="admin@example.com",
             token_teams=None,
         )
 
@@ -2698,7 +2706,14 @@ class TestRPCEndpoints:
     @patch("mcpgateway.main.prompt_service.get_prompt")
     # @patch("mcpgateway.main.validate_request")
     def test_rpc_prompt_get(self, mock_get_prompt, test_client, auth_headers):
-        """Test prompt retrieval via JSON-RPC."""
+        """Test prompt retrieval via JSON-RPC.
+
+        The ``test_client`` fixture authenticates as an admin without a verified JWT payload
+        (basic-auth / dev-mode context), so ``get_scoped_resource_access_context`` grants Layer-1
+        admin bypass and passes ``token_teams=None``. The superseded inline derivation only
+        inspected the JWT ``is_admin`` claim and incorrectly narrowed this caller to public-only
+        (``token_teams=[]``) - see issue #4451.
+        """
         mock_get_prompt.return_value = {
             "messages": [{"role": "user", "content": {"type": "text", "text": "Rendered prompt"}}],
             "description": "A test prompt",
@@ -2721,7 +2736,7 @@ class TestRPCEndpoints:
             {"param": "value"},  # arguments
             user="test_user@example.com",
             server_id=None,
-            token_teams=[],
+            token_teams=None,
             plugin_context_table=None,
             plugin_global_context=ANY,
             _meta_data=None,
@@ -3247,8 +3262,12 @@ class TestRPCEndpoints:
     @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
     def test_rpc_completion_complete_admin_bypass(self, mock_completion, mock_filter_context, test_client, auth_headers):
-        """RPC completion should preserve explicit admin bypass context."""
-        mock_filter_context.return_value = (None, None)
+        """RPC completion should preserve explicit admin bypass context.
+
+        Issue #4694: admin bypass keeps user_email set so the service can still match the
+        admin's own private rows. The dispatcher passes the scoped context through verbatim.
+        """
+        mock_filter_context.return_value = ("admin@example.com", None)
         mock_completion.return_value = {"result": "done"}
         req = {"jsonrpc": "2.0", "id": "test-id", "method": "completion/complete", "params": {"ref": {"type": "ref/prompt", "name": "p1"}}}
 
@@ -3256,7 +3275,7 @@ class TestRPCEndpoints:
 
         assert response.status_code == 200
         assert response.json()["result"]["result"] == "done"
-        mock_completion.assert_awaited_once_with(ANY, req["params"], user_email=None, token_teams=None)
+        mock_completion.assert_awaited_once_with(ANY, req["params"], user_email="admin@example.com", token_teams=None)
 
     @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
@@ -6058,21 +6077,22 @@ class TestA2AInvokeBodyEndpoint:
         assert response.status_code in [200, 404]
 
     @patch("mcpgateway.main.a2a_service")
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_invoke_admin_bypass_no_team_restrictions(self, mock_context, mock_service, test_client, auth_headers):
         """Test admin bypass when teams=None. Covers: main.py lines 5173-5174"""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
-        mock_context.return_value = ("admin@example.com", None, True)
+        # Issue #4694: admin bypass keeps user_email set for owner matching on own private rows
+        mock_context.return_value = ("admin@example.com", None)
         response = test_client.post("/a2a/invoke", json={"agent_id": "test-agent", "parameters": {}}, headers=auth_headers)
         assert response.status_code in [200, 404]
         assert mock_context.called
 
     @patch("mcpgateway.main.a2a_service")
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_invoke_non_admin_no_teams_public_only(self, mock_context, mock_service, test_client, auth_headers):
         """Test non-admin gets public-only access. Covers: main.py lines 5175-5176"""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
-        mock_context.return_value = ("user@example.com", None, False)
+        mock_context.return_value = ("user@example.com", [])
         response = test_client.post("/a2a/invoke", json={"agent_id": "test-agent", "parameters": {}}, headers=auth_headers)
         assert response.status_code in [200, 404]
         assert mock_context.called
@@ -6105,11 +6125,11 @@ class TestA2AInvokeBodyEndpoint:
         assert response.status_code in [200, 404]
 
     @patch("mcpgateway.main.a2a_service")
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_invoke_rpc_filter_context_extraction(self, mock_context, mock_service, test_client, auth_headers):
-        """Test RPC filter context extraction. Covers: main.py line 5170"""
+        """Test scoped resource access context extraction. Covers: main.py line 5170"""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
-        mock_context.return_value = ("user@example.com", ["team-1"], False)
+        mock_context.return_value = ("user@example.com", ["team-1"])
         response = test_client.post("/a2a/invoke", json={"agent_id": "test-agent", "parameters": {}}, headers=auth_headers)
         assert mock_context.called
         assert response.status_code in [200, 404]
@@ -6135,22 +6155,22 @@ class TestA2AInvokeBodyEndpoint:
         assert "Invalid configuration" in response.json()["detail"]
 
     @patch("mcpgateway.main.a2a_service")
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_invoke_user_id_from_non_dict_user(self, mock_context, mock_service, test_client, auth_headers):
         """Test user_id extraction when user is not a dict. Covers: main.py line 5182"""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
         # Return a string user instead of dict
-        mock_context.return_value = ("user@example.com", ["string-user-id"], False)
+        mock_context.return_value = ("user@example.com", ["string-user-id"])
         response = test_client.post("/a2a/invoke", json={"agent_id": "test-agent", "parameters": {}}, headers=auth_headers)
         assert response.status_code in [200, 404]
         assert mock_context.called
 
     @patch("mcpgateway.main.a2a_service")
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     def test_invoke_by_id_user_id_from_non_dict_user(self, mock_context, mock_service, test_client, auth_headers):
         """Test user_id extraction when user is not a dict for /a2a/{agent_id}/invoke."""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
-        mock_context.return_value = ("user@example.com", "string-user-id", False)
+        mock_context.return_value = ("user@example.com", "string-user-id")
         response = test_client.post("/a2a/agent-1/invoke", json={"parameters": {}, "interaction_type": "query"}, headers=auth_headers)
         assert response.status_code in [200, 404]
         assert mock_context.called

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -805,14 +805,14 @@ class TestProtocolEndpoints:
         assert response.status_code == 200
         mock_completion.assert_called_once_with(ANY, req, user_email="viewer@example.com", token_teams=[])
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion")
     def test_handle_completion_endpoint_maps_completion_error(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """Protocol completion endpoint should map completion validation errors to 400."""
         # First-Party
         from mcpgateway.services.completion_service import CompletionError
 
-        mock_filter_context.return_value = ("viewer@example.com", ["team-1"], False)
+        mock_filter_context.return_value = ("viewer@example.com", ["team-1"])
         mock_completion.side_effect = CompletionError("invalid completion request")
 
         req = {"ref": {"type": "ref/prompt", "name": "test"}}
@@ -3291,14 +3291,14 @@ class TestRPCEndpoints:
         assert response.json()["result"]["result"] == "done"
         mock_completion.assert_awaited_once_with(ANY, req["params"], user_email="viewer@example.com", token_teams=[])
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
     def test_rpc_completion_complete_maps_completion_error(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """RPC completion/complete should map CompletionError to JSON-RPC -32602."""
         # First-Party
         from mcpgateway.services.completion_service import CompletionError
 
-        mock_filter_context.return_value = ("user@example.com", ["t1"], False)
+        mock_filter_context.return_value = ("user@example.com", ["t1"])
         mock_completion.side_effect = CompletionError("invalid ref")
         req = {"jsonrpc": "2.0", "id": "test-id", "method": "completion/complete", "params": {"ref": {"type": "ref/prompt", "name": "p1"}}}
 
@@ -3435,11 +3435,11 @@ class TestRPCEndpoints:
         assert body["error"]["code"] == -32600
         assert body["error"]["message"] == "Invalid Request"
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tool_service.list_tools", new_callable=AsyncMock)
     def test_rpc_null_params_normalized_to_empty_dict(self, mock_list, mock_filter, test_client, auth_headers):
         """RPC with null params should normalize to empty dict and dispatch normally."""
-        mock_filter.return_value = ("user@example.com", [], False)
+        mock_filter.return_value = ("user@example.com", [])
         mock_list.return_value = ([], None)
         req = {"jsonrpc": "2.0", "id": "null-p", "method": "tools/list", "params": None}
         response = test_client.post("/rpc/", json=req, headers=auth_headers)

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -2392,8 +2392,8 @@ class TestTagEndpoints:
     def test_list_tags_admin_bypass_passes_unrestricted_scope(self, mock_get_tags, mock_filter_context, test_client, auth_headers):
         """Explicit admin bypass token should pass unrestricted scope to tag service.
 
-        Issue #4694: admin bypass keeps user_email set so the service can still match the
-        admin's own private rows. The endpoint passes the scoped context through verbatim.
+        Admin bypass keeps user_email set so the service can still match the admin's own
+        private rows. The endpoint passes the scoped context through verbatim.
         """
         mock_filter_context.return_value = ("admin@example.com", None)
         mock_get_tags.return_value = []
@@ -2432,8 +2432,8 @@ class TestTagEndpoints:
     def test_get_entities_by_tag_admin_bypass_passes_unrestricted_scope(self, mock_get_entities, mock_filter_context, test_client, auth_headers):
         """Admin bypass context should pass unrestricted scope to tag entity lookup.
 
-        Issue #4694: admin bypass keeps user_email set so the service can still match the
-        admin's own private rows. The endpoint passes the scoped context through verbatim.
+        Admin bypass keeps user_email set so the service can still match the admin's own
+        private rows. The endpoint passes the scoped context through verbatim.
         """
         mock_filter_context.return_value = ("admin@example.com", None)
         mock_get_entities.return_value = []
@@ -2712,7 +2712,7 @@ class TestRPCEndpoints:
         (basic-auth / dev-mode context), so ``get_scoped_resource_access_context`` grants Layer-1
         admin bypass and passes ``token_teams=None``. The superseded inline derivation only
         inspected the JWT ``is_admin`` claim and incorrectly narrowed this caller to public-only
-        (``token_teams=[]``) - see issue #4451.
+        (``token_teams=[]``).
         """
         mock_get_prompt.return_value = {
             "messages": [{"role": "user", "content": {"type": "text", "text": "Rendered prompt"}}],
@@ -3264,8 +3264,8 @@ class TestRPCEndpoints:
     def test_rpc_completion_complete_admin_bypass(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """RPC completion should preserve explicit admin bypass context.
 
-        Issue #4694: admin bypass keeps user_email set so the service can still match the
-        admin's own private rows. The dispatcher passes the scoped context through verbatim.
+        Admin bypass keeps user_email set so the service can still match the admin's own
+        private rows. The dispatcher passes the scoped context through verbatim.
         """
         mock_filter_context.return_value = ("admin@example.com", None)
         mock_completion.return_value = {"result": "done"}
@@ -6081,7 +6081,7 @@ class TestA2AInvokeBodyEndpoint:
     def test_invoke_admin_bypass_no_team_restrictions(self, mock_context, mock_service, test_client, auth_headers):
         """Test admin bypass when teams=None. Covers: main.py lines 5173-5174"""
         mock_service.invoke_agent = AsyncMock(return_value={"ok": True})
-        # Issue #4694: admin bypass keeps user_email set for owner matching on own private rows
+        # Admin bypass keeps user_email set for owner matching on own private rows
         mock_context.return_value = ("admin@example.com", None)
         response = test_client.post("/a2a/invoke", json={"agent_id": "test-agent", "parameters": {}}, headers=auth_headers)
         assert response.status_code in [200, 404]

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -768,22 +768,22 @@ class TestProtocolEndpoints:
         assert response.status_code == 200
         mock_notify.assert_called_once()
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion")
     def test_handle_completion_endpoint(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """Test completion handling endpoint."""
-        mock_filter_context.return_value = ("scoped@example.com", ["team-1"], False)
+        mock_filter_context.return_value = ("scoped@example.com", ["team-1"])
         mock_completion.return_value = {"result": "completion_result"}
         req = {"ref": {"type": "ref/prompt", "name": "test"}}
         response = test_client.post("/protocol/completion/complete", json=req, headers=auth_headers)
         assert response.status_code == 200
         mock_completion.assert_called_once_with(ANY, req, user_email="scoped@example.com", token_teams=["team-1"])
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion")
     def test_handle_completion_endpoint_admin_bypass(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """Protocol completion should preserve admin user_email for private resource access (issue #4694)."""
-        mock_filter_context.return_value = ("admin@example.com", None, True)
+        mock_filter_context.return_value = ("admin@example.com", None)
         mock_completion.return_value = {"result": "completion_result"}
 
         req = {"ref": {"type": "ref/prompt", "name": "test"}}
@@ -792,11 +792,11 @@ class TestProtocolEndpoints:
         assert response.status_code == 200
         mock_completion.assert_called_once_with(ANY, req, user_email="admin@example.com", token_teams=None)
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion")
     def test_handle_completion_endpoint_defaults_to_public_scope_when_token_teams_none(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """Protocol completion should treat token_teams=None as public-only for non-admin context."""
-        mock_filter_context.return_value = ("viewer@example.com", None, False)
+        mock_filter_context.return_value = ("viewer@example.com", [])
         mock_completion.return_value = {"result": "completion_result"}
 
         req = {"ref": {"type": "ref/prompt", "name": "test"}}
@@ -2351,11 +2351,11 @@ class TestGatewayEndpoints:
 # Tag Endpoints Tests                                   #
 # ----------------------------------------------------- #
 class TestTagEndpoints:
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_all_tags", new_callable=AsyncMock)
     def test_list_tags_passes_token_scope(self, mock_get_tags, mock_filter_context, test_client, auth_headers):
         """Tag list endpoint should pass scoped visibility context to service."""
-        mock_filter_context.return_value = ("scoped@example.com", ["team-1"], False)
+        mock_filter_context.return_value = ("scoped@example.com", ["team-1"])
         mock_get_tags.return_value = []
 
         response = test_client.get("/tags", headers=auth_headers)
@@ -2369,11 +2369,11 @@ class TestTagEndpoints:
             token_teams=["team-1"],
         )
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_entities_by_tag", new_callable=AsyncMock)
     def test_get_entities_by_tag_passes_public_only_scope(self, mock_get_entities, mock_filter_context, test_client, auth_headers):
         """Tag entity lookup should preserve public-only token semantics."""
-        mock_filter_context.return_value = ("admin@example.com", [], False)
+        mock_filter_context.return_value = ("admin@example.com", [])
         mock_get_entities.return_value = []
 
         response = test_client.get("/tags/test/entities", headers=auth_headers)
@@ -2387,11 +2387,11 @@ class TestTagEndpoints:
             token_teams=[],
         )
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_all_tags", new_callable=AsyncMock)
     def test_list_tags_admin_bypass_passes_unrestricted_scope(self, mock_get_tags, mock_filter_context, test_client, auth_headers):
         """Explicit admin bypass token should pass unrestricted scope to tag service."""
-        mock_filter_context.return_value = ("admin@example.com", None, True)
+        mock_filter_context.return_value = (None, None)
         mock_get_tags.return_value = []
 
         response = test_client.get("/tags", headers=auth_headers)
@@ -2405,11 +2405,11 @@ class TestTagEndpoints:
             token_teams=None,
         )
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_all_tags", new_callable=AsyncMock)
     def test_list_tags_defaults_to_public_scope_when_token_teams_none(self, mock_get_tags, mock_filter_context, test_client, auth_headers):
         """Non-admin token_teams=None should be normalized to public-only scope."""
-        mock_filter_context.return_value = ("viewer@example.com", None, False)
+        mock_filter_context.return_value = ("viewer@example.com", [])
         mock_get_tags.return_value = []
 
         response = test_client.get("/tags", headers=auth_headers)
@@ -2423,11 +2423,11 @@ class TestTagEndpoints:
             token_teams=[],
         )
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_entities_by_tag", new_callable=AsyncMock)
     def test_get_entities_by_tag_admin_bypass_passes_unrestricted_scope(self, mock_get_entities, mock_filter_context, test_client, auth_headers):
         """Admin bypass context should pass unrestricted scope to tag entity lookup."""
-        mock_filter_context.return_value = ("admin@example.com", None, True)
+        mock_filter_context.return_value = (None, None)
         mock_get_entities.return_value = []
 
         response = test_client.get("/tags/test/entities", headers=auth_headers)
@@ -2441,11 +2441,11 @@ class TestTagEndpoints:
             token_teams=None,
         )
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.tag_service.get_entities_by_tag", new_callable=AsyncMock)
     def test_get_entities_by_tag_defaults_to_public_scope_when_token_teams_none(self, mock_get_entities, mock_filter_context, test_client, auth_headers):
         """Non-admin token_teams=None should be normalized to public-only for tag entity lookup."""
-        mock_filter_context.return_value = ("viewer@example.com", None, False)
+        mock_filter_context.return_value = ("viewer@example.com", [])
         mock_get_entities.return_value = []
 
         response = test_client.get("/tags/test/entities", headers=auth_headers)
@@ -3231,11 +3231,11 @@ class TestRPCEndpoints:
         assert response.status_code == 200
         assert response.json()["result"] == {}
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
     def test_rpc_completion_complete(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """Test completion/complete JSON-RPC method."""
-        mock_filter_context.return_value = ("rpc-user@example.com", ["team-2"], False)
+        mock_filter_context.return_value = ("rpc-user@example.com", ["team-2"])
         mock_completion.return_value = {"result": "done"}
         req = {"jsonrpc": "2.0", "id": "test-id", "method": "completion/complete", "params": {"ref": {"type": "ref/prompt", "name": "p1"}}}
         response = test_client.post("/rpc/", json=req, headers=auth_headers)
@@ -3244,11 +3244,11 @@ class TestRPCEndpoints:
         assert response.json()["result"]["result"] == "done"
         mock_completion.assert_awaited_once_with(ANY, req["params"], user_email="rpc-user@example.com", token_teams=["team-2"])
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
     def test_rpc_completion_complete_admin_bypass(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """RPC completion should preserve explicit admin bypass context."""
-        mock_filter_context.return_value = ("admin@example.com", None, True)
+        mock_filter_context.return_value = (None, None)
         mock_completion.return_value = {"result": "done"}
         req = {"jsonrpc": "2.0", "id": "test-id", "method": "completion/complete", "params": {"ref": {"type": "ref/prompt", "name": "p1"}}}
 
@@ -3258,11 +3258,11 @@ class TestRPCEndpoints:
         assert response.json()["result"]["result"] == "done"
         mock_completion.assert_awaited_once_with(ANY, req["params"], user_email=None, token_teams=None)
 
-    @patch("mcpgateway.main.get_rpc_filter_context")
+    @patch("mcpgateway.main.get_scoped_resource_access_context")
     @patch("mcpgateway.main.completion_service.handle_completion", new_callable=AsyncMock)
     def test_rpc_completion_complete_defaults_to_public_scope_when_token_teams_none(self, mock_completion, mock_filter_context, test_client, auth_headers):
         """RPC completion should normalize non-admin token_teams=None to public-only."""
-        mock_filter_context.return_value = ("viewer@example.com", None, False)
+        mock_filter_context.return_value = ("viewer@example.com", [])
         mock_completion.return_value = {"result": "done"}
         req = {"jsonrpc": "2.0", "id": "test-id", "method": "completion/complete", "params": {"ref": {"type": "ref/prompt", "name": "p1"}}}
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3692,7 +3692,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id="team-1")
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", ["team-1"]))
 
         response = await list_resources(
             request,
@@ -3710,7 +3710,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([resource], "next-cursor")),
@@ -3734,7 +3734,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([resource], None)),
@@ -3755,7 +3755,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
             AsyncMock(return_value=([], None)),
@@ -3775,7 +3775,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         list_resources_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
@@ -3796,7 +3796,7 @@ class TestServerEndpointCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(team_id=None)
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         list_resources_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(
             "mcpgateway.main.resource_service.list_resources",
@@ -6515,10 +6515,13 @@ class TestA2ABranchCoverage:
         svc = MagicMock()
         svc.invoke_agent = AsyncMock(return_value={"ok": True})
         monkeypatch.setattr(main_mod, "a2a_service", svc)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        # invoke_a2a_agent derives its scope through _extract_a2a_request_context, which uses the
+        # centralized helper; patch that rather than the raw pre-rule derivation it no longer calls.
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         result = await main_mod.invoke_a2a_agent("agent", request, parameters={}, interaction_type="query", db=MagicMock(), user={"email": "user@example.com"})
         assert result["ok"] is True
         assert svc.invoke_agent.await_args.kwargs["token_teams"] == []
+        assert svc.invoke_agent.await_args.kwargs["user_email"] == "user@example.com"
 
         svc.invoke_agent = AsyncMock(side_effect=A2AAgentNotFoundError("missing"))
         with pytest.raises(HTTPException) as excinfo:
@@ -6531,7 +6534,7 @@ class TestA2ABranchCoverage:
         assert excinfo.value.status_code == 400
 
         # Cover user_id=str(user) branch by bypassing RBAC wrapper.
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         svc.invoke_agent = AsyncMock(return_value={"ok": True})
         result = await main_mod.invoke_a2a_agent.__wrapped__("agent", request, parameters={}, interaction_type="query", db=MagicMock(), user="basic-user")
         assert result["ok"] is True
@@ -6634,7 +6637,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.tool_service.list_server_tools", new=AsyncMock(return_value=[tool])) as mock_list_server_tools,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
             assert len(result["result"]["tools"]) == 1
@@ -6654,7 +6657,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.tool_service.list_server_tools", new=AsyncMock(return_value=[tool])) as mock_list_server_tools,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
 
@@ -6675,7 +6678,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))) as mock_list_tools,
             patch("mcpgateway.main.tool_service.list_server_tools", new=AsyncMock()) as mock_list_server_tools,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
 
@@ -6790,7 +6793,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_internal_mcp_rpc(request)
 
@@ -7183,7 +7186,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.list_resources", new=AsyncMock(return_value=([resource], "next-1"))),
         ):
             response = await handle_internal_mcp_resources_list(request)
@@ -7224,7 +7227,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(return_value=resource)),
         ):
             response = await handle_internal_mcp_resources_read(request)
@@ -7272,7 +7275,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(return_value=resource)),
         ):
             response = await handle_internal_mcp_resources_read(request)
@@ -7311,7 +7314,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.list_resource_templates", new=AsyncMock(return_value=[template])),
         ):
             response = await handle_internal_mcp_resource_templates_list(request)
@@ -7338,7 +7341,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=ok_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main._enforce_internal_mcp_server_scope"),
             patch("mcpgateway.main.resource_service.list_resource_templates", new=AsyncMock(return_value=[template])),
         ):
@@ -7351,7 +7354,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=err_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.list_resource_templates", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             with pytest.raises(RuntimeError, match="boom"):
@@ -7531,7 +7534,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.list_prompts", new=AsyncMock(return_value=([prompt], "next-prompt"))),
         ):
             response = await handle_internal_mcp_prompts_list(request)
@@ -7572,7 +7575,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(return_value=prompt)),
         ):
             response = await handle_internal_mcp_prompts_get(request)
@@ -7675,7 +7678,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.completion_service.handle_completion", new=AsyncMock(return_value={"completion": {"text": "done"}})),
         ):
             response = await handle_internal_mcp_completion_complete(request)
@@ -7709,7 +7712,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.completion_service.handle_completion", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             response = await handle_internal_mcp_completion_complete(request)
@@ -7736,7 +7739,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=ok_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main._enforce_internal_mcp_server_scope"),
             patch("mcpgateway.main.completion_service.handle_completion", new=AsyncMock(return_value={"completion": {"text": "ok"}})),
         ):
@@ -7749,7 +7752,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=err_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.completion_service.handle_completion", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             response = await handle_internal_mcp_completion_complete(request)
@@ -8155,7 +8158,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", ["team-a"], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", ["team-a"])),
             patch(
                 "mcpgateway.main.tool_service.list_server_mcp_tool_definitions",
                 new=AsyncMock(return_value=[{"name": "echo", "inputSchema": {"type": "object"}, "annotations": {}}]),
@@ -8398,7 +8401,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=ok_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.tool_service.list_server_mcp_tool_definitions", new=AsyncMock(return_value=[])),
         ):
             response = await handle_internal_mcp_tools_list(request)
@@ -8429,7 +8432,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=generic_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.tool_service.list_server_mcp_tool_definitions", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             response = await handle_internal_mcp_tools_list(request_public)
@@ -8752,7 +8755,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.resource_service.list_server_resources", new=AsyncMock(return_value=[resource])),
         ):
             response = await handle_internal_mcp_resources_list(request)
@@ -8776,7 +8779,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=list_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.list_resources", new=AsyncMock(return_value=([resource], "next-cursor"))),
         ):
             response = await handle_internal_mcp_resources_list(request)
@@ -8788,7 +8791,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=error_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.list_resources", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             response = await handle_internal_mcp_resources_list(request)
@@ -8830,7 +8833,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(return_value={"uri": "resource://one"})),
         ):
             response = await handle_internal_mcp_resources_read(request)
@@ -8854,7 +8857,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(side_effect=ResourceNotFoundError("missing"))),
         ):
             response = await handle_internal_mcp_resources_read(request)
@@ -8877,7 +8880,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             response = await handle_internal_mcp_resources_read(request)
@@ -8901,7 +8904,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch(
                 "mcpgateway.main.resource_service.read_resource",
                 new=AsyncMock(side_effect=ResourceError("Resource URI 'resource://dup' is ambiguous across multiple servers; use /servers/{id}/mcp.")),
@@ -8931,7 +8934,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.list_server_prompts", new=AsyncMock(return_value=[prompt])),
         ):
             response = await handle_internal_mcp_prompts_list(request)
@@ -8955,7 +8958,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=admin_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.prompt_service.list_prompts", new=AsyncMock(return_value=([prompt], "next"))),
         ):
             response = await handle_internal_mcp_prompts_list(request)
@@ -8967,7 +8970,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=error_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.list_prompts", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             with pytest.raises(RuntimeError, match="boom"):
@@ -9008,7 +9011,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(side_effect=PromptNotFoundError("missing"))),
         ):
             response = await handle_internal_mcp_prompts_get(request_not_found)
@@ -9027,7 +9030,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "admin@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(side_effect=PromptError("bad prompt arguments"))),
         ):
             response = await handle_internal_mcp_prompts_get(request_invalid)
@@ -9055,7 +9058,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=ok_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(return_value=payload)),
         ):
             response = await handle_internal_mcp_prompts_get(request)
@@ -9067,7 +9070,7 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=err_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(side_effect=RuntimeError("boom"))),
         ):
             with pytest.raises(RuntimeError, match="boom"):
@@ -9520,7 +9523,7 @@ class TestRpcHandling:
         request.state._mcp_internal_auth_context = {"scoped_server_id": "srv-1"}
 
         with (
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.tool_service.list_server_mcp_tool_definitions", new=AsyncMock(return_value=[])),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -9544,7 +9547,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], "next-cursor"))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
             assert result["result"]["nextCursor"] == "next-cursor"
@@ -9634,7 +9637,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.resource_service.list_resources", new=AsyncMock(return_value=([resource], "next-cursor"))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
             assert result["result"]["resources"][0]["id"] == "res-1"
@@ -9650,7 +9653,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(return_value=resource)),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["contents"][0]["uri"] == "resource://one"
@@ -9658,7 +9661,7 @@ class TestRpcHandling:
         # Gateway forwarding is removed, so missing resource returns error
         with (
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(side_effect=ValueError("no local"))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
             assert "error" in result
@@ -9704,7 +9707,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.prompt_service.list_server_prompts", new=AsyncMock(return_value=[prompt])),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
             assert result["result"]["prompts"][0]["name"] == "prompt-1"
@@ -9717,7 +9720,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(return_value=prompt_payload)),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request_get, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["name"] == "prompt-1"
@@ -9735,7 +9738,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.resource_service.list_resource_templates", new=AsyncMock(return_value=[template])),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             result = await handle_rpc(request_templates, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["resourceTemplates"][0]["uriTemplate"] == "resource://{id}"
@@ -9942,7 +9945,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([], None))) as list_tools,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             await handle_rpc(request, db=mock_db, user={"email": "user@example.com"})
             list_tools.assert_called_once()
@@ -9954,7 +9957,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.tool_service.list_server_tools", new=AsyncMock(return_value=[tool])) as list_server_tools,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request_legacy, db=MagicMock(), user={"email": "user@example.com"})
             list_server_tools.assert_called_once()
@@ -9968,7 +9971,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.resource_service.list_resources", new=AsyncMock(return_value=([resource], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request_list, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["resources"][0]["id"] == "res-admin"
@@ -9991,7 +9994,7 @@ class TestRpcHandling:
         # Gateway forwarding is removed, so missing resource returns error
         with (
             patch("mcpgateway.main.resource_service.read_resource", new=AsyncMock(side_effect=ValueError("no local"))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
             assert "error" in result
@@ -10005,7 +10008,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.prompt_service.list_prompts", new=AsyncMock(return_value=([prompt], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request_list, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["prompts"][0]["name"] == "prompt-admin"
@@ -10024,7 +10027,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.prompt_service.get_prompt", new=AsyncMock(return_value=prompt_payload)),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request_get, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["name"] == "prompt-admin"
@@ -10083,7 +10086,7 @@ class TestRpcHandling:
 
         with (
             patch("mcpgateway.main.resource_service.list_resource_templates", new=AsyncMock(return_value=[template])),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, True)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", None)),
         ):
             result = await handle_rpc(request_templates, db=MagicMock(), user={"email": "user@example.com"})
             assert result["result"]["resourceTemplates"][0]["uriTemplate"] == "resource://{id}"
@@ -10548,7 +10551,7 @@ class TestA2AListAndGet:
 
         with (
             patch("mcpgateway.main.a2a_service") as mock_service,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             mock_service.list_agents = AsyncMock(return_value=([agent], "next-cursor"))
             result = await list_a2a_agents(request, include_pagination=True, db=MagicMock(), user={"email": "user@example.com"})
@@ -10562,7 +10565,7 @@ class TestA2AListAndGet:
 
         with (
             patch("mcpgateway.main.a2a_service") as mock_service,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", ["team-a"], False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", ["team-a"])),
         ):
             mock_service.list_agents = AsyncMock(return_value=([], None))
             response = await list_a2a_agents(request, team_id="team-b", db=MagicMock(), user={"email": "user@example.com"})
@@ -10574,7 +10577,7 @@ class TestA2AListAndGet:
 
         with (
             patch("mcpgateway.main.a2a_service") as mock_service,
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
         ):
             mock_service.get_agent = AsyncMock(return_value={"id": "agent-1"})
             result = await get_a2a_agent("agent-1", request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13694,7 +13697,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13710,7 +13713,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13726,7 +13729,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13742,7 +13745,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13836,7 +13839,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
@@ -13859,7 +13862,7 @@ class TestRpcScopedPermissions:
 
         with (
             patch("mcpgateway.main.tool_service.list_tools", new=AsyncMock(return_value=([tool], None))),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)),
+            patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=True)),
         ):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3647,7 +3647,7 @@ class TestServerEndpointCoverage:
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "tool-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: (None, None))
         list_tools = AsyncMock(return_value=[tool])
         monkeypatch.setattr("mcpgateway.main.tool_service.list_server_tools", list_tools)
 
@@ -3663,7 +3663,7 @@ class TestServerEndpointCoverage:
         resource = MagicMock()
         resource.model_dump.return_value = {"id": "res-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         list_resources = AsyncMock(return_value=[resource])
         monkeypatch.setattr("mcpgateway.main.resource_service.list_server_resources", list_resources)
 
@@ -3679,7 +3679,7 @@ class TestServerEndpointCoverage:
         prompt = MagicMock()
         prompt.model_dump.return_value = {"id": "prompt-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         list_prompts = AsyncMock(return_value=[prompt])
         monkeypatch.setattr("mcpgateway.main.prompt_service.list_server_prompts", list_prompts)
 
@@ -4728,7 +4728,7 @@ class TestToolListEndpointCoverage:
         list_tools_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", list_tools_mock)
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
         await main_mod.list_tools(
             request,
             cursor=None,
@@ -4747,7 +4747,7 @@ class TestToolListEndpointCoverage:
         assert list_tools_mock.await_args.kwargs["user_email"] == "user@example.com"
         assert list_tools_mock.await_args.kwargs["token_teams"] is None
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         await main_mod.list_tools(
             request,
             cursor=None,
@@ -12518,11 +12518,11 @@ class TestRemainingCoverageGaps:
 
         monkeypatch.setattr(main_mod.resource_service, "list_resource_templates", AsyncMock(return_value=[]))
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
         result = await main_mod.list_resource_templates.__wrapped__(request, db=MagicMock(), include_inactive=False, tags="a, b", visibility=None, user={"email": "u"})
         assert result.resource_templates == []
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         result = await main_mod.list_resource_templates.__wrapped__(request, db=MagicMock(), include_inactive=False, tags=None, visibility=None, user={"email": "u"})
         assert result.resource_templates == []
 
@@ -12536,7 +12536,7 @@ class TestRemainingCoverageGaps:
         list_prompts = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts)
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
         await main_mod.list_prompts.__wrapped__(
             request,
             cursor=None,
@@ -12553,7 +12553,7 @@ class TestRemainingCoverageGaps:
         assert list_prompts.call_args.kwargs["user_email"] == "u"
         assert list_prompts.call_args.kwargs["token_teams"] is None
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         await main_mod.list_prompts.__wrapped__(
             request,
             cursor=None,
@@ -12583,7 +12583,7 @@ class TestRemainingCoverageGaps:
         prompt.model_dump.return_value = {"id": "p1"}
         monkeypatch.setattr(main_mod.prompt_service, "list_server_prompts", AsyncMock(return_value=[prompt]))
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
         result = await main_mod.server_get_resources.__wrapped__(request, "srv", include_inactive=False, db=MagicMock(), user={"email": "u"})
         assert result == [{"id": "r1"}]
 
@@ -13563,7 +13563,7 @@ async def test_protocol_completion_endpoint_direct_admin_null_teams_preserves_by
     db = object()
 
     monkeypatch.setattr(main_mod, "_read_request_json", AsyncMock(return_value=payload))
-    monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("admin@example.com", None, True))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
     completion_mock = AsyncMock(return_value={"result": "ok"})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -13587,7 +13587,7 @@ async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_
     db = object()
 
     monkeypatch.setattr(main_mod, "_read_request_json", AsyncMock(return_value=payload))
-    monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("viewer@example.com", None, False))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("viewer@example.com", []))
     completion_mock = AsyncMock(return_value={"result": "ok"})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -13612,7 +13612,7 @@ async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(mo
     db = MagicMock()
 
     monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
-    monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("admin@example.com", None, True))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
     completion_mock = AsyncMock(return_value={"done": True})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -13637,7 +13637,7 @@ async def test_handle_rpc_completion_direct_non_admin_none_teams_becomes_public_
     db = MagicMock()
 
     monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
-    monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("viewer@example.com", None, False))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("viewer@example.com", []))
     completion_mock = AsyncMock(return_value={"done": True})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -13603,8 +13603,8 @@ async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_
 async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(monkeypatch):
     """RPC completion direct path should preserve admin bypass context.
 
-    Issue #4694: admin bypass keeps user_email set so the completion service can still match
-    the admin's own private rows. The dispatcher passes the scoped context through verbatim.
+    Admin bypass keeps user_email set so the completion service can still match the admin's
+    own private rows. The dispatcher passes the scoped context through verbatim.
     """
     # First-Party
     import mcpgateway.main as main_mod

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3647,7 +3647,7 @@ class TestServerEndpointCoverage:
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "tool-1"}
 
-        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: (None, None))
+        monkeypatch.setattr("mcpgateway.main.get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         list_tools = AsyncMock(return_value=[tool])
         monkeypatch.setattr("mcpgateway.main.tool_service.list_server_tools", list_tools)
 
@@ -4728,7 +4728,7 @@ class TestToolListEndpointCoverage:
         list_tools_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", list_tools_mock)
 
-        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
         await main_mod.list_tools(
             request,
             cursor=None,
@@ -12518,7 +12518,7 @@ class TestRemainingCoverageGaps:
 
         monkeypatch.setattr(main_mod.resource_service, "list_resource_templates", AsyncMock(return_value=[]))
 
-        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", None))
         result = await main_mod.list_resource_templates.__wrapped__(request, db=MagicMock(), include_inactive=False, tags="a, b", visibility=None, user={"email": "u"})
         assert result.resource_templates == []
 
@@ -12536,7 +12536,7 @@ class TestRemainingCoverageGaps:
         list_prompts = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts)
 
-        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", None))
         await main_mod.list_prompts.__wrapped__(
             request,
             cursor=None,
@@ -12583,7 +12583,7 @@ class TestRemainingCoverageGaps:
         prompt.model_dump.return_value = {"id": "p1"}
         monkeypatch.setattr(main_mod.prompt_service, "list_server_prompts", AsyncMock(return_value=[prompt]))
 
-        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", None))
         result = await main_mod.server_get_resources.__wrapped__(request, "srv", include_inactive=False, db=MagicMock(), user={"email": "u"})
         assert result == [{"id": "r1"}]
 
@@ -13563,7 +13563,7 @@ async def test_protocol_completion_endpoint_direct_admin_null_teams_preserves_by
     db = object()
 
     monkeypatch.setattr(main_mod, "_read_request_json", AsyncMock(return_value=payload))
-    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("admin@example.com", None))
     completion_mock = AsyncMock(return_value={"result": "ok"})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -13601,7 +13601,11 @@ async def test_protocol_completion_endpoint_direct_non_admin_none_teams_becomes_
 
 @pytest.mark.asyncio
 async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(monkeypatch):
-    """RPC completion direct path should preserve admin bypass context."""
+    """RPC completion direct path should preserve admin bypass context.
+
+    Issue #4694: admin bypass keeps user_email set so the completion service can still match
+    the admin's own private rows. The dispatcher passes the scoped context through verbatim.
+    """
     # First-Party
     import mcpgateway.main as main_mod
 
@@ -13612,7 +13616,7 @@ async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(mo
     db = MagicMock()
 
     monkeypatch.setattr(main_mod.settings, "mcpgateway_session_affinity_enabled", False)
-    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: (None, None))
+    monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("admin@example.com", None))
     completion_mock = AsyncMock(return_value={"done": True})
     monkeypatch.setattr(main_mod.completion_service, "handle_completion", completion_mock)
 
@@ -13620,7 +13624,7 @@ async def test_handle_rpc_completion_direct_admin_null_teams_preserves_bypass(mo
     assert result["jsonrpc"] == "2.0"
     assert result["id"] == "rpc-id"
     assert result["result"] == {"done": True}
-    assert completion_mock.await_args.kwargs["user_email"] is None
+    assert completion_mock.await_args.kwargs["user_email"] == "admin@example.com"
     assert completion_mock.await_args.kwargs["token_teams"] is None
 
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -3583,7 +3583,7 @@ class TestServerEndpointCoverage:
         db = MagicMock()
         tool = SimpleNamespace(to_dict=lambda **_kwargs: {"id": "tool-1"})
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda *_args, **_kwargs: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=tool))
 
@@ -4696,7 +4696,7 @@ class TestToolListEndpointCoverage:
         tool.model_dump.return_value = {"id": "tool-1"}
         list_tools_mock = AsyncMock(return_value=([tool], "next"))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", list_tools_mock)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", ["team-1"]))
 
         result = await main_mod.list_tools(
             request,
@@ -4773,7 +4773,7 @@ class TestToolListEndpointCoverage:
         request.state = SimpleNamespace(team_id="team-1")
         db = MagicMock()
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", ["team-1"]))
         response = await main_mod.list_tools(
             request,
             cursor=None,
@@ -4807,7 +4807,7 @@ class TestPromptListEndpointCoverage:
         prompt.model_dump.return_value = {"id": "prompt-1"}
         list_prompts_mock = AsyncMock(return_value=([prompt], "next"))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts_mock)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", ["team-1"]))
 
         result = await main_mod.list_prompts(
             request,
@@ -4834,7 +4834,7 @@ class TestPromptListEndpointCoverage:
         request.state = SimpleNamespace(team_id="team-1")
         db = MagicMock()
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", ["team-1"], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", ["team-1"]))
         response = await main_mod.list_prompts(
             request,
             cursor=None,
@@ -4861,7 +4861,7 @@ class TestPromptListEndpointCoverage:
 
         list_prompts_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts_mock)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
 
         await main_mod.list_prompts(
             request,
@@ -4890,7 +4890,7 @@ class TestPromptListEndpointCoverage:
 
         list_prompts_mock = AsyncMock(return_value=([], None))
         monkeypatch.setattr(main_mod.prompt_service, "list_prompts", list_prompts_mock)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
 
         await main_mod.list_prompts(
             request,
@@ -6572,7 +6572,7 @@ class TestA2ABranchCoverage:
         svc.list_agents = AsyncMock(return_value=([agent], "next"))
         svc.get_agent = AsyncMock(side_effect=A2AAgentNotFoundError("missing"))
         monkeypatch.setattr(main_mod, "a2a_service", svc)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", None, True))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", None))
 
         result = await main_mod.list_a2a_agents(
             request,
@@ -8124,7 +8124,6 @@ class TestRpcHandling:
         with (
             patch("mcpgateway.main.SessionLocal", return_value=mock_db),
             patch("mcpgateway.main._authorize_internal_mcp_request", new=AsyncMock(return_value={"email": "user@example.com"})),
-            patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", [], False)),
             patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])),
             patch(patch_target, new=AsyncMock(return_value=patch_value)),
         ):
@@ -9623,7 +9622,7 @@ class TestRpcHandling:
         payload = {"jsonrpc": "2.0", "id": "1", "method": "resources/read", "params": {}}
         request = self._make_request(payload)
 
-        with patch("mcpgateway.main.get_rpc_filter_context", return_value=("user@example.com", None, False)):
+        with patch("mcpgateway.main.get_scoped_resource_access_context", return_value=("user@example.com", [])):
             result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
             assert "error" in result
 
@@ -11818,7 +11817,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
         monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(return_value={"filtered": True}))
 
@@ -11866,7 +11865,7 @@ class TestRemainingCoverageGaps:
         tool2.to_dict.return_value = {"id": "t2", "name": "Tool 2"}
 
         # Mock list_tools to return tools with a next_cursor
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool1, tool2], "cursor123")))
 
         # Mock jsonpath_modifier to return transformed data
@@ -11922,7 +11921,7 @@ class TestRemainingCoverageGaps:
         tool1.to_dict.return_value = {"id": "t1", "name": "Tool 1"}
 
         # Mock list_tools to return tools with None as next_cursor (last page)
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool1], None)))
 
         def mock_jsonpath_modifier(data, jsonpath, mapping):
@@ -11968,7 +11967,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
 
         # Invalid JSON string for apijsonpath
@@ -12001,7 +12000,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "t1", "name": "test"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], "next_cursor_123")))
 
         # Pass JsonPathModifier instance but with None jsonpath to trigger parsed_apijsonpath=None path
@@ -12040,7 +12039,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
 
         # Make jsonpath_modifier raise an exception
@@ -12079,7 +12078,7 @@ class TestRemainingCoverageGaps:
         request.state = SimpleNamespace(team_id=None)
 
         # Empty tools list
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([], None)))
         monkeypatch.setattr(main_mod, "jsonpath_modifier", MagicMock(return_value={"filtered": []}))
 
@@ -12115,7 +12114,7 @@ class TestRemainingCoverageGaps:
         async def mock_get_tool(*args, **kwargs):
             return data
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", mock_get_tool)
 
@@ -12133,7 +12132,7 @@ class TestRemainingCoverageGaps:
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
 
@@ -12157,7 +12156,7 @@ class TestRemainingCoverageGaps:
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
 
@@ -12182,7 +12181,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
 
         # Make jsonpath_modifier raise HTTPException (e.g., from invalid JSONPath)
@@ -12220,7 +12219,7 @@ class TestRemainingCoverageGaps:
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
 
@@ -12244,7 +12243,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "t1", "name": "test"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], "cursor_abc")))
 
         # Pass apijsonpath=None to trigger pagination path
@@ -12284,7 +12283,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
 
         # Pass invalid type (integer) - should raise 400 with clear message
@@ -12319,7 +12318,7 @@ class TestRemainingCoverageGaps:
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
 
@@ -12341,7 +12340,7 @@ class TestRemainingCoverageGaps:
 
         tool = MagicMock()
         tool.to_dict.return_value = {"id": "t1"}
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("user@example.com", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("user@example.com", []))
         monkeypatch.setattr(main_mod.tool_service, "list_tools", AsyncMock(return_value=([tool], None)))
 
         # Empty jsonpath string - should raise 400
@@ -12375,7 +12374,7 @@ class TestRemainingCoverageGaps:
         data = MagicMock()
         data.to_dict.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod, "get_user_team_roles", lambda _db, _email: None)
         monkeypatch.setattr(main_mod.tool_service, "get_tool", AsyncMock(return_value=data))
 
@@ -12744,7 +12743,7 @@ class TestRemainingCoverageGaps:
         tool = MagicMock()
         tool.model_dump.return_value = {"id": "t1"}
 
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _req, _user: ("u", None, False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _req, _user: ("u", []))
         monkeypatch.setattr(main_mod.tool_service, "list_server_tools", AsyncMock(return_value=[tool]))
 
         result = await main_mod.server_get_tools.__wrapped__(request, "srv", include_inactive=False, include_metrics=False, db=MagicMock(), user={"email": "u"})
@@ -12755,7 +12754,7 @@ class TestRemainingCoverageGaps:
         import mcpgateway.main as main_mod
 
         request = _make_request("/tags")
-        monkeypatch.setattr(main_mod, "get_rpc_filter_context", lambda _request, _user: ("u", [], False))
+        monkeypatch.setattr(main_mod, "get_scoped_resource_access_context", lambda _request, _user: ("u", []))
 
         monkeypatch.setattr(main_mod.tag_service, "get_all_tags", AsyncMock(return_value=[]))
         _ = await main_mod.list_tags.__wrapped__(request, "Tools, Servers", include_entities=False, db=MagicMock(), user={"email": "u"})

--- a/tests/unit/mcpgateway/test_mcp_apps_security.py
+++ b/tests/unit/mcpgateway/test_mcp_apps_security.py
@@ -461,7 +461,12 @@ class TestAppBridgeEndpoints:
 
     @pytest.mark.asyncio
     async def test_create_session_uses_admin_bypass_scope_and_returns_payload(self, monkeypatch, mock_db):
-        """Admin app sessions should use unrestricted resource lookup and return session metadata."""
+        """Admin app sessions should use unrestricted resource lookup and return session metadata.
+
+        Admin bypass keeps the caller's email so the resource service can still owner-match the
+        admin's own private ``ui://`` resource; nulling it excluded every private row and turned
+        an owned resource into a 404.
+        """
         # First-Party
         from mcpgateway import main as main_mod
 
@@ -475,14 +480,14 @@ class TestAppBridgeEndpoints:
 
         with (
             patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
-            patch.object(main_mod, "get_rpc_filter_context", return_value=("admin@example.com", None, True)),
+            patch.object(main_mod, "get_scoped_resource_access_context", return_value=("admin@example.com", None)),
             patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(return_value=SimpleNamespace())) as read_mock,
             patch.object(main_mod.mcp_app_session_service, "create_session", return_value=app_session) as create_mock,
         ):
             response = await main_mod.create_mcp_app_session.__wrapped__(request=request, db=mock_db, user={"email": "admin@example.com", "is_admin": True})
 
         read_mock.assert_awaited_once()
-        assert read_mock.await_args.kwargs["user"] is None
+        assert read_mock.await_args.kwargs["user"] == "admin@example.com"
         assert read_mock.await_args.kwargs["token_teams"] is None
         create_mock.assert_called_once()
         assert create_mock.call_args.kwargs["token_teams"] is None
@@ -553,7 +558,7 @@ class TestAppBridgeEndpoints:
 
         with (
             patch.object(main_mod, "_assert_session_owner_or_admin", new=AsyncMock()),
-            patch.object(main_mod, "get_rpc_filter_context", return_value=("user@example.com", ["team-b"], False)),
+            patch.object(main_mod, "get_scoped_resource_access_context", return_value=("user@example.com", ["team-b"])),
             patch.object(main_mod.resource_service, "read_resource", new=AsyncMock(side_effect=ResourceNotFoundError("Resource not found"))) as read_mock,
             patch.object(main_mod.mcp_app_session_service, "create_session") as create_mock,
         ):


### PR DESCRIPTION
## 🔗 Related Issue

Closes #4451

---

## 📝 Summary

Centralizes Layer-1 visibility filtering across `mcpgateway/main.py` by replacing inline derivations of the admin-bypass + public-only-secure-default rule with calls to `get_scoped_resource_access_context()` from `mcpgateway/auth_context.py`.

**Problem**: the rule was hand-copied at every call site. The copies drifted — different comments, and more importantly two incompatible behaviours for admin bypass (some preserved `user_email`, some nulled it). Each copy is a place a future change to the Layer-1 contract can be missed.

**Result**: inline derivations drop from 33 to 6, with the 6 remaining documented in-line as deliberate exceptions.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## ⚠️ Behaviour changes (both intentional)

Response shapes, error codes, and non-admin visibility are unchanged. What changes is how many rows an **admin** token sees. The boundary that hides *other* users' private rows is unchanged and covered by deny-path tests. Recorded under **Breaking Changes** in `CHANGELOG.md`.

**1. Basic-auth / dev-mode admins gain admin bypass across all 27 migrated call sites.**
The superseded inline derivation read `is_admin` only from a verified JWT payload, so an admin authenticating without one — basic auth, or `AUTH_REQUIRED=false` local setups — was narrowed to public-only. Such callers now get the intended bypass: public + team + their own private rows. This is the wider-reaching of the two changes and affects an entire authentication mode.

**2. JWT-authenticated admins now see their own private rows on 9 endpoints.**
These sites discarded the caller's email when granting bypass, which drops *every* private row from the result — including the admin's own — because the service layer needs the email to owner-match:

`GET /tags`, `GET /tags/{tag}/entities`, JSON-RPC `completion/complete`, and the internal MCP `tools/list`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`, and `completion/complete` handlers.

---

## 📓 Notes

### Preserved exceptions (6)

These still call `get_rpc_filter_context()` directly and carry an inline `# Layer-1 exception` comment naming the reason:

| Function | Reason |
|---|---|
| `_build_internal_mcp_auth_context_for_rpc` | Forwards an auth context rather than deriving visibility scope; needs the raw `is_admin` flag |
| `_authorize_run_cancellation` | Compares requester against run owner; needs raw token teams and `is_admin`, not the normalized scope |
| `_execute_rpc_tools_call` | Captures run ownership from the raw context before admin-bypass normalization is applied |
| `create_mcp_app_session` | Keeps the resource-scope email separate from `user_email`, which the single-value helper contract cannot express |
| `handle_internal_mcp_tools_call_resolve` | Tool-execution authorization, not resource visibility |
| `tools/call` branch of `_handle_rpc_authenticated` | Tool-execution authorization; kept in sync with `_execute_rpc_tools_call` |

The two tool-execution sites are deliberately left alone: routing them through the helper would widen admin *execution* scope to the admin's own private tools, which is a separate behavioural change and belongs in its own PR.

### Other fixes in this change

- **Request-scoped memoization** of the derived triple, keyed on the identity of the `user` object rather than the request alone. Handlers needing both the scope and the requester identity previously derived twice, and that derivation can issue a live `EmailUser` lookup for session tokens. Keying on the user object matters: one request may derive for more than one principal (the synthetic forwarded user built for trusted internal A2A dispatch), and those must not read each other's cached entry.
- **Malformed cached JWT payload no longer raises.** `get_rpc_filter_context()` called `.get()` on the cached payload without a type check, turning a non-dict payload into a JSON-RPC `-32603 Internal error` instead of a normal RBAC decision. Guarded with `isinstance`, and it now logs a warning like the sibling type-check below it.
- **Corrected the documented contract.** Both the module docstring and `get_scoped_resource_access_context()`'s own docstring stated that admin bypass returns `(None, None)`; the code returns `(email, None)` by design, so the email survives for owner matching. `(None, None)` means bypass for a caller with no resolvable email.

### Tests

- **`tests/unit/mcpgateway/test_auth_context.py`** (new) — pins the Layer-1 rule itself. `auth_context.py` had no test file, and endpoint tests mock the helper, so nothing exercised the rule directly once it moved out of `main.py`. Also covers the memoization and malformed-payload behaviour above.
- **`tests/integration/test_admin_bypass_owner_visibility.py`** (new) — real DB, real login, real service layer, across `GET /tags`, `GET /tags/{tag}/entities`, JSON-RPC `completion/complete`, and the internal MCP `prompts/list` and `resources/list` handlers. Each asserts both directions: the admin sees their own private row, and still cannot see another user's. Covers 4 of the 9 endpoints above; the remaining 5 share the same `BaseService._apply_visibility_scope` enforcement.
- **Mock retargeting** — tests patching `mcpgateway.main.get_rpc_filter_context` against a migrated handler no longer intercept anything, so the real derivation ran instead and they passed without verifying what they were written to verify. Those are retargeted to the centralized helper with post-rule 2-tuples. The patches that remain all target the 6 preserved sites.

### Docs

- `AGENTS.md` gains an **Implementation Helpers** section under *Token Scoping Quick Reference* describing when to use `get_scoped_resource_access_context()`, `get_request_identity()`, and the raw `get_rpc_filter_context()`.
- `CHANGELOG.md` entry under **Breaking Changes**, split so the basic-auth change is its own headline rather than a trailing clause.

### Scope

Per the issue's own out-of-scope note, `streamablehttp_transport.py` and `routers/teams.py` are untouched. No schema or Alembic change — this is a runtime filter.

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (`AGENTS.md`, `CHANGELOG.md`)
- [x] No secrets or credentials committed
