### PR TITLE
fix(plugins): Return operator labels in GET /admin/plugins to match PUT input

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-12T10:04:13Z",
+  "generated_at": "2026-06-05T10:00:50Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4264,40 +4264,6 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/admin.py": [
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4180,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4821,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4823,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15369,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-12T09:52:40Z",
+  "generated_at": "2026-05-12T10:04:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4272,7 +4272,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4182,
+        "line_number": 4180,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4280,7 +4280,7 @@
         "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4824,
+        "line_number": 4821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4288,7 +4288,7 @@
         "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4826,
+        "line_number": 4823,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4296,7 +4296,7 @@
         "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15372,
+        "line_number": 15369,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-04T16:06:29Z",
+  "generated_at": "2026-05-12T09:52:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4264,6 +4264,40 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/admin.py": [
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4182,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4824,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4826,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15372,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],

--- a/mcpgateway/services/plugin_service.py
+++ b/mcpgateway/services/plugin_service.py
@@ -12,13 +12,46 @@ statistics, and configuration from the PluginManager.
 # Standard
 from collections import defaultdict
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 # Third-Party
 from cpex.framework import PluginManager
 from cpex.framework.models import PluginMode
 
 logger = logging.getLogger(__name__)
+
+
+def _framework_mode_to_operator_label(mode: Union[str, PluginMode]) -> str:
+    """Convert cpex framework mode to operator label.
+
+    The cpex framework internally migrates legacy operator labels to framework
+    labels (enforce→sequential, permissive→transform). This helper reverses
+    that mapping so the admin API echoes the operator vocabulary that was
+    originally configured, matching the behavior of the tool plugin bindings API.
+
+    Args:
+        mode: Framework mode (PluginMode enum or string value).
+
+    Returns:
+        Operator label string (enforce, permissive, disabled, or passthrough for unknown).
+
+    Examples:
+        >>> _framework_mode_to_operator_label(PluginMode.SEQUENTIAL)
+        'enforce'
+        >>> _framework_mode_to_operator_label("transform")
+        'permissive'
+        >>> _framework_mode_to_operator_label("disabled")
+        'disabled'
+    """
+    mode_str = mode.value if isinstance(mode, PluginMode) else mode
+    # Reverse the cpex migration mapping: framework → operator
+    mapping = {
+        "sequential": "enforce",
+        "transform": "permissive",
+        "disabled": "disabled",
+    }
+    return mapping.get(mode_str, mode_str)
+
 
 # Cache import (lazy to avoid circular dependencies)
 _ADMIN_STATS_CACHE = None
@@ -95,7 +128,7 @@ class PluginService:
                 "description": plugin_config.description if plugin_config and plugin_config.description else "",
                 "author": plugin_config.author if plugin_config and plugin_config.author else "Unknown",
                 "version": plugin_config.version if plugin_config and plugin_config.version else "0.0.0",
-                "mode": plugin_ref.mode if isinstance(plugin_ref.mode, str) else plugin_ref.mode.value if plugin_ref.mode else "disabled",
+                "mode": _framework_mode_to_operator_label(plugin_ref.mode) if plugin_ref.mode else "disabled",
                 "priority": plugin_ref.priority,
                 "hooks": [hook if isinstance(hook, str) else hook.value for hook in plugin_ref.hooks] if plugin_ref.hooks else [],
                 "tags": plugin_ref.tags or [],
@@ -123,7 +156,7 @@ class PluginService:
                         "description": plugin_config.description or "",
                         "author": plugin_config.author or "Unknown",
                         "version": plugin_config.version or "0.0.0",
-                        "mode": plugin_config.mode if isinstance(plugin_config.mode, str) else plugin_config.mode.value,
+                        "mode": _framework_mode_to_operator_label(plugin_config.mode),
                         "priority": plugin_config.priority or 100,
                         "hooks": [hook if isinstance(hook, str) else hook.value for hook in plugin_config.hooks] if plugin_config.hooks else [],
                         "tags": plugin_config.tags or [],
@@ -166,7 +199,7 @@ class PluginService:
                 "description": plugin_config.description if plugin_config and plugin_config.description else "",
                 "author": plugin_config.author if plugin_config and plugin_config.author else "Unknown",
                 "version": plugin_config.version if plugin_config and plugin_config.version else "0.0.0",
-                "mode": plugin_ref.mode if isinstance(plugin_ref.mode, str) else plugin_ref.mode.value if plugin_ref.mode else "disabled",
+                "mode": _framework_mode_to_operator_label(plugin_ref.mode) if plugin_ref.mode else "disabled",
                 "priority": plugin_ref.priority,
                 "hooks": [hook if isinstance(hook, str) else hook.value for hook in plugin_ref.hooks] if plugin_ref.hooks else [],
                 "tags": plugin_ref.tags or [],
@@ -193,7 +226,7 @@ class PluginService:
                         "description": plugin_config.description or "",
                         "author": plugin_config.author or "Unknown",
                         "version": plugin_config.version or "0.0.0",
-                        "mode": plugin_config.mode if isinstance(plugin_config.mode, str) else plugin_config.mode.value,
+                        "mode": _framework_mode_to_operator_label(plugin_config.mode),
                         "priority": plugin_config.priority or 100,
                         "hooks": [hook if isinstance(hook, str) else hook.value for hook in plugin_config.hooks] if plugin_config.hooks else [],
                         "tags": plugin_config.tags or [],

--- a/tests/unit/mcpgateway/services/test_plugin_service.py
+++ b/tests/unit/mcpgateway/services/test_plugin_service.py
@@ -120,7 +120,9 @@ def test_search_plugins(mock_manager):
     all_p = service.search_plugins()
     assert all_p
     assert service.search_plugins(query="sample")
-    assert service.search_plugins(mode=PluginMode.SEQUENTIAL)
+    # Search by operator label (enforce) not framework label (sequential)
+    # because the service now returns operator labels per issue #4709 fix
+    assert service.search_plugins(mode="enforce")
     assert service.search_plugins(hook="hookA")
     assert service.search_plugins(tag="tag1")
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4709

---

## 📝 Summary

This PR fixes the inconsistent plugin mode labels between `GET /admin/plugins` and `GET /v1/tools/plugin_bindings/` endpoints.

**Problem**: The cpex framework internally migrates operator labels (`enforce`, `permissive`) to framework labels (`sequential`, `transform`). This caused `GET /admin/plugins` to return framework labels while `PUT /admin/plugins/{name}` accepted operator labels, creating confusion when operators set `mode: "enforce"` but saw `mode: "sequential"` in the response.

**Solution**: Added a reverse mapping helper function that converts framework labels back to operator labels in the serialization layer, ensuring both admin and bindings APIs consistently return operator vocabulary.

**Changes**:
- Added `_framework_mode_to_operator_label()` helper in [`plugin_service.py`](mcpgateway/services/plugin_service.py:24-53)
- Updated 4 serialization points in `PluginService` to use operator labels (lines 130, 163, 206, 233)
- Updated test to search by operator label instead of framework label

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Mapping Applied**:
- `sequential` → `enforce`
- `transform` → `permissive`
- `disabled` → `disabled` (unchanged)

**API Behavior After Fix**:
- `PUT /admin/plugins/{name}` with `mode: "enforce"` → `GET /admin/plugins` returns `mode: "enforce"` ✅
- Both admin and bindings APIs now use consistent operator vocabulary
- Aligns with documentation and operator expectations
- Integration tests already expected operator labels, confirming this is the correct behavior