### PR TITLE
fix: tool validation hardening — name length limit, skipped-tool feed…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -7848,7 +7848,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 615,
+        "line_number": 616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7856,7 +7856,7 @@
         "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 638,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4204,7 +4204,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4205,
+        "line_number": 4207,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4212,7 +4212,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4840,
+        "line_number": 4842,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4220,7 +4220,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4842,
+        "line_number": 4844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4228,7 +4228,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15211,
+        "line_number": 15218,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4924,7 +4924,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 752,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5060,7 +5060,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4221,
+        "line_number": 4224,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5068,7 +5068,7 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5353,
+        "line_number": 5356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5076,7 +5076,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5702,
+        "line_number": 5705,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5084,7 +5084,7 @@
         "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5759,
+        "line_number": 5762,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5092,7 +5092,7 @@
         "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5797,
+        "line_number": 5800,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5100,7 +5100,7 @@
         "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5798,
+        "line_number": 5801,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -7738,7 +7738,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 639,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7746,7 +7746,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 637,
+        "line_number": 640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7754,7 +7754,7 @@
         "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1522,
+        "line_number": 1528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7762,7 +7762,7 @@
         "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5096,
+        "line_number": 5185,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7770,7 +7770,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5101,
+        "line_number": 5190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7778,7 +7778,7 @@
         "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6642,
+        "line_number": 6731,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7786,7 +7786,7 @@
         "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7239,
+        "line_number": 7328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7794,7 +7794,7 @@
         "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7258,
+        "line_number": 7347,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7802,7 +7802,7 @@
         "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7464,
+        "line_number": 7553,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -7810,7 +7810,7 @@
         "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7483,
+        "line_number": 7572,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -9234,7 +9234,7 @@
         "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 781,
+        "line_number": 779,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9242,7 +9242,7 @@
         "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 975,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9250,7 +9250,7 @@
         "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 967,
+        "line_number": 980,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9258,7 +9258,7 @@
         "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 993,
+        "line_number": 1006,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9266,7 +9266,7 @@
         "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1011,
+        "line_number": 1024,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9274,7 +9274,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1224,
+        "line_number": 1235,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -9282,7 +9282,7 @@
         "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1340,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-08T06:46:35Z",
+  "generated_at": "2026-05-08T07:30:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4934,7 +4934,7 @@
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 250,
+        "line_number": 249,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -4942,7 +4942,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2763,
+        "line_number": 2759,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -54,7 +54,7 @@ import orjson
 from pydantic import SecretStr, ValidationError
 from pydantic_core import ValidationError as CoreValidationError
 from sqlalchemy import and_, bindparam, case, cast, desc, false, func, or_, select, String, text
-from sqlalchemy.exc import IntegrityError, InvalidRequestError, OperationalError
+from sqlalchemy.exc import DataError, IntegrityError, InvalidRequestError, OperationalError
 from sqlalchemy.orm import joinedload, selectinload, Session, with_loader_criteria
 from sqlalchemy.sql.functions import coalesce
 from starlette.background import BackgroundTask
@@ -2989,7 +2989,8 @@ async def admin_add_server(request: Request, db: Session = Depends(get_db), user
     except IntegrityError as ex:
         return ORJSONResponse(content=ErrorFormatter.format_database_error(ex), status_code=409)
     except Exception as ex:
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_add_server: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/servers/{server_id}/edit")
@@ -3142,7 +3143,8 @@ async def admin_edit_server(
     except HTTPException:
         raise
     except Exception as ex:
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_edit_server: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/servers/{server_id}/state")
@@ -11777,8 +11779,8 @@ async def admin_edit_tool(
         LOGGER.error(f"ValidationError in admin_edit_tool: {str(ex)}")
         return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
     except Exception as ex:  # Generic catch-all for unexpected errors
-        LOGGER.error(f"Unexpected error in admin_edit_tool: {str(ex)}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_edit_tool: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/tools/generate-schemas-from-openapi")
@@ -12243,7 +12245,7 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         metadata = MetadataCapture.extract_creation_metadata(request, user)
 
         team_id_cast = typing_cast(Optional[str], team_id)
-        await gateway_service.register_gateway(
+        result = await gateway_service.register_gateway(
             db,
             gateway,
             created_by=metadata["created_by"],
@@ -12269,8 +12271,9 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
                 "4. Return to the admin panel\n\n"
                 "Tools will not work until OAuth authorization is completed."
             )
+        skipped_tools = result.skipped_tools if result and result.skipped_tools else []
         return ORJSONResponse(
-            content={"message": message, "success": True},
+            content={"message": message, "success": True, "skipped_tools": skipped_tools},
             status_code=200,
         )
 
@@ -12289,8 +12292,11 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=400)
     except IntegrityError as ex:
         return ORJSONResponse(content=ErrorFormatter.format_database_error(ex), status_code=409)
+    except DataError as ex:
+        return ORJSONResponse(content=ErrorFormatter.format_database_error(ex), status_code=400)
     except Exception as ex:
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_add_gateway: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 # OAuth callback is now handled by the dedicated OAuth router at /oauth/callback
@@ -12502,7 +12508,8 @@ async def admin_edit_gateway(
         # NOTE: Pydantic's ValidationError subclasses ValueError, so ValidationError must be handled first.
         if isinstance(ex, ValueError):
             return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=400)
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_edit_gateway: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/gateways/{gateway_id}/delete")
@@ -12765,8 +12772,8 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
                 },
                 status_code=415,
             )
-        LOGGER.error(f"Error in admin_add_resource: {ex}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_add_resource: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/resources/{resource_id}/edit")
@@ -12894,8 +12901,8 @@ async def admin_edit_resource(
                     "allowed_types": ex.allowed_types,
                 },
             )
-        LOGGER.error(f"Error in admin_edit_resource: {ex}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_edit_resource: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/resources/{resource_id}/delete")
@@ -13157,8 +13164,8 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
                 },
             )
 
-        LOGGER.error(f"Error in admin_add_prompt: {ex}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_add_prompt: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/prompts/{prompt_id}/edit")
@@ -13287,8 +13294,8 @@ async def admin_edit_prompt(
                     "success": False,
                 },
             )
-        LOGGER.error(f"Error in admin_edit_prompt: {ex}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error in admin_edit_prompt: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/prompts/{prompt_id}/delete")
@@ -15619,8 +15626,8 @@ async def admin_add_a2a_agent(
     except HTTPException:
         raise
     except Exception as ex:
-        LOGGER.error(f"Error creating A2A agent: {ex}")
-        return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        LOGGER.exception(f"Unexpected error creating A2A agent: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
 @admin_router.post("/a2a/{agent_id}/edit")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12271,7 +12271,7 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
                 "4. Return to the admin panel\n\n"
                 "Tools will not work until OAuth authorization is completed."
             )
-        skipped_tools = result.skipped_tools if result and result.skipped_tools else []
+        skipped_tools = result.skipped_tools if isinstance(getattr(result, "skipped_tools", None), list) else []
         return ORJSONResponse(
             content={"message": message, "success": True, "skipped_tools": skipped_tools},
             status_code=200,

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -8,7 +8,7 @@ import {
   validateUrl,
 } from "./security";
 import { getEditSelections } from "./servers";
-import { isInactiveChecked, safeGetElement, showErrorMessage } from "./utils";
+import { isInactiveChecked, safeGetElement, showErrorMessage, showSkippedToolsWarning } from "./utils";
 
 // ===================================================================
 // ENHANCED FORM HANDLERS with Input Validation
@@ -123,6 +123,9 @@ export const handleGatewayFormSubmit = async function (e) {
     if (!result || !result.success) {
       throw new Error(result?.message || "Failed to add Gateway");
     } else {
+      if (result.skipped_tools && result.skipped_tools.length > 0) {
+        await showSkippedToolsWarning(result.skipped_tools);
+      }
       const teamId = new URL(window.location.href).searchParams.get("team_id");
       const searchParams = new URLSearchParams();
       if (isInactiveCheckedBool) {
@@ -822,6 +825,9 @@ export const handleEditGatewayFormSubmit = async function (e) {
       throw new Error(result?.message || "Failed to edit Gateway");
     }
     // Only redirect on success
+    if (result.skipped_tools && result.skipped_tools.length > 0) {
+      await showSkippedToolsWarning(result.skipped_tools);
+    }
     const teamId = new URL(window.location.href).searchParams.get("team_id");
 
     const searchParams = new URLSearchParams();

--- a/mcpgateway/admin_ui/utils.js
+++ b/mcpgateway/admin_ui/utils.js
@@ -311,8 +311,14 @@ export function showSkippedToolsWarning(skippedTools) {
       const reason = colonIdx !== -1 ? entry.slice(colonIdx + 2) : "Unknown error";
       const tr = document.createElement("tr");
       tr.className = "border-b border-gray-100 last:border-0";
-      tr.innerHTML = `<td class="px-3 py-2 font-mono text-xs text-gray-800 align-top break-all">${toolName}</td>
-        <td class="px-3 py-2 text-gray-700 align-top">${reason}</td>`;
+      const toolNameCell = document.createElement("td");
+      toolNameCell.className = "px-3 py-2 font-mono text-xs text-gray-800 align-top break-all";
+      toolNameCell.textContent = toolName;
+      const reasonCell = document.createElement("td");
+      reasonCell.className = "px-3 py-2 text-gray-700 align-top";
+      reasonCell.textContent = reason;
+      tr.appendChild(toolNameCell);
+      tr.appendChild(reasonCell);
       tbody.appendChild(tr);
     }
 

--- a/mcpgateway/admin_ui/utils.js
+++ b/mcpgateway/admin_ui/utils.js
@@ -274,6 +274,71 @@ export function showSuccessMessage(message) {
   }, 3000);
 }
 
+// Show a persistent modal warning listing tools that were skipped during gateway import.
+// Returns a Promise that resolves when the user dismisses the modal.
+export function showSkippedToolsWarning(skippedTools) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50";
+
+    const modal = document.createElement("div");
+    modal.className = "bg-white rounded-lg shadow-xl p-6 max-w-2xl w-full mx-4";
+
+    const title = document.createElement("h2");
+    title.className = "text-lg font-semibold text-yellow-700 mb-3";
+    title.textContent = "Some tools were skipped";
+
+    const intro = document.createElement("p");
+    intro.className = "text-sm text-gray-600 mb-3";
+    intro.textContent = "The following tools could not be imported due to validation errors:";
+
+    const tableWrapper = document.createElement("div");
+    tableWrapper.className = "overflow-auto max-h-64 mb-4 border border-gray-200 rounded";
+
+    const table = document.createElement("table");
+    table.className = "w-full text-sm border-collapse";
+
+    const thead = document.createElement("thead");
+    thead.innerHTML = `<tr class="bg-gray-100 text-left">
+      <th class="px-3 py-2 font-semibold text-gray-700 border-b border-gray-200 w-1/2">Tool name</th>
+      <th class="px-3 py-2 font-semibold text-gray-700 border-b border-gray-200">Reason</th>
+    </tr>`;
+
+    const tbody = document.createElement("tbody");
+    for (const entry of skippedTools) {
+      const colonIdx = entry.indexOf(": ");
+      const toolName = colonIdx !== -1 ? entry.slice(0, colonIdx) : entry;
+      const reason = colonIdx !== -1 ? entry.slice(colonIdx + 2) : "Unknown error";
+      const tr = document.createElement("tr");
+      tr.className = "border-b border-gray-100 last:border-0";
+      tr.innerHTML = `<td class="px-3 py-2 font-mono text-xs text-gray-800 align-top break-all">${toolName}</td>
+        <td class="px-3 py-2 text-gray-700 align-top">${reason}</td>`;
+      tbody.appendChild(tr);
+    }
+
+    table.appendChild(thead);
+    table.appendChild(tbody);
+    tableWrapper.appendChild(table);
+
+    const dismissBtn = document.createElement("button");
+    dismissBtn.className = "bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded text-sm font-medium";
+    dismissBtn.textContent = "Dismiss";
+    dismissBtn.addEventListener("click", () => {
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+      resolve();
+    });
+
+    modal.appendChild(title);
+    modal.appendChild(intro);
+    modal.appendChild(tableWrapper);
+    modal.appendChild(dismissBtn);
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+  });
+}
+
 // Handle HTMX after-request for user delete — extracts plain text from the
 // HTML error response and surfaces it via the toast notification system.
 // Exposed on window so inline hx-on::after-request handlers can call it.

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -698,7 +698,7 @@ class SecurityValidator:
             >>> try:
             ...     SecurityValidator.validate_tool_name(long_tool_name)
             ... except ValueError as e:
