### PR TITLE
feat(security): expand inbound passthrough denylist to block protocol-level headers

### DIFF
--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -52,6 +52,35 @@ HEADER_NAME_REGEX = re.compile(r"^[A-Za-z0-9\-]+$")
 # Maximum header value length (4KB)
 MAX_HEADER_VALUE_LENGTH = 4096
 
+# Inbound passthrough denylist: protocol-level headers that must never be
+# forwarded from client requests, regardless of allowlist configuration.
+# These headers control request encoding, routing, and connection management
+# and must be set by the gateway, not by clients.
+#
+# Security rationale per header:
+# - content-type: Prevents encoding-dispatch bypass
+# - content-length: httpx auto-recalculates; defence-in-depth
+# - host: Prevents vhost selection / cache-poisoning attacks
+# - transfer-encoding: Prevents request-smuggling attacks
+# - connection, keep-alive, proxy-connection, te, trailer, upgrade: Hop-by-hop headers
+#
+# Note: authorization is intentionally NOT on this list — it has gateway-auth-aware
+# handling earlier in get_passthrough_headers / compute_passthrough_headers_cached.
+_INBOUND_PASSTHROUGH_DENYLIST: frozenset[str] = frozenset(
+    {
+        "content-type",
+        "content-length",
+        "host",
+        "transfer-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "upgrade",
+    }
+)
+
 
 class PassthroughHeadersError(Exception):
     """Base class for passthrough headers-related errors.
@@ -275,6 +304,12 @@ def get_passthrough_headers(request_headers: Dict[str, str], base_headers: Dict[
                 continue
 
             header_lower = header_name.lower()
+
+            # Block protocol-level headers from inbound passthrough
+            if header_lower in _INBOUND_PASSTHROUGH_DENYLIST:
+                logger.warning(f"Refusing inbound passthrough of protocol-level header '{header_name}' (security policy)")
+                continue
+
             header_value = request_headers_lower.get(header_lower)
 
             if header_value:
@@ -398,6 +433,12 @@ def compute_passthrough_headers_cached(
                 continue
 
             header_lower = header_name.lower()
+
+            # Block protocol-level headers from inbound passthrough
+            if header_lower in _INBOUND_PASSTHROUGH_DENYLIST:
+                logger.warning(f"Refusing inbound passthrough of protocol-level header '{header_name}' (security policy)")
+                continue
+
             header_value = request_headers_lower.get(header_lower)
 
             if header_value:

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -43,11 +43,11 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = {"x-tenant-id": "acme-corp", "x-trace-id": "trace-456", "user-agent": "TestClient/1.0"}  # Not in allowed headers
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
-        expected = {"Content-Type": "application/json", "X-Tenant-Id": "acme-corp", "X-Trace-Id": "trace-456"}
+        expected = {"X-Custom-Type": "application/json", "X-Tenant-Id": "acme-corp", "X-Trace-Id": "trace-456"}
         assert result == expected
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -66,11 +66,11 @@ class TestPassthroughHeaders:
         mock_gateway.auth_type = None
 
         request_headers = {"x-custom-header": "custom-value", "x-tenant-id": "should-be-ignored", "x-trace-id": "also-ignored"}  # Not in gateway config
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
 
-        expected = {"Content-Type": "application/json", "X-Custom-Header": "custom-value"}
+        expected = {"X-Custom-Type": "application/json", "X-Custom-Header": "custom-value"}
         assert result == expected
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -89,13 +89,13 @@ class TestPassthroughHeaders:
         mock_gateway.name = "test-gateway"
 
         request_headers = {"authorization": "Bearer should-be-blocked", "x-tenant-id": "acme-corp"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
 
         # Authorization should be blocked, X-Tenant-Id should pass through
-        expected = {"Content-Type": "application/json", "X-Tenant-Id": "acme-corp"}
+        expected = {"X-Custom-Type": "application/json", "X-Tenant-Id": "acme-corp"}
         assert result == expected
 
         # Check warning was logged
@@ -117,13 +117,13 @@ class TestPassthroughHeaders:
         mock_gateway.name = "bearer-gateway"
 
         request_headers = {"authorization": "Bearer should-be-blocked"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
 
         # Only base headers should remain
-        expected = {"Content-Type": "application/json"}
+        expected = {"X-Custom-Type": "application/json"}
         assert result == expected
 
         # Check warning was logged
@@ -137,17 +137,17 @@ class TestPassthroughHeaders:
 
         mock_db = Mock()
         mock_global_config = Mock(spec=GlobalConfig)
-        mock_global_config.passthrough_headers = ["Content-Type", "X-Tenant-Id"]
+        mock_global_config.passthrough_headers = ["X-Custom-Type", "X-Tenant-Id"]
         mock_db.query.return_value.first.return_value = mock_global_config
 
-        request_headers = {"content-type": "text/plain", "x-tenant-id": "acme-corp"}  # Conflicts with base header  # Should pass through
-        base_headers = {"Content-Type": "application/json"}
+        request_headers = {"x-custom-type": "text/plain", "x-tenant-id": "acme-corp"}  # Conflicts with base header  # Should pass through
+        base_headers = {"X-Custom-Type": "application/json"}
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Base header preserved, tenant ID added
-        expected = {"Content-Type": "application/json", "X-Tenant-Id": "acme-corp"}
+        expected = {"X-Custom-Type": "application/json", "X-Tenant-Id": "acme-corp"}
         assert result == expected
 
         # Check conflict warning was logged
@@ -184,13 +184,13 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = {"x-present": "present-value"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         with caplog.at_level(logging.WARNING):
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Only present header should be included
-        expected = {"Content-Type": "application/json", "X-Present": "present-value"}
+        expected = {"X-Custom-Type": "application/json", "X-Present": "present-value"}
         assert result == expected
 
         # Check debug message for missing header
@@ -211,12 +211,12 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = {"x-tenant-id": "should-be-ignored"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Only base headers should remain
-        expected = {"Content-Type": "application/json"}
+        expected = {"X-Custom-Type": "application/json"}
         assert result == expected
 
     def test_none_allowed_headers(self):
@@ -227,7 +227,7 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = {"x-tenant-id": "should-be-ignored"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         # Mock settings fallback
         with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
@@ -236,7 +236,7 @@ class TestPassthroughHeaders:
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Should fall back to settings, but request doesn't have X-Default
-        expected = {"Content-Type": "application/json"}
+        expected = {"X-Custom-Type": "application/json"}
         assert result == expected
 
     def test_no_global_config_fallback_to_settings(self):
@@ -245,7 +245,7 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = None  # No global config
 
         request_headers = {"x-default": "default-value"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         # Mock settings fallback
         with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
@@ -253,7 +253,7 @@ class TestPassthroughHeaders:
 
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
-        expected = {"Content-Type": "application/json", "X-Default": "default-value"}
+        expected = {"X-Custom-Type": "application/json", "X-Default": "default-value"}
         assert result == expected
 
     def test_empty_request_headers(self):
@@ -264,12 +264,12 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers: dict[str, str] = {}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Only base headers should remain
-        expected = {"Content-Type": "application/json"}
+        expected = {"X-Custom-Type": "application/json"}
         assert result == expected
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -305,12 +305,12 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = None
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db)  # type: ignore[arg-type]
 
         # Only base headers should remain
-        expected = {"Content-Type": "application/json"}
+        expected = {"X-Custom-Type": "application/json"}
         assert result == expected
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -324,7 +324,7 @@ class TestPassthroughHeaders:
         mock_db.query.return_value.first.return_value = mock_global_config
 
         request_headers = {"x-tenant-id": "acme-corp"}
-        base_headers = {"Content-Type": "application/json"}
+        base_headers = {"X-Custom-Type": "application/json"}
         original_base = base_headers.copy()
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db)
@@ -333,7 +333,7 @@ class TestPassthroughHeaders:
         assert base_headers == original_base
 
         # Result should include both base and passthrough headers
-        assert "Content-Type" in result
+        assert "X-Custom-Type" in result
         assert "X-Tenant-Id" in result
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -394,11 +394,11 @@ class TestPassthroughHeaders:
             "x-conflict": "conflict-value",  # Should pass through (in both configs)
             "x-random": "random-value",  # Not configured, ignored
         }
-        base_headers = {"Content-Type": "application/json", "User-Agent": "MCPGateway/1.0"}
+        base_headers = {"X-Custom-Type": "application/json", "User-Agent": "MCPGateway/1.0"}
 
         result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
 
-        expected = {"Content-Type": "application/json", "User-Agent": "MCPGateway/1.0", "X-Gateway": "gateway-value", "X-Conflict": "conflict-value"}
+        expected = {"X-Custom-Type": "application/json", "User-Agent": "MCPGateway/1.0", "X-Gateway": "gateway-value", "X-Conflict": "conflict-value"}
         assert result == expected
 
     @patch("mcpgateway.utils.passthrough_headers.settings")
@@ -457,19 +457,19 @@ class TestPassthroughHeaders:
         """Test that enable_overwrite_base_headers allows overriding base headers."""
         mock_settings.enable_header_passthrough = True
         mock_settings.enable_overwrite_base_headers = True  # Enable override
-        mock_settings.default_passthrough_headers = ["Content-Type", "X-Tenant-Id"]
+        mock_settings.default_passthrough_headers = ["X-Custom-Type", "X-Tenant-Id"]
 
         mock_db = Mock()
         mock_db.query.return_value.first.return_value = None
 
-        request_headers = {"content-type": "text/plain", "x-tenant-id": "acme-corp"}
-        base_headers = {"Content-Type": "application/json", "User-Agent": "MCPGateway"}
+        request_headers = {"x-custom-type": "text/plain", "x-tenant-id": "acme-corp"}
+        base_headers = {"X-Custom-Type": "application/json", "User-Agent": "MCPGateway"}
 
         with patch("mcpgateway.utils.passthrough_headers.logger") as mock_logger:
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Should override Content-Type and add X-Tenant-Id
-        expected = {"Content-Type": "text/plain", "User-Agent": "MCPGateway", "X-Tenant-Id": "acme-corp"}
+        expected = {"X-Custom-Type": "text/plain", "User-Agent": "MCPGateway", "X-Tenant-Id": "acme-corp"}
         assert result == expected
 
         # Should log debug message about override being enabled
@@ -480,19 +480,19 @@ class TestPassthroughHeaders:
         """Test that when overwrite is disabled, base header conflicts are prevented."""
         mock_settings.enable_header_passthrough = True
         mock_settings.enable_overwrite_base_headers = False  # Disable override (default)
-        mock_settings.default_passthrough_headers = ["Content-Type", "X-Tenant-Id"]
+        mock_settings.default_passthrough_headers = ["X-Custom-Type", "X-Tenant-Id"]
 
         mock_db = Mock()
         mock_db.query.return_value.first.return_value = None
 
-        request_headers = {"content-type": "text/plain", "x-tenant-id": "acme-corp"}
-        base_headers = {"Content-Type": "application/json", "User-Agent": "MCPGateway"}
+        request_headers = {"x-custom-type": "text/plain", "x-tenant-id": "acme-corp"}
+        base_headers = {"X-Custom-Type": "application/json", "User-Agent": "MCPGateway"}
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = get_passthrough_headers(request_headers, base_headers, mock_db)
 
         # Should preserve base Content-Type and add X-Tenant-Id
-        expected = {"Content-Type": "application/json", "User-Agent": "MCPGateway", "X-Tenant-Id": "acme-corp"}
+        expected = {"X-Custom-Type": "application/json", "User-Agent": "MCPGateway", "X-Tenant-Id": "acme-corp"}
         assert result == expected
 
         # Should log warning about conflict

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers_fixed.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers_fixed.py
@@ -472,18 +472,19 @@ class TestComputePassthroughHeadersCached:
         mock_settings.enable_header_passthrough = True
         mock_settings.enable_overwrite_base_headers = False
 
+        # Use X-Custom-Type instead of Content-Type (which is now in denylist
         request_headers = {
             "x-tenant-id": "acme",
-            "content-type": "text/plain",
+            "x-custom-type": "text/plain",
             "x-empty": "\r\n\t",
         }
-        base_headers = {"Content-Type": "application/json"}
-        allowed = ["X-Tenant-Id", "Bad Header", "Content-Type", "X-Empty", "X-Missing"]
+        base_headers = {"X-Custom-Type": "application/json"}
+        allowed = ["X-Tenant-Id", "Bad Header", "X-Custom-Type", "X-Empty", "X-Missing"]
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = compute_passthrough_headers_cached(request_headers=request_headers, base_headers=base_headers, allowed_headers=allowed, gateway_auth_type=None)
 
-        assert result["Content-Type"] == "application/json"
+        assert result["X-Custom-Type"] == "application/json"
         assert result["X-Tenant-Id"] == "acme"
         assert "X-Empty" not in result
         assert any("Invalid header name" in record.message for record in caplog.records)
@@ -495,14 +496,15 @@ class TestComputePassthroughHeadersCached:
         mock_settings.enable_header_passthrough = True
         mock_settings.enable_overwrite_base_headers = True
 
-        request_headers = {"content-type": "text/plain", "authorization": "Bearer should-be-blocked"}
-        base_headers = {"Content-Type": "application/json"}
-        allowed = ["Content-Type", "Authorization"]
+        # Use X-Custom-Type instead of Content-Type (which is now in denylist per Issue #4450)
+        request_headers = {"x-custom-type": "text/plain", "authorization": "Bearer should-be-blocked"}
+        base_headers = {"X-Custom-Type": "application/json"}
+        allowed = ["X-Custom-Type", "Authorization"]
 
         with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
             result = compute_passthrough_headers_cached(request_headers=request_headers, base_headers=base_headers, allowed_headers=allowed, gateway_auth_type="basic")
 
-        assert result["Content-Type"] == "text/plain"
+        assert result["X-Custom-Type"] == "text/plain"
         assert "Authorization" not in result
         assert any("Skipping Authorization header passthrough" in record.message for record in caplog.records)
 

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers_security.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers_security.py
@@ -702,3 +702,184 @@ class TestInboundPassthroughDenylist:
             # Should log security warnings
             assert any("Refusing inbound passthrough of protocol-level header 'Content-Type'" in record.message for record in caplog.records)
             assert any("Refusing inbound passthrough of protocol-level header 'Host'" in record.message for record in caplog.records)
+
+    def test_denylist_in_compute_passthrough_headers_cached_with_gateway_override(self, caplog):
+        """Test denylist enforcement with gateway_passthrough_headers override."""
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
+
+        with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
+            mock_settings.enable_header_passthrough = True
+            mock_settings.enable_overwrite_base_headers = False
+
+            request_headers = {
+                "content-type": "text/html",
+                "host": "evil.com",
+                "transfer-encoding": "chunked",
+                "x-safe-header": "safe-value",
+            }
+            base_headers = {}
+            # Gateway-specific headers (override branch)
+            gateway_passthrough_headers = ["Content-Type", "Host", "Transfer-Encoding", "X-Safe-Header"]
+
+            # Standard
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+                result = compute_passthrough_headers_cached(
+                    request_headers, base_headers, allowed_headers=[], gateway_passthrough_headers=gateway_passthrough_headers
+                )
+
+            # Denylist headers should be blocked even with gateway override
+            assert "Content-Type" not in result
+            assert "Host" not in result
+            assert "Transfer-Encoding" not in result
+
+            # Safe header should pass
+            assert result.get("X-Safe-Header") == "safe-value"
+
+            # Should log security warnings for each blocked header
+            assert any("Refusing inbound passthrough of protocol-level header 'Content-Type'" in record.message for record in caplog.records)
+            assert any("Refusing inbound passthrough of protocol-level header 'Host'" in record.message for record in caplog.records)
+            assert any("Refusing inbound passthrough of protocol-level header 'Transfer-Encoding'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_host_header_denied_via_gateway_passthrough(self, mock_settings, caplog):
+        """Test that Host header is denied via gateway-specific passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = ["Host", "X-Safe-Header"]
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {"host": "evil.example.com", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # Host should be blocked
+        assert "Host" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Host'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_transfer_encoding_denied_via_gateway_passthrough(self, mock_settings, caplog):
+        """Test that Transfer-Encoding is denied via gateway-specific passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = ["Transfer-Encoding", "X-Safe-Header"]
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {"transfer-encoding": "chunked", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # Transfer-Encoding should be blocked
+        assert "Transfer-Encoding" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Transfer-Encoding'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_content_length_denied_via_gateway_passthrough(self, mock_settings, caplog):
+        """Test that Content-Length is denied via gateway-specific passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = ["Content-Length", "X-Safe-Header"]
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {"content-length": "9999", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # Content-Length should be blocked
+        assert "Content-Length" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Content-Length'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_hop_by_hop_headers_denied_via_gateway_passthrough(self, mock_settings, caplog):
+        """Test that hop-by-hop headers are denied via gateway-specific passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = [
+            "Connection",
+            "Keep-Alive",
+            "Proxy-Connection",
+            "TE",
+            "Trailer",
+            "Upgrade",
+            "X-Safe-Header",
+        ]
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {
+            "connection": "keep-alive",
+            "keep-alive": "timeout=5",
+            "proxy-connection": "keep-alive",
+            "te": "trailers",
+            "trailer": "Expires",
+            "upgrade": "websocket",
+            "x-safe-header": "safe-value",
+        }
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # All hop-by-hop headers should be blocked
+        assert "Connection" not in result
+        assert "Keep-Alive" not in result
+        assert "Proxy-Connection" not in result
+        assert "TE" not in result
+        assert "Trailer" not in result
+        assert "Upgrade" not in result
+
+        # Safe header should pass
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warnings for each
+        hop_by_hop_headers = ["Connection", "Keep-Alive", "Proxy-Connection", "TE", "Trailer", "Upgrade"]
+        for header in hop_by_hop_headers:
+            assert any(f"Refusing inbound passthrough of protocol-level header '{header}'" in record.message for record in caplog.records)

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers_security.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers_security.py
@@ -256,10 +256,11 @@ class TestHeaderSecurity:
     def test_case_sensitivity_security(self):
         """Test that case sensitivity doesn't create security bypasses."""
         # Ensure that different cases of the same header are handled consistently
+        # Note: Content-Type is now in the denylist (Issue #4450), so we test with safe headers
         test_cases = [
             ("Authorization", "authorization"),
             ("X-Tenant-Id", "x-tenant-id"),
-            ("Content-Type", "content-type"),
+            ("X-Custom-Header", "x-custom-header"),
         ]
 
         for config_case, request_case in test_cases:
@@ -378,3 +379,326 @@ class TestConfigSecurity:
 
             # Should include all headers (validation happens during use, not config)
             assert len(settings.default_passthrough_headers) == 3
+
+
+class TestInboundPassthroughDenylist:
+    """Test inbound passthrough denylist security (Issue #4450)."""
+
+    def setup_method(self):
+        """Clear the global config cache before each test to ensure isolation."""
+        global_config_cache.invalidate()
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_content_type_denied_via_default_passthrough(self, mock_settings, caplog):
+        """Test that Content-Type is denied even when in default_passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.enable_overwrite_base_headers = False
+        mock_settings.default_passthrough_headers = ["Content-Type", "X-Safe-Header"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {"content-type": "application/x-www-form-urlencoded", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # Content-Type should be blocked, X-Safe-Header should pass
+        assert "Content-Type" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Content-Type'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_content_type_denied_via_gateway_passthrough(self, mock_settings, caplog):
+        """Test that Content-Type is denied via gateway-specific passthrough_headers."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.enable_overwrite_base_headers = False
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = ["Content-Type", "X-Safe-Header"]
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {"content-type": "text/plain", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # Content-Type should be blocked
+        assert "Content-Type" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Content-Type'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_host_header_denied(self, mock_settings, caplog):
+        """Test that Host header is denied (vhost/cache-poisoning protection)."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = ["Host", "X-Safe-Header"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {"host": "evil.example.com", "x-safe-header": "safe-value"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # Host should be blocked
+        assert "Host" not in result
+        assert result.get("X-Safe-Header") == "safe-value"
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Host'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_transfer_encoding_denied(self, mock_settings, caplog):
+        """Test that Transfer-Encoding is denied (request-smuggling protection)."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = ["Transfer-Encoding"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {"transfer-encoding": "chunked"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # Transfer-Encoding should be blocked
+        assert "Transfer-Encoding" not in result
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Transfer-Encoding'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_content_length_denied(self, mock_settings, caplog):
+        """Test that Content-Length is denied (defence-in-depth)."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = ["Content-Length"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {"content-length": "9999"}
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # Content-Length should be blocked
+        assert "Content-Length" not in result
+
+        # Should log security warning
+        assert any("Refusing inbound passthrough of protocol-level header 'Content-Length'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_hop_by_hop_headers_denied(self, mock_settings, caplog):
+        """Test that hop-by-hop headers are denied."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = [
+            "Connection",
+            "Keep-Alive",
+            "Proxy-Connection",
+            "TE",
+            "Trailer",
+            "Upgrade",
+        ]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {
+            "connection": "keep-alive",
+            "keep-alive": "timeout=5",
+            "proxy-connection": "keep-alive",
+            "te": "trailers",
+            "trailer": "Expires",
+            "upgrade": "websocket",
+        }
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # All hop-by-hop headers should be blocked
+        assert "Connection" not in result
+        assert "Keep-Alive" not in result
+        assert "Proxy-Connection" not in result
+        assert "TE" not in result
+        assert "Trailer" not in result
+        assert "Upgrade" not in result
+
+        # Should log security warnings for each
+        hop_by_hop_headers = ["Connection", "Keep-Alive", "Proxy-Connection", "TE", "Trailer", "Upgrade"]
+        for header in hop_by_hop_headers:
+            assert any(f"Refusing inbound passthrough of protocol-level header '{header}'" in record.message for record in caplog.records)
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_all_denylist_headers_blocked_together(self, mock_settings, caplog):
+        """Test that all denylist headers are blocked when configured together."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = [
+            "Content-Type",
+            "Content-Length",
+            "Host",
+            "Transfer-Encoding",
+            "Connection",
+            "Keep-Alive",
+            "Proxy-Connection",
+            "TE",
+            "Trailer",
+            "Upgrade",
+            "X-Safe-Header",  # This one should pass
+        ]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {
+            "content-type": "text/html",
+            "content-length": "100",
+            "host": "evil.com",
+            "transfer-encoding": "chunked",
+            "connection": "close",
+            "keep-alive": "timeout=5",
+            "proxy-connection": "keep-alive",
+            "te": "trailers",
+            "trailer": "Expires",
+            "upgrade": "h2c",
+            "x-safe-header": "this-should-pass",
+        }
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # All denylist headers should be blocked
+        assert "Content-Type" not in result
+        assert "Content-Length" not in result
+        assert "Host" not in result
+        assert "Transfer-Encoding" not in result
+        assert "Connection" not in result
+        assert "Keep-Alive" not in result
+        assert "Proxy-Connection" not in result
+        assert "TE" not in result
+        assert "Trailer" not in result
+        assert "Upgrade" not in result
+
+        # Safe header should pass
+        assert result.get("X-Safe-Header") == "this-should-pass"
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_authorization_not_in_denylist(self, mock_settings):
+        """Test that Authorization is NOT in the denylist (has special handling)."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = ["Authorization"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        # Gateway with no auth should allow Authorization passthrough
+        mock_gateway = Mock()
+        mock_gateway.passthrough_headers = None
+        mock_gateway.auth_type = "none"
+        mock_gateway.name = "test-gateway"
+
+        request_headers = {"authorization": "Bearer token123"}
+        base_headers = {}
+
+        result = get_passthrough_headers(request_headers, base_headers, mock_db, mock_gateway)
+
+        # Authorization should pass through (not in denylist, handled by auth logic)
+        assert result.get("Authorization") == "Bearer token123"
+
+    @patch("mcpgateway.utils.passthrough_headers.settings")
+    def test_denylist_case_insensitive(self, mock_settings, caplog):
+        """Test that denylist matching is case-insensitive."""
+        mock_settings.enable_header_passthrough = True
+        mock_settings.default_passthrough_headers = ["CONTENT-TYPE", "content-length", "HoSt"]
+
+        mock_db = Mock()
+        mock_db.query.return_value.first.return_value = None
+
+        request_headers = {
+            "CONTENT-TYPE": "text/html",
+            "content-length": "100",
+            "HoSt": "evil.com",
+        }
+        base_headers = {}
+
+        # Standard
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+            result = get_passthrough_headers(request_headers, base_headers, mock_db)
+
+        # All should be blocked regardless of case
+        assert "CONTENT-TYPE" not in result
+        assert "content-length" not in result
+        assert "HoSt" not in result
+
+    def test_denylist_in_compute_passthrough_headers_cached(self, caplog):
+        """Test that denylist is enforced in compute_passthrough_headers_cached."""
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
+
+        with patch("mcpgateway.utils.passthrough_headers.settings") as mock_settings:
+            mock_settings.enable_header_passthrough = True
+            mock_settings.enable_overwrite_base_headers = False
+
+            request_headers = {
+                "content-type": "text/html",
+                "host": "evil.com",
+                "x-safe-header": "safe-value",
+            }
+            base_headers = {}
+            allowed_headers = ["Content-Type", "Host", "X-Safe-Header"]
+
+            # Standard
+            import logging
+
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.utils.passthrough_headers"):
+                result = compute_passthrough_headers_cached(request_headers, base_headers, allowed_headers)
+
+            # Denylist headers should be blocked
+            assert "Content-Type" not in result
+            assert "Host" not in result
+
+            # Safe header should pass
+            assert result.get("X-Safe-Header") == "safe-value"
+
+            # Should log security warnings
+            assert any("Refusing inbound passthrough of protocol-level header 'Content-Type'" in record.message for record in caplog.records)
+            assert any("Refusing inbound passthrough of protocol-level header 'Host'" in record.message for record in caplog.records)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4450

---

## 📝 Summary

Creates the explicit inbound passthrough header denylist for `get_passthrough_headers()` and `compute_passthrough_headers_cached()`, blocking 10 protocol-level headers that pose security risks when client-controlled. This prevents vhost selection attacks, cache poisoning, request smuggling, and encoding-dispatch bypasses.

**What existed before:**
Previously, headers like `content-type` were only implicitly blocked via conflict detection with `base_headers` when `ENABLE_OVERWRITE_BASE_HEADERS=false` (the default). This left security gaps: if the override flag was enabled OR if a gateway didn't set `Content-Type` in its `base_headers`, clients could inject `content-type` via passthrough configuration.

**What changed:**
- Added `_INBOUND_PASSTHROUGH_DENYLIST` constant as the first explicit security denylist for inbound passthrough
- Enforced denylist in both `get_passthrough_headers()` and `compute_passthrough_headers_cached()`
- Headers are now **always** blocked regardless of `base_headers` or `ENABLE_OVERWRITE_BASE_HEADERS` setting
- Added 18 comprehensive security tests covering individual, combined, and gateway-override denial scenarios
- Updated existing tests to use safe alternative headers (`X-Custom-Type` instead of `Content-Type`)

**Headers now blocked from inbound passthrough:**
- `content-type` — encoding-dispatch protection (issue #4450, related to PR #4139)
- `host` — vhost selection / cache-poisoning protection
- `transfer-encoding` — request-smuggling protection
- `content-length` — httpx auto-recalculates; defence-in-depth
- `connection`, `keep-alive`, `proxy-connection`, `te`, `trailer`, `upgrade` — hop-by-hop headers

**Note:** `authorization` is intentionally NOT in the denylist as it has existing gateway-auth-aware handling via `X-Upstream-Authorization` rename logic.

---

## 🏷️ Type of Change
- [x] Bug fix (security hardening)
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass    |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass   |

**Test coverage:**
- 18 new security tests in `TestInboundPassthroughDenylist` class
- Tests verify each header is denied via both `default_passthrough_headers` and per-gateway `passthrough_headers`
- Tests verify denylist enforcement in both `get_passthrough_headers()` and `compute_passthrough_headers_cached()` hot path
- Tests verify `compute_passthrough_headers_cached()` gateway-override branch (`gateway_passthrough_headers` parameter)
- Tests verify case-insensitive matching and WARNING-level logging
- Tests verify `authorization` is NOT blocked (existing special handling preserved)

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

**Security rationale per header:**

| Header | Risk if client-supplied | Severity |
|--------|------------------------|----------|
| `host` | Wrong upstream vhost selection on multi-tenant origins; cache-poisoning class | Medium |
| `transfer-encoding` | Request-smuggling primitive against fragile upstream parsers | Medium |
| `content-type` | Encoding-dispatch bypass (issue #4450) | Medium |
| `content-length` | httpx auto-recalculates; defence-in-depth | Low |
| `connection`, `keep-alive`, `proxy-connection`, `te`, `trailer`, `upgrade` | Hop-by-hop — httpx manages; defence-in-depth | Low |

**Why explicit denylist vs. implicit conflict detection:**

The old implicit approach (checking `base_headers_keys`) had gaps:
- Only worked when the header was already in `base_headers`
- Could be bypassed with `ENABLE_OVERWRITE_BASE_HEADERS=true`
- Different gateways could have inconsistent protection depending on their `base_headers`

The new explicit denylist provides consistent, unconditional protection across all gateways and configurations.

**Breaking change:**
Deployments that explicitly added `Host`, `Content-Length`, `Transfer-Encoding`, or hop-by-hop headers (`Connection`, `Keep-Alive`, `Proxy-Connection`, `TE`, `Trailer`, `Upgrade`) to `default_passthrough_headers` or a gateway's `passthrough_headers` will no longer forward these headers. This is intentional security hardening. Check WARNING logs if you relied on this behavior.

**Design decisions:**
- Mirrored the protocol-level subset of existing `_LOOPBACK_SKIP_HEADERS` constant (same file, line 552 in parent commit)
- Excluded gateway-internal routing headers (`mcp-session-id`, `x-forwarded-internally`) as they only matter in loopback contexts
- Excluded `authorization` to preserve existing gateway-auth-aware handling
- Logs at WARNING level when blocking headers for visibility and troubleshooting

**Files modified:**
- `mcpgateway/utils/passthrough_headers.py` — added denylist constant and enforcement logic
- `tests/unit/mcpgateway/utils/test_passthrough_headers_security.py` — added 18 new security tests
- `tests/unit/mcpgateway/utils/test_passthrough_headers.py` — fixed 8 tests expecting `Content-Type` passthrough
- `tests/unit/mcpgateway/utils/test_passthrough_headers_fixed.py` — fixed 4 tests expecting `Content-Type` passthrough
