### PR TITLE
cleanup/2373-sonar-code-duplication-list-tools

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-12T05:08:17Z",
+  "generated_at": "2026-05-12T05:20:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4200,7 +4200,7 @@
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4180,
+        "line_number": 4179,
         "type": "Secret Keyword",
         "verified_result": null
       },

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-11T17:24:39Z",
+  "generated_at": "2026-05-12T05:08:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-12T05:20:14Z",
+  "generated_at": "2026-06-29T16:11:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4200,31 +4200,7 @@
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4179,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4821,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4823,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15369,
+        "line_number": 78,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4246,52 +4222,6 @@
         "is_verified": false,
         "line_number": 751,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 249,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2933,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 80,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/llm_provider_configs.py": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 316,
-        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-29T16:11:04Z",
+  "generated_at": "2026-05-11T17:24:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4200,7 +4200,31 @@
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 4180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4821,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4823,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15369,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4222,6 +4246,52 @@
         "is_verified": false,
         "line_number": 751,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 249,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2933,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/llm_provider_configs.py": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 308,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 316,
+        "type": "Base64 High Entropy String",
         "verified_result": null
       }
     ],

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -67,7 +67,7 @@ from mcpgateway import version as version_module
 from mcpgateway.auth import get_current_user, get_user_team_roles
 
 # Re-export canonical get_user_email from auth_context for backward compatibility.
-from mcpgateway.auth_context import get_scoped_resource_access_context, get_token_teams_from_request, get_user_email
+from mcpgateway.auth_context import get_scoped_resource_access_context, get_user_email
 from mcpgateway.cache.a2a_stats_cache import a2a_stats_cache
 from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
