### PR TITLE
fix(config): resolve CSRF token creation in admin UI by fixing .env d…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,13 +40,13 @@ CSRF_SECRET_KEY=
 CSRF_TOKEN_NAME=X-CSRF-Token
 
 # Cookie name for CSRF token
-CSRF_COOKIE_NAME=csrf_token
+CSRF_COOKIE_NAME=mcpgateway_csrf_token
 
 # CSRF token expiration time in seconds (default: 3600 = 1 hour)
 CSRF_TOKEN_EXPIRY=3600
 
-# Set Secure flag on CSRF cookie (HTTPS only, default: true)
-CSRF_COOKIE_SECURE=true
+# Set Secure flag on CSRF cookie (HTTPS only for production, false for local development on http://localhost)
+CSRF_COOKIE_SECURE=false
 
 # SameSite attribute for CSRF cookie (Strict, Lax, or None)
 CSRF_COOKIE_SAMESITE=Strict


### PR DESCRIPTION


## Summary
Fixed "Failed to create token: CSRF validation failed" error in admin UI by correcting CSRF cookie security settings in .env.example. The issue occurred because CSRF_COOKIE_SECURE=true prevents cookies from working on local HTTP development (http://localhost).

## Changes
- **CSRF_COOKIE_SECURE**: Changed from `true` to `false` for local development
  - `true` enforces HTTPS-only (Secure flag) — breaks http://localhost
  - `false` allows cookies over HTTP for development
- **CSRF_COOKIE_NAME**: Changed from `csrf_token` to `mcpgateway_csrf_token`
  - Aligns with actual cookie name expected by middleware

## Impact
- Users can now create API tokens through admin UI on local development setup
- Production deployments should set CSRF_COOKIE_SECURE=true with HTTPS
- No code changes required — configuration-only fix

Closes #4712

