### PR TITLE
fix: sync password length UI with API validation (22 chars)

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3936,7 +3936,7 @@ async def admin_ui(
             "ui_hidden_tabs": ui_visibility_config["hidden_tabs"],
             "user_permissions": user_permissions,
             # Password policy flags for frontend templates
-            "password_min_length": getattr(settings, "password_min_length", 8),
+            "password_min_length": getattr(settings, "password_min_length_privileged", 22),
             "password_require_uppercase": getattr(settings, "password_require_uppercase", False),
             "password_require_lowercase": getattr(settings, "password_require_lowercase", False),
             "password_require_numbers": getattr(settings, "password_require_numbers", False),
@@ -4785,7 +4785,7 @@ async def change_password_required_page(request: Request) -> HTMLResponse:
             "root_path": root_path,
             "ui_airgapped": settings.mcpgateway_ui_airgapped,
             "password_policy_enabled": getattr(settings, "password_policy_enabled", True),
-            "password_min_length": getattr(settings, "password_min_length", 8),
+            "password_min_length": getattr(settings, "password_min_length_privileged", 22),
             "password_require_uppercase": getattr(settings, "password_require_uppercase", False),
             "password_require_lowercase": getattr(settings, "password_require_lowercase", False),
             "password_require_numbers": getattr(settings, "password_require_numbers", False),

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -6284,7 +6284,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                         <ul class="mt-2 space-y-1">
                           <li id="req-length" class="flex items-start">
                             <i class="fas fa-circle text-gray-400 mr-2"></i>
-                            At least {{ password_min_length or 8 }} characters long
+                            At least {{ password_min_length or 22 }} characters long
                           </li>
                           {% if password_require_uppercase %}
                           <li id="req-uppercase" class="flex items-start">
@@ -6318,7 +6318,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 <script nonce="{{ csp_nonce(request) }}">
                   // Validate the Create User password box and update requirement icons
                   (function(){
-                    const minLen = {{ password_min_length | tojson }} || 8;
+                    const minLen = {{ password_min_length | tojson }} || 22;
                     const REQ_UPPER = {{ password_require_uppercase | tojson }};
                     const REQ_LOWER = {{ password_require_lowercase | tojson }};
                     const REQ_NUMS = {{ password_require_numbers | tojson }};

--- a/mcpgateway/templates/change-password-required.html
+++ b/mcpgateway/templates/change-password-required.html
@@ -240,7 +240,7 @@
                 <ul class="text-xs text-blue-600 dark:text-blue-400 space-y-1">
                   <li id="req-length" class="flex items-center">
                     <i class="fas fa-circle text-gray-400 mr-2"></i>
-                    At least {{ password_min_length or 8 }} characters long
+                    At least {{ password_min_length or 22 }} characters long
                   </li>
                   {% if password_require_uppercase %}
                   <li id="req-uppercase" class="flex items-center">
@@ -505,7 +505,7 @@
       // Password policy settings from server
       const passwordPolicy = {
         enabled: {{ password_policy_enabled | tojson }},
-        minLength: {{ password_min_length | tojson }} || 8,
+        minLength: {{ password_min_length | tojson }} || 22,
         requireUppercase: {{ password_require_uppercase | tojson }},
         requireLowercase: {{ password_require_lowercase | tojson }},
         requireNumbers: {{ password_require_numbers | tojson }},


### PR DESCRIPTION
## Summary

This PR fixes the password length mismatch between UI display and API validation.

Related to #4736

## Problem

The UI displayed "At least 8 characters" for password requirements, but the API actually validates against 22 characters for privileged accounts. This caused user confusion when passwords meeting the displayed requirement (8 chars) were rejected by the backend validation (22 chars).

## Solution

Updated all UI components to display the correct minimum password length (22 characters) by using `password_min_length_privileged` instead of the legacy `password_min_length` setting.

## Changes

**mcpgateway/admin.py** (2 locations):
- Line 3939: Changed from `password_min_length` (8) to `password_min_length_privileged` (22)
- Line 4788: Changed from `password_min_length` (8) to `password_min_length_privileged` (22)

**mcpgateway/templates/change-password-required.html**:
- Line 508: Updated JavaScript fallback from `|| 8` to `|| 22`

**mcpgateway/templates/admin.html** (2 locations):
- Line 6287: Updated template fallback from `or 8` to `or 22`
- Line 6321: Updated JavaScript fallback from `|| 8` to `|| 22`

## Impact

- ✅ UI now correctly displays 22 character minimum for privileged accounts
- ✅ Eliminates user confusion from UI/API mismatch
- ✅ No breaking changes to existing functionality
- ✅ Aligns with OWASP password recommendations for privileged accounts

## Testing

Manual verification:
1. Navigate to password change page
2. Verify UI displays "At least 22 characters long"
3. Verify JavaScript validation enforces 22 character minimum
4. Confirm backend validation matches UI requirements