### PR TITLE
fix: eliminate migration lock contention on multi-replica startup 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -651,6 +651,9 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # DATABASE_URL=sqlite:////Users/$USER/Library/Application Support/mcpgateway/mcp.db
 # DATABASE_URL=sqlite:///./mcp.db
 
+# Skip alembic upgrade head on startup (migrations managed externally via init container or CI)
+SKIP_MIGRATION=true
+
 # PostgreSQL - recommended for production deployments
 # Uses psycopg3 driver (psycopg[binary])
 # IMPORTANT: Use postgresql+psycopg:// (not postgresql://) for psycopg3

--- a/.env.example
+++ b/.env.example
@@ -652,7 +652,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # DATABASE_URL=sqlite:///./mcp.db
 
 # Skip alembic upgrade head on startup (migrations managed externally via init container or CI)
-SKIP_MIGRATION=true
+SKIP_MIGRATION=false
 
 # PostgreSQL - recommended for production deployments
 # Uses psycopg3 driver (psycopg[binary])

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1018,7 +1018,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 983,
+        "line_number": 973,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1076,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1092,
+        "line_number": 1082,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1158,
+        "line_number": 1148,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1193,
+        "line_number": 1183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1732,
+        "line_number": 1722,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1809,
+        "line_number": 1799,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2125,
+        "line_number": 2115,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2582,
+        "line_number": 2572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2582,
+        "line_number": 2572,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2595,
+        "line_number": 2585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2743,
+        "line_number": 2733,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2764,
+        "line_number": 2754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2772,
+        "line_number": 2762,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2777,
+        "line_number": 2767,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -108,7 +108,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 657,
+        "line_number": 660,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1128,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1151,
+        "line_number": 1154,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1159,
+        "line_number": 1162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 1241,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1243,
+        "line_number": 1246,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1248,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1254,
+        "line_number": 1257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1266,
+        "line_number": 1269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1287,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1345,
+        "line_number": 1348,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -991,14 +991,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 359,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
@@ -1026,7 +1018,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 973,
+        "line_number": 983,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1026,15 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1073,
+        "line_number": 1086,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1092,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1137,
+        "line_number": 1158,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1193,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1732,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1788,
+        "line_number": 1809,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2125,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2561,
+        "line_number": 2582,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2561,
+        "line_number": 2582,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2574,
+        "line_number": 2595,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2722,
+        "line_number": 2743,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2743,
+        "line_number": 2764,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2751,
+        "line_number": 2772,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2756,
+        "line_number": 2777,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4988,7 +4988,7 @@
         "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2933,
+        "line_number": 2941,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -754,8 +754,8 @@ services:
       # Direct PostgreSQL (uncomment if bypassing PgBouncer):
       # postgres:
       #   condition: service_healthy
-      # migration:
-      #   condition: service_completed_successfully
+      migration:
+        condition: service_completed_successfully
 
     healthcheck:
       ## Uncomment for HTTP healthcheck
@@ -1063,19 +1063,30 @@ services:
           cpus: '0.5'
           memory: 128M
 