-            ...     'exceeds maximum length' in str(e)
+            ...     'exceeds MCP spec limit' in str(e)
             True
         """
         if not value:

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -348,6 +348,7 @@ class SecurityValidator:
 
     # MCP-compliant limits (configurable)
     MAX_NAME_LENGTH = settings.validation_max_name_length  # Default: 255
+    MAX_TOOL_NAME_LENGTH = settings.validation_max_tool_name_length  # Default: 128 (MCP spec)
     MAX_DESCRIPTION_LENGTH = settings.validation_max_description_length  # Default: 8192 (8KB)
     MAX_TEMPLATE_LENGTH = settings.validation_max_template_length  # Default: 65536
     MAX_CONTENT_LENGTH = settings.validation_max_content_length  # Default: 1048576 (1MB)
@@ -711,8 +712,8 @@ class SecurityValidator:
         if _HTML_SPECIAL_CHARS_RE.search(value):
             raise ValueError("Tool name cannot contain HTML special characters")
 
-        if len(value) > cls.MAX_NAME_LENGTH:
-            raise ValueError(f"Tool name exceeds maximum length of {cls.MAX_NAME_LENGTH}")
+        if len(value) > cls.MAX_TOOL_NAME_LENGTH:
+            raise ValueError(f"Tool name exceeds MCP spec limit of {cls.MAX_TOOL_NAME_LENGTH} characters (got {len(value)})")
 
         return value
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -385,11 +385,9 @@ class Settings(BaseSettings):
         # RFC 7230 token = 1*tchar; tchar = "!" / "#" / "$" / "%" / "&" / "'"
         # / "*" / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
         if not re.fullmatch(r"[A-Za-z0-9!#$%&'*+\-.^_`|~]+", cleaned):
-            raise ValueError(
-                f"AUTH_HEADER_NAME '{v}' is not a valid HTTP header token "
-                "(RFC 7230). Use only ASCII letters, digits, and !#$%&'*+-.^_`|~."
-            )
+            raise ValueError(f"AUTH_HEADER_NAME '{v}' is not a valid HTTP header token " "(RFC 7230). Use only ASCII letters, digits, and !#$%&'*+-.^_`|~.")
         return cleaned
+
     basic_auth_user: str = "admin"
     basic_auth_password: SecretStr = Field(default=SecretStr("changeme"))
     jwt_algorithm: str = "HS256"
@@ -489,7 +487,7 @@ class Settings(BaseSettings):
     )
     tool_description_forbidden_patterns_enabled: bool = Field(default=True, description="Enable forbidden pattern validation on tool descriptions. Set to false to disable all checks.")
     tool_description_forbidden_patterns: List[str] = Field(
-        default_factory=lambda: ["&&", "||", "$(", "> ", "< "],
+        default_factory=lambda: ["&&", "||", "$("],
         description='Substrings forbidden in tool descriptions. Override via TOOL_DESCRIPTION_FORBIDDEN_PATTERNS env var as a JSON array, e.g. \'["&&","||"]\'.',
     )
 
@@ -2948,6 +2946,7 @@ Disallow: /
 
     # MCP-compliant size limits (configurable via env)
     validation_max_name_length: int = 255
+    validation_max_tool_name_length: int = 128  # MCP spec SHOULD limit for tool names
     validation_max_description_length: int = 8192  # 8KB
     validation_max_template_length: int = 65536  # 64KB
     validation_max_content_length: int = 1048576  # 1MB

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1853,16 +1853,17 @@ def validate_security_configuration():
 
         # Warn about ephemeral storage without strict user-in-DB mode
         if not getattr(current_settings, "require_user_in_db", False):
-            is_ephemeral = ":memory:" in settings.database_url or settings.database_url == "sqlite:///./mcp.db"
+            database_url = getattr(current_settings, "database_url", settings.database_url)
+            is_ephemeral = ":memory:" in database_url or database_url == "sqlite:///./mcp.db"
             if is_ephemeral:
                 logger.warning("Using potentially ephemeral storage with platform admin bootstrap enabled. Consider using persistent storage or setting REQUIRE_USER_IN_DB=true for production.")
 
         # Warn about default JWT issuer/audience in non-development environments
         if current_settings.environment != "development":
             if current_settings.jwt_issuer == "mcpgateway":
-                logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", settings.environment)
+                logger.warning("Using default JWT_ISSUER in %s environment. Set a unique JWT_ISSUER per environment to prevent cross-environment token acceptance.", current_settings.environment)
             if current_settings.jwt_audience == "mcpgateway-api":
-                logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", settings.environment)
+                logger.warning("Using default JWT_AUDIENCE in %s environment. Set a unique JWT_AUDIENCE per environment to prevent cross-environment token acceptance.", current_settings.environment)
 
         # UAID Cross-Gateway Routing Security Check
         if not current_settings.uaid_allowed_domains:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -62,7 +62,7 @@ from jsonpath_ng.jsonpath import JSONPath
 import orjson
 from pydantic import ValidationError
 from sqlalchemy import text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request as starletteRequest
@@ -6595,6 +6595,8 @@ async def register_gateway(
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=status.HTTP_422_UNPROCESSABLE_CONTENT)
         if isinstance(ex, IntegrityError):
             return ORJSONResponse(status_code=status.HTTP_409_CONFLICT, content=ErrorFormatter.format_database_error(ex))
+        if isinstance(ex, DataError):
+            return ORJSONResponse(content=ErrorFormatter.format_database_error(ex), status_code=status.HTTP_400_BAD_REQUEST)
         return ORJSONResponse(content={"message": "Unexpected error"}, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3526,6 +3526,9 @@ class GatewayRead(BaseModelWithConfigDict):
     # Tool count (populated from the tools relationship; 0 when not loaded)
     tool_count: int = Field(default=0, description="Number of tools registered for this gateway")
 
+    # Tools skipped during gateway import due to validation errors (transient, not persisted)
+    skipped_tools: List[str] = Field(default_factory=list, description="Tools skipped during gateway import due to validation errors")
+
     @model_validator(mode="before")
     @classmethod
     def _mask_query_param_auth(cls, data: Any) -> Any:

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1046,7 +1046,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
             if initialize_timeout is not None:
                 try:
-                    capabilities, tools, resources, prompts = await asyncio.wait_for(
+                    capabilities, tools, resources, prompts, validation_errors = await asyncio.wait_for(
                         self._initialize_gateway(
                             init_url,  # URL with query params if applicable
                             authentication_headers,
@@ -1064,7 +1064,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     sanitized = sanitize_url_for_logging(init_url, auth_query_params_decrypted)
                     raise GatewayConnectionError(f"Gateway initialization timed out after {initialize_timeout}s for {sanitized}") from exc
             else:
-                capabilities, tools, resources, prompts = await self._initialize_gateway(
+                capabilities, tools, resources, prompts, validation_errors = await self._initialize_gateway(
                     init_url,  # URL with query params if applicable
                     authentication_headers,
                     gateway.transport,
@@ -1411,7 +1411,11 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 },
             )
 
-            return self.convert_gateway_to_read(db_gateway)
+            gateway_read = self.convert_gateway_to_read(db_gateway)
+            gateway_read.skipped_tools = validation_errors
+            if validation_errors:
+                logger.warning(f"Gateway '{db_gateway.name}' registered successfully but {len(validation_errors)} tool(s) were " f"skipped due to validation errors: {validation_errors}")
+            return gateway_read
         except* GatewayConnectionError as ge:  # pragma: no mutate
             if TYPE_CHECKING:
                 ge: ExceptionGroup[GatewayConnectionError]
@@ -1605,10 +1609,10 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
             # Use the existing connection logic with validation context for diagnostics
             if gateway.transport.upper() == "SSE":
-                capabilities, tools, resources, prompts = await self._connect_to_sse_server_without_validation(gateway.url, authentication, validation_warnings=token_validation.warnings)
+                capabilities, tools, resources, prompts, _ = await self._connect_to_sse_server_without_validation(gateway.url, authentication, validation_warnings=token_validation.warnings)
             elif gateway.transport.upper() == "STREAMABLEHTTP":
                 try:
-                    capabilities, tools, resources, prompts = await self.connect_to_streamablehttp_server(gateway.url, authentication)
+                    capabilities, tools, resources, prompts, _ = await self.connect_to_streamablehttp_server(gateway.url, authentication)
                 except Exception as streamable_err:
                     # Surface diagnostic context for likely auth rejections (401/403)
                     error_str = str(streamable_err).lower()
@@ -2380,7 +2384,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             update_client_key = _enc.decrypt_secret_or_plaintext(update_client_key)
                         except Exception:
                             logger.debug("client_key decryption skipped during gateway re-init")
-                    capabilities, tools, resources, prompts = await self._initialize_gateway(
+                    capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
                         init_url,
                         gateway.auth_value,
                         gateway.transport,
@@ -2961,7 +2965,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                                 act_client_key = _enc.decrypt_secret_or_plaintext(act_client_key)
                             except Exception:
                                 logger.debug("client_key decryption skipped during gateway activation")
-                        capabilities, tools, resources, prompts = await self._initialize_gateway(
+                        capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
                             init_url,
                             gateway.auth_value,
                             gateway.transport,
@@ -4035,7 +4039,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         oauth_auto_fetch_tool_flag: Optional[bool] = False,
         client_cert: Optional[str] = None,
         client_key: Optional[str] = None,
-    ) -> tuple[Dict[str, Any], List[ToolCreate], List[ResourceCreate], List[PromptCreate]]:
+    ) -> tuple[Dict[str, Any], List[ToolCreate], List[ResourceCreate], List[PromptCreate], List[str]]:
         """Initialize connection to a gateway and retrieve its capabilities.
 
         Connects to an MCP gateway using the specified transport protocol,
