### PR TITLE
fix: guard 356a2d4eed6f downgrade when prompts/resources tables are a…

### DIFF
--- a/mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py
+++ b/mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py
@@ -643,6 +643,11 @@ def downgrade() -> None:
     conn = op.get_bind()
     dialect = conn.dialect.name if hasattr(conn, "dialect") else None
 
+    inspector = sa.inspect(conn)
+    if not inspector.has_table("prompts") and not inspector.has_table("resources"):
+        print("prompts and resources tables not found. Skipping downgrade.")
+        return
+
     # Best-effort: rebuild integer prompt ids and remap dependent FK columns.
     # 1) Create old-style prompts table with integer id (autoincrement)
     # If a previous partial downgrade left these tables behind, drop them first

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -131,7 +131,7 @@ plugins:
         "tool_post_invoke",
       ]
     tags: ["plugin", "transformer", "regex", "search-and-replace", "pre-post"]
-    mode: "enforce" # enforce | enforce_ignore_error | permissive | disabled
+    mode: "disabled" # enforce | enforce_ignore_error | permissive | disabled
     priority: 150
     # conditions:
     #   # Apply to specific tools/servers
@@ -399,7 +399,7 @@ plugins:
     author: "Mihai Criveti"
     hooks: ["tool_post_invoke"]
     tags: ["retry", "backoff", "resilience"]
-    mode: "permissive"
+    mode: "disabled"
     priority: 170
     conditions: []
     config:


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary

Two fixes on top of the upgrade path fixes already merged in #4738.

**1. `356a2d4eed6f` — missing guard in `downgrade()` when core tables are absent**

The `downgrade()` function assumed `prompts` and `resources` always exist. On environments where `Base.metadata.create_all()` was never called (e.g. CI running alembic directly on an empty DB), the downgrade crashed with `no such table: prompts`. Fix: add an existence check at the start of `downgrade()`, consistent with the guard already present in `upgrade()`.

**2. `plugins/config.yaml` — disable noisy default plugins**

Set `regex_transformer` (`enforce` → `disabled`) and `retry_backoff` (`permissive` → `disabled`) to avoid unintended side effects in default deployments.

---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |
| Manual downgrade to `aac21d6f9522` | `alembic downgrade aac21d6f9522` | ✅ PASS |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

The downgrade crash is a pre-existing bug — `downgrade()` in `356a2d4eed6f` lacked the same table-existence guard that its own `upgrade()` already had. Verified by running `alembic upgrade head && alembic downgrade aac21d6f9522` on a clean empty database.