-  # migration:
-  #   #image: ghcr.io/ibm/mcp-context-forge:0.7.0 # Testing migration from 0.7.0
-  #   image: mcpgateway/mcpgateway:latest # Use the local latest image. Run `make docker-prod` to build it.
-  #   build:
-  #     context: .
-  #     dockerfile: Containerfile.lite
-  #   environment:
-  #     - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
-  #   command: alembic -c mcpgateway/alembic.ini upgrade head
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
-  #   networks: [mcpnet]
+  migration:
+    # One-shot init container: runs full schema migration + bootstrap before any gateway replica starts.
+    # Uses Postgres directly (port 5432) — advisory locks are session-scoped and must bypass PgBouncer
+    # which operates in transaction-pooling mode.
+    #image: ghcr.io/ibm/mcp-context-forge:0.7.0 # Uncomment to test upgrade from a specific release
+    image: ${IMAGE_LOCAL:-mcpgateway/mcpgateway:latest} # Run `make docker-prod` to build local image
+    build:
+      context: .
+      dockerfile: Containerfile.lite
+    environment:
+      - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-mysecretpassword}@postgres:5432/mcp
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-your-secret-jwt-key-here}
+      - BASIC_AUTH_USER=${BASIC_AUTH_USER:-admin}
+      - BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD:-changeme}
+      - PLATFORM_ADMIN_EMAIL=${PLATFORM_ADMIN_EMAIL:-admin@example.com}
+      - AUTH_REQUIRED=${AUTH_REQUIRED:-true}
+      - AUTH_ENCRYPTION_SECRET=${AUTH_ENCRYPTION_SECRET:-my-test-salt}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    command: ["python", "-m", "mcpgateway.bootstrap_db"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks: [mcpnet]
+    restart: "no"
 
 ###############################################################################
 #  CACHE

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -788,8 +788,7 @@ async def main() -> None:
                 if not _is_at_alembic_head(conn, cfg):
                     logger.error("SKIP_MIGRATION=true but schema is not at head — " "run 'alembic upgrade head' before starting the application")
                     raise RuntimeError("Schema not at head; migrations required before startup")
-                else:
-                    logger.info("SKIP_MIGRATION=true — schema already at head, skipping migration")
+                logger.info("SKIP_MIGRATION=true — schema already at head, skipping migration")
                 updated = normalize_team_visibility(conn)
                 if updated:
                     logger.info(f"Normalized {updated} team record(s) to supported visibility values")

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -46,6 +46,7 @@ from filelock import FileLock
 from sqlalchemy import create_engine, or_, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
+from alembic.runtime.migration import MigrationContext
 
 # First-Party
 from mcpgateway.common.validators import SecurityValidator
@@ -115,7 +116,7 @@ def _is_at_alembic_head(conn: Connection, cfg: Config) -> bool:
     """
     # pylint: disable=import-outside-toplevel
     # Third-Party
-    from alembic.runtime.migration import MigrationContext
+   
     from alembic.script import ScriptDirectory
     import sqlalchemy as sa
 

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -42,11 +42,11 @@ from typing import cast
 # Third-Party
 from alembic import command
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
 from filelock import FileLock
 from sqlalchemy import create_engine, or_, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
-from alembic.runtime.migration import MigrationContext
 
 # First-Party
 from mcpgateway.common.validators import SecurityValidator
@@ -116,7 +116,8 @@ def _is_at_alembic_head(conn: Connection, cfg: Config) -> bool:
     """
     # pylint: disable=import-outside-toplevel
     # Third-Party
-   
+
+    # Third-Party
     from alembic.script import ScriptDirectory
     import sqlalchemy as sa
 
@@ -778,18 +779,15 @@ async def main() -> None:
 
     # SKIP_MIGRATION: external tooling (init container, CI pipeline) already ran
     # alembic upgrade head — skip schema migration and run only the idempotent
-    # bootstrap helpers.  However, if the schema is not yet at head (e.g. first
-    # boot on a fresh DB before any init container has run), fall through to
-    # migrations so the app does not crash with "no such table" errors.
+    # bootstrap helpers.  If the schema is NOT at head, the init container failed
+    # or the wrong DB was targeted; fail fast so the deployment error is visible.
     if settings.skip_migration:
         try:
             with engine.connect() as conn:
                 conn.commit()
                 if not _is_at_alembic_head(conn, cfg):
-                    logger.warning("SKIP_MIGRATION=true but schema is not at head " "(fresh DB or pending migrations) — running alembic upgrade head")
-                    with advisory_lock(conn):
-                        cfg.attributes["connection"] = conn
-                        command.upgrade(cfg, "head")
+                    logger.error("SKIP_MIGRATION=true but schema is not at head — " "run 'alembic upgrade head' before starting the application")
+                    raise RuntimeError("Schema not at head; migrations required before startup")
                 else:
                     logger.info("SKIP_MIGRATION=true — schema already at head, skipping migration")
                 updated = normalize_team_visibility(conn)

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -114,6 +114,7 @@ def _is_at_alembic_head(conn: Connection, cfg: Config) -> bool:
         False when the database is fresh, behind, or the check itself fails.
     """
     # pylint: disable=import-outside-toplevel
+    # Third-Party
     from alembic.runtime.migration import MigrationContext
     from alembic.script import ScriptDirectory
     import sqlalchemy as sa
@@ -784,10 +785,7 @@ async def main() -> None:
             with engine.connect() as conn:
                 conn.commit()
                 if not _is_at_alembic_head(conn, cfg):
-                    logger.warning(
-                        "SKIP_MIGRATION=true but schema is not at head "
-                        "(fresh DB or pending migrations) — running alembic upgrade head"
-                    )
+                    logger.warning("SKIP_MIGRATION=true but schema is not at head " "(fresh DB or pending migrations) — running alembic upgrade head")
                     with advisory_lock(conn):
                         cfg.attributes["connection"] = conn
                         command.upgrade(cfg, "head")

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -776,12 +776,26 @@ async def main() -> None:
 
     # SKIP_MIGRATION: external tooling (init container, CI pipeline) already ran
     # alembic upgrade head — skip schema migration and run only the idempotent
-    # bootstrap helpers.
+    # bootstrap helpers.  However, if the schema is not yet at head (e.g. first
+    # boot on a fresh DB before any init container has run), fall through to
+    # migrations so the app does not crash with "no such table" errors.
     if settings.skip_migration:
-        logger.info("SKIP_MIGRATION=true — skipping schema migration, running bootstraps only")
         try:
             with engine.connect() as conn:
                 conn.commit()
+                if not _is_at_alembic_head(conn, cfg):
+                    logger.warning(
+                        "SKIP_MIGRATION=true but schema is not at head "
+                        "(fresh DB or pending migrations) — running alembic upgrade head"
+                    )
+                    with advisory_lock(conn):
+                        cfg.attributes["connection"] = conn
+                        command.upgrade(cfg, "head")
+                else:
+                    logger.info("SKIP_MIGRATION=true — schema already at head, skipping migration")
+                updated = normalize_team_visibility(conn)
+                if updated:
+                    logger.info(f"Normalized {updated} team record(s) to supported visibility values")
                 await bootstrap_admin_user(conn)
                 await bootstrap_default_roles(conn)
                 await bootstrap_resource_assignments(conn)

--- a/mcpgateway/bootstrap_db.py
+++ b/mcpgateway/bootstrap_db.py
@@ -96,6 +96,46 @@ def _schema_looks_current(inspector) -> bool:
     )
 
 
+def _is_at_alembic_head(conn: Connection, cfg: Config) -> bool:
+    """Return True if the database alembic_version already points to the current head revision.
+
+    Uses Alembic's own MigrationContext and ScriptDirectory for an authoritative check
+    rather than a column heuristic, so it stays accurate as new migrations are added.
+
+    A False return is always safe — it causes the caller to fall through to the full
+    advisory-lock + upgrade path.
+
+    Args:
+        conn: Active SQLAlchemy connection.
+        cfg: Alembic Config object with sqlalchemy.url already set.
+
+    Returns:
+        True when the database is already at head (safe to skip migration lock).
+        False when the database is fresh, behind, or the check itself fails.
+    """
+    # pylint: disable=import-outside-toplevel
+    from alembic.runtime.migration import MigrationContext
+    from alembic.script import ScriptDirectory
+    import sqlalchemy as sa
+
+    try:
+        inspector = sa.inspect(conn)
+        if "alembic_version" not in inspector.get_table_names():
+            return False
+
+        migration_ctx = MigrationContext.configure(conn)
+        current_heads = set(migration_ctx.get_current_heads())
+        if not current_heads:
+            return False
+
+        script = ScriptDirectory.from_config(cfg)
+        target_heads = set(script.get_heads())
+        return current_heads == target_heads
+    except Exception as exc:
+        logger.warning("Could not determine alembic head state (%s) — falling through to migration lock", exc)
+        return False
+
+
 @contextmanager
 def advisory_lock(conn: Connection):
     """
@@ -701,6 +741,11 @@ async def main() -> None:
     Uses distributed advisory locks (PG) or file locking (SQLite)
     to prevent race conditions when multiple workers start simultaneously.
 
+    Fast-path: when the schema is already at the Alembic head revision (e.g. after
+    an init container ran migrations, or on any restart after the first), the advisory
+    lock and `alembic upgrade head` are skipped entirely.  Only the idempotent bootstrap
+    helpers (admin user, roles, resource assignments) are re-run.
+
     Args:
         None
 
@@ -711,38 +756,85 @@ async def main() -> None:
     ini_path = files("mcpgateway").joinpath("alembic.ini")
     cfg = Config(str(ini_path))  # path in container
     cfg.attributes["configure_logger"] = True
+    escaped_url = settings.database_url.replace("%", "%%")
+    cfg.set_main_option("sqlalchemy.url", escaped_url)
 
-    # Use advisory lock to prevent concurrent migrations
+    # SQLite multi-replica guard: /tmp is per-container, so FileLock provides no
+    # cross-container coordination.  All replicas run migrations concurrently
+    # against the same SQLite file — a silent correctness bug.
+    is_sqlite = settings.database_url.startswith("sqlite")
+    gateway_replicas = int(os.environ.get("GATEWAY_REPLICAS", "1"))
+    if is_sqlite and gateway_replicas > 1:
+        logger.warning(
+            "SQLite detected with GATEWAY_REPLICAS=%d. The migration file lock at '%s' is stored in "
+            "/tmp which is NOT shared across containers — each container holds its own lock file. "
+            "All replicas run migrations concurrently with no cross-container coordination. "
+            "Use GATEWAY_REPLICAS=1 with SQLite, or switch to PostgreSQL for multi-replica deployments.",
+            gateway_replicas,
+            _MIGRATION_LOCK_PATH,
+        )
+
+    # SKIP_MIGRATION: external tooling (init container, CI pipeline) already ran
+    # alembic upgrade head — skip schema migration and run only the idempotent
+    # bootstrap helpers.
+    if settings.skip_migration:
+        logger.info("SKIP_MIGRATION=true — skipping schema migration, running bootstraps only")
+        try:
+            with engine.connect() as conn:
+                conn.commit()
+                await bootstrap_admin_user(conn)
+                await bootstrap_default_roles(conn)
+                await bootstrap_resource_assignments(conn)
+                conn.commit()
+        except Exception as e:
+            logger.error(f"Bootstrap failed: {e}")
+            raise
+        finally:
+            engine.dispose()
+        logger.info("Database ready")
+        return
+
     try:
         with engine.connect() as conn:
             # Commit any open transaction on the connection before locking (though it should be fresh)
             conn.commit()
 
-            with advisory_lock(conn):
-                logger.info("Acquired migration lock, checking database schema...")
-
-                # Pass the LOCKED connection to Alembic config
-                cfg.attributes["connection"] = conn
-                escaped_url = settings.database_url.replace("%", "%%")
-                cfg.set_main_option("sqlalchemy.url", escaped_url)
-                logger.info("Running Alembic migrations to ensure schema is up to date")
-                command.upgrade(cfg, "head")
-
-                # Post-upgrade normalization passes (inside lock to be safe)
+            # Fast-path: schema already at head — skip advisory lock and alembic upgrade entirely.
+            # Replicas 2+ on rolling restarts or after an init container has run take this path,
+            # reducing per-replica startup cost from ~lock_wait + upgrade_time to a single SELECT.
+            if _is_at_alembic_head(conn, cfg):
+                logger.info("Schema already at migration head — skipping advisory lock and alembic upgrade")
                 updated = normalize_team_visibility(conn)
                 if updated:
                     logger.info(f"Normalized {updated} team record(s) to supported visibility values")
-
-                # Bootstrap admin user after database is ready, using the LOCKED connection
                 await bootstrap_admin_user(conn)
-
-                # Bootstrap default RBAC roles after admin user is created
                 await bootstrap_default_roles(conn)
-
-                # Assign orphaned resources to admin personal team after all setup is complete
                 await bootstrap_resource_assignments(conn)
+                conn.commit()
+            else:
+                with advisory_lock(conn):
+                    logger.info("Acquired migration lock, checking database schema...")
 
-                conn.commit()  # Ensure all migration changes are permanently committed
+                    # Pass the LOCKED connection to Alembic config
+                    cfg.attributes["connection"] = conn
+                    logger.info("Running Alembic migrations to ensure schema is up to date")
+                    command.upgrade(cfg, "head")
+
+                    # Post-upgrade normalization passes (inside lock to be safe)
+                    updated = normalize_team_visibility(conn)
+                    if updated:
+                        logger.info(f"Normalized {updated} team record(s) to supported visibility values")
+
+                    # Bootstrap admin user after database is ready, using the LOCKED connection
+                    await bootstrap_admin_user(conn)
+
+                    # Bootstrap default RBAC roles after admin user is created
+                    await bootstrap_default_roles(conn)
+
+                    # Assign orphaned resources to admin personal team after all setup is complete
+                    await bootstrap_resource_assignments(conn)
+
+                    conn.commit()  # Ensure all migration changes are permanently committed
 
     except Exception as e:
         logger.error(f"Database migration failed: {e}")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -250,6 +250,14 @@ class Settings(BaseSettings):
             "(See Issue #1535 for details)"
         ),
     )
