### PR TITLE
fix(sso): support IdP-initiated chiclet flow on /auth/sso/login

### DIFF
--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -11,10 +11,11 @@ Handles SSO login flows, provider configuration, and callback handling.
 # Standard
 import secrets
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -219,7 +220,16 @@ async def initiate_sso_login(
     provider_id: str,
     request: Request,
     response: Response,
-    redirect_uri: str = Query(..., max_length=2048, description="Callback URI after authentication"),
+    redirect_uri: Optional[str] = Query(
+        None,
+        max_length=2048,
+        description=(
+            "Callback URI after authentication. When omitted, defaults to this "
+            "gateway's /auth/sso/callback/{provider_id} on the same origin, which "
+            "is the right answer for both the SP-initiated form and IdP-initiated "
+            "chiclet flows."
+        ),
+    ),
     # scopes is space-separated per RFC 6749 Section 3.3 and its character set is
     # provider-specific (Google scopes are URLs, Microsoft Graph allows many special
     # chars). Server-side resolution in _resolve_login_scopes enforces the provider
@@ -229,9 +239,16 @@ async def initiate_sso_login(
 ) -> SSOLoginResponse:
     """Initiate SSO authentication flow.
 
-    Validates the redirect_uri against a server-side allowlist to prevent open redirect attacks.
-    Only allows relative URIs, URIs matching app_domain, or URIs from configured allowed_origins.
-    Does NOT trust the Host header for validation.
+    When ``redirect_uri`` is supplied, it is validated against a server-side
+    allowlist (relative URIs, ``app_domain``, or ``allowed_origins``) to prevent
+    open redirect attacks; the Host header is not trusted for validation. When
+    omitted, the URI is built server-side from the route name and used as-is —
+    suitable for IdP-initiated chiclet flows on a properly proxy-fronted
+    deployment.
+
+    Browser navigations (``Accept: text/html``) get a 302 to the IdP's
+    authorize endpoint; XHR clients (``Accept: application/json``) keep
+    receiving an ``SSOLoginResponse``.
 
     Args:
         provider_id: SSO provider identifier (e.g., 'github', 'google')
@@ -255,9 +272,13 @@ async def initiate_sso_login(
     if not settings.sso_enabled:
         raise HTTPException(status_code=404, detail="SSO authentication is disabled")
 
-    # Validate redirect_uri to prevent open redirect attacks
-    # Uses server-side allowlist (allowed_origins, app_domain) - does NOT trust Host header
-    if not _validate_redirect_uri(redirect_uri, request):
+    # If the caller didn't supply a redirect_uri, point at our own callback
+    # for this provider. Skipping the allowlist check here is safe only as
+    # long as the request host is itself trustworthy (proxy-normalized in
+    # production); the open-redirect threat model targets user-supplied URIs.
+    if redirect_uri is None:
+        redirect_uri = str(request.url_for("handle_sso_callback", provider_id=provider_id))
+    elif not _validate_redirect_uri(redirect_uri, request):
         # Sanitize untrusted redirect_uri before logging to prevent log injection
         logger.warning(f"SSO login rejected - invalid redirect_uri: {sanitize_for_log(redirect_uri)}")
         raise HTTPException(
@@ -277,23 +298,32 @@ async def initiate_sso_login(
     if not auth_url:
         raise HTTPException(status_code=404, detail=f"SSO provider '{provider_id}' not found or disabled")
 
-    # Extract state from URL for client reference
-    # Standard
-    import urllib.parse
-
-    parsed = urllib.parse.urlparse(auth_url)
-    params = urllib.parse.parse_qs(parsed.query)
-    state = params.get("state", [""])[0]
-
     use_secure = (settings.environment == "production") or settings.secure_cookies
-    response.set_cookie(
-        key="sso_session_id",
-        value=browser_session_binding,
-        httponly=True,
-        secure=use_secure,
-        samesite=settings.cookie_samesite,
-        path=settings.app_root_path or "/",
-    )
+    cookie_kwargs = {
+        "key": "sso_session_id",
+        "value": browser_session_binding,
+        "httponly": True,
+        "secure": use_secure,
+        "samesite": settings.cookie_samesite,
+        "path": settings.app_root_path or "/",
+    }
+
+    # Direct browser navigation (e.g. an IdP-initiated chiclet click that
+    # lands users on this URL with a pre-filled redirect_uri) wants a 302
+    # to the IdP's /authorize, not a JSON payload. The XHR-driven login
+    # form keeps getting JSON because it sends Accept: application/json.
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept and "application/json" not in accept:
+        redirect_response = RedirectResponse(url=auth_url, status_code=302)
+        redirect_response.set_cookie(**cookie_kwargs)
+        return redirect_response
+
+    response.set_cookie(**cookie_kwargs)
+
+    # Extract state from URL for client reference
+    parsed = urlparse(auth_url)
+    params = parse_qs(parsed.query)
+    state = params.get("state", [""])[0]
 
     return SSOLoginResponse(authorization_url=auth_url, state=state)
 


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
_Link to the epic or parent issue:_
Closes #

---

## 🚀 Summary (1-2 sentences)
Make `/auth/sso/login/{provider_id}` usable as an IdP-initiated chiclet entry point: `redirect_uri` becomes optional (server-built default) and the response is content-negotiated so browsers get a 302 to the IdP while XHR clients keep getting JSON.

---

## 🧪 Checks

- [x] `make lint` passes (`black`, `ruff` clean on the touched file)
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

---

## 📓 Notes

Two changes to `mcpgateway/routers/sso.py`:

1. **`redirect_uri` is now optional.** When omitted, it is built from `request.url_for("handle_sso_callback", ...)` so it resolves to this gateway's own `/auth/sso/callback/{provider_id}` on the request origin (honouring `app_root_path` / proxy headers). Skipping the user-input `_validate_redirect_uri` check is safe as long as the request host is itself trustworthy (proxy-normalized in production); that check exists to defend against open redirects on caller-supplied URIs, not server-built ones.

2. **Content-negotiated response.** Browser navigation (`Accept: text/html` without `application/json`) gets a 302 straight to the IdP's authorization URL; XHR clients sending `Accept: application/json` keep getting the `SSOLoginResponse` JSON they parse today. The session-binding cookie is set on the `RedirectResponse` explicitly because returning a `Response` object bypasses the injected `response` parameter.

Combined effect: an Okta app can register

    Login Flow = Redirect to app to initiate login (OIDC Compliant)
    Login URI  = https://<host>/auth/sso/login/okta

and clicking the chiclet lands the user signed in at `/admin` in one hop. The existing `/admin/login` form path is byte-identical to before.

```mermaid
sequenceDiagram
    participant User
    participant Okta
    participant Gateway
    User->>Okta: clicks chiclet
    Okta->>User: 302 to /auth/sso/login/okta
    User->>Gateway: GET /auth/sso/login/okta (Accept: text/html)
    Gateway->>User: 302 to Okta /authorize (cookie set)
    User->>Okta: /authorize
    Okta->>User: 302 to /auth/sso/callback/okta?code=...
    User->>Gateway: GET /auth/sso/callback/okta
    Gateway->>User: signed in, 302 to /admin
```