@@ -4117,7 +4121,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
                         # Skip MCP server connection for Authorization Code flow
                         # Tools will be fetched after OAuth completion
-                        return {}, [], [], []
+                        return {}, [], [], [], []
                     # When flag is True (activation), skip token fetch but try to connect
                     # This allows activation to proceed - actual auth happens during tool invocation
                     logger.debug("OAuth Authorization Code gateway activation - skipping token fetch")
@@ -4135,18 +4139,19 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             tools = []
             resources = []
             prompts = []
+            validation_errors: list[str] = []
             if auth_type in ("basic", "bearer", "authheaders") and isinstance(authentication, str):
                 authentication = decode_auth(authentication)
             if transport.lower() == "sse":
-                capabilities, tools, resources, prompts = await self.connect_to_sse_server(
+                capabilities, tools, resources, prompts, validation_errors = await self.connect_to_sse_server(
                     url, authentication, ca_certificate, include_prompts, include_resources, auth_query_params, client_cert=client_cert, client_key=client_key
                 )
             elif transport.lower() == "streamablehttp":
-                capabilities, tools, resources, prompts = await self.connect_to_streamablehttp_server(
+                capabilities, tools, resources, prompts, validation_errors = await self.connect_to_streamablehttp_server(
                     url, authentication, ca_certificate, include_prompts, include_resources, auth_query_params, client_cert=client_cert, client_key=client_key
                 )
 
-            return capabilities, tools, resources, prompts
+            return capabilities, tools, resources, prompts, validation_errors
         except Exception as e:
 
             # MCP SDK uses TaskGroup which wraps exceptions in ExceptionGroup
@@ -5106,7 +5111,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     _refresh_key = _enc.decrypt_secret_or_plaintext(_refresh_key)
                 except Exception:
                     logger.debug("client_key decryption skipped during gateway refresh")
-            _capabilities, tools, resources, prompts = await self._initialize_gateway(
+            _capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
                 url=gateway_url,
                 authentication=gateway_auth_value,
                 transport=gateway_transport,
@@ -5456,8 +5461,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 valid_tools.append(validated_tool)
                 logger.debug(f"Tool '{tool_name}' validated successfully")
             except ValidationError as e:
-                error_msg = f"Validation failed for tool '{tool_name}': {e.errors()}"
-                logger.error(error_msg)
+                clean_msgs = "; ".join(err["msg"].removeprefix("Value error, ") for err in e.errors())
+                error_msg = f"{tool_name}: {clean_msgs}"
+                logger.error(f"Validation failed for tool '{tool_name}': {e.errors()}")
                 logger.debug(f"Failed tool schema: {tool_dict}")
                 validation_errors.append(error_msg)
             except ValueError as e:
@@ -5520,7 +5526,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     tools = response.tools
                     tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
-                    tools, _ = self._validate_tools(tools, context="oauth")
+                    tools, validation_errors = self._validate_tools(tools, context="oauth")
                     if tools:
                         logger.info(f"Fetched {len(tools)} tools from gateway")
                     # Fetch resources if supported
@@ -5605,7 +5611,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         except Exception as e:
                             logger.warning(f"Failed to fetch prompts: {e}")
 
-                    return capabilities, tools, resources, prompts
+                    return capabilities, tools, resources, prompts, validation_errors
         except Exception as e:
             # Note: This function is for OAuth servers only, which don't use query param auth
             # Still sanitize in case exception contains URL with static sensitive params
@@ -5698,7 +5704,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 tools = response.tools
                 tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
-                tools, _ = self._validate_tools(tools)
+                tools, validation_errors = self._validate_tools(tools)
                 if tools:
                     logger.info(f"Fetched {len(tools)} tools from gateway")
                 # Fetch resources if supported
@@ -5784,7 +5790,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         except Exception as e:
                             logger.warning(f"Failed to fetch prompts: {e}")
 
-                return capabilities, tools, resources, prompts
+                return capabilities, tools, resources, prompts, validation_errors
         sanitized_url = sanitize_url_for_logging(server_url, auth_query_params)
         raise GatewayConnectionError(f"Failed to initialize gateway at {sanitized_url}: Connection could not be established")
 
@@ -5863,7 +5869,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 tools = response.tools
                 tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
-                tools, _ = self._validate_tools(tools)
+                tools, validation_errors = self._validate_tools(tools)
                 for tool in tools:
                     tool.request_type = "STREAMABLEHTTP"
                 if tools:
@@ -5942,7 +5948,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         except Exception as e:
                             logger.warning(f"Failed to fetch prompts: {e}")
 
-                return capabilities, tools, resources, prompts
+                return capabilities, tools, resources, prompts, validation_errors
         sanitized_url = sanitize_url_for_logging(server_url, auth_query_params)
         raise GatewayConnectionError(f"Failed to initialize gateway at {sanitized_url}: Connection could not be established")
 

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -826,7 +826,7 @@ class TestToolAPIs:
         long_name = "a" * 300
         response = await client.post("/tools", json={"tool": {"name": long_name, "url": "https://example.com"}}, headers=TEST_AUTH_HEADER)
         assert response.status_code == 422
-        assert "exceeds maximum length" in str(response.json())
+        assert "exceeds MCP spec limit" in str(response.json())
 
     async def test_get_tool(self, client: AsyncClient, mock_auth):
         """Test GET /tools/{tool_id}."""

--- a/tests/unit/mcpgateway/services/test_gateway_auto_refresh.py
+++ b/tests/unit/mcpgateway/services/test_gateway_auto_refresh.py
@@ -170,7 +170,7 @@ class TestAutoRefreshGatewayToolsResourcesPrompts:
         ):
             mock_fresh.return_value.__enter__.return_value = mock_session
             # Empty response from auth_code gateway
-            mock_init.return_value = ({}, [], [], [])
+            mock_init.return_value = ({}, [], [], [], [])
 
             result = await gateway_service._refresh_gateway_tools_resources_prompts("gw-123")
 
@@ -199,7 +199,7 @@ class TestAutoRefreshGatewayToolsResourcesPrompts:
         ):
             mock_fresh.return_value.__enter__.return_value = mock_session
             # Empty response from client_credentials gateway
-            mock_init.return_value = ({}, [], [], [])
+            mock_init.return_value = ({}, [], [], [], [])
             mock_cache.return_value = AsyncMock()
             mock_tool_cache.return_value = AsyncMock()
 
@@ -234,7 +234,7 @@ class TestAutoRefreshGatewayToolsResourcesPrompts:
         ):
             mock_fresh.return_value.__enter__.return_value = mock_session
             # Empty response - should only remove MCP-discovered tools
-            mock_init.return_value = ({}, [], [], [])
+            mock_init.return_value = ({}, [], [], [], [])
             mock_cache.return_value = AsyncMock()
             mock_tool_cache.return_value = AsyncMock()
 
@@ -258,7 +258,7 @@ class TestAutoRefreshGatewayToolsResourcesPrompts:
             patch.object(gateway_service, "_initialize_gateway", new_callable=AsyncMock) as mock_init,
         ):
             mock_fresh.return_value.__enter__.return_value = mock_session
-            mock_init.return_value = ({}, [], [], [])
+            mock_init.return_value = ({}, [], [], [], [])
 
             await gateway_service._refresh_gateway_tools_resources_prompts("gw-123", pre_auth_headers=pre_auth_headers)
 
@@ -277,7 +277,7 @@ class TestInitializeGatewayPreAuthHeaders:
         pre_auth_headers = {"Authorization": "Bearer pre-fetched-token"}
 
         with (patch.object(gateway_service, "connect_to_sse_server", new_callable=AsyncMock) as mock_connect,):
-            mock_connect.return_value = ({}, [], [], [])
+            mock_connect.return_value = ({}, [], [], [], [])
 
             await gateway_service._initialize_gateway(
                 url="http://test:8000",
@@ -327,7 +327,7 @@ class TestCacheInvalidationPerType:
             patch("mcpgateway.services.gateway_service._get_tool_lookup_cache") as get_tool_cache,
         ):
             mock_fresh.return_value.__enter__.return_value = mock_session
-            mock_init.return_value = ({}, [mock_tool_schema], [], [])
+            mock_init.return_value = ({}, [mock_tool_schema], [], [], [])
             get_cache.return_value = mock_cache
             get_tool_cache.return_value = mock_tool_lookup_cache
 

--- a/tests/unit/mcpgateway/services/test_gateway_hot_cold_integration.py
+++ b/tests/unit/mcpgateway/services/test_gateway_hot_cold_integration.py
@@ -627,7 +627,7 @@ class TestMarkPollCompletedInRefreshPath:
 
         # Mock _initialize_gateway to return empty (no changes, but success)
         with (
-            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], [], []))),
             patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
             patch("mcpgateway.services.gateway_service._get_registry_cache") as mock_cache_fn,
             patch("mcpgateway.services.gateway_service._get_tool_lookup_cache") as mock_tl_fn,