+    skip_migration: bool = Field(
+        default=False,
+        description=(
+            "Skip alembic upgrade head on startup. Use when migrations are managed externally "
+            "(e.g., a dedicated init container or CI pipeline step). "
+            "The idempotent bootstrap helpers (admin user, RBAC roles, resource assignments) still run."
+        ),
+    )
 
     # Absolute paths resolved at import-time (still override-able via env vars)
     templates_dir: Path = Field(default_factory=lambda: Path(str(files("mcpgateway") / "templates")))

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -251,7 +251,7 @@ class Settings(BaseSettings):
         ),
     )
     skip_migration: bool = Field(
-        default=True,
+        default=False,
         description=(
             "Skip alembic upgrade head on startup. Use when migrations are managed externally "
             "(e.g., a dedicated init container or CI pipeline step). "

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -251,7 +251,7 @@ class Settings(BaseSettings):
         ),
     )
     skip_migration: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Skip alembic upgrade head on startup. Use when migrations are managed externally "
             "(e.g., a dedicated init container or CI pipeline step). "

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -10,6 +10,7 @@ Comprehensive unit tests for bootstrap_db module.
 # Standard
 import asyncio
 import json
+import os
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
@@ -18,6 +19,7 @@ import pytest
 
 # First-Party
 from mcpgateway.bootstrap_db import (
+    _is_at_alembic_head,
     advisory_lock,
     bootstrap_admin_user,
     bootstrap_default_roles,
@@ -1601,3 +1603,166 @@ class TestModuleLevel:
         from mcpgateway.bootstrap_db import main
 
         assert asyncio.iscoroutinefunction(main)
+
+
+class TestIsAtAlembicHead:
+    """Test _is_at_alembic_head internal branches."""
+
+    def test_returns_false_when_empty_current_heads(self):
+        """alembic_version table exists but no current heads → False (lines 126-129)."""
+        mock_conn = Mock()
+        mock_cfg = Mock()
+        with patch("sqlalchemy.inspect") as mock_inspect, patch("alembic.runtime.migration.MigrationContext") as mock_mc:
+            mock_inspector = Mock()
+            mock_inspector.get_table_names.return_value = ["alembic_version"]
+            mock_inspect.return_value = mock_inspector
+            mock_ctx = Mock()
+            mock_ctx.get_current_heads.return_value = ()
+            mock_mc.configure.return_value = mock_ctx
+            assert _is_at_alembic_head(mock_conn, mock_cfg) is False
+
+    def test_returns_true_when_heads_match(self):
+        """Current heads equal target heads → True (lines 131-133)."""
+        mock_conn = Mock()
+        mock_cfg = Mock()
+        with (
+            patch("sqlalchemy.inspect") as mock_inspect,
+            patch("alembic.runtime.migration.MigrationContext") as mock_mc,
+            patch("alembic.script.ScriptDirectory") as mock_sd,
+        ):
+            mock_inspector = Mock()
+            mock_inspector.get_table_names.return_value = ["alembic_version"]
+            mock_inspect.return_value = mock_inspector
+            mock_ctx = Mock()
+            mock_ctx.get_current_heads.return_value = ("abc123",)
+            mock_mc.configure.return_value = mock_ctx
+            mock_script = Mock()
+            mock_script.get_heads.return_value = ["abc123"]
+            mock_sd.from_config.return_value = mock_script
+            assert _is_at_alembic_head(mock_conn, mock_cfg) is True
+
+    def test_returns_false_when_heads_differ(self):
+        """Current heads differ from target → False (lines 131-133)."""
+        mock_conn = Mock()
+        mock_cfg = Mock()
+        with (
+            patch("sqlalchemy.inspect") as mock_inspect,
+            patch("alembic.runtime.migration.MigrationContext") as mock_mc,
+            patch("alembic.script.ScriptDirectory") as mock_sd,
+        ):
+            mock_inspector = Mock()
+            mock_inspector.get_table_names.return_value = ["alembic_version"]
+            mock_inspect.return_value = mock_inspector
+            mock_ctx = Mock()
+            mock_ctx.get_current_heads.return_value = ("old_rev",)
+            mock_mc.configure.return_value = mock_ctx
+            mock_script = Mock()
+            mock_script.get_heads.return_value = ["new_rev"]
+            mock_sd.from_config.return_value = mock_script
+            assert _is_at_alembic_head(mock_conn, mock_cfg) is False
+
+
+class TestMainAdditionalBranches:
+    """Cover bootstrap_db.main() branches not exercised by TestMain."""
+
+    def _make_engine_cm(self):
+        mock_engine = Mock()
+        mock_conn = Mock()
+        mock_conn.commit = Mock()
+        mock_cm = Mock()
+        mock_cm.__enter__ = Mock(return_value=mock_conn)
+        mock_cm.__exit__ = Mock(return_value=None)
+        mock_engine.connect = Mock(return_value=mock_cm)
+        return mock_engine, mock_conn
+
+    @pytest.mark.asyncio
+    async def test_main_skip_migration_at_head_with_normalization(self, mock_settings):
+        """skip_migration=True, at head, normalize_team_visibility > 0 logs info (line 798)."""
+        mock_settings.skip_migration = True
+        mock_engine, _ = self._make_engine_cm()
+
+        with (
+            patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
+            patch("importlib.resources.files") as mock_files,
+            patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
+            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=3),
+            patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.logger") as mock_logger,
+        ):
+            mock_files.return_value.joinpath.return_value = "alembic.ini"
+            await main()
+            mock_logger.info.assert_any_call("Normalized 3 team record(s) to supported visibility values")
+
+    @pytest.mark.asyncio
+    async def test_main_skip_migration_exception_reraises(self, mock_settings):
+        """skip_migration=True, exception inside try: logged and re-raised (lines 803-805)."""
+        mock_settings.skip_migration = True
+        mock_engine, _ = self._make_engine_cm()
+
+        with (
+            patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
+            patch("importlib.resources.files") as mock_files,
+            patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
+            patch("mcpgateway.bootstrap_db._is_at_alembic_head", side_effect=RuntimeError("alembic check failed")),
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.logger") as mock_logger,
+        ):
+            mock_files.return_value.joinpath.return_value = "alembic.ini"
+            with pytest.raises(RuntimeError, match="alembic check failed"):
+                await main()
+            mock_logger.error.assert_called_with("Bootstrap failed: alembic check failed")
+
+    @pytest.mark.asyncio
+    async def test_main_fast_path_already_at_head(self, mock_settings):
+        """skip_migration=False, already at head: skips advisory lock, commits (lines 820, 827)."""
+        mock_settings.skip_migration = False
+        mock_engine, mock_conn = self._make_engine_cm()
+
+        with (
+            patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
+            patch("importlib.resources.files") as mock_files,
+            patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
+            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0),
+            patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin,
+            patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles,
+            patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()) as mock_resources,
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.logger") as mock_logger,
+        ):
+            mock_files.return_value.joinpath.return_value = "alembic.ini"
+            await main()
+            mock_logger.info.assert_any_call("Schema already at migration head — skipping advisory lock and alembic upgrade")
+            mock_conn.commit.assert_called()
+            mock_admin.assert_called_once()
+            mock_roles.assert_called_once()
+            mock_resources.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_main_sqlite_multi_replica_warning(self, mock_settings):
+        """SQLite + GATEWAY_REPLICAS > 1 emits warning (line 768)."""
+        mock_settings.skip_migration = False
+        mock_settings.database_url = "sqlite:///./mcp.db"
+        mock_engine, _ = self._make_engine_cm()
+
+        with (
+            patch.dict(os.environ, {"GATEWAY_REPLICAS": "2"}),
+            patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine),
+            patch("importlib.resources.files") as mock_files,
+            patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})),
+            patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True),
+            patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0),
+            patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()),
+            patch("mcpgateway.bootstrap_db.settings", mock_settings),
+            patch("mcpgateway.bootstrap_db.logger") as mock_logger,
+        ):
+            mock_files.return_value.joinpath.return_value = "alembic.ini"
+            await main()
+            warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+            assert any("GATEWAY_REPLICAS" in c for c in warning_calls)

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -1532,8 +1532,7 @@ class TestMain:
 
     @pytest.mark.asyncio
     async def test_main_skip_migration_fresh_db(self, mock_settings):
