### PR TITLE
Fix idepotency in migration

### DIFF
--- a/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
+++ b/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
@@ -59,6 +59,11 @@ def _replace_single_fk_with_cascade(table_name: str, referred_table: str, local_
         return
 
     fk_names = _get_fk_names(inspector, table_name, referred_table)
+    # If no named FK found, the table was likely created fresh from db.py models
+    # which already have CASCADE. Skip migration for idempotency.
+    if len(fk_names) == 0:
+        return
+        
     if len(fk_names) != 1:
         raise RuntimeError(f"Expected exactly one foreign key from {table_name} to {referred_table}, found {fk_names}")
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary
_What does this PR do and why?_

It fixes the sqlite upgrade from 0.9.0 to 1.0.1 on alembic  `9fb98535724d_add_ondelete_cascade_to_metrics_and_.py`  file

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