@@ -672,7 +672,7 @@ class TestMarkPollCompletedInRefreshPath:
         mock_gateway.refresh_interval_seconds = None
 
         with (
-            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch.object(gateway_service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], [], []))),
             patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh_db,
             patch("mcpgateway.services.gateway_service._get_registry_cache") as mock_cache_fn,
             patch("mcpgateway.services.gateway_service._get_tool_lookup_cache") as mock_tl_fn,
@@ -800,7 +800,7 @@ class TestUpdateGatewayPollSchedule:
         gateway_update.gateway_mode = None
 
         with (
-            patch.object(service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], []))),
+            patch.object(service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], [], []))),
             patch.object(service, "_notify_gateway_updated", AsyncMock()),
             patch("mcpgateway.services.gateway_service._get_registry_cache", return_value=AsyncMock()),
             patch("mcpgateway.services.gateway_service._get_tool_lookup_cache", return_value=AsyncMock()),

--- a/tests/unit/mcpgateway/services/test_gateway_query_param_auth.py
+++ b/tests/unit/mcpgateway/services/test_gateway_query_param_auth.py
@@ -172,7 +172,7 @@ class TestQueryParamAuthRegistration:
 
         async def capture_init(*args, **kwargs):
             captured_params.update(kwargs.get("auth_query_params", {}) or {})
-            return ({"tools": {"listChanged": True}}, [], [], [])
+            return ({"tools": {"listChanged": True}}, [], [], [], [])
 
         gateway_service._initialize_gateway = AsyncMock(side_effect=capture_init)
         gateway_service._notify_gateway_added = AsyncMock()

--- a/tests/unit/mcpgateway/services/test_gateway_query_param_auth.py
+++ b/tests/unit/mcpgateway/services/test_gateway_query_param_auth.py
@@ -116,7 +116,7 @@ class TestQueryParamAuthRegistration:
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
         url = url_normalize("https://api.tavily.com/mcp")
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_added = AsyncMock()
 
         mock_model = Mock()
@@ -266,7 +266,7 @@ class TestQueryParamAuthUpdate:
             ]
         )
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_changed = AsyncMock()
 
         mock_model = Mock()

--- a/tests/unit/mcpgateway/services/test_gateway_resources_prompts.py
+++ b/tests/unit/mcpgateway/services/test_gateway_resources_prompts.py
@@ -75,7 +75,7 @@ class TestGatewayResourcesPrompts:
             mock_session_instance.list_prompts.return_value = mock_prompts_response
 
             # Execute
-            capabilities, tools, resources, prompts = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+            capabilities, tools, resources, prompts, _ = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
             # Verify
             assert capabilities["resources"]["listChanged"] is True
@@ -132,7 +132,7 @@ class TestGatewayResourcesPrompts:
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
-            capabilities, tools, resources, prompts = await service._initialize_gateway("http://test.example.com", None, "SSE")
+            capabilities, tools, resources, prompts, _ = await service._initialize_gateway("http://test.example.com", None, "SSE")
 
             # Verify
             assert "resources" not in capabilities
@@ -191,7 +191,7 @@ class TestGatewayResourcesPrompts:
             mock_session_instance.list_prompts.side_effect = Exception("Failed to fetch prompts")
 
             # Execute
-            capabilities, tools, resources, prompts = await service._initialize_gateway("http://test.example.com", None, "SSE")
+            capabilities, tools, resources, prompts, _ = await service._initialize_gateway("http://test.example.com", None, "SSE")
 
             # Verify - should return empty lists for resources/prompts on failure
             assert len(tools) == 1

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -263,6 +263,7 @@ class TestGatewayService:
                 [],
                 [],
                 [],
+                [],
             )
         )
         gateway_service._notify_gateway_added = AsyncMock()
@@ -369,6 +370,7 @@ class TestGatewayService:
                 [],
                 [],
                 [],
+                [],
             )
         )
 
@@ -419,6 +421,7 @@ class TestGatewayService:
                     "tools": {"listChanged": True},
                 },
                 mock_tools,
+                [],
                 [],
                 [],
             )
@@ -481,7 +484,7 @@ class TestGatewayService:
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
 
         gateway_create = GatewayCreate(
             name="test_gateway",
@@ -547,7 +550,7 @@ class TestGatewayService:
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
 
         gateway_create = GatewayCreate(
             name="test_gateway",
@@ -575,7 +578,7 @@ class TestGatewayService:
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_added = AsyncMock()
 
         mock_model = Mock()
@@ -610,7 +613,7 @@ class TestGatewayService:
         test_db.flush = Mock()
         test_db.refresh = Mock()
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_added = AsyncMock()
 
         captured_gateway: dict[str, object] = {}
@@ -687,7 +690,7 @@ class TestGatewayService:
         test_db.flush = Mock()
         test_db.refresh = Mock()
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_added = AsyncMock()
 
         captured_gateway: dict[str, object] = {}
@@ -727,7 +730,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"subscribe": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"subscribe": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(
@@ -762,7 +765,7 @@ class TestGatewayService:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"subscribe": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"subscribe": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(client_key=settings.masked_auth_value)
@@ -786,7 +789,7 @@ class TestGatewayService:
         # Mock query for _check_gateway_uniqueness
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(all=Mock(return_value=[])))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
 
         gateway_create = GatewayCreate(
             name="test_gateway",
@@ -1051,6 +1054,9 @@ class TestGatewayService:
                     "tools": {"subscribe": True},
                 },
                 [],
+                [],
+                [],
+                [],
             )
         )
         gateway_service._notify_gateway_updated = AsyncMock()
@@ -1123,7 +1129,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         # Mock settings for auth value checking
@@ -1154,7 +1160,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(auth_type="")
@@ -1200,7 +1206,7 @@ class TestGatewayService:
             ToolCreate(name="new_tool", description="Brand new tool", integration_type="REST", request_type="POST", input_schema={"type": "object"}),
         ]
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, new_tools, [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, new_tools, [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
         url = GatewayService.normalize_url("http://example.com/new-url")
         gateway_update = GatewayUpdate(url=url)
@@ -1444,7 +1450,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         # Only update description
@@ -1491,7 +1497,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(description="New description")
@@ -1544,7 +1550,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(description="New description")
@@ -1599,7 +1605,7 @@ class TestGatewayService:
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(transport="STREAMABLEHTTP")
@@ -1665,7 +1671,7 @@ class TestGatewayService:
         # Setup gateway service mocks
         gateway_service._notify_gateway_activated = AsyncMock()
         gateway_service._notify_gateway_deactivated = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], [], []))
 
         # Patch model_validate to return a mock with .masked()
         mock_gateway_read = MagicMock()
@@ -1703,7 +1709,7 @@ class TestGatewayService:
         # Setup gateway service mocks
         gateway_service._notify_gateway_activated = AsyncMock()
         gateway_service._notify_gateway_deactivated = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], [], []))
 
         # Patch model_validate to return a mock with .masked()
         mock_gateway_read = MagicMock()
@@ -1733,7 +1739,7 @@ class TestGatewayService:
 
         # Setup gateway service mocks
         gateway_service._notify_gateway_offline = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], [], []))
 
         # Patch model_validate to return a mock with .masked()
         mock_gateway_read = MagicMock()
@@ -1772,7 +1778,7 @@ class TestGatewayService:
 
         # Setup gateway service mocks
         gateway_service._notify_gateway_deactivated = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"prompts": {}}, [], [], [], []))
 
         # The set_gateway_state method will catch the exception and raise GatewayError
         with pytest.raises(GatewayError) as exc_info:
@@ -1808,7 +1814,7 @@ class TestGatewayService:
 
         gateway_service._notify_gateway_activated = AsyncMock()
         # _initialize_gateway returns empty — simulates unauthenticated connection
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
 
         mock_gateway_read = MagicMock()
         mock_gateway_read.masked.return_value = mock_gateway_read
@@ -1849,7 +1855,7 @@ class TestGatewayService:
 
         gateway_service._notify_gateway_activated = AsyncMock()
         # Empty return — but NOT auth_code, so cleanup should proceed
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
 
         mock_gateway_read = MagicMock()
         mock_gateway_read.masked.return_value = mock_gateway_read
@@ -1892,7 +1898,7 @@ class TestGatewayService:
         test_db.expire = Mock()
 
         gateway_service._notify_gateway_activated = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [new_tool], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [new_tool], [], [], []))
         gateway_service._update_or_create_tools = Mock(return_value=[])
         gateway_service._update_or_create_resources = Mock(return_value=[])
         gateway_service._update_or_create_prompts = Mock(return_value=[])
@@ -1931,7 +1937,7 @@ class TestGatewayService:
         test_db.refresh = Mock()
 
         gateway_service._notify_gateway_activated = AsyncMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
 
         mock_gateway_read = MagicMock()
         mock_gateway_read.masked.return_value = mock_gateway_read
@@ -2162,7 +2168,7 @@ class TestGatewayService:
             mock_session_instance.list_prompts.return_value = mock_prompts_response
 
             # Execute
-            capabilities, tools, resources, prompts = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+            capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
             # Verify
             assert "resources" in capabilities
@@ -2227,7 +2233,7 @@ class TestGatewayService:
                 mock_resource_create.return_value = MagicMock()
 
                 # Execute
-                capabilities, tools, resources, prompts = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+                capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
                 # Verify fallback resource creation was used
                 assert len(resources) == 1
@@ -2281,7 +2287,7 @@ class TestGatewayService:
                 mock_prompt_create.return_value = MagicMock()
 
                 # Execute
-                capabilities, tools, resources, prompts = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+                capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
                 # Verify fallback prompt creation was used
                 assert len(prompts) == 1
@@ -2326,7 +2332,7 @@ class TestGatewayService:
             mock_session_instance.list_resources.side_effect = Exception("Resource fetch failed")
 
             # Execute
-            capabilities, tools, resources, prompts = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+            capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
             # Verify
             assert "resources" in capabilities
@@ -2371,7 +2377,7 @@ class TestGatewayService:
             mock_session_instance.list_prompts.side_effect = Exception("Prompt fetch failed")
 
             # Execute
-            capabilities, tools, resources, prompts = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+            capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
             # Verify
             assert "prompts" in capabilities
@@ -2380,10 +2386,10 @@ class TestGatewayService:
     @pytest.mark.asyncio
     async def test_initialize_gateway_oauth_auth_code_returns_empty(self, gateway_service):
         """OAuth auth_code should short-circuit and skip connection unless flag set."""
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
 
         oauth_config = {"grant_type": "authorization_code"}