-        """skip_migration=True on a fresh DB must still run alembic upgrade head."""
-        # mock_settings.skip_migration is a truthy Mock attribute — tests skip_migration=True path
+        """skip_migration=True on a DB not at head raises RuntimeError (fail-fast)."""
         mock_engine = Mock()
         mock_conn = Mock()
         mock_conn.commit = Mock()
@@ -1543,27 +1542,14 @@ class TestMain:
         mock_connect_cm.__exit__ = Mock(return_value=None)
         mock_engine.connect = Mock(return_value=mock_connect_cm)
 
-        mock_command = Mock()
-        mock_advisory_lock_cm = MagicMock()
-        mock_advisory_lock_cm.__enter__ = Mock(return_value=None)
-        mock_advisory_lock_cm.__exit__ = Mock(return_value=None)
-
         with patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine), \
              patch("importlib.resources.files") as mock_files, \
              patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})), \
-             patch("mcpgateway.bootstrap_db.command", mock_command), \
              patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=False), \
-             patch("mcpgateway.bootstrap_db.advisory_lock", return_value=mock_advisory_lock_cm), \
-             patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0), \
-             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()), \
-             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()), \
-             patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()), \
              patch("mcpgateway.bootstrap_db.settings", mock_settings):
             mock_files.return_value.joinpath.return_value = "alembic.ini"
