### PR TITLE
fix(helm): default app images to chart appVersion

### DIFF
--- a/charts/mcp-stack/CHANGELOG.md
+++ b/charts/mcp-stack/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+* Default ContextForge gateway and migration image tags now resolve to the chart `appVersion` when no explicit tag override is set, avoiding mutable `latest` deployments.
+
 ### Changed
 
 #### **🔐 Production-Hardened Default Values** ([#3550](https://github.com/IBM/mcp-context-forge/pull/3550))

--- a/charts/mcp-stack/Chart.yaml
+++ b/charts/mcp-stack/Chart.yaml
@@ -19,8 +19,8 @@ type: application
 # Versioning
 # * version      - chart package version (SemVer).  Bump on *any* chart
 #                  change, even if the app container tag is the same.
-# * appVersion   - upstream application version; shown in UIs but not
-#                  used for upgrade logic.
+# * appVersion   - upstream application version; also the default
+#                  ContextForge image tag when values do not override it.
 # --------------------------------------------------------------------
 version: 1.0.0
 appVersion: "1.0.0"

--- a/charts/mcp-stack/README.md
+++ b/charts/mcp-stack/README.md
@@ -158,7 +158,7 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | mcpContextForge.replicaCount | int | `2` |  |
 | mcpContextForge.hpa | object | `{"enabled":true,"maxReplicas":10,"minReplicas":2,"targetCPUUtilizationPercentage":90,"targetMemoryUtilizationPercentage":90}` | ------------------------------------------------------------------ |
 | mcpContextForge.image.repository | string | `"ghcr.io/ibm/mcp-context-forge"` |  |
-| mcpContextForge.image.tag | string | `"latest"` |  |
+| mcpContextForge.image.tag | string | `""` | Defaults to chart appVersion when empty. |
 | mcpContextForge.image.pullPolicy | string | `"Always"` |  |
 | mcpContextForge.service.type | string | `"ClusterIP"` |  |
 | mcpContextForge.service.port | int | `80` |  |