-        capabilities, tools, resources, prompts = await gateway_service._initialize_gateway(
+        capabilities, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway(
             "http://test.example.com",
             authentication=None,
             transport="SSE",
@@ -2401,7 +2407,7 @@ class TestGatewayService:
     @pytest.mark.asyncio
     async def test_initialize_gateway_oauth_client_credentials(self, gateway_service):
         """OAuth client_credentials should fetch token and connect."""
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
         gateway_service.oauth_manager.get_access_token = AsyncMock(return_value="token123")
 
         oauth_config = {"grant_type": "client_credentials"}
@@ -2509,7 +2515,7 @@ class TestGatewayService:
 
         # Mock _initialize_gateway to return empty lists
         async def mock_init(*args, **kwargs):
-            return {}, [], [], []
+            return {}, [], [], [], []
 
         gateway_service._initialize_gateway = mock_init
 
@@ -2545,7 +2551,7 @@ class TestGatewayService:
 
         # Mock _initialize_gateway to return empty lists
         async def mock_init(*args, **kwargs):
-            return {}, [], [], []
+            return {}, [], [], [], []
 
         gateway_service._initialize_gateway = mock_init
 
@@ -2585,7 +2591,7 @@ class TestGatewayService:
 
         # Mock _initialize_gateway to return empty lists
         async def mock_init(*args, **kwargs):
-            return {}, [], [], []
+            return {}, [], [], [], []
 
         gateway_service._initialize_gateway = mock_init
 
@@ -2649,7 +2655,7 @@ class TestGatewayService:
         session.execute.return_value = _make_execute_result(scalar=existing_gateway)
         session.commit = MagicMock()
         session.refresh = MagicMock()
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         gateway_service._publish_event = AsyncMock()
 
         # Update to cache mode
@@ -2716,7 +2722,7 @@ class TestGatewayRefresh:
             new_resources = [MagicMock(uri="res1")]
             new_prompts = [MagicMock(name="prompt1")]
 
-            gateway_service._initialize_gateway = AsyncMock(return_value=({}, new_tools, new_resources, new_prompts))  # capabilities
+            gateway_service._initialize_gateway = AsyncMock(return_value=({}, new_tools, new_resources, new_prompts, []))  # capabilities
 
             # Mock update/create helpers
             gateway_service._update_or_create_tools = Mock(return_value=[MagicMock()])
@@ -2743,7 +2749,7 @@ class TestGatewayRefresh:
 
         with patch("mcpgateway.services.gateway_service.fresh_db_session", return_value=mock_db_session):
             # Mock empty return from initialize
-            gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+            gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
 
             # Mock update methods to avoid real execution errors
             gateway_service._update_or_create_tools = Mock(return_value=[])
@@ -2893,6 +2899,85 @@ class TestGatewayRefresh:
         assert len(validation_errors) == 1
         assert "invalid_tool" in validation_errors[0]
 
+    def test_validate_tools_error_message(self, gateway_service):
+        """Validation errors must be 'toolname: reason' strings, not raw pydantic dicts (issue #136 Bug C).
+
+        Previously _validate_tools emitted raw pydantic error dicts which rendered as
+        "[{'type': 'value_error', 'msg': 'Value error, ...'}]" in the UI modal.
+        """
+        long_name = "a" * 129  # Exceeds MCP spec limit of 128 chars
+        tools = [
+            {"name": "valid_tool", "description": "ok", "inputSchema": {}},
+            {"name": long_name, "inputSchema": {}},
+        ]
+
+        valid_tools, errors = gateway_service._validate_tools(tools)
+
+        assert len(valid_tools) == 1
+        expected = [f"{long_name}: Tool name exceeds MCP spec limit of 128 characters (got 129)"]
+        assert errors == expected
+
+    @pytest.mark.asyncio
+    async def test_validate_tools_skipped_tools_set_on_register_gateway(self, gateway_service):
+        """register_gateway must expose validation_errors as skipped_tools on the returned GatewayRead (issue #136 Bug C).
+
+        Mocks only the MCP transport layer so the real connect_to_sse_server → _validate_tools
+        chain runs against a tool whose name exceeds the 128-char limit. The exact error string
+        produced by the validator is asserted end-to-end.
+        """
+        from mcpgateway.schemas import GatewayCreate
+
+        gateway_data = GatewayCreate(
+            name="Test Gateway",
+            url="https://test.example.com",
+            transport="SSE",
+        )
+
+        long_name = "a" * 129
+
+        # Mock the MCP session to return two tools: one valid, one with an oversized name.
+        # _validate_tools only returns errors (instead of raising) when at least one tool passes,
+        # so we need the valid tool to exercise the partial-failure path.
+        # Capabilities are intentionally empty so resources/prompts fetches are skipped.
+        mock_session = AsyncMock()
+        mock_init = MagicMock()
+        mock_init.capabilities.model_dump.return_value = {}
+        mock_session.initialize.return_value = mock_init
+
+        valid_tool = MagicMock()
+        valid_tool.model_dump.return_value = {"name": "valid_tool", "description": "ok", "inputSchema": {}}
+        long_name_tool = MagicMock()
+        long_name_tool.model_dump.return_value = {"name": long_name, "inputSchema": {}}
+        mock_list_tools = MagicMock()
+        mock_list_tools.tools = [valid_tool, long_name_tool]
+        mock_session.list_tools.return_value = mock_list_tools
+
+        mock_sse_cm = AsyncMock()
+        mock_sse_cm.__aenter__.return_value = (MagicMock(), MagicMock())
+        mock_sse_cm.__aexit__.return_value = None
+
+        mock_client_cm = AsyncMock()
+        mock_client_cm.__aenter__.return_value = mock_session
+        mock_client_cm.__aexit__.return_value = None
+
+        gateway_service._notify_gateway_added = AsyncMock()
+
+        db = MagicMock()
+        # Return scalar=None so all uniqueness/name-conflict queries find nothing
+        db.execute.return_value = _make_execute_result(scalar=None)
+        db.add = MagicMock()
+        db.flush = MagicMock()
+        db.refresh = MagicMock()
+        db.commit = MagicMock()
+
+        with patch("mcpgateway.services.gateway_service.sse_client", return_value=mock_sse_cm):
+            with patch("mcpgateway.services.gateway_service.ClientSession", return_value=mock_client_cm):
+                result = await gateway_service.register_gateway(db, gateway_data, created_by="test@example.com")
+
+        assert result.skipped_tools == [
+            f"{long_name}: Tool name exceeds MCP spec limit of 128 characters (got 129)"
+        ]
+
     def test_validate_tools_all_invalid(self, gateway_service):
         """Test failure when all tools are invalid."""
         tools = [
@@ -2971,7 +3056,7 @@ class TestGatewayRefresh:
         with patch("mcpgateway.services.gateway_service.sse_client", return_value=mock_sse_cm):
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=mock_client_cm):
                 # Execute
-                capabilities, tools, resources, prompts = await gateway_service._connect_to_sse_server_without_validation("http://test.com")
+                capabilities, tools, resources, prompts, validation_errors = await gateway_service._connect_to_sse_server_without_validation("http://test.com")
 
                 assert len(tools) == 1
                 assert len(resources) == 1
@@ -3009,7 +3094,7 @@ class TestGatewayRefresh:
         with patch("mcpgateway.services.gateway_service.sse_client", return_value=mock_sse_cm):
             with patch("mcpgateway.services.gateway_service.ClientSession", return_value=mock_client_cm):
                 # Execute
-                capabilities, tools, resources, prompts = await gateway_service._connect_to_sse_server_without_validation("http://test.com")
+                capabilities, tools, resources, prompts, validation_errors = await gateway_service._connect_to_sse_server_without_validation("http://test.com")
 
                 # Should return empty lists for failed parts, not raise exception
                 assert len(resources) == 0
@@ -3434,8 +3519,9 @@ async def test_register_gateway_auth_value_decode_failure(gateway_service, monke
     )
 
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], []))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
     gateway_service._notify_gateway_added = AsyncMock()
+    gateway_service.convert_gateway_to_read = MagicMock(return_value=MagicMock())
 
     db = MagicMock()
     db.add = Mock()
@@ -3458,8 +3544,9 @@ async def test_register_gateway_auth_headers_one_time_auth(gateway_service, monk
     )
 
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], []))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
     gateway_service._notify_gateway_added = AsyncMock()
+    gateway_service.convert_gateway_to_read = MagicMock(return_value=MagicMock())
 
     db = MagicMock()
     db.add = Mock()
@@ -3487,7 +3574,7 @@ async def test_register_gateway_query_param_timeout(gateway_service, monkeypatch
     monkeypatch.setattr("mcpgateway.services.gateway_service.asyncio.wait_for", _fake_wait_for)
 
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], []))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
 
     with pytest.raises(GatewayConnectionError):
         await gateway_service.register_gateway(MagicMock(), gateway, initialize_timeout=0.01)
@@ -3546,8 +3633,9 @@ async def test_register_gateway_reassigns_orphaned_resource(gateway_service, mon
     )
 
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [resource], [prompt]))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [resource], [prompt], []))
     gateway_service._notify_gateway_added = AsyncMock()
+    gateway_service.convert_gateway_to_read = MagicMock(return_value=MagicMock())
 
     await gateway_service.register_gateway(
         db,
@@ -3728,7 +3816,7 @@ async def test_connect_to_sse_server_without_validation_fallbacks(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.gateway_service.ResourceCreate.model_validate", _resource_validate)
     monkeypatch.setattr("mcpgateway.services.gateway_service.PromptCreate.model_validate", _prompt_validate)
 
-    capabilities, tools, resources, prompts = await service._connect_to_sse_server_without_validation("http://server")
+    capabilities, tools, resources, prompts, validation_errors = await service._connect_to_sse_server_without_validation("http://server")
 
     assert capabilities["resources"] is True
     assert tools == []
@@ -3839,7 +3927,7 @@ async def test_connect_to_streamablehttp_server_resources_and_prompts(monkeypatc
     monkeypatch.setattr("mcpgateway.services.gateway_service.ClientSession", lambda *_args: DummySession())
     monkeypatch.setattr("mcpgateway.services.gateway_service.ResourceCreate.model_validate", _resource_validate)
 
-    capabilities, tools, resources, prompts = await service.connect_to_streamablehttp_server("http://server", ca_certificate=b"cert")
+    capabilities, tools, resources, prompts, validation_errors = await service.connect_to_streamablehttp_server("http://server", ca_certificate=b"cert")
 
     assert capabilities["resources"] is True
     assert tool_obj.request_type == "STREAMABLEHTTP"
@@ -3955,7 +4043,7 @@ async def test_connect_to_sse_server_resources_and_prompts(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.gateway_service.ResourceCreate.model_validate", _resource_validate)
     monkeypatch.setattr("mcpgateway.services.gateway_service.PromptCreate.model_validate", _prompt_validate)
 
-    capabilities, tools, resources, prompts = await service.connect_to_sse_server("http://server")
+    capabilities, tools, resources, prompts, validation_errors = await service.connect_to_sse_server("http://server")
 
     assert capabilities["resources"] is True
     assert tools == []
@@ -4018,8 +4106,9 @@ async def test_register_gateway_creates_new_resources_and_prompts(gateway_servic
     )
 
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [resource], [prompt]))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [resource], [prompt], []))
     gateway_service._notify_gateway_added = AsyncMock()