-            await main()
-
-        # upgrade must be called despite skip_migration=True (fresh DB detected)
-        mock_command.upgrade.assert_called_once_with(ANY, "head")
+            with pytest.raises(RuntimeError, match="Schema not at head; migrations required before startup"):
+                await main()
 
     @pytest.mark.asyncio
     async def test_main_exception_handling(self, mock_settings):
@@ -1627,7 +1613,7 @@ class TestIsAtAlembicHead:
         mock_cfg = Mock()
         with (
             patch("sqlalchemy.inspect") as mock_inspect,
-            patch("alembic.runtime.migration.MigrationContext") as mock_mc,
+            patch("mcpgateway.bootstrap_db.MigrationContext") as mock_mc,
             patch("alembic.script.ScriptDirectory") as mock_sd,
         ):
             mock_inspector = Mock()

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -1456,6 +1456,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_with_normalization(self, mock_settings):
         """Test main function with team normalization."""
+        mock_settings.skip_migration = False
         mock_engine = Mock()
         mock_conn = Mock()
         mock_conn.commit = Mock()
@@ -1526,6 +1527,7 @@ class TestMain:
     @pytest.mark.asyncio
     async def test_main_exception_handling(self, mock_settings):
         """Test main function exception handling and re-raise."""
+        mock_settings.skip_migration = False
         mock_engine = Mock()
 
         # Mock engine.connect() to raise an exception

