### PR TITLE
fix(visibility): globally-public items hidden when team filter is active in Admin UI

### DIFF
--- a/mcpgateway/services/base_service.py
+++ b/mcpgateway/services/base_service.py
@@ -140,7 +140,7 @@ class BaseService(ABC):
         tokens. Use _apply_access_control() which handles this automatically.
 
         Access rules:
-        - public: visible to all (global listing only; excluded when team_id is set)
+        - public: visible to all — always included, even when team_id is set
         - team: visible to team members (token_teams contains team_id)
         - private: visible only to owner (requires user_email)
 
@@ -159,7 +159,10 @@ class BaseService(ABC):
             if team_id not in token_teams:
                 return query.where(False)
 
-            access_conditions = [and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"]))]
+            access_conditions = [
+                and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"])),
+                model_cls.visibility == "public",  # globally public items from any team are always visible
+            ]
             if user_email:
                 access_conditions.append(and_(model_cls.team_id == team_id, model_cls.owner_email == user_email, model_cls.visibility == "private"))
             return query.where(or_(*access_conditions))

--- a/tests/unit/mcpgateway/services/test_base_service.py
+++ b/tests/unit/mcpgateway/services/test_base_service.py
@@ -337,20 +337,22 @@ class TestApplyVisibilityFilter:
         assert "team_id" not in sql
 
     def test_team_scoped_in_token_teams(self, service, base_query):
-        """Team-scoped (team_id in token_teams): returns team+public and private-owner conditions."""
+        """Team-scoped (team_id in token_teams): returns team+public, private-owner, and global-public conditions."""
         result = service._apply_visibility_filter(base_query, user_email="owner@test.com", token_teams=["team-1"], team_id="team-1")
         sql = _compile_where(result)
         assert "team_id = 'team-1'" in sql
         assert "visibility IN ('team', 'public')" in sql
         assert "owner_email = 'owner@test.com'" in sql
         assert "visibility = 'private'" in sql
+        assert "visibility = 'public'" in sql  # globally public items are always included
 
     def test_team_scoped_in_token_teams_no_email(self, service, base_query):
-        """Team-scoped (team_id in token_teams, no user_email): team+public but no private-owner."""
+        """Team-scoped (team_id in token_teams, no user_email): team+public, global-public, no private-owner."""
         result = service._apply_visibility_filter(base_query, user_email=None, token_teams=["team-1"], team_id="team-1")
         sql = _compile_where(result)
         assert "team_id = 'team-1'" in sql
         assert "visibility IN ('team', 'public')" in sql
+        assert "visibility = 'public'" in sql  # globally public items are always included
         assert "owner_email" not in sql
 
     def test_team_scoped_not_in_token_teams(self, service, base_query):
@@ -360,3 +362,15 @@ class TestApplyVisibilityFilter:
         # SQLAlchemy compiles where(False) as "WHERE false" or "WHERE 1!=1"
         lower_sql = sql.lower()
         assert "false" in lower_sql or "1 != 1" in lower_sql or "1!=1" in lower_sql
+
+    def test_team_scoped_always_includes_globally_public_items(self, service, base_query):
+        """Team-scoped filter always ORs in a global public condition.
+
+        When team_id=X is supplied, items with visibility='public' owned by *other*
+        teams must still be returned.  The generated WHERE clause must contain the
+        standalone ``visibility = 'public'`` condition (not gated on team_id).
+        """
+        result = service._apply_visibility_filter(base_query, user_email=None, token_teams=["team-1"], team_id="team-1")
+        sql = _compile_where(result)
+        # The standalone public condition must be present in addition to the team-scoped one
+        assert "visibility = 'public'" in sql


### PR DESCRIPTION
## 📌 Summary
When the Admin UI team switcher selects a team, it appends `?team_id=X` to every entity list request. The `_apply_visibility_filter` method in `BaseService` was restricting results to rows where `team_id == X`, which silently excluded globally-public items registered under any other team. Since `visibility = 'public'` is documented as platform-wide visibility, these items should always be returned regardless of which team filter is active. This PR fixes the SQL predicate so the `public` condition is unconditional, aligning behaviour with the documented intent.

> **Note:** This fix is applied at the API/service layer. The `?team_id=` parameter now means "items belonging to team X **plus** all globally-public items from any team" instead of "items strictly belonging to team X". Any client relying on `?team_id=` as a strict single-team isolation filter will receive more rows than before. Strict data isolation remains the responsibility of `token_teams` (Layer 1 token scoping), not this UI routing hint.

## 🔗 Related Issue
Closes: #4732

## 🔁 Reproduction Steps
See https://github.com/IBM/mcp-context-forge/issues/4732

1. Register an A2A agent with `visibility: public` under **team A**.
2. Sign in as a user who belongs only to **team B**.
3. In the Admin UI, select **team B** in the team switcher.
4. Navigate to the **A2A Agents** tab — the public agent from team A is missing.
5. Direct `GET /a2a` (no `?team_id=`) correctly returns it, confirming the narrowing is caused by the `?team_id=` query parameter appended by the UI.

## 🐞 Root Cause
`_apply_visibility_filter` in `mcpgateway/services/base_service.py` built the `WHERE` clause for the `team_id` branch as:

```python
access_conditions = [
    and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"]))
]
```

The `public` condition was gated on `team_id == X`, so public items belonging to any other team were excluded. This affects every entity type that inherits `BaseService` (tools, resources, prompts, gateways, servers, A2A agents).

## 💡 Fix Description
Added a second, standalone condition to the OR list in `_apply_visibility_filter`:

```python
access_conditions = [
    and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"])),
    model_cls.visibility == "public",  # globally public items from any team are always visible
]
```

The generated SQL for a `team_id`-scoped query becomes:

```sql
WHERE (team_id = :x AND visibility IN ('team','public'))
   OR (visibility = 'public')
```

Global-public items are now always returned regardless of the team filter, matching the documented intent of `visibility = 'public'`. Private items from other teams remain excluded — the private-owner condition stays gated on `team_id == X AND owner_email == user`. The `token_teams` membership guard (`if team_id not in token_teams: return where(False)`) is unchanged. The docstring was updated to reflect that `public` is always included even when `team_id` is set.

## 🧪 Verification

| Check                             | Command                                                                  | Status |
|-----------------------------------|--------------------------------------------------------------------------|--------|
| Lint suite                        | `make lint`                                                              |        |
| Unit tests                        | `make test`                                                              |        |
| Coverage ≥ 90 %                   | `make coverage`                                                          |        |
| Manual regression no longer fails | Select team B → A2A tab → public agent from team A now appears           |        |

New and updated tests in `tests/unit/mcpgateway/services/test_base_service.py`:

- `test_team_scoped_always_includes_globally_public_items` — asserts the standalone `visibility = 'public'` condition is present in the compiled SQL (not gated on `team_id`)
- `test_team_scoped_in_token_teams` — updated to also assert the global-public condition
- `test_team_scoped_in_token_teams_no_email` — updated to also assert the global-public condition

Integration-verified against an in-memory SQLite DB: public items from other teams are returned; team-visibility items from other teams and private items from other users remain hidden.

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed