### PR TITLE
fix: use Admin namespace for LLM provider/model form onsubmit handlers

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -2078,7 +2078,7 @@
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="Admin.closeLLMProviderModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
             <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-              <form id="llm-provider-form" onsubmit="saveLLMProvider(event)">
+              <form id="llm-provider-form" onsubmit="Admin.saveLLMProvider(event)">
                 <input type="hidden" id="llm-provider-id" name="provider_id" value="">
                 <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4" id="llm-provider-modal-title">
@@ -2176,7 +2176,7 @@
             <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="Admin.closeLLMModelModal()"></div>
             <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
             <div class="relative z-20 inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
-              <form id="llm-model-form" onsubmit="saveLLMModel(event)">
+              <form id="llm-model-form" onsubmit="Admin.saveLLMModel(event)">
                 <input type="hidden" id="llm-model-id" name="model_id" value="">
                 <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-white mb-4" id="llm-model-modal-title">


### PR DESCRIPTION
## Summary

- Fixes `onsubmit="saveLLMProvider(event)"` → `onsubmit="Admin.saveLLMProvider(event)"`
- Fixes `onsubmit="saveLLMModel(event)"` → `onsubmit="Admin.saveLLMModel(event)"`

## Problem

The LLM provider and model modals in the Admin UI silently did nothing when clicking Save. The root cause: `saveLLMProvider` and `saveLLMModel` are only registered on `window.Admin`, not as global functions. When called bare in `onsubmit`, the browser throws a `ReferenceError`, `event.preventDefault()` is never invoked, and the form falls back to a native HTML submission (page reload). No data is saved.

## Fix

Two-line change in `mcpgateway/templates/admin.html` to prefix both handlers with `Admin.`

## Test plan

- [ ] Open Admin UI → LLM Settings → Add Provider, fill form, click Save → provider is created
- [ ] Open Admin UI → LLM Settings → Add Model, fill form, click Save → model is created
- [ ] Edit existing provider/model → changes are saved correctly

Closes #4662

🤖 Generated with [Claude Code](https://claude.ai/claude-code)