--- a/tests/unit/mcpgateway/test_bootstrap_db.py
+++ b/tests/unit/mcpgateway/test_bootstrap_db.py
@@ -1489,7 +1489,8 @@ class TestMain:
 
     @pytest.mark.asyncio
     async def test_main_complete_flow(self, mock_settings):
-        """Test complete main flow with all bootstrap steps."""
+        """Test complete main flow: skip_migration=True with schema already at head."""
+        # mock_settings.skip_migration is a truthy Mock attribute — tests skip_migration=True path
         mock_engine = Mock()
         mock_conn = Mock()
         mock_conn.commit = Mock()
@@ -1508,21 +1509,59 @@ class TestMain:
                 mock_files.return_value.joinpath.return_value = "alembic.ini"
 
                 with patch("mcpgateway.bootstrap_db.Config", return_value=mock_config):
-                    with patch("mcpgateway.bootstrap_db.command"):
-                        with patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0):
-                            with patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin:
-                                with patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles:
-                                    with patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()) as mock_resources:
-                                        with patch("mcpgateway.bootstrap_db.settings", mock_settings):
-                                            with patch("mcpgateway.bootstrap_db.advisory_lock"):
-                                                with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
-                                                    await main()
+                    with patch("mcpgateway.bootstrap_db.command") as mock_command:
+                        with patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=True):
+                            with patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0):
+                                with patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()) as mock_admin:
+                                    with patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()) as mock_roles:
+                                        with patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()) as mock_resources:
+                                            with patch("mcpgateway.bootstrap_db.settings", mock_settings):
+                                                with patch("mcpgateway.bootstrap_db.advisory_lock"):
+                                                    with patch("mcpgateway.bootstrap_db.logger") as mock_logger:
+                                                        await main()
 