+    gateway_service.convert_gateway_to_read = MagicMock(return_value=MagicMock())
 
     await gateway_service.register_gateway(db, gateway)
 
@@ -4198,7 +4287,7 @@ async def test_fetch_tools_after_oauth_streamablehttp(gateway_service, monkeypat
             return "token"
 
     monkeypatch.setattr("mcpgateway.services.token_storage_service.TokenStorageService", DummyTokenStorage)
-    gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [], [], []))
+    gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
     gateway_service._update_or_create_tools = MagicMock(return_value=[])
     gateway_service._update_or_create_resources = MagicMock(return_value=[])
     gateway_service._update_or_create_prompts = MagicMock(return_value=[])
@@ -4250,7 +4339,7 @@ async def test_fetch_tools_after_oauth_cleanup_and_adds_items(gateway_service, m
 
     monkeypatch.setattr("mcpgateway.services.token_storage_service.TokenStorageService", DummyTokenStorage)
     gateway_service._connect_to_sse_server_without_validation = AsyncMock(
-        return_value=({"resources": True, "prompts": True}, [SimpleNamespace(name="keep-tool")], [SimpleNamespace(uri="keep://res")], [SimpleNamespace(name="keep-prompt")])
+        return_value=({"resources": True, "prompts": True}, [SimpleNamespace(name="keep-tool")], [SimpleNamespace(uri="keep://res")], [SimpleNamespace(name="keep-prompt")], [])
     )
     gateway_service._update_or_create_tools = MagicMock(return_value=[MagicMock()])
     gateway_service._update_or_create_resources = MagicMock(return_value=[MagicMock()])
@@ -4926,7 +5015,7 @@ class TestSetGatewayState:
             version=1,
         )
         db = self._make_db_for_state(gw)
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         gateway_service._event_service = AsyncMock()
 
         result = await gateway_service.set_gateway_state(db, "gw-1", activate=True, reachable=True)
@@ -5100,7 +5189,7 @@ class TestSetGatewayState:
         # Mock decode_auth to return decrypted value
         monkeypatch.setattr("mcpgateway.services.gateway_service.decode_auth", lambda x: {"api_key": "secret123"})
         monkeypatch.setattr("mcpgateway.services.gateway_service.apply_query_param_auth", lambda url, params: url + "?api_key=secret123")
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         gateway_service._event_service = AsyncMock()
 
         result = await gateway_service.set_gateway_state(db, "gw-1", activate=True, reachable=True)
@@ -5834,7 +5923,7 @@ class TestInitializeGateway:
     @pytest.mark.asyncio
     async def test_oauth_auth_code_skips_connection(self, gateway_service):
         """OAuth authorization_code without flag returns empty."""
-        caps, tools, resources, prompts = await gateway_service._initialize_gateway(
+        caps, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway(
             url="http://example.com",
             auth_type="oauth",
             oauth_config={"grant_type": "authorization_code"},
@@ -5849,8 +5938,8 @@ class TestInitializeGateway:
     async def test_oauth_client_credentials_success(self, gateway_service):
         gateway_service.oauth_manager = AsyncMock()
         gateway_service.oauth_manager.get_access_token = AsyncMock(return_value="access-tok")
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], []))
-        caps, tools, resources, prompts = await gateway_service._initialize_gateway(
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {"listChanged": True}}, [], [], [], []))
+        caps, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway(
             url="http://example.com",
             auth_type="oauth",
             oauth_config={"grant_type": "client_credentials"},
@@ -5872,21 +5961,21 @@ class TestInitializeGateway:
 
     @pytest.mark.asyncio
     async def test_sse_transport(self, gateway_service):
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], []))
-        caps, tools, resources, prompts = await gateway_service._initialize_gateway(url="http://example.com", transport="SSE")
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], [], []))
+        caps, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway(url="http://example.com", transport="SSE")
         assert len(tools) == 1
         gateway_service.connect_to_sse_server.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_streamablehttp_transport(self, gateway_service):
-        gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], []))
-        caps, tools, resources, prompts = await gateway_service._initialize_gateway(url="http://example.com", transport="StreamableHTTP")
+        gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], [], []))
+        caps, tools, resources, prompts, validation_errors = await gateway_service._initialize_gateway(url="http://example.com", transport="StreamableHTTP")
         assert len(tools) == 1
         gateway_service.connect_to_streamablehttp_server.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_pre_auth_headers_used(self, gateway_service):
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], [], []))
         await gateway_service._initialize_gateway(
             url="http://example.com",
             authentication={"old": "header"},
@@ -5900,7 +5989,7 @@ class TestInitializeGateway:
     @pytest.mark.asyncio
     async def test_string_auth_decoded(self, gateway_service, monkeypatch):
         monkeypatch.setattr("mcpgateway.services.gateway_service.decode_auth", lambda x: {"Authorization": "decoded"})
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], [], []))
         await gateway_service._initialize_gateway(
             url="http://example.com",
             authentication="encoded_string",
@@ -5920,7 +6009,7 @@ class TestInitializeGateway:
 
     @pytest.mark.asyncio
     async def test_none_authentication_defaults_to_empty_dict(self, gateway_service):
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({}, [], [], [], []))
         await gateway_service._initialize_gateway(url="http://example.com", authentication=None, transport="SSE")
         call_args = gateway_service.connect_to_sse_server.call_args
         assert call_args[0][1] == {}
@@ -5928,8 +6017,8 @@ class TestInitializeGateway:
     @pytest.mark.asyncio
     async def test_oauth_auth_code_with_flag(self, gateway_service):
         """With oauth_auto_fetch_tool_flag=True, auth code gateway connects."""
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], []))
-        caps, tools, _, _ = await gateway_service._initialize_gateway(
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [SimpleNamespace(name="t1")], [], [], []))
+        caps, tools, _, _, _ = await gateway_service._initialize_gateway(
             url="http://example.com",
             auth_type="oauth",
             oauth_config={"grant_type": "authorization_code"},
@@ -5941,7 +6030,7 @@ class TestInitializeGateway:
     @pytest.mark.asyncio
     async def test_initialize_gateway_passes_mtls_to_sse(self, gateway_service):
         """_initialize_gateway passes client_cert/client_key to connect_to_sse_server (line 5227)."""
-        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], []))
+        gateway_service.connect_to_sse_server = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
         await gateway_service._initialize_gateway(
             url="https://example.com",
             transport="SSE",
@@ -5956,7 +6045,7 @@ class TestInitializeGateway:
     @pytest.mark.asyncio
     async def test_initialize_gateway_passes_mtls_to_streamablehttp(self, gateway_service):
         """_initialize_gateway passes client_cert/client_key to connect_to_streamablehttp_server (line 5393-5394)."""
-        gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [], [], []))
+        gateway_service.connect_to_streamablehttp_server = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
         await gateway_service._initialize_gateway(
             url="https://example.com",
             transport="StreamableHTTP",
@@ -6030,7 +6119,7 @@ class TestRefreshGatewayToolsResourcesPrompts:
             ca_certificate=None,
             auth_query_params=None,
         )
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         result = await gateway_service._refresh_gateway_tools_resources_prompts("gw-1", gateway=gw)
         assert result["tools_added"] == 0
         assert result["success"] is True
@@ -6436,7 +6525,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.passthrough_headers == ["X-Custom", "X-Other"]
@@ -6468,7 +6557,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.passthrough_headers == ["X-Custom", "X-Other"]
@@ -6530,7 +6619,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert isinstance(mock_gateway.auth_value, dict) and len(mock_gateway.auth_value) > 0
@@ -6570,7 +6659,7 @@ class TestUpdateGatewayAdvanced:
 
         # _initialize_gateway returns a new tool with different name
         new_tool = SimpleNamespace(name="new_tool", description="new", inputSchema={"type": "object"})
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [new_tool], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [new_tool], [], [], [])))
         monkeypatch.setattr(gateway_service, "_create_db_tool", MagicMock(return_value=MagicMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service.get_for_update", MagicMock(side_effect=[mock_gateway, None]))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
@@ -6612,7 +6701,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.oauth_config == {"client_id": "cid", "grant_type": "client_credentials"}
@@ -6653,7 +6742,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         await gateway_service.update_gateway(db, mock_gateway.id, update_data)
 
@@ -6694,7 +6783,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         await gateway_service.update_gateway(db, mock_gateway.id, update_data)
 
@@ -6729,7 +6818,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(
             db,
@@ -6810,7 +6899,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.auth_type == ""
@@ -6845,7 +6934,7 @@ class TestUpdateGatewayAdvanced:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.auth_query_params is None
@@ -7208,7 +7297,7 @@ class TestSetGatewayStateActivation:
         mock_gateway.prompts = []
 
         new_tool = SimpleNamespace(name="fresh_tool", description="d", inputSchema={"type": "object"})
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [new_tool], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [new_tool], [], [], [])))
         monkeypatch.setattr(gateway_service, "_create_db_tool", MagicMock(return_value=MagicMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
@@ -7238,7 +7327,7 @@ class TestSetGatewayStateActivation:
 
         monkeypatch.setattr("mcpgateway.services.gateway_service.decode_auth", MagicMock(return_value={"api_key": "raw_key"}))
         monkeypatch.setattr("mcpgateway.services.gateway_service.apply_query_param_auth", MagicMock(return_value="http://example.com?api_key=raw_key"))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
@@ -7263,7 +7352,7 @@ class TestSetGatewayStateActivation:
         mock_gateway.prompts = []
 
         monkeypatch.setattr("mcpgateway.services.gateway_service.decode_auth", MagicMock(side_effect=Exception("decrypt error")))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
@@ -7290,7 +7379,7 @@ class TestSetGatewayStateActivation:
         new_tool = SimpleNamespace(name="tool1", description="d", inputSchema={"type": "object"})
         new_resource = SimpleNamespace(uri="res://1", name="res1", description="d", mimeType="text/plain")
         new_prompt = SimpleNamespace(name="prompt1", description="d", arguments=[])
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}, "resources": {}, "prompts": {}}, [new_tool], [new_resource], [new_prompt])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}, "resources": {}, "prompts": {}}, [new_tool], [new_resource], [new_prompt], [])))
         monkeypatch.setattr(gateway_service, "_create_db_tool", MagicMock(return_value=MagicMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
@@ -7314,7 +7403,7 @@ class TestSetGatewayStateActivation:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         gateway_service._publish_event = AsyncMock()
 
         result = await gateway_service.set_gateway_state(db, mock_gateway.id, activate=True, reachable=True, only_update_reachable=True)
@@ -7448,7 +7537,7 @@ class TestUpdateGatewayQueryParam:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert mock_gateway.auth_type == "query_param"
@@ -7485,7 +7574,7 @@ class TestUpdateGatewayQueryParam:
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: MagicMock(invalidate_gateways=AsyncMock()))
         monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: MagicMock(invalidate_gateway=AsyncMock()))
         monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", MagicMock(invalidate_tags=AsyncMock()))
