### PR TITLE
feat(admin): add A2A protocol version dropdown to agent form

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4338,7 +4338,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15066,
+        "line_number": 15109,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-22T21:53:08Z",
+  "generated_at": "2026-05-22T22:14:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4338,7 +4338,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15109,
+        "line_number": 15099,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -15761,6 +15761,7 @@ async def admin_add_a2a_agent(
             description=form.get("description"),
             endpoint_url=form["endpoint_url"],
             agent_type=form.get("agent_type", "generic"),
+            protocol_version=str(form.get("protocol_version", "1.0")),
             auth_type=auth_type_from_form,
             auth_username=str(form.get("auth_username", "")),
             auth_password=str(form.get("auth_password", "")),
@@ -16050,6 +16051,11 @@ async def admin_edit_a2a_agent(
             uaid_protocol=uaid_protocol,
             uaid_native_id_override=uaid_native_id_override if generate_uaid else None,
         )
+        # Only update protocol_version when the field is explicitly submitted.
+        # Defaulting on edit would silently coerce an existing 0.3 agent back
+        # to "1.0" for any caller (cached form, scripted PATCH) that omits the field.
+        if form.get("protocol_version"):
+            agent_update.protocol_version = str(form["protocol_version"])
 
         mod_metadata = MetadataCapture.extract_modification_metadata(request, user, 0)
         await a2a_service.update_agent(

--- a/mcpgateway/admin_ui/a2aAgents.js
+++ b/mcpgateway/admin_ui/a2aAgents.js
@@ -358,6 +358,11 @@ export const editA2AAgent = async function (agentId) {
 
     console.log("Agent Type: ", agent.agentType);
 
+    const protocolVersionField = safeGetElement("a2a-protocol-version-edit");
+    if (protocolVersionField) {
+      protocolVersionField.value = agent.protocolVersion || "1.0";
+    }
+
     if (nameField && nameValidation.valid) {
       nameField.value = nameValidation.value;
     }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -6966,6 +6966,23 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                 </select>
               </div>
 
+              <!-- Protocol Version -->
+              <div>
+                <label
+                  for="a2a-protocol-version"
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-400"
+                  >Protocol Version</label
+                >
+                <select
+                  id="a2a-protocol-version"
+                  name="protocol_version"
+                  class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
+                >
+                  <option value="1.0" selected>1.0</option>
+                  <option value="0.3">0.3</option>
+                </select>
+              </div>
+
               <!-- Authentication Type -->
               <div>
                 <label
@@ -10530,6 +10547,22 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <option value="openai">OpenAI</option>
                           <option value="anthropic">Anthropic</option>
                           <option value="custom">Custom</option>
+                        </select>
+                      </div>
+
+                      <!-- Protocol Version -->
+                      <div>
+                        <label for="a2a-protocol-version-edit" class="block text-sm font-medium text-gray-700 dark:text-gray-400">
+                          Protocol Version
+                        </label>
+                        <select
+                          id="a2a-protocol-version-edit"
+                          name="protocol_version"
+                          class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
+                                focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
+                        >
+                          <option value="1.0">1.0</option>
+                          <option value="0.3">0.3</option>
                         </select>
                       </div>
 

--- a/tests/playwright/pages/agents_page.py
+++ b/tests/playwright/pages/agents_page.py
@@ -65,6 +65,11 @@ class AgentsPage(BasePage):
         return self.add_agent_form.locator("#a2a-agent-type")
 
     @property
+    def protocol_version_select(self) -> Locator:
+        """A2A protocol version select field (Add form)."""
+        return self.add_agent_form.locator("#a2a-protocol-version")
+
+    @property
     def auth_type_select(self) -> Locator:
         """Authentication type select field."""
         return self.add_agent_form.locator("#auth-type-a2a")
@@ -127,6 +132,11 @@ class AgentsPage(BasePage):
     def edit_modal(self) -> Locator:
         """Edit agent modal."""
         return self.page.locator("#a2a-edit-modal")
+
+    @property
+    def edit_protocol_version_select(self) -> Locator:
+        """A2A protocol version select field in edit modal."""
+        return self.edit_modal.locator("#a2a-protocol-version-edit")
 
     @property
     def edit_generate_uaid_checkbox(self) -> Locator:

--- a/tests/playwright/test_agents.py
+++ b/tests/playwright/test_agents.py
@@ -514,6 +514,52 @@ class TestAgentsUI:
         protocol_value = agents_page.edit_uaid_protocol_select.input_value()
         assert protocol_value == "a2a"
 
+    def test_protocol_version_select_present(self, agents_page: AgentsPage):
+        """Test that the A2A protocol version select is present on the add form."""
+        agents_page.navigate_to_agents_tab()
+
+        expect(agents_page.protocol_version_select).to_be_visible()
+
+    def test_protocol_version_options_and_default(self, agents_page: AgentsPage):
+        """Test that the protocol version select exposes 1.0/0.3 with 1.0 as default."""
+        agents_page.navigate_to_agents_tab()
+
+        options = agents_page.protocol_version_select.locator("option")
+        option_values = [options.nth(i).get_attribute("value") for i in range(options.count())]
+
+        assert option_values == ["1.0", "0.3"], f"Unexpected protocol version options: {option_values}"
+
+        default_value = agents_page.protocol_version_select.input_value()
+        assert default_value == "1.0"
+
+    def test_edit_agent_protocol_version_prefilled(self, agents_page: AgentsPage):
+        """Test that the edit modal prefills the protocol version from the saved agent."""
+        agents_page.navigate_to_agents_tab()
+
+        agent_name = f"Test Agent Protocol {uuid.uuid4().hex[:8]}"
+
+        agents_page.fill_locator(agents_page.agent_name_input, agent_name)
+        agents_page.fill_locator(agents_page.agent_endpoint_url_input, "https://httpbin.org/get")
+        agents_page.agent_type_select.select_option("custom")
+        agents_page.protocol_version_select.select_option("0.3")
+
+        with agents_page.page.expect_response(lambda response: "/admin/a2a" in response.url and response.request.method == "POST", timeout=10000) as response_info:
+            agents_page.submit_agent_form()
+
+        response = response_info.value
+        if response.status >= 400:
+            pytest.skip(f"Agent creation failed (HTTP {response.status})")
+
+        agents_page.page.wait_for_load_state("domcontentloaded")
+        agents_page.page.wait_for_timeout(1000)
+
+        agents_page.navigate_to_agents_tab()
+        agents_page.wait_for_agent_visible(agent_name)
+        agents_page.open_edit_modal_by_name(agent_name)
+
+        expect(agents_page.edit_protocol_version_select).to_be_visible()
+        assert agents_page.edit_protocol_version_select.input_value() == "0.3"
+
     def test_edit_agent_with_uaid_fields_readonly(self, agents_page: AgentsPage):
         """Test that editing an agent with UAID shows read-only fields."""
         # Navigate to agents tab

--- a/tests/unit/js/a2aAgents.test.js
+++ b/tests/unit/js/a2aAgents.test.js
@@ -220,6 +220,56 @@ describe("editA2AAgent", () => {
     expect(openModal).toHaveBeenCalledWith("a2a-edit-modal");
   });
 
+  test("prefills protocol_version dropdown from agent data", async () => {
+    window.ROOT_PATH = "";
+    document.body.innerHTML = `
+      <form id="edit-a2a-agent-form"></form>
+      <input id="a2a-agent-name-edit" />
+      <input id="a2a-agent-endpoint-url-edit" />
+      <textarea id="a2a-agent-description-edit"></textarea>
+      <select id="a2a-agent-type-edit"><option value="A2A">A2A</option></select>
+      <select id="a2a-protocol-version-edit">
+        <option value="1.0">1.0</option>
+        <option value="0.3">0.3</option>
+      </select>
+      <input id="a2a-agent-tags-edit" />
+      <input id="a2a-agent-capabilities-edit" />
+      <input id="a2a-agent-config-edit" />
+      <input id="edit-a2a-visibility-public" type="radio" />
+      <input id="edit-a2a-visibility-team" type="radio" />
+      <input id="edit-a2a-visibility-private" type="radio" />
+      <select id="auth-type-a2a-edit"><option value="">None</option></select>
+      <div id="auth-basic-fields-a2a-edit" style="display:none"></div>
+      <div id="auth-bearer-fields-a2a-edit" style="display:none"></div>
+      <div id="auth-headers-fields-a2a-edit" style="display:none"></div>
+      <div id="auth-oauth-fields-a2a-edit" style="display:none"></div>
+      <div id="auth-query_param-fields-a2a-edit" style="display:none"></div>
+      <div id="a2a-edit-modal" class="hidden"></div>
+    `;
+
+    const agent = {
+      name: "Legacy Agent",
+      endpointUrl: "http://localhost:9000/a2a",
+      description: "v0.3 agent",
+      agentType: "A2A",
+      protocolVersion: "0.3",
+      visibility: "private",
+      authType: "",
+      tags: [],
+      capabilities: {},
+      config: {},
+    };
+
+    fetchWithTimeout.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(agent),
+    });
+
+    await editA2AAgent("agent-legacy");
+
+    expect(document.getElementById("a2a-protocol-version-edit").value).toBe("0.3");
+  });
+
   test("shows error on fetch failure", async () => {
     window.ROOT_PATH = "";
     document.body.innerHTML = '<form id="edit-a2a-agent-form"></form>';

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -13069,6 +13069,92 @@ class TestAdminAdditionalCoverage:
         assert response.status_code == 200
         mock_service.register_agent.assert_called_once()
 
+    async def test_admin_add_a2a_agent_protocol_version_defaults_to_1_0(self, monkeypatch, mock_request, mock_db):
+        """Omitting protocol_version in the form should fall back to '1.0'."""
+        monkeypatch.setattr(settings, "mcpgateway_a2a_enabled", True)
+        mock_service = MagicMock()
+        mock_service.register_agent = AsyncMock()
+        monkeypatch.setattr("mcpgateway.admin.a2a_service", mock_service)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            MagicMock(
+                return_value={
+                    "created_by": "user",
+                    "created_from_ip": "127.0.0.1",
+                    "created_via": "ui",
+                    "created_user_agent": "test",
+                    "import_batch_id": None,
+                    "federation_source": None,
+                }
+            ),
+        )
+
+        form_data = FakeForm({"name": "Agent Default", "endpoint_url": "http://example.com/agent"})
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        response = await admin_add_a2a_agent(mock_request, mock_db, user={"email": "user@example.com", "db": mock_db})
+        assert response.status_code == 200
+        agent_data = mock_service.register_agent.call_args.args[1]
+        assert agent_data.protocol_version == "1.0"
+
+    async def test_admin_add_a2a_agent_protocol_version_legacy(self, monkeypatch, mock_request, mock_db):
+        """Submitting protocol_version='0.3' should propagate to A2AAgentCreate."""
+        monkeypatch.setattr(settings, "mcpgateway_a2a_enabled", True)
+        mock_service = MagicMock()
+        mock_service.register_agent = AsyncMock()
+        monkeypatch.setattr("mcpgateway.admin.a2a_service", mock_service)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_creation_metadata",
+            MagicMock(
+                return_value={
+                    "created_by": "user",
+                    "created_from_ip": "127.0.0.1",
+                    "created_via": "ui",
+                    "created_user_agent": "test",
+                    "import_batch_id": None,
+                    "federation_source": None,
+                }
+            ),
+        )
+
+        form_data = FakeForm({"name": "Agent Legacy", "endpoint_url": "http://example.com/agent", "protocol_version": "0.3"})
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        response = await admin_add_a2a_agent(mock_request, mock_db, user={"email": "user@example.com", "db": mock_db})
+        assert response.status_code == 200
+        agent_data = mock_service.register_agent.call_args.args[1]
+        assert agent_data.protocol_version == "0.3"
+
+    async def test_admin_edit_a2a_agent_protocol_version_legacy(self, monkeypatch, mock_request, mock_db):
+        """Editing with protocol_version='0.3' should propagate to A2AAgentUpdate."""
+        mock_service = MagicMock()
+        mock_service.update_agent = AsyncMock()
+        monkeypatch.setattr("mcpgateway.admin.a2a_service", mock_service)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: team_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.MetadataCapture.extract_modification_metadata",
+            MagicMock(return_value={"modified_by": "user", "modified_from_ip": "127.0.0.1", "modified_via": "ui", "modified_user_agent": "test"}),
+        )
+
+        form_data = FakeForm({"name": "Agent Updated", "endpoint_url": "http://example.com/agent", "protocol_version": "0.3"})
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        response = await admin_edit_a2a_agent("agent-1", mock_request, mock_db, user={"email": "user@example.com", "db": mock_db})
+        assert response.status_code == 200
+        agent_data = mock_service.update_agent.call_args.kwargs["agent_data"]
+        assert agent_data.protocol_version == "0.3"
+
     async def test_admin_edit_a2a_agent_success(self, monkeypatch, mock_request, mock_db):
         """Edit A2A agent successfully with oauth config."""
         mock_service = MagicMock()


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4760

---

## 📝 Summary
Adds a Protocol Version selector (`1.0` / `0.3`, default `1.0`) to the A2A agent create and edit forms in the admin UI.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   pass     |
| Unit tests                | `make test`     |   pass     |
| Coverage ≥ 80%            | `make coverage` |        |

I've done playwright e2e test.

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

### AS-IS
<img width="989" height="831" alt="592399004-52de6857-a2c3-4739-9809-1a35302cabe3" src="https://github.com/user-attachments/assets/fb1aa4e4-d7fa-4270-9aca-e508d95d87a5" />

### TO-BE
<img width="1254" height="1272" alt="스크린샷 2026-05-14 오후 6 19 59" src="https://github.com/user-attachments/assets/5f62551d-7d07-46ca-93e6-99c3f8666a43" />

<img width="1254" height="1272" alt="스크린샷 2026-05-14 오후 6 20 06" src="https://github.com/user-attachments/assets/7d6a3426-ba5d-4fc1-a4b5-446b25bbbece" />
Protocol set with 0.3 version

<img width="1254" height="1272" alt="스크린샷 2026-05-14 오후 6 20 14" src="https://github.com/user-attachments/assets/4dd6bb70-e475-466b-8dc3-03d78484337a" />
In edit page