@@ -923,7 +923,7 @@ For detailed guidance on resource limits and process management, see `docs/docs/
 | migration.backoffLimit | int | `3` |  |
 | migration.activeDeadlineSeconds | int | `600` |  |
 | migration.image.repository | string | `"ghcr.io/ibm/mcp-context-forge"` |  |
-| migration.image.tag | string | `"latest"` |  |
+| migration.image.tag | string | `""` | Defaults to mcpContextForge.image.tag, then chart appVersion when empty. |
 | migration.image.pullPolicy | string | `"Always"` |  |
 | migration.resources.limits.cpu | string | `"500m"` |  |
 | migration.resources.limits.memory | string | `"1Gi"` |  |

--- a/charts/mcp-stack/templates/NOTES.txt
+++ b/charts/mcp-stack/templates/NOTES.txt
@@ -68,7 +68,7 @@
   {{- end }}
 
 🏗️ **Infrastructure Stack**
-  - ContextForge    : {{ .Values.mcpContextForge.replicaCount }} replica(s) - {{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag }}
+  - ContextForge    : {{ .Values.mcpContextForge.replicaCount }} replica(s) - {{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag | default .Chart.AppVersion }}
   {{- if .Values.mcpFastTimeServer.enabled }}
   - Fast Time Srv  : {{ .Values.mcpFastTimeServer.replicaCount }} replica(s) - {{ .Values.mcpFastTimeServer.image.repository }}:{{ .Values.mcpFastTimeServer.image.tag }}
   {{- end }}

--- a/charts/mcp-stack/templates/deployment-mcpgateway.yaml
+++ b/charts/mcp-stack/templates/deployment-mcpgateway.yaml
@@ -50,7 +50,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "{{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag }}"
+          image: "{{ .Values.mcpContextForge.image.repository }}:{{ .Values.mcpContextForge.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.mcpContextForge.image.pullPolicy }}
           {{- $pluginsConfigFile := default "plugins/config.yaml" .Values.mcpContextForge.config.PLUGINS_CONFIG_FILE }}
 

--- a/charts/mcp-stack/templates/job-migration.yaml
+++ b/charts/mcp-stack/templates/job-migration.yaml
@@ -39,7 +39,7 @@ spec:
             capabilities:
               drop:
                 - ALL
-          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
+          image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag | default .Values.mcpContextForge.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.migration.image.pullPolicy }}
 
           # Migration workflow: wait for DB → run migrations

--- a/charts/mcp-stack/values.schema.json
+++ b/charts/mcp-stack/values.schema.json
@@ -1535,8 +1535,8 @@
             },
             "tag": {
               "type": "string",
-              "description": "Image tag",
-              "default": "latest"
+              "description": "Image tag (defaults to chart appVersion when empty)",
+              "default": ""
             }
           },
           "description": "Container image configuration"
@@ -2529,8 +2529,8 @@
             },
             "tag": {
               "type": "string",
-              "description": "Image tag",
-              "default": "latest"
+              "description": "Image tag (defaults to mcpContextForge.image.tag, then chart appVersion when empty)",
+              "default": ""
             }
           },
           "description": "Migration image configuration"

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -85,7 +85,7 @@ mcpContextForge:
 
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: latest                 # PRODUCTION: pin a specific immutable tag (e.g. "1.0.0")
+    tag: ""                     # Defaults to Chart.appVersion (e.g. "1.0.0"); set to override
     pullPolicy: IfNotPresent    # use Always only for dev/testing with mutable tags
 
   # Service that fronts the gateway
@@ -1015,7 +1015,7 @@ migration:
   # Use same image as mcpgateway
   image:
     repository: ghcr.io/ibm/mcp-context-forge
-    tag: latest                             # Should match mcpContextForge.image.tag
+    tag: ""                                 # Defaults to mcpContextForge.image.tag, then Chart.appVersion
     pullPolicy: IfNotPresent                # use Always only for dev/testing with mutable tags
 
   # Resource limits for the migration job


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Closes #4401.

Defaults the ContextForge gateway and migration image tags to the chart `appVersion` when no explicit image tag override is set. This keeps chart installs pinned to the released application version instead of the mutable `latest` tag.

## 🔁 Reproduction Steps
Render or install `charts/mcp-stack` with the default values. Before this change, `mcpContextForge.image.tag` and `migration.image.tag` defaulted to `latest`, and the templates rendered those mutable tags directly.

## 🐞 Root Cause
The chart values set the primary ContextForge and migration image tags to `latest`, and the templates used `.Values.*.image.tag` without a fallback to `.Chart.AppVersion`.

## 💡 Fix Description
- Make the gateway and migration image tag values empty by default.
- Render the gateway image tag with `.Chart.AppVersion` when unset.
- Render the migration image tag with `migration.image.tag`, then `mcpContextForge.image.tag`, then `.Chart.AppVersion`, preserving override behavior while keeping defaults pinned.
- Update schema, README, NOTES, Chart.yaml comments, and changelog text for the new default behavior.

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Helm lint | `helm lint charts/mcp-stack` | ✅ Pass |
| Helm strict lint | `helm lint --strict charts/mcp-stack` | ✅ Pass |
| Template render | `helm template mcp-stack charts/mcp-stack` | ✅ Pass |
| YAML/JSON parse | Python `yaml.safe_load` / `yaml.safe_load_all` / `json.load` for chart values/schema/rendered manifests | ✅ Pass |
| Default rendered image tags | Python assertion on rendered Deployment/Job images | ✅ `ghcr.io/ibm/mcp-context-forge:1.0.0` |
| Gateway override behavior | `helm template ... --set mcpContextForge.image.tag=dev-build` | ✅ Gateway and migration use override |
| Migration override behavior | `helm template ... --set migration.image.tag=migration-build` | ✅ Migration override remains independent |
| Whitespace check | `git diff --check` | ✅ Pass |

Full repository `make lint`, `make test`, coverage, Docker, and database matrix checks were not run because this is a focused Helm chart templating/default-values fix.

## 📐 MCP Compliance (if relevant)
- [x] Not applicable; Helm chart image tag default only.

## ✅ Checklist
- [x] Documentation updated (README/CHANGELOG/Chart comments/NOTES).
- [x] No secrets/credentials committed.