-                                                    # Verify all bootstrap functions were called
-                                                    mock_admin.assert_called_once()
-                                                    mock_roles.assert_called_once()
-                                                    mock_resources.assert_called_once()
-                                                    mock_logger.info.assert_any_call("Database ready")
+                                                        # Schema at head — upgrade must NOT be called
+                                                        mock_command.upgrade.assert_not_called()
+                                                        # All bootstrap functions were called
+                                                        mock_admin.assert_called_once()
+                                                        mock_roles.assert_called_once()
+                                                        mock_resources.assert_called_once()
+                                                        mock_logger.info.assert_any_call("Database ready")
+
+    @pytest.mark.asyncio
+    async def test_main_skip_migration_fresh_db(self, mock_settings):
+        """skip_migration=True on a fresh DB must still run alembic upgrade head."""
+        # mock_settings.skip_migration is a truthy Mock attribute — tests skip_migration=True path
+        mock_engine = Mock()
+        mock_conn = Mock()
+        mock_conn.commit = Mock()
+
+        mock_connect_cm = Mock()
+        mock_connect_cm.__enter__ = Mock(return_value=mock_conn)
+        mock_connect_cm.__exit__ = Mock(return_value=None)
+        mock_engine.connect = Mock(return_value=mock_connect_cm)
+
+        mock_command = Mock()
+        mock_advisory_lock_cm = MagicMock()
+        mock_advisory_lock_cm.__enter__ = Mock(return_value=None)
+        mock_advisory_lock_cm.__exit__ = Mock(return_value=None)
+
+        with patch("mcpgateway.bootstrap_db.create_engine", return_value=mock_engine), \
+             patch("importlib.resources.files") as mock_files, \
+             patch("mcpgateway.bootstrap_db.Config", return_value=MagicMock(attributes={})), \
+             patch("mcpgateway.bootstrap_db.command", mock_command), \
+             patch("mcpgateway.bootstrap_db._is_at_alembic_head", return_value=False), \
+             patch("mcpgateway.bootstrap_db.advisory_lock", return_value=mock_advisory_lock_cm), \
+             patch("mcpgateway.bootstrap_db.normalize_team_visibility", return_value=0), \
+             patch("mcpgateway.bootstrap_db.bootstrap_admin_user", new=AsyncMock()), \
+             patch("mcpgateway.bootstrap_db.bootstrap_default_roles", new=AsyncMock()), \
+             patch("mcpgateway.bootstrap_db.bootstrap_resource_assignments", new=AsyncMock()), \
+             patch("mcpgateway.bootstrap_db.settings", mock_settings):
+            mock_files.return_value.joinpath.return_value = "alembic.ini"
+            await main()
+
+        # upgrade must be called despite skip_migration=True (fresh DB detected)
+        mock_command.upgrade.assert_called_once_with(ANY, "head")
 
     @pytest.mark.asyncio
     async def test_main_exception_handling(self, mock_settings):


### PR DESCRIPTION
## Summary

Fixes the startup serialization bug reported in #4783 where all N gateway replicas
unconditionally acquire the Alembic migration lock at boot, making startup time scale
linearly with replica count. Also surfaces the silent SQLite correctness bug where
per-container `/tmp` file locks provide no cross-container coordination.

Three complementary fixes are applied together:

- **Fast-path head check** — before acquiring the advisory lock, each replica does a
  single `SELECT` on `alembic_version` and compares to the known head revision. If
  already at head the lock and `alembic upgrade head` are skipped entirely; only the
  idempotent bootstrap helpers (admin user, RBAC roles, resource assignments) re-run.
- **Init container** — the previously commented-out `migration:` service in
  `docker-compose.yml` is enabled. It runs the full bootstrap once against Postgres
  directly (bypassing PgBouncer), then exits. All gateway replicas depend on
  `service_completed_successfully`, so they start in parallel only after the schema
  is ready — and all take the fast-path immediately.
- **SQLite multi-replica guard** — when `DATABASE_URL` starts with `sqlite` and
  `GATEWAY_REPLICAS > 1`, a `WARNING` is logged at startup explaining that `/tmp`
  is not shared across containers and the file lock provides no cross-container
  protection. The warning does not abort startup so existing single-node deployments
  that happen to set `GATEWAY_REPLICAS` are unaffected.

A fourth addition, `SKIP_MIGRATION=false` (new env var), lets operators or external
CI pipelines declare that schema is already current, running only the bootstrap
helpers and skipping Alembic entirely.

Closes #4783

---

## Changes

### `mcpgateway/bootstrap_db.py`

**New function: `_is_at_alembic_head(conn, cfg) -> bool`** (after `_schema_looks_current`)

Uses Alembic's own `MigrationContext.get_current_heads()` and
`ScriptDirectory.get_heads()` for an authoritative revision comparison — not a
column heuristic. Returns `False` on any exception (fail-safe: always falls through
to the full migration path). This keeps the check accurate across future migrations
without manual maintenance.

```
_is_at_alembic_head logic:
  1. sa.inspect(conn) → check alembic_version table exists
  2. MigrationContext.configure(conn).get_current_heads() → current DB revision(s)
  3. ScriptDirectory.from_config(cfg).get_heads() → target revision(s) from scripts
  4. return current_heads == target_heads
  5. on any exception → log WARNING, return False
```

**Modified: `main()`**

Four additions, in order of execution:

1. `cfg.set_main_option("sqlalchemy.url", escaped_url)` moved **before** the
   connection block so `cfg` is ready for `_is_at_alembic_head` without needing
   a locked connection.
2. **SQLite multi-replica guard** — reads `GATEWAY_REPLICAS` env var; logs `WARNING`
   when `sqlite` + replicas > 1 explaining the per-container lock limitation.
3. **`SKIP_MIGRATION` early-return** — if `settings.skip_migration` is `True`, runs
   only the three idempotent bootstrap helpers and returns. Intended for deployments
   where an external tool (init container, CI step) already ran `alembic upgrade head`.