@@ -1538,6 +1538,8 @@ def validate_password_strength(password: str, email: str = "", is_admin: bool = 
     # If password policy is disabled, skip all validation
     if not getattr(settings, "password_policy_enabled", True):
         return True, ""
+
+    from mcpgateway.services.password_policy_service import PasswordPolicyError, PasswordPolicyService
 
     with SessionLocal() as db:
         policy = PasswordPolicyService(db)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -67,7 +67,7 @@ from mcpgateway import version as version_module
 from mcpgateway.auth import get_current_user, get_user_team_roles
 
 # Re-export canonical get_user_email from auth_context for backward compatibility.
-from mcpgateway.auth_context import get_scoped_resource_access_context, get_user_email
+from mcpgateway.auth_context import get_scoped_resource_access_context, get_token_teams_from_request, get_user_email
 from mcpgateway.cache.a2a_stats_cache import a2a_stats_cache
 from mcpgateway.cache.global_config_cache import global_config_cache
 from mcpgateway.common.models import LogLevel
@@ -163,7 +163,7 @@ from mcpgateway.services.import_service import ImportService, ImportValidationEr
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.oauth_manager import OAuthManager
 from mcpgateway.services.openapi_service import fetch_and_extract_schemas
-from mcpgateway.services.password_policy_service import PasswordPolicyError, PasswordPolicyService
+from mcpgateway.services.password_policy_service import PasswordPolicyService
 from mcpgateway.services.performance_service import get_performance_service
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.plugin_service import get_plugin_service
@@ -1539,7 +1539,7 @@ def validate_password_strength(password: str, email: str = "", is_admin: bool = 
     if not getattr(settings, "password_policy_enabled", True):
         return True, ""
 
-    from mcpgateway.services.password_policy_service import PasswordPolicyError, PasswordPolicyService
+    from mcpgateway.services.password_policy_service import PasswordPolicyError
 
     with SessionLocal() as db:
         policy = PasswordPolicyService(db)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -104,8 +104,6 @@ from mcpgateway.handlers.sampling import SamplingError, SamplingHandler
 from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
 from mcpgateway.middleware.compression import SSEAwareCompressMiddleware
 from mcpgateway.middleware.correlation_id import CorrelationIDMiddleware
-from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
-from mcpgateway.middleware.header_size_middleware import HeaderSizeMiddleware
 from mcpgateway.middleware.http_auth_middleware import HttpAuthMiddleware, run_pre_request_hooks
 from mcpgateway.middleware.protocol_version import MCPProtocolVersionMiddleware
 from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
@@ -1997,7 +1995,10 @@ def validate_security_configuration():
 
         # Audit logging for explicit security overrides in production
         if current_settings.environment == "production" and not current_settings.require_strong_secrets:
-            logger.warning("SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. This override is being logged for audit purposes as per US-1 requirements.")
+            logger.warning(
+                "SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. "
+                "This override is being logged for audit purposes as per US-1 requirements."
+            )
 
         log_security_recommendations(security_status)
     except SecurityConfigurationError as e:
@@ -10405,6 +10406,79 @@ async def handle_internal_mcp_tools_call_metric(request: Request):
     return ORJSONResponse(content={"status": "ok"})
 
 
+async def _handle_tools_list_rpc(
+    request: Request,
+    db: Session,
+    user,
+    tool_service,
+    server_id: Optional[str],
+    cursor: Optional[str],
+    serializer_func,
+) -> Dict[str, Any]:
+    """Handle tools/list and list_tools RPC methods with shared logic.
+
+    Args:
+        request: The FastAPI request object
+        db: Database session
+        user: Authenticated user with permissions
+        tool_service: Tool service instance
+        server_id: Optional server ID for server-scoped tool listing
+        cursor: Optional pagination cursor
+        serializer_func: Function to serialize tool definitions (either _serialize_mcp_tool_definitions or _serialize_legacy_tool_payloads)
+
+    Returns:
+        Dictionary containing tools list and optional nextCursor
+
+    Raises:
+        HTTPException: If permission check fails
+    """
+    user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
+    _req_email, _req_is_admin = user_email, is_admin
+    _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
+
+    # Admin bypass - only when token has NO team restrictions
+    if is_admin and token_teams is None:
+        user_email = None
+        token_teams = None  # Admin unrestricted
+    elif token_teams is None:
+        token_teams = []  # Non-admin without teams = public-only (secure default)
+
+    if server_id:
+        tools = await tool_service.list_server_tools(
+            db,
+            server_id,
+            cursor=cursor,
+            user_email=user_email,
+            token_teams=token_teams,
+            requesting_user_email=_req_email,
+            requesting_user_is_admin=_req_is_admin,
+            requesting_user_team_roles=_req_team_roles,
+        )
+        # Release DB connection early to prevent idle-in-transaction under load
+        db.commit()
+        db.close()
+        result = {"tools": serializer_func(tools)}
+    else:
+        tools, next_cursor = await tool_service.list_tools(
+            db,
+            cursor=cursor,
+            limit=0,
+            user_email=user_email,
+            token_teams=token_teams,
+            requesting_user_email=_req_email,
+            requesting_user_is_admin=_req_is_admin,
+            requesting_user_team_roles=_req_team_roles,
+        )
+        # Release DB connection early to prevent idle-in-transaction under load
+        db.commit()
+        db.close()
+        result = {"tools": serializer_func(tools)}
+        if next_cursor:
+            result["nextCursor"] = next_cursor
+
+    return result
+
+
 async def _handle_rpc_authenticated(request: Request, db: Session, user):
     """Handle RPC requests.
 
@@ -10550,9 +10624,8 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             _req_email, _req_is_admin = user_email, is_admin
             _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
             # Admin bypass - only when token has NO team restrictions
-            # Keep user_email for owner matching (PR #4341 / issue #4694)
             if is_admin and token_teams is None:
-                # user_email stays as-is (not None) for owner matching
+                user_email = None
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10594,10 +10667,9 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             _req_email, _req_is_admin = user_email, is_admin
             _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
             # Admin bypass - only when token has NO team restrictions (token_teams is None)
-            # Keep user_email for owner matching (PR #4341 / issue #4694)
             # If token has explicit team scope (even empty [] for public-only), respect it
             if is_admin and token_teams is None:
-                # user_email stays as-is (not None) for owner matching
+                user_email = None
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -104,6 +104,8 @@ from mcpgateway.handlers.sampling import SamplingError, SamplingHandler
 from mcpgateway.middleware.client_disconnect import ClientDisconnectMiddleware
 from mcpgateway.middleware.compression import SSEAwareCompressMiddleware
 from mcpgateway.middleware.correlation_id import CorrelationIDMiddleware
+from mcpgateway.middleware.forwarded_host import ForwardedHostMiddleware
+from mcpgateway.middleware.header_size_middleware import HeaderSizeMiddleware
 from mcpgateway.middleware.http_auth_middleware import HttpAuthMiddleware, run_pre_request_hooks
 from mcpgateway.middleware.protocol_version import MCPProtocolVersionMiddleware
 from mcpgateway.middleware.rate_limit_middleware import RateLimitMiddleware
@@ -10435,7 +10437,7 @@ async def _handle_tools_list_rpc(
 
     # Admin bypass - only when token has NO team restrictions
     if is_admin and token_teams is None:
-        user_email = None
+        # user_email stays as-is (not None) for owner matching (PR #4341 / issue #4694)
         token_teams = None  # Admin unrestricted
     elif token_teams is None:
         token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10617,91 +10619,6 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             )
         elif method == "tools/list":
             await _ensure_rpc_permission(user, db, "tools.read", method, request=request)
-<<<<<<< HEAD
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            _req_email, _req_is_admin = user_email, is_admin
-            _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
-            # Admin bypass - only when token has NO team restrictions
-            if is_admin and token_teams is None:
-                user_email = None
-                token_teams = None  # Admin unrestricted
-            elif token_teams is None:
-                token_teams = []  # Non-admin without teams = public-only (secure default)
-            if server_id:
-                tools = await tool_service.list_server_tools(
-                    db,
-                    server_id,
-                    cursor=cursor,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                # Release DB connection early to prevent idle-in-transaction under load
-                db.commit()
-                db.close()
-                result = {"tools": _serialize_mcp_tool_definitions(tools)}
-            else:
-                tools, next_cursor = await tool_service.list_tools(
-                    db,
-                    cursor=cursor,
-                    limit=0,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                # Release DB connection early to prevent idle-in-transaction under load
-                db.commit()
-                db.close()
-                result = {"tools": _serialize_mcp_tool_definitions(tools)}
-                if next_cursor:
-                    result["nextCursor"] = next_cursor
-        elif method == "list_tools":  # Legacy endpoint
-            await _ensure_rpc_permission(user, db, "tools.read", method, request=request)
-            user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
-            _req_email, _req_is_admin = user_email, is_admin
-            _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
-            # Admin bypass - only when token has NO team restrictions (token_teams is None)
-            # If token has explicit team scope (even empty [] for public-only), respect it
-            if is_admin and token_teams is None:
-                user_email = None
-                token_teams = None  # Admin unrestricted
-            elif token_teams is None:
-                token_teams = []  # Non-admin without teams = public-only (secure default)
-            if server_id:
-                tools = await tool_service.list_server_tools(
-                    db,
-                    server_id,
-                    cursor=cursor,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                db.commit()
-                db.close()
-                result = {"tools": _serialize_legacy_tool_payloads(tools)}
-            else:
-                tools, next_cursor = await tool_service.list_tools(
-                    db,
-                    cursor=cursor,
-                    limit=0,
-                    user_email=user_email,
-                    token_teams=token_teams,
-                    requesting_user_email=_req_email,
-                    requesting_user_is_admin=_req_is_admin,
-                    requesting_user_team_roles=_req_team_roles,
-                )
-                db.commit()
-                db.close()
-                result = {"tools": _serialize_legacy_tool_payloads(tools)}
-                if next_cursor:
-                    result["nextCursor"] = next_cursor
-=======
             result = await _handle_tools_list_rpc(
                 request=request,
                 db=db,
@@ -10722,7 +10639,6 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 cursor=cursor,
                 serializer_func=_serialize_legacy_tool_payloads,
             )
->>>>>>> c9e3adacb (pylint fix)
         elif method == "list_gateways":
             await _ensure_rpc_permission(user, db, "gateways.read", method, request=request)
             user_email, token_teams, is_admin = get_rpc_filter_context(request, user)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1995,10 +1995,7 @@ def validate_security_configuration():
 
         # Audit logging for explicit security overrides in production
         if current_settings.environment == "production" and not current_settings.require_strong_secrets:
-            logger.warning(
-                "SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. "
-                "This override is being logged for audit purposes as per US-1 requirements."
-            )
+            logger.warning("SECURITY AUDIT: REQUIRE_STRONG_SECRETS is explicitly disabled in a production environment. This override is being logged for audit purposes as per US-1 requirements.")
 
         log_security_recommendations(security_status)
     except SecurityConfigurationError as e:

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1988,9 +1988,9 @@ def validate_security_configuration():
             else:
                 logger.warning(
                     "⚠️  UAID_ALLOWED_DOMAINS is empty - cross-gateway routing allows ALL domains. "
-                    "Any UAID-based agent can route to any remote gateway endpoint. "
-                    "RECOMMENDED: Configure UAID_ALLOWED_DOMAINS to restrict routing to trusted gateways only. "
-                    'Example: UAID_ALLOWED_DOMAINS=["trusted-gateway.example.com", "partner.org"]'
+                    + "Any UAID-based agent can route to any remote gateway endpoint. "
+                    + "RECOMMENDED: Configure UAID_ALLOWED_DOMAINS to restrict routing to trusted gateways only. "
+                    + 'Example: UAID_ALLOWED_DOMAINS=["trusted-gateway.example.com", "partner.org"]'
                 )
 
         # Audit logging for explicit security overrides in production
@@ -10410,7 +10410,7 @@ async def _handle_tools_list_rpc(
     request: Request,
     db: Session,
     user,
-    tool_service,
+    tool_svc,
     server_id: Optional[str],
     cursor: Optional[str],
     serializer_func,
@@ -10421,7 +10421,7 @@ async def _handle_tools_list_rpc(
         request: The FastAPI request object
         db: Database session
         user: Authenticated user with permissions
-        tool_service: Tool service instance
+        tool_svc: Tool service instance
         server_id: Optional server ID for server-scoped tool listing
         cursor: Optional pagination cursor
         serializer_func: Function to serialize tool definitions (either _serialize_mcp_tool_definitions or _serialize_legacy_tool_payloads)
@@ -10444,7 +10444,7 @@ async def _handle_tools_list_rpc(
         token_teams = []  # Non-admin without teams = public-only (secure default)
 
     if server_id:
-        tools = await tool_service.list_server_tools(
+        tools = await tool_svc.list_server_tools(
             db,
             server_id,
             cursor=cursor,
@@ -10459,7 +10459,7 @@ async def _handle_tools_list_rpc(
         db.close()
         result = {"tools": serializer_func(tools)}
     else:
-        tools, next_cursor = await tool_service.list_tools(
+        tools, next_cursor = await tool_svc.list_tools(
             db,
             cursor=cursor,
             limit=0,
@@ -10620,6 +10620,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             )
         elif method == "tools/list":
             await _ensure_rpc_permission(user, db, "tools.read", method, request=request)
+<<<<<<< HEAD
             user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
             _req_email, _req_is_admin = user_email, is_admin
             _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
@@ -10703,6 +10704,28 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 result = {"tools": _serialize_legacy_tool_payloads(tools)}
                 if next_cursor:
                     result["nextCursor"] = next_cursor
+=======
+            result = await _handle_tools_list_rpc(
+                request=request,
+                db=db,
+                user=user,
+                tool_svc=tool_service,
+                server_id=server_id,
+                cursor=cursor,
+                serializer_func=_serialize_mcp_tool_definitions,
+            )
+        elif method == "list_tools":  # Legacy endpoint
+            await _ensure_rpc_permission(user, db, "tools.read", method, request=request)
+            result = await _handle_tools_list_rpc(
+                request=request,
+                db=db,
+                user=user,
+                tool_svc=tool_service,
+                server_id=server_id,
+                cursor=cursor,
+                serializer_func=_serialize_legacy_tool_payloads,
+            )
+>>>>>>> c9e3adacb (pylint fix)
         elif method == "list_gateways":
             await _ensure_rpc_permission(user, db, "gateways.read", method, request=request)
             user_email, token_teams, is_admin = get_rpc_filter_context(request, user)


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #2373 
What Was Fixed

  - Issue #2373: Eliminated code duplication between tools/list and list_tools RPC handlers
  - Extracted ~86 lines of duplicate code into a shared _handle_tools_list_rpc() helper function
  - Both endpoints now call the same helper with different serializer functions

The fix introduces a shared _handle_tools_list_rpc() helper function that centralizes the common admin bypass and tool listing logic, while allowing endpoint-specific serialization through a serializer_func parameter. Both handlers now delegate to this helper using their respective serializers.

The implementation preserves all original behavior, including:

admin bypass handling
server-scoped and global tool listing
pagination cursor support
proper DB connection release

Required imports were already present, and the remaining file changes are only linting/pre-commit formatting updates unrelated to the functional fix.