### PR TITLE
fix: preserve timeout message through BaseExceptionGroup unwrapping

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-11T18:48:41Z",
+  "generated_at": "2026-05-13T06:06:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -8464,7 +8464,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4204,
+        "line_number": 4314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8472,7 +8472,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7588,
+        "line_number": 7698,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8480,7 +8480,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8080,
+        "line_number": 8190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8488,7 +8488,7 @@
         "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9427,
+        "line_number": 9537,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8496,7 +8496,7 @@
         "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 9571,
+        "line_number": 9681,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -8504,7 +8504,7 @@
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10052,
+        "line_number": 10162,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5452,10 +5452,14 @@ class ToolService(BaseService):
                             if isinstance(e, BaseExceptionGroup):
                                 while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:
                                     root_cause = root_cause.exceptions[0]
+                            # Preserve timeout context when message is lost during ExceptionGroup wrapping
+                            root_cause_message = str(root_cause)
+                            if not root_cause_message and isinstance(root_cause, (TimeoutError, asyncio.TimeoutError)):
+                                root_cause_message = f"Tool invocation timed out after {effective_timeout}s"
                             # Log failed MCP call (using local variables)
                             mcp_duration_ms = (time.time() - mcp_start_time) * 1000
                             # Sanitize error message to prevent URL secrets from leaking in logs