-        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [])))
+        monkeypatch.setattr(gateway_service, "_initialize_gateway", AsyncMock(return_value=({"tools": {}}, [], [], [], [])))
 
         result = await gateway_service.update_gateway(db, mock_gateway.id, update_data)
         assert result is not None
@@ -7603,7 +7692,7 @@ async def test_register_gateway_direct_proxy_allowed_when_enabled(gateway_servic
 
     # Let the rest of the method proceed past the guard
     gateway_service._check_gateway_uniqueness = MagicMock(return_value=None)
-    gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+    gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
     gateway_service._notify_gateway_added = AsyncMock()
 
     with patch("mcpgateway.services.gateway_service.settings", mock_settings):
@@ -7715,7 +7804,7 @@ class TestMtlsDecryptExceptionBranches:
         test_db.commit = Mock()
         test_db.refresh = Mock()
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [], [], [], []))
         gateway_service._notify_gateway_updated = AsyncMock()
 
         gateway_update = GatewayUpdate(url="http://example.com/updated")
@@ -7751,7 +7840,7 @@ class TestMtlsDecryptExceptionBranches:
             client_key="raw-key",
         )
 
-        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], []))
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
         monkeypatch.setattr("mcpgateway.services.gateway_service.fresh_db_session", MagicMock())
 
         with patch("mcpgateway.services.gateway_service.get_encryption_service", side_effect=RuntimeError("no enc")):

--- a/tests/unit/mcpgateway/services/test_gateway_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_extended.py
@@ -94,7 +94,7 @@ class TestGatewayServiceExtended:
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
-            capabilities, tools, resources, prompts = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
+            capabilities, tools, resources, prompts, _ = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "SSE")
 
             # Verify
             assert capabilities == {"protocolVersion": "0.1.0"}
@@ -142,7 +142,7 @@ class TestGatewayServiceExtended:
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
-            capabilities, tools, resources, prompts = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "streamablehttp")
+            capabilities, tools, resources, prompts, _ = await service._initialize_gateway("http://test.example.com", {"Authorization": "Bearer token"}, "streamablehttp")
 
             # Verify
             assert capabilities == {"protocolVersion": "0.1.0"}
@@ -1743,7 +1743,7 @@ class TestGatewayServiceExtended:
                 patch.object(
                     service,
                     "_connect_to_sse_server_without_validation",
-                    new=AsyncMock(return_value=({}, [], [], [prompt_from_server])),
+                    new=AsyncMock(return_value=({}, [], [], [prompt_from_server], [])),
                 ),
                 patch.object(service, "_update_or_create_tools", return_value=[]),
                 patch.object(service, "_update_or_create_resources", return_value=[]),

--- a/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
@@ -186,7 +186,7 @@ async def test_authheaders_auth_value_stored_as_dict(monkeypatch):
 
     service = GatewayService()
     service._check_gateway_uniqueness = MagicMock(return_value=None)
-    service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [fake_tool], [], []))
+    service._initialize_gateway = AsyncMock(return_value=({"tools": {}}, [fake_tool], [], [], []))
     service._notify_gateway_added = AsyncMock()
 
     monkeypatch.setattr("mcpgateway.services.gateway_service.get_for_update", lambda *_a, **_kw: None)

--- a/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_helpers.py
@@ -192,7 +192,7 @@ async def test_authheaders_auth_value_stored_as_dict(monkeypatch):
     monkeypatch.setattr("mcpgateway.services.gateway_service.get_for_update", lambda *_a, **_kw: None)
     monkeypatch.setattr(
         "mcpgateway.services.gateway_service.GatewayRead.model_validate",
-        lambda x: MagicMock(masked=lambda: x),
+        lambda x: MagicMock(),
     )
 
     db = MagicMock()

--- a/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py
@@ -500,6 +500,7 @@ class TestGatewayServiceOAuthComprehensive:
                     [mock_tool],  # tools
                     [],  # resources
                     [],  # prompts
+                    [],  # validation_errors
                 )
             )
 
@@ -715,7 +716,7 @@ class TestFetchToolsAfterOauthTokenValidation:
         ):
             mock_tss_inst = MockTSS.return_value
             mock_tss_inst.get_user_token = AsyncMock(return_value=token)
-            mock_connect.return_value = ({}, [], [], [])
+            mock_connect.return_value = ({}, [], [], [], [])
 
             with pytest.raises(GatewayConnectionError, match="audience"):
                 await gateway_service.fetch_tools_after_oauth(test_db, "gw-id", "user@example.com")
@@ -734,7 +735,7 @@ class TestFetchToolsAfterOauthTokenValidation:
         ):
             mock_tss_inst = MockTSS.return_value
             mock_tss_inst.get_user_token = AsyncMock(return_value="opaque-token-not-jwt")
-            mock_connect.return_value = ({}, [], [], [])
+            mock_connect.return_value = ({}, [], [], [], [])
 
             await gateway_service.fetch_tools_after_oauth(test_db, "gw-id", "user@example.com")
 

--- a/tests/unit/mcpgateway/services/test_logging_service.py
+++ b/tests/unit/mcpgateway/services/test_logging_service.py
@@ -33,14 +33,17 @@ from mcpgateway.services.logging_service import CorrelationIdJsonFormatter, Logg
 
 @pytest.fixture(autouse=True)
 def _restore_root_logger_level():
-    """Prevent set_level() calls from leaking global root logger state into other test modules."""
+    """Prevent set_level() calls from leaking global logger state into other test modules."""
     root = logging.getLogger()
     saved_level = root.level
     saved_handler_levels = [(h, h.level) for h in root.handlers]
+    saved_logger_levels = {name: logger.level for name, logger in logging.Logger.manager.loggerDict.items() if isinstance(logger, logging.Logger)}
     yield
     root.setLevel(saved_level)
     for handler, level in saved_handler_levels:
         handler.setLevel(level)
+    for name, level in saved_logger_levels.items():
+        logging.getLogger(name).setLevel(level)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_logging_service_comprehensive.py
+++ b/tests/unit/mcpgateway/services/test_logging_service_comprehensive.py
@@ -25,14 +25,17 @@ from mcpgateway.services.logging_service import _get_file_handler, _get_text_han
 
 @pytest.fixture(autouse=True)
 def _restore_root_logger_level():
-    """Prevent set_level() calls from leaking global root logger state into other test modules."""
+    """Prevent set_level() calls from leaking global logger state into other test modules."""
     root = logging.getLogger()
     saved_level = root.level
     saved_handler_levels = [(h, h.level) for h in root.handlers]
+    saved_logger_levels = {name: logger.level for name, logger in logging.Logger.manager.loggerDict.items() if isinstance(logger, logging.Logger)}
     yield
     root.setLevel(saved_level)
     for handler, level in saved_handler_levels:
         handler.setLevel(level)
