### PR TITLE
fix: upgrade path from 0.9.0 - unnamed FK handling, temp table cleanup

### DIFF
--- a/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
+++ b/mcpgateway/alembic/versions/9fb98535724d_add_ondelete_cascade_to_metrics_and_.py
@@ -47,8 +47,31 @@ def _has_cascade_fk(inspector, table_name: str, referred_table: str) -> bool:
     return False
 
 
+def _strip_all_unnamed_fks(table: sa.Table) -> None:
+    """Remove all unnamed FK constraints from a reflected Table object in-place.
+
+    When batch_alter_table is called with copy_from=table, Alembic uses the
+    provided Table as the schema for the recreated table.  Any unnamed FK
+    constraints left here would silently persist alongside the new named
+    CASCADE FK we are about to add, creating duplicate conflicting FKs.
+    Unnamed FKs arise in SQLite when upgrading from schema versions that
+    pre-date explicit constraint naming (e.g. 0.9.0 databases).
+    """
+    for c in list(table.constraints):
+        if isinstance(c, sa.ForeignKeyConstraint) and c.name is None:
+            table.constraints.discard(c)
+            for fk_elem in c.elements:
+                fk_elem.parent.foreign_keys.discard(fk_elem)
+
+
 def _replace_single_fk_with_cascade(table_name: str, referred_table: str, local_cols: list[str], remote_cols: list[str]) -> None:
-    """Replace a single FK to the referred table with an ON DELETE CASCADE version."""
+    """Replace a single FK to the referred table with an ON DELETE CASCADE version.
+
+    Handles both named and unnamed FKs (unnamed FKs are common in SQLite when
+    upgrading from older schema versions that did not assign constraint names).
+    For unnamed FKs, Alembic batch mode cannot drop-by-name, so we reflect the
+    table, strip the unnamed FK, and use copy_from to recreate the table cleanly.
+    """
     bind = op.get_bind()
     inspector = sa.inspect(bind)
 