-                            sanitized_error = sanitize_exception_message(str(root_cause), gateway_auth_query_params_decrypted)
+                            sanitized_error = sanitize_exception_message(root_cause_message, gateway_auth_query_params_decrypted)
                             structured_logger.log(
                                 level="ERROR",
                                 message=f"MCP tool call failed: {tool_name_original}",
@@ -5638,10 +5642,14 @@ class ToolService(BaseService):
                             if isinstance(e, BaseExceptionGroup):
                                 while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:
                                     root_cause = root_cause.exceptions[0]
+                            # Preserve timeout context when message is lost during ExceptionGroup wrapping
+                            root_cause_message = str(root_cause)
+                            if not root_cause_message and isinstance(root_cause, (TimeoutError, asyncio.TimeoutError)):
+                                root_cause_message = f"Tool invocation timed out after {effective_timeout}s"
                             # Log failed MCP call
                             mcp_duration_ms = (time.time() - mcp_start_time) * 1000
                             # Sanitize error message to prevent URL secrets from leaking in logs
-                            sanitized_error = sanitize_exception_message(str(root_cause), gateway_auth_query_params_decrypted)
+                            sanitized_error = sanitize_exception_message(root_cause_message, gateway_auth_query_params_decrypted)
                             structured_logger.log(
                                 level="ERROR",
                                 message=f"MCP tool call failed: {tool_name_original}",
@@ -5949,6 +5957,9 @@ class ToolService(BaseService):
                     while isinstance(root_cause, BaseExceptionGroup) and root_cause.exceptions:
                         root_cause = root_cause.exceptions[0]
                 error_message = str(root_cause)
+                # Preserve timeout context when message is lost during ExceptionGroup wrapping
+                if not error_message and isinstance(root_cause, (TimeoutError, asyncio.TimeoutError)):
+                    error_message = f"Tool invocation timed out after {effective_timeout}s"
                 # Set span error status
                 if span:
                     set_span_error(span, error_message)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -3794,6 +3794,48 @@ class TestToolService:
             assert "Connection refused by upstream MCP server" in call_kwargs["error_message"]
 
     @pytest.mark.asyncio
+    async def test_invoke_tool_timeout_message_preserved_through_exception_group(self, tool_service, mock_tool, mock_global_config_obj, test_db):
+        """Bare TimeoutError() wrapped in ExceptionGroup must produce a descriptive fallback message.
+
+        Regression test for GitHub issue #2782: TimeoutError() stringifies to '' when
+        wrapped in BaseExceptionGroup during MCP SDK TaskGroup cleanup, causing clients
+        to receive an empty error string. The fix detects this case and substitutes
+        "Tool invocation timed out after {effective_timeout}s".
+        """
+        mock_tool.integration_type = "REST"
+        mock_tool.request_type = "POST"
+        mock_tool.auth_value = None
+
+        setup_db_execute_mock(test_db, mock_tool, mock_global_config_obj)
+
+        # Bare TimeoutError() has no message — str(TimeoutError()) == ''
+        bare_timeout = TimeoutError()
+        assert str(bare_timeout) == "", "precondition: bare TimeoutError must stringify to empty string"
+
+        inner_group = ExceptionGroup("inner task group", [bare_timeout])
+        outer_group = ExceptionGroup("unhandled errors in a TaskGroup (1 sub-exception)", [inner_group])
+        tool_service._http_client.request.side_effect = outer_group
+
+        mock_metrics_buffer = Mock()
+        mock_metrics_buffer.record_tool_metric = Mock()
+        with (
+            patch("mcpgateway.services.tool_service.metrics_buffer", mock_metrics_buffer),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+        ):
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "test_tool", {"param": "value"}, request_headers=None)
+
+            error_str = str(exc_info.value)
+            assert error_str.strip(), "error message must not be empty"
+            assert "timed out after" in error_str
+            assert str(settings.tool_timeout) in error_str
+
+            mock_metrics_buffer.record_tool_metric.assert_called_once()
+            call_kwargs = mock_metrics_buffer.record_tool_metric.call_args[1]
+            assert call_kwargs["success"] is False
+            assert "timed out after" in call_kwargs["error_message"]
+
+    @pytest.mark.asyncio
     async def test_reset_metrics(self, tool_service, test_db):
         """Test resetting metrics."""
         # Mock DB operations

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -3836,6 +3836,74 @@ class TestToolService:
             assert "timed out after" in call_kwargs["error_message"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "transport,request_type,url,client_patch,client_yields",
+        [
+            ("SSE", "SSE", "http://fake-mcp:8080/sse", "mcpgateway.services.tool_service.sse_client", ("read", "write")),
+            ("STREAMABLEHTTP", "StreamableHTTP", "http://fake-mcp:8080/mcp", "mcpgateway.services.tool_service.streamablehttp_client", ("read", "write", None)),
+        ],
+    )
+    async def test_invoke_tool_mcp_inner_timeout_message_preserved_through_exception_group(self, tool_service, mock_tool, test_db, transport, request_type, url, client_patch, client_yields):
+        """SSE/StreamableHTTP inner handlers: bare TimeoutError wrapped in ExceptionGroup produces descriptive log message.
+
+        Covers tool_service.py lines 5458 (SSE) and 5648 (StreamableHTTP) — the
+        root_cause_message fallback inside each transport's except BaseException handler.
+        """
+        # Standard
+        from contextlib import asynccontextmanager
+        from types import SimpleNamespace
+
+        # First-Party
+        from mcpgateway.services.upstream_session_registry import RegistryNotInitializedError
+
+        mock_gateway = SimpleNamespace(id="42", name="test_gateway", slug="test-gateway", url=url, enabled=True, reachable=True, auth_type=None, auth_value=None, capabilities={}, transport=transport, passthrough_headers=[])
+        mock_tool.integration_type = "MCP"
+        mock_tool.request_type = request_type
+        mock_tool.jsonpath_filter = ""
+        mock_tool.auth_type = None
+        mock_tool.auth_value = None
+        mock_tool.original_name = "dummy_tool"
+        mock_tool.headers = {}
+        mock_tool.name = "test-gateway-dummy-tool"
+        mock_tool.gateway_slug = "test-gateway"
+        mock_tool.gateway_id = mock_gateway.id
+
+        returns = [mock_tool, mock_gateway, mock_gateway]
+
+        def execute_side_effect(*_args, **_kwargs):
+            value = returns.pop(0) if returns else None
+            m = Mock()
+            m.scalar_one_or_none.return_value = value
+            m.scalars.return_value = m
+            m.all.return_value = [] if value is None else [value]
+            return m
+
+        test_db.execute = Mock(side_effect=execute_side_effect)
+
+        outer_group = ExceptionGroup("outer", [ExceptionGroup("inner", [TimeoutError()])])
+        session_mock = AsyncMock()
+        session_mock.initialize = AsyncMock()
+        session_mock.call_tool = AsyncMock(side_effect=outer_group)
+        client_session_cm = AsyncMock()
+        client_session_cm.__aenter__.return_value = session_mock
+        client_session_cm.__aexit__.return_value = False
+
+        @asynccontextmanager
+        async def mock_transport_client(*_args, **_kwargs):
+            yield client_yields
+
+        with (
+            patch(client_patch, mock_transport_client),
+            patch("mcpgateway.services.tool_service.ClientSession", return_value=client_session_cm),
+            patch("mcpgateway.services.tool_service.decode_auth", return_value={}),
+            patch("mcpgateway.services.tool_service.get_upstream_session_registry", side_effect=RegistryNotInitializedError("not init")),
+        ):
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "dummy_tool", {"param": "value"}, request_headers=None)
+
+        assert "timed out after" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_reset_metrics(self, tool_service, test_db):
         """Test resetting metrics."""
         # Mock DB operations


