### PR TITLE
bugfix/4400-migration-blocked-missing-gateway-secret

### DIFF
--- a/charts/mcp-stack/templates/secret-gateway.yaml
+++ b/charts/mcp-stack/templates/secret-gateway.yaml
@@ -6,9 +6,9 @@
      - Uses stringData so you can keep readable values in your values.yaml;
        Kubernetes will base64-encode them on creation.
      - Put ONLY sensitive credentials or tokens here.
+     - Always created (even if empty) to prevent migration job failures
      ------------------------------------------------------------------- */}}
 
-{{- if .Values.mcpContextForge.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,9 +17,12 @@ metadata:
     {{- include "mcp-stack.labels" . | nindent 4 }}
     app.kubernetes.io/component: gateway
 type: Opaque
+{{- if .Values.mcpContextForge.secret }}
 stringData:
 {{- /* Iterate over every key in mcpContextForge.secret */}}
 {{- range $key, $val := .Values.mcpContextForge.secret }}
   {{ $key }}: {{ $val | quote }}
 {{- end }}
+{{- else }}
+stringData: {}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #4400 

Removed the outer conditional -- the Secret resource is now always created, regardless of whether mcpContextForge.secret has values
Moved the conditional inside -- only the stringData content is conditional, with stringData: {} as the fallback when no secrets are provided

The fix is minimal, targeted, and solves the root cause: ensuring the Secret resource always exists so the migration job (and the main deployment at deployment-mcpgateway.yaml:208, which references the secret without optional: true) never fails due to a missing secret.


Testing Performed
 ✅ Validated all scenarios:
 1. Fresh install without secrets - Original bug scenario, now works 
 2.Fresh install with secrets - Standard deployment, still works 
 3.Upgrade existing deployment - Preserves existing secrets 
 4.Migration job startup - Succeeds with empty or populated secret 
 5. Gateway deployment startup - Works in all configurations
