### PR TITLE
fix(serve): use project .venv exclusively in run-gunicorn.sh

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-13T13:03:20Z",
+  "generated_at": "2026-05-14T12:57:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5886,7 +5886,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 296,
+        "line_number": 290,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/run-gunicorn.sh
+++ b/run-gunicorn.sh
@@ -125,18 +125,12 @@ echo $$ > "${LOCK_FILE}"
 
 #────────────────────────────────────────────────────────────────────────────────
 # SECTION 3: Virtual Environment Activation
-# Check if a virtual environment is already active. If not, try to activate one
-# from known locations. This ensures dependencies are properly isolated.
+# Check if a virtual environment is already active. If not, activate the one
+# created by `make install` in the project directory.
 #────────────────────────────────────────────────────────────────────────────────
 if [[ -z "${VIRTUAL_ENV:-}" ]]; then
-    # Check for virtual environment in user's home directory (preferred location)
-    if [[ -f "${HOME}/.venv/mcpgateway/bin/activate" ]]; then
-        echo "🔧  Activating virtual environment: ${HOME}/.venv/mcpgateway"
-        # shellcheck disable=SC1090
-        source "${HOME}/.venv/mcpgateway/bin/activate"
-
-    # Check for virtual environment in script directory (development setup)
-    elif [[ -f "${SCRIPT_DIR}/.venv/bin/activate" ]]; then
+    # Use the project-local virtual environment created by `make install`
+    if [[ -f "${SCRIPT_DIR}/.venv/bin/activate" ]]; then
         echo "🔧  Activating virtual environment in script directory"
         # shellcheck disable=SC1090
         source "${SCRIPT_DIR}/.venv/bin/activate"
@@ -146,7 +140,7 @@ if [[ -z "${VIRTUAL_ENV:-}" ]]; then
         echo "⚠️  WARNING: No virtual environment found!"
         echo "   This may lead to dependency conflicts."
         echo "   Consider creating a virtual environment with:"
-        echo "   python3 -m venv ~/.venv/mcpgateway"
+        echo "   make venv install-dev"
 
         # Optional: Uncomment the following lines to enforce virtual environment usage
         # echo "❌  FATAL: Virtual environment required for production deployments"


### PR DESCRIPTION
## Summary

- `run-gunicorn.sh` was checking `~/.venv/mcpgateway` (stale global) before
  `${SCRIPT_DIR}/.venv` (project-local, built by `make install`). This caused
  `make serve` to activate the wrong environment, breaking packages like `cpex`
  that are installed only in the project venv.
- Removed the `~/.venv/mcpgateway` fallback entirely. Script now activates only
  `${SCRIPT_DIR}/.venv`, which is the sole venv managed by `make venv / make install`.
- Updated the "no venv found" warning to suggest `make venv install-dev` instead
  of the now-removed `python3 -m venv ~/.venv/mcpgateway`.

Closes #4765