+    for name, level in saved_logger_levels.items():
+        logging.getLogger(name).setLevel(level)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1524,7 +1524,7 @@ class TestAdminToolRoutes:
         result = await admin_edit_tool(tool_id, mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert result.status_code == 500
-        assert b"Unexpected error" in result.body
+        assert b"An unexpected error occurred" in result.body
 
     async def test_admin_edit_tool_validation_error(self, mock_request, mock_db):
         """Cover ValidationError handler in admin_edit_tool (invalid requestType literal)."""
@@ -6517,7 +6517,7 @@ class TestErrorHandlingPaths:
         assert result.status_code == 500
         body = json.loads(result.body)
         assert body["success"] is False
-        assert "Unexpected error" in body["message"]
+        assert "An unexpected error occurred" in body["message"]
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_validation_error_with_context(self, mock_register_gateway, mock_request, mock_db):

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -176,6 +176,7 @@ MOCK_GATEWAY_READ = {
     "enabled": True,
     "reachable": True,
     "auth_type": None,
+    "skipped_tools": [],
 }
 
 MOCK_ROOT = {
@@ -2006,6 +2007,21 @@ class TestGatewayEndpoints:
         response = test_client.post("/gateways/", json=req, headers=auth_headers)
         assert response.status_code == 200
         mock_create.assert_called_once()
+
+    @patch("mcpgateway.main.gateway_service.register_gateway")
+    def test_create_gateway_endpoint_skipped_tools_in_response(self, mock_create, test_client, auth_headers):
+        """POST /gateways/ must include skipped_tools in the response body when tools are skipped (issue #136 Bug C)."""
+        skipped = [
+            "too_long_name_aaaa: Tool name exceeds MCP spec limit of 128 characters (got 135)",
+            "bad&&tool: contains unsafe characters",
+        ]
+        gateway_read = GatewayRead(**{**MOCK_GATEWAY_READ, "skipped_tools": skipped})
+        mock_create.return_value = gateway_read
+        req = {"name": "test_gateway", "url": "http://example.com"}
+        response = test_client.post("/gateways/", json=req, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["skippedTools"] == skipped
 
     @patch("mcpgateway.main.gateway_service.get_gateway")
     def test_get_gateway_endpoint(self, mock_get, test_client, auth_headers):

--- a/tests/unit/mcpgateway/test_main_helpers_extra.py
+++ b/tests/unit/mcpgateway/test_main_helpers_extra.py
@@ -81,7 +81,7 @@ def test_validate_security_configuration_logs_default_jwt_warnings(monkeypatch: 
     )
     monkeypatch.setattr(main, "get_settings", lambda: fake_settings)
 
-    caplog.set_level("WARNING")
+    caplog.set_level("WARNING", logger="mcpgateway")
 
     main.validate_security_configuration()
 

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -155,7 +155,7 @@ class TestToolUpdateDescriptionValidationStrict:
     def test_forbidden_pattern_rejected_in_strict_mode(self, monkeypatch):
         """Descriptions with shell metacharacters raise ValueError when VALIDATION_STRICT=true."""
         monkeypatch.setattr(settings, "validation_strict", True)
-        for pat in ["&&", "||", "$(", "> ", "< "]:
+        for pat in ["&&", "||", "$("]:
             with pytest.raises(ValueError, match="unsafe characters"):
                 ToolUpdate.validate_description(f"Valid prefix {pat} suffix")
 
@@ -177,10 +177,8 @@ class TestToolUpdateDescriptionValidationStrict:
             "run cmd1 && cmd2",
             "try this || that",
             "expand $(cmd)",
-            "Search docs > results",
-            "read < file",
         ],
-        ids=["ampersand", "or", "subshell", "redirect_out", "redirect_in"],
+        ids=["ampersand", "or", "subshell"],
     )
     def test_forbidden_pattern_allowed_in_non_strict_mode(self, monkeypatch, caplog, description):
         """Each forbidden pattern is accepted (with warning) when VALIDATION_STRICT=false."""
@@ -217,7 +215,7 @@ class TestToolUpdateDescriptionValidationStrict:
     def test_forbidden_patterns_match_tool_create(self, monkeypatch):
         """Ensure ToolCreate and ToolUpdate reject the exact same set of forbidden patterns in strict mode."""
         monkeypatch.setattr(settings, "validation_strict", True)
-        forbidden_patterns = ["&&", "||", "$(", "> ", "< "]
+        forbidden_patterns = ["&&", "||", "$("]
         for pat in forbidden_patterns:
             payload = f"test {pat} injection"
             with pytest.raises(ValueError, match="unsafe characters"):
@@ -887,11 +885,26 @@ class TestToolDescriptionForbiddenPatterns:
     def test_default_patterns_block_forbidden_chars(self, monkeypatch):
         """Default forbidden patterns reject known unsafe substrings in strict mode."""
         monkeypatch.setattr(settings, "tool_description_forbidden_patterns_enabled", True)
-        monkeypatch.setattr(settings, "tool_description_forbidden_patterns", ["&&", ";", "||", "$(", "> ", "< "])
+        monkeypatch.setattr(settings, "tool_description_forbidden_patterns", ["&&", ";", "||", "$("])
         monkeypatch.setattr(settings, "validation_strict", True)
-        for pat in ["&&", ";", "||", "$(", "> ", "< "]:
+        for pat in ["&&", ";", "||", "$("]:
             with pytest.raises(ValueError, match="unsafe characters"):
                 ToolCreate.validate_description(f"description with {pat} inside")
+
+    def test_redirect_operators_allowed_by_default(self, monkeypatch):
+        """'> ' and '< ' are NOT in the default forbidden list (issue #136 fix).
+
+        These appear in legitimate tool descriptions:
+          - comparison operators: "returns a if a > b"
+          - Markdown blockquotes: "> See also: ..."
+          - generic type signatures: "List<str>"
+        """
+        monkeypatch.setattr(settings, "tool_description_forbidden_patterns_enabled", True)
+        monkeypatch.setattr(settings, "tool_description_forbidden_patterns", ["&&", "||", "$("])
+        monkeypatch.setattr(settings, "validation_strict", True)
+        assert ToolCreate.validate_description("Returns a if a > b else c") is not None
+        assert ToolCreate.validate_description("read < file.txt") is not None
+        assert ToolCreate.validate_description("> blockquote style description") is not None
 
     def test_non_strict_mode_warns_instead_of_rejecting(self, monkeypatch):
         """When VALIDATION_STRICT=false, forbidden patterns produce a warning, not an error."""
@@ -1101,7 +1114,7 @@ class TestToolCreateDescriptionValidationStrict:
     def test_forbidden_pattern_rejected_in_strict_mode(self, monkeypatch):
         """Descriptions with shell metacharacters raise ValueError when VALIDATION_STRICT=true."""
         monkeypatch.setattr(settings, "validation_strict", True)
-        for pat in ["&&", "||", "$(", "> ", "< "]:
+        for pat in ["&&", "||", "$("]:
             with pytest.raises(ValueError, match="unsafe characters"):
                 ToolCreate.validate_description(f"Valid prefix {pat} suffix")
 
@@ -1123,10 +1136,8 @@ class TestToolCreateDescriptionValidationStrict:
             "run cmd1 && cmd2",
             "try this || that",
             "expand $(cmd)",
-            "Search docs > results",
-            "read < file",
         ],
-        ids=["ampersand", "or", "subshell", "redirect_out", "redirect_in"],
+        ids=["ampersand", "or", "subshell"],
     )
     def test_forbidden_pattern_allowed_in_non_strict_mode(self, monkeypatch, caplog, description):
         """Each forbidden pattern is accepted (with warning) when VALIDATION_STRICT=false."""
@@ -1507,3 +1518,20 @@ def test_read_schemas_have_visibility_coercion_wired():
     """All Read schemas must have _normalize_visibility wired so legacy DB rows don't crash reads."""
     for schema_cls in [ToolRead, ResourceRead, PromptRead, GatewayRead, ServerRead, A2AAgentRead, GrpcServiceRead]:
         assert hasattr(schema_cls, "_normalize_visibility"), f"{schema_cls.__name__} missing _normalize_visibility"
+
+
+class TestToolNameLengthValidation:
+    """Tests for MCP spec tool name length limit (issue #136 Bug B)."""
+
+    def test_tool_name_exactly_128_chars_accepted(self):
+        """Tool name at the MCP spec limit (128 chars) should be accepted."""
+        name = "a" * 128
+        tool = ToolCreate(name=name, inputSchema={})
+        assert tool.name == name
+
+    def test_tool_name_over_128_chars_rejected(self):
+        """Tool name over the MCP spec limit should be rejected with a clear message."""
+        name = "a" * 129
+        with pytest.raises(ValidationError) as exc_info:
+            ToolCreate(name=name, inputSchema={})
+        assert "Tool name exceeds MCP spec limit of 128 characters (got 129)" in str(exc_info.value)

--- a/tests/unit/mcpgateway/validation/test_validators.py
+++ b/tests/unit/mcpgateway/validation/test_validators.py
@@ -225,8 +225,8 @@ def test_validate_tool_name_html_special_chars_even_if_regex_allows(monkeypatch)
 
 def test_validate_tool_name_too_long():
     with pytest.raises(ValueError):
-        SecurityValidator.validate_tool_name("a" * 11)
-    SecurityValidator.validate_tool_name("a" * 10)
+        SecurityValidator.validate_tool_name("a" * 129)
+    SecurityValidator.validate_tool_name("a" * 128)
 
 
 def test_validate_template_valid():

--- a/tests/unit/mcpgateway/validation/test_validators_advanced.py
+++ b/tests/unit/mcpgateway/validation/test_validators_advanced.py
@@ -539,12 +539,12 @@ def test_validate_tool_name_valid_with_leading_underscore_or_number():
 def test_validate_tool_name_length():
     """Test tool name length validation."""
     # At limit
-    valid_name = "t" + "o" * 99  # 100 chars total, starts with letter
+    valid_name = "t" + "o" * 127  # 128 chars total, starts with letter
     assert SecurityValidator.validate_tool_name(valid_name) == valid_name
 
     # Over limit
-    with pytest.raises(ValueError, match="exceeds maximum length"):
-        SecurityValidator.validate_tool_name("t" + "o" * 100)  # 101 chars
+    with pytest.raises(ValueError, match="exceeds MCP spec limit"):
+        SecurityValidator.validate_tool_name("t" + "o" * 128)  # 129 chars
 
 
 # =============================================================================


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4650

---

## 📝 Summary

Fixes three gaps in MCP tool validation that caused silent failures or incorrect rejections during gateway registration:

**Bug A — False-positive forbidden character rejections**
`"> "` and `"< "` were included in the default `validation_forbidden_chars` set, causing tool names containing `>` or `<` (valid in some MCP server naming conventions) to be incorrectly rejected. Removed these two entries from the defaults in `config.py`.

**Bug B — Missing tool name length enforcement**
The MCP spec caps tool names at 128 characters, but no length check existed. Added `validation_max_tool_name_length = 128` to `config.py` and a corresponding validator in `common/validators.py` (`ToolCreate`) that raises a `ValidationError` when exceeded.

**Bug C — Skipped tools were silently dropped**
When one or more tools failed validation during gateway registration, those tools were silently discarded with no feedback to the caller and no server-side log entry.
- Added `skipped_tools: List[str]` field to `GatewayRead` schema (`schemas.py`)
- `register_gateway` in `gateway_service.py` now populates `skipped_tools` with per-tool error messages and emits a `logger.warning` listing each skipped tool
- REST API (main.py) and Admin API (`admin.py`) return `skipped_tools` in the success response and handle `DataError` (DB-level data violations) with a clean 400 via `ErrorFormatter.format_database_error`
- Admin UI (`utils.js`, `formSubmitHandlers.js`) shows a warning modal listing skipped tools when `skippedTools` is non-empty in the response
<img width="1920" height="985" alt="image" src="https://github.com/user-attachments/assets/4ab2de44-9b08-41c0-a200-0c24d318ad7c" />


---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint-quick` | ✅ Passed |
| Unit tests                | `make test`     | ✅ 297 passed, 1 skipped |
| Pre-commit hooks          | `pre-commit run --files ...` | ✅ All passed |

---

## ✅ Checklist
- [x] Code formatted (`make lint-fix` + `pre-commit`)
- [x] Tests added/updated for changes (`test_gateway_service.py`, `test_main.py`, `test_schemas_validators_extra.py`)
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

- `skipped_tools` is serialized as `skippedTools` (camelCase) in JSON responses via `alias_generator=to_camel_case` on `GatewayRead`.
- `DataError` is a defense-in-depth catch for DB-level rejections (e.g. a value exceeding a column constraint that bypassed application-layer validation). The primary guard for Bug B is the `ToolCreate` Pydantic validator.
- The 128-char limit and forbidden chars list are both configurable via `config.py` (`validation_max_tool_name_length`, `validation_forbidden_chars`).