@@ -58,21 +81,31 @@ def _replace_single_fk_with_cascade(table_name: str, referred_table: str, local_
     if _has_cascade_fk(inspector, table_name, referred_table):
         return
 
-    fk_names = _get_fk_names(inspector, table_name, referred_table)
-    # If no named FK found, the table was likely created fresh from db.py models
-    # which already have CASCADE. Skip migration for idempotency.
-    if len(fk_names) == 0:
-        return
-        
-    if len(fk_names) != 1:
-        raise RuntimeError(f"Expected exactly one foreign key from {table_name} to {referred_table}, found {fk_names}")
+    # Collect ALL FKs to the referred table, including unnamed ones (name=None).
+    all_fks_to_target = [fk for fk in inspector.get_foreign_keys(table_name) if fk.get("referred_table") == referred_table]
 
-    fk_name = fk_names[0]
+    if len(all_fks_to_target) > 1:
+        raise RuntimeError(f"Expected at most one foreign key from {table_name} to {referred_table}, found {all_fks_to_target}")
+
     new_fk_name = f"fk_{table_name}_{local_cols[0]}"
+    fk_name = all_fks_to_target[0].get("name") if all_fks_to_target else None
+    is_unnamed = bool(all_fks_to_target) and fk_name is None
 
-    with op.batch_alter_table(table_name, schema=None) as batch_op:
-        batch_op.drop_constraint(fk_name, type_="foreignkey")
-        batch_op.create_foreign_key(new_fk_name, referred_table, local_cols, remote_cols, ondelete="CASCADE")
+    if is_unnamed:
+        # Unnamed FK: reflect the table, strip all unnamed FKs so copy_from
+        # won't recreate them, then add only the new named CASCADE FK.
+        meta = sa.MetaData()
+        copy_tbl = sa.Table(table_name, meta, autoload_with=bind)
+        _strip_all_unnamed_fks(copy_tbl)
+        with op.batch_alter_table(table_name, schema=None, copy_from=copy_tbl) as batch_op:
+            batch_op.create_foreign_key(new_fk_name, referred_table, local_cols, remote_cols, ondelete="CASCADE")
+    else:
+        with op.batch_alter_table(table_name, schema=None) as batch_op:
+            if fk_name:
+                # Named FK: drop it explicitly by name.
+                batch_op.drop_constraint(fk_name, type_="foreignkey")
+            # If no FK exists at all: just add the CASCADE FK.
+            batch_op.create_foreign_key(new_fk_name, referred_table, local_cols, remote_cols, ondelete="CASCADE")
 
 
 def _replace_all_fks_with_cascade(table_name: str, fk_specs: list[tuple[str, list[str], list[str]]]) -> None:
@@ -87,28 +120,33 @@ def _replace_all_fks_with_cascade(table_name: str, fk_specs: list[tuple[str, lis
     if not current_fks:
         return
 
-    all_cascade = True
-    for referred_table, _local_cols, _remote_cols in fk_specs:
-        if not _has_cascade_fk(inspector, table_name, referred_table):
-            all_cascade = False
-            break
-
+    all_cascade = all(_has_cascade_fk(inspector, table_name, rt) for rt, _, _ in fk_specs)
     if all_cascade:
         return
 
-    fk_names = [fk.get("name") for fk in current_fks if fk.get("name")]
     expected_targets = {spec[0] for spec in fk_specs}
     actual_targets = {fk.get("referred_table") for fk in current_fks}
 
     if actual_targets != expected_targets:
-        raise RuntimeError(f"Unexpected foreign key layout for {table_name}: targets={sorted(actual_targets)} names={fk_names}")
+        raise RuntimeError(f"Unexpected foreign key layout for {table_name}: targets={sorted(actual_targets)}")
 
-    with op.batch_alter_table(table_name, schema=None) as batch_op:
-        for fk_name in fk_names:
-            batch_op.drop_constraint(fk_name, type_="foreignkey")
+    has_unnamed = any(fk.get("name") is None for fk in current_fks)
 
-        for referred_table, local_cols, remote_cols in fk_specs:
-            batch_op.create_foreign_key(f"fk_{table_name}_{local_cols[0]}", referred_table, local_cols, remote_cols, ondelete="CASCADE")
+    if has_unnamed:
+        # Unnamed FKs: reflect the table, strip all unnamed FKs, add CASCADE FKs.
+        meta = sa.MetaData()
+        copy_tbl = sa.Table(table_name, meta, autoload_with=bind)
+        _strip_all_unnamed_fks(copy_tbl)
+        with op.batch_alter_table(table_name, schema=None, copy_from=copy_tbl) as batch_op:
+            for referred_table, local_cols, remote_cols in fk_specs:
+                batch_op.create_foreign_key(f"fk_{table_name}_{local_cols[0]}", referred_table, local_cols, remote_cols, ondelete="CASCADE")
+    else:
+        named_fk_names = [fk.get("name") for fk in current_fks]
+        with op.batch_alter_table(table_name, schema=None) as batch_op:
+            for fk_name in named_fk_names:
+                batch_op.drop_constraint(fk_name, type_="foreignkey")
+            for referred_table, local_cols, remote_cols in fk_specs:
+                batch_op.create_foreign_key(f"fk_{table_name}_{local_cols[0]}", referred_table, local_cols, remote_cols, ondelete="CASCADE")
 
 
 def upgrade() -> None:

--- a/mcpgateway/alembic/versions/r2b3c4d5e6f7_add_prompt_namespacing_fields.py
+++ b/mcpgateway/alembic/versions/r2b3c4d5e6f7_add_prompt_namespacing_fields.py
@@ -32,6 +32,11 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Add prompt name fields and backfill namespaced values."""
     bind = op.get_bind()
+
+    # Clean up any leftover temp table from a failed or interrupted previous
+    # migration attempt (e.g. SQLite batch_alter_table race on multi-worker startup)
+    bind.execute(sa.text("DROP TABLE IF EXISTS _alembic_tmp_prompts"))
+
     inspector = sa.inspect(bind)
 
     if not inspector.has_table("prompts"):

--- a/scripts/ci/run_upgrade_validation.sh
+++ b/scripts/ci/run_upgrade_validation.sh
@@ -464,6 +464,7 @@ run_postgres_upgrade() {
     local pg_container="${NAME_PREFIX}-pg-upgrade-db"
     local old_container="${NAME_PREFIX}-pg-upgrade-old"
     local new_container="${NAME_PREFIX}-pg-upgrade-new"
+    local base_db_url
     local db_url
     local versions
     local markers
@@ -484,12 +485,14 @@ run_postgres_upgrade() {
 
     wait_for_postgres_ready "${pg_container}"
 
+    # Use the driver that the base image actually ships with (psycopg2 for old releases).
+    base_db_url="postgresql+${BASE_IMAGE_PG_DRIVER}://postgres:upgrade-test-password@${pg_container}:5432/mcp"
     db_url="postgresql+psycopg://postgres:upgrade-test-password@${pg_container}:5432/mcp"
     docker run -d \
         --name "${old_container}" \
         --network "${network}" \
         -p "${port}:4444" \
-        -e "DATABASE_URL=${db_url}" \
+        -e "DATABASE_URL=${base_db_url}" \
         -e "AUTH_REQUIRED=false" \
         -e "CACHE_TYPE=memory" \
         -e "HOST=0.0.0.0" \
@@ -621,6 +624,7 @@ run_postgres_roundtrip() {
     local pg_container="${NAME_PREFIX}-pg-rt-db"
     local old_container="${NAME_PREFIX}-pg-rt-old"
     local new_container="${NAME_PREFIX}-pg-rt-new"
+    local base_db_url
     local db_url
     local base_version
     local post_upgrade_version
@@ -643,6 +647,8 @@ run_postgres_roundtrip() {
 
     wait_for_postgres_ready "${pg_container}"
 
+    # Use the driver that the base image actually ships with (psycopg2 for old releases).
+    base_db_url="postgresql+${BASE_IMAGE_PG_DRIVER}://postgres:upgrade-test-password@${pg_container}:5432/mcp"
     db_url="postgresql+psycopg://postgres:upgrade-test-password@${pg_container}:5432/mcp"
 
     # Phase 1: boot base image – auto-migrates to its head revision
@@ -650,7 +656,7 @@ run_postgres_roundtrip() {
         --name "${old_container}" \
         --network "${network}" \
         -p "${port}:4444" \
-        -e "DATABASE_URL=${db_url}" \
+        -e "DATABASE_URL=${base_db_url}" \
         -e "AUTH_REQUIRED=false" \
         -e "CACHE_TYPE=memory" \
         -e "HOST=0.0.0.0" \
@@ -725,6 +731,15 @@ main() {
 
     expected_head="$(get_expected_head)"
     log "Expected alembic head: ${expected_head}"
+
+    # Detect which PostgreSQL driver the base image ships with.
+    # Releases up to ~0.9.x used psycopg2; later releases switched to psycopg (v3).
+    if docker run --rm --entrypoint="" "${BASE_IMAGE}" python3 -c "import psycopg" >/dev/null 2>&1; then
+        BASE_IMAGE_PG_DRIVER="psycopg"
+    else
+        BASE_IMAGE_PG_DRIVER="psycopg2"
+    fi
+    log "Base image PostgreSQL driver: ${BASE_IMAGE_PG_DRIVER}"
 
     # Each test gets its own non-overlapping port range (base + 0..999)
     run_sqlite_fresh       "${expected_head}" "$(next_port 22000)"


### PR DESCRIPTION
## 📝 Summary

Fixes three bugs that prevented clean upgrades from 0.9.0 to 1.0.1.

**1. `r2b3c4d5e6f7` — temp table race condition (SQLite)**
When multiple Gunicorn workers start simultaneously, the first worker to run the
`add_prompt_namespacing_fields` migration creates `_alembic_tmp_prompts` via
`batch_alter_table`. If that worker is killed mid-migration, the temp table is left
behind. Every subsequent worker then fails with:
```
sqlalchemy.exc.OperationalError: table _alembic_tmp_prompts already exists
```
Fix: add `DROP TABLE IF EXISTS _alembic_tmp_prompts` at the start of `upgrade()` —
a no-op on a clean database, a safe cleanup on a dirty one.

**2. `9fb98535724d` — unnamed FK constraints (SQLite upgrade from 0.9.0)**
In 0.9.0 databases, all foreign key constraints are unnamed (e.g.
`FOREIGN KEY(tool_id) REFERENCES tools (id)`). The `add_ondelete_cascade` migration
calls `inspector.get_foreign_keys()` which returns `{'name': None, ...}` for these.
The original code/previous fix either crashed or silently skipped adding
`ON DELETE CASCADE`, leaving upgraded databases without the required cascade behavior.
Fix: detect unnamed FKs, reflect the full table into a `sa.Table` object, strip the
unnamed FK constraints via `_strip_all_unnamed_fks()`, then pass `copy_from=` to
`batch_alter_table()` so SQLite recreates the table correctly with a new named
`ON DELETE CASCADE` FK.

**3. `scripts/ci/run_upgrade_validation.sh` — psycopg driver mismatch**
The validation script was hardcoding `postgresql+psycopg://` (psycopg3) for both
the base and target containers. The 0.9.0 image ships only `psycopg2_binary`, so
starting the base container immediately crashed with:
```
ModuleNotFoundError: No module named 'psycopg'
```
Fix: at startup, probe the base image with `docker run ... python3 -c "import psycopg"`.
If it fails, use `postgresql+psycopg2://` for the base container; the target container
always uses `postgresql+psycopg://` (psycopg3).

---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |
| Upgrade validation (all 6 scenarios) | `make upgrade-validate UPGRADE_BASE_IMAGE=ghcr.io/ibm/mcp-context-forge:0.9.0 UPGRADE_TARGET_IMAGE=mcpgateway/mcpgateway:latest` | ✅ PASS |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

All 6 upgrade validation scenarios pass (SQLite fresh, SQLite upgrade, PostgreSQL fresh,
PostgreSQL upgrade, SQLite round-trip, PostgreSQL round-trip) against a real 0.9.0 base
image (`ghcr.io/ibm/mcp-context-forge:0.9.0`).
```