4. **Fast-path branch** — wraps the existing `advisory_lock` block in an `else`:

   ```python
   if _is_at_alembic_head(conn, cfg):
       # skip lock — run idempotent bootstraps only
   else:
       with advisory_lock(conn):
           command.upgrade(cfg, "head")
           # ... normalization + bootstraps
   ```

The slow path (advisory lock + `alembic upgrade head`) is completely unchanged.

### `mcpgateway/config.py`

New field in `Settings`:

```python
skip_migration: bool = Field(
    default=False,
    description="Skip alembic upgrade head on startup. ..."
)
```

Env var: `SKIP_MIGRATION=true`. Default `false` — no behavior change for existing
deployments.

### `docker-compose.yml`

**Enabled `migration:` service** (was fully commented out):

```yaml
migration:
  image: ${IMAGE_LOCAL:-mcpgateway/mcpgateway:latest}
  build:
    context: .
    dockerfile: Containerfile.lite
  environment:
    - DATABASE_URL=postgresql+psycopg://postgres:${POSTGRES_PASSWORD:-...}@postgres:5432/mcp
    - JWT_SECRET_KEY=...
    - BASIC_AUTH_USER=...
    - BASIC_AUTH_PASSWORD=...
    - PLATFORM_ADMIN_EMAIL=...
    - AUTH_REQUIRED=...
    - AUTH_ENCRYPTION_SECRET=...
    - LOG_LEVEL=...
  command: ["python", "-m", "mcpgateway.bootstrap_db"]
  depends_on:
    postgres:
      condition: service_healthy
  networks: [mcpnet]
  restart: "no"
```

Key decisions:

- `DATABASE_URL` points to `postgres:5432` **not** `pgbouncer:6432`. Postgres
  advisory locks are session-scoped; PgBouncer in transaction-pooling mode releases
  the session between statements, which breaks session-level lock semantics.
- `command: python -m mcpgateway.bootstrap_db` runs the **full** bootstrap (schema +
  admin user + roles + resource assignments), not just `alembic upgrade head`. This
  means gateway replicas skip all bootstrap work on fast-path, not just migration.
- `restart: "no"` — the container must exit 0 for Docker Compose's
  `service_completed_successfully` condition to fire. If it fails, replicas never
  start and the operator sees a clear error in `docker compose logs migration`.

**Updated `gateway.depends_on`** — uncommenting the previously commented condition:

```yaml
depends_on:
  pgbouncer:
    condition: service_healthy
  redis:
    condition: service_started
  migration:
    condition: service_completed_successfully
```

### `mcpgateway/services/base_service.py`

Fixed team-scoped visibility leak in `_apply_team_filter()`. Previously a standalone
`model_cls.visibility == "public"` condition was appended unconditionally, causing
globally public items from **other teams** to appear in team-scoped listings. The
condition is removed; when `team_id` is set, only items belonging to that team (with
`team` or `public` visibility) are returned. The docstring was updated to reflect the
corrected semantics.

### `mcpgateway/admin.py`

UI fix in the team members panel: updated the close button's `data-action-click`
attribute to use the correct handler.

### `mcpgateway/templates/admin.html`

Removed three stale `window.Admin` registrations (`loadTeamMembersView`,
`approveJoinRequest`, `rejectJoinRequest`) that no longer correspond to defined
functions.

---

## Behavior by Scenario

| Scenario                                                     | Before                                                             | After                                                                                   |
| ------------------------------------------------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
| `make serve` / `make dev` (SQLite, 1 replica, no Docker) | Lock → migrate → bootstrap                                       | First start: identical. Subsequent restarts: fast-path (single SELECT, ~100ms vs 1–3s) |
| `make testing-up` cold start (PG, 3 replicas)              | All 3 race for advisory lock, start serially (~3× migration time) | Init container migrates once → all 3 replicas fast-path skip → start in parallel      |
| `make testing-up` existing stack (schema at head)          | All 3 acquire lock, run no-op upgrade                              | Init container exits immediately → all 3 fast-path skip immediately                    |
| Rolling restart (PG, 3 replicas, no compose)                 | All 3 serialize on advisory lock                                   | All replicas fast-path (schema already at head, no lock acquired)                      |
| SQLite +`GATEWAY_REPLICAS > 1` (accidental)                | Silent correctness bug — no cross-container lock                  | `WARNING` logged at startup explaining the per-container lock limitation              |
| External migration tool / CI pipeline                        | N/A                                                                | `SKIP_MIGRATION=true` skips Alembic, runs bootstraps only                             |

---

## Notes

- The fast-path check is **fail-safe**: any exception from `_is_at_alembic_head`
  returns `False`, which falls through to the existing advisory-lock path. A false
  negative (unnecessary lock acquisition) is safe; Alembic's `upgrade head` is
  idempotent. A false positive (skipping a needed migration) cannot occur because the
  check compares actual Alembic revision hashes, not schema column presence.
- The TOCTOU race between fast-path check and lock acquisition is safe: if two
  replicas both see "not at head" and both enter `advisory_lock`, the second waits
  for the first, then runs `command.upgrade` which is a no-op. Existing behavior.
- The `migration:` service is intentionally not gated behind a Compose profile so
  it activates automatically for all `make testing-up` / `make compose-up` users
  without any additional flags.