### PR DESCRIPTION
# Bug-fix PR

## 📌 Summary

When a tool invocation times out via StreamableHTTP or SSE transport, the error
response returned to the client contains an empty message (`"Tool invocation failed: "`).
The descriptive timeout message is generated correctly but lost during exception
propagation through Python 3.11+ `BaseExceptionGroup` wrapping.

## 🔗 Related Issue

Closes: #2782

## 🔁 Reproduction Steps

See [#2781](https://github.com/IBM/mcp-context-forge/issues/2781) and [#2782](https://github.com/IBM/mcp-context-forge/issues/2782).

1. Register an MCP server reachable via StreamableHTTP or SSE transport.
2. Set a short `tool_timeout` so the tool times out reliably.
3. Invoke the tool — the client receives `"Tool invocation failed: "` (empty message).

## 🐞 Root Cause

`tool_service.py` raises `ToolTimeoutError("Tool invocation timed out after {N}s")`
inside nested `async with` context managers (`streamablehttp_client`, `ClientSession`).
During `__aexit__` cleanup the MCP SDK's internal `TaskGroup` may raise additional
exceptions from cancelled tasks, causing Python 3.11+ to wrap everything in a
`BaseExceptionGroup`.

In the outer `invoke_tool` handler:

1. `except ToolTimeoutError` does not match a `BaseExceptionGroup` containing a `ToolTimeoutError`.
2. Falls through to `except BaseException`.
3. The unwrapping loop (`exceptions[0]`) finds the bare `asyncio.TimeoutError` — which carries no message.
4. `str(asyncio.TimeoutError())` → `""` → the client sees an empty error message.

The same silent-message loss affected the structured logger in the SSE and
StreamableHTTP inner handlers (logged `error_message: ""` instead of the timeout
description).

## 💡 Fix Description

After unwrapping the `BaseExceptionGroup` root cause, add a fallback that
re-attaches the descriptive timeout message whenever the root cause is a bare
`TimeoutError` / `asyncio.TimeoutError` with an empty string representation:

```python
error_message = str(root_cause)
# Preserve timeout context when message is lost during ExceptionGroup wrapping
if not error_message and isinstance(root_cause, (TimeoutError, asyncio.TimeoutError)):
    error_message = f"Tool invocation timed out after {effective_timeout}s"
```

Applied to three locations:

| File | Line | Path | Variable |
|---|---|---|---|
| `tool_service.py` | ~5457 | SSE inner handler | `root_cause_message` (logging) |
| `tool_service.py` | ~5647 | StreamableHTTP inner handler | `root_cause_message` (logging) |
| `tool_service.py` | ~5961 | Outer `invoke_tool` handler | `error_message` (returned to client) |

The fallback is only triggered when the message is empty **and** the root cause
is a `TimeoutError` subclass, so normal non-timeout errors are completely
unaffected.

## 🧪 Verification

A regression test was added to `tests/unit/mcpgateway/services/test_tool_service.py`:

```
test_invoke_tool_timeout_message_preserved_through_exception_group
```

It constructs a nested `ExceptionGroup(ExceptionGroup(TimeoutError()))`, asserts the raised
`ToolInvocationError` contains `"timed out after"`, and verifies the metrics buffer records
the correct non-empty `error_message`.

| Check                             | Command             |    Status     |
|-----------------------------------|---------------------|---------------|
| Lint suite                        | `make lint`         |    Passed     |
| Unit tests                        | `make test`         |    Passed     |
| Coverage ≥ 90 %                   | `make coverage`     |    Passed     |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Regression test added (`test_invoke_tool_timeout_message_preserved_through_exception_group`)
- [x] No secrets/credentials committed