### PR TITLE
feat(observability): add baggage attribute mapping for span customization

### DIFF
--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -18,6 +18,7 @@ import { applyVisibilityRestrictions, isTeamScopedView } from "./teams.js";
 import {
   decodeHtml,
   fetchWithTimeout,
+  getCookie,
   getCurrentTeamId,
   handleFetchError,
   isInactiveChecked,
@@ -2927,6 +2928,12 @@ export const runToolValidation = async function (testIndex) {
     const requestHeaders = {
       "Content-Type": "application/json",
     };
+
+    // Add CSRF token from cookie to headers
+    const csrfToken = getCookie("mcpgateway_csrf_token");
+    if (csrfToken) {
+      requestHeaders["x-csrf-token"] = csrfToken;
+    }
 
     // Authentication will be handled automatically by the JWT cookie
     // that was set when the admin UI loaded. The credentials header


### PR DESCRIPTION
## Problem

Issue #4700 requests the ability to remap baggage-derived span attributes (like `baggage.tenant.id`) to custom keys (like `tenant.id`) for backend compatibility with observability systems that expect specific attribute names.

## Solution

Implements Option A semantics for the SpanAttributeCustomizer plugin:

1. **Extract mapping at startup**: `extract_span_attribute_mapping()` reads `attribute_mapping` from plugin config
2. **Add span processor**: `BaggageAttributeSpanProcessor` duplicates baggage.* attributes onto mapped keys
3. **Initialize after plugins**: Telemetry initialization moved after plugin manager setup to access config
4. **Comprehensive tests**: Added test coverage for mapping extraction and processor behavior

## Changes

- `mcpgateway/observability.py`: Added extraction function and span processor
- `mcpgateway/main.py`: Reordered telemetry init to access plugin config
- `tests/unit/mcpgateway/test_observability.py`: Added test coverage

## Configuration Example

```yaml
plugins:
  - name: SpanAttributeCustomizer
    kind: plugins.span_attribute_customizer.span_attribute_customizer.SpanAttributeCustomizerPlugin
    config:
      attribute_mapping:
        baggage.tenant.id: tenant.id
        baggage.user.email: user.email
```

## Testing

The processor safely handles:
- Missing source attributes (no-op)
- Non-baggage mappings (ignored)
- Malformed config (fail-closed)

Fixes #4700