### PR TITLE
fix: LLMChat disconnect button race condition and Anthropic streaming

### DIFF
--- a/mcpgateway/admin_ui/eventDelegation.js
+++ b/mcpgateway/admin_ui/eventDelegation.js
@@ -332,7 +332,8 @@ function clearCustomValidity(event) {
  * @param {Event} event - Input event
  */
 function autoResizeTextarea(event) {
-  const el = event.target;
+  const el = event?.target;
+  if (!el?.style) return;
   el.style.height = 'auto';
   el.style.height = Math.min(el.scrollHeight, 120) + 'px';
 }

--- a/mcpgateway/admin_ui/llmChat.js
+++ b/mcpgateway/admin_ui/llmChat.js
@@ -458,6 +458,12 @@ const updateConnectButtonState = function () {
  * Connect to LLM chat
  */
 
+const CONNECT_BTN_HTML = `<svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M13 10V3L4 14h7v7l9-11h-7z" />
+    </svg>
+    Connect`;
+
 export const connectLLMChat = async function () {
   if (!llmChatState.selectedServerId) {
     showErrorMessage("Please select a virtual server first");
@@ -477,7 +483,6 @@ export const connectLLMChat = async function () {
 
   // Show loading state
   const connectBtn = safeGetElement("llm-connect-btn");
-  const originalText = connectBtn.textContent;
   connectBtn.textContent = "Connecting...";
   connectBtn.disabled = true;
 
@@ -633,7 +638,7 @@ export const connectLLMChat = async function () {
     // Display the backend error message to the user
     showConnectionError(error.message);
   } finally {
-    connectBtn.textContent = originalText;
+    connectBtn.innerHTML = CONNECT_BTN_HTML;
     connectBtn.disabled = false;
   }
 };
@@ -1075,14 +1080,26 @@ const showConnectionError = function (message) {
  * Disconnect from LLM chat
  */
 
+const DISCONNECT_BTN_HTML = `<svg class="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+    </svg>
+    Disconnect`;
+
 export const disconnectLLMChat = async function () {
   if (!llmChatState.isConnected) {
     console.warn("No active connection to disconnect");
     return;
   }
 
+  // Re-entrancy guard: if a disconnect is already in-flight, bail out
+  if (disconnectLLMChat._inProgress) {
+    console.warn("Disconnect already in progress, skipping duplicate call");
+    return;
+  }
+  disconnectLLMChat._inProgress = true;
+
   const disconnectBtn = safeGetElement("llm-disconnect-btn");
-  const originalText = disconnectBtn.textContent;
   disconnectBtn.textContent = "Disconnecting...";
   disconnectBtn.disabled = true;
 
@@ -1233,9 +1250,10 @@ export const disconnectLLMChat = async function () {
       `Disconnection error: ${error.message}. Local session cleared.`
     );
   } finally {
-    // Reset button state only if it's still visible (error case where we didn't disconnect)
-    if (disconnectBtn && !disconnectBtn.classList.contains("hidden")) {
-      disconnectBtn.textContent = originalText;
+    disconnectLLMChat._inProgress = false;
+    // Always reset button state — even if hidden, a future connect will un-hide it
+    if (disconnectBtn) {
+      disconnectBtn.innerHTML = DISCONNECT_BTN_HTML;
       disconnectBtn.disabled = false;
     }
   }

--- a/mcpgateway/services/mcp_client_chat_service.py
+++ b/mcpgateway/services/mcp_client_chat_service.py
@@ -2649,6 +2649,12 @@ class MCPChatService:
                     chunk = event.get("data", {}).get("chunk")
                     if chunk and hasattr(chunk, "content"):
                         content = chunk.content
+                        # Anthropic returns content blocks as a list
+                        if isinstance(content, list):
+                            content = "".join(
+                                block.get("text", "") if isinstance(block, dict) else str(block)
+                                for block in content
+                            )
                         if content:
                             full_response += content
                             yield content
@@ -2899,6 +2905,12 @@ class MCPChatService:
                             chunk = event.get("data", {}).get("chunk")
                             if chunk and hasattr(chunk, "content"):
                                 content = chunk.content
+                                # Anthropic returns content blocks as a list
+                                if isinstance(content, list):
+                                    content = "".join(
+                                        block.get("text", "") if isinstance(block, dict) else str(block)
+                                        for block in content
+                                    )
                                 if content:
                                     full_response += content
                                     yield {"type": "token", "content": content}


### PR DESCRIPTION
## Summary

Two targeted fixes for the Admin UI LLMChat feature discovered during a healthcare RBAC demo:

### 1. Disconnect button stuck in "Disconnecting..." state

**Behavior observed:** When rapidly switching virtual servers (connect → disconnect → connect), the `#llm-disconnect-btn` freezes with "Disconnecting..." text and `disabled=true`. The user can no longer interact with it. The same stuck state occurs when clicking Disconnect while a prior disconnect is still in-flight.

**Root cause:** `disconnectLLMChat()` sets button text to "Disconnecting..." at the top of the async function. On the success path, the button is hidden via `classList.add("hidden")`. The `finally` block only resets text/disabled if the button is *not* hidden — so it skips the reset. When the next `connectLLMChat()` or `showConnectionSuccess()` un-hides the button, it appears with stale state.

A secondary issue: `textContent` was used to save/restore button state, but the buttons contain SVG icon children. `textContent =` destroys all child nodes (including the SVG), and restoring only puts back flat text — the icon is permanently lost.

**Fix:**
- Always reset button state in `finally`, unconditionally
- Use `innerHTML` with constant templates instead of `textContent` save/restore
- Add `_inProgress` re-entrancy guard to `disconnectLLMChat`

**Note:** This is a targeted fix for the observed symptoms. The underlying architecture — multiple independent async code paths (`connectLLMChat`, `disconnectLLMChat`, `showConnectionSuccess`, SSE error handlers) each directly manipulating the same button DOM state — remains fragile. A more robust approach would centralize into a single `syncButtonUI()` driven by a connection phase state machine. Additionally, `eventDelegation.js` dispatches async handlers fire-and-forget (no `await`), so concurrent clicks are never serialized. Both of these are worth exploring as follow-ups.

### 2. Anthropic streaming returns content blocks as lists

**Behavior observed:** When using Anthropic models (Claude) via LLMChat, streamed responses produce no visible output — the response silently drops.

**Root cause:** Anthropic's streaming API returns `chunk.content` as a list of content block objects (`[{"type": "text", "text": "..."}]`) rather than a plain string. The handler expected a string and silently dropped list-typed content.

**Fix:** Detect list-typed content and join text fields before yielding. Applied to both `_stream_litellm_response` and `_process_streaming_response`.

### 3. Guard null event target in autoResizeTextarea

Defensive optional chaining for `event.target` in `autoResizeTextarea` — can be null during rapid DOM mutations.

## Test plan

- [ ] Connect to a virtual server, disconnect, reconnect to a different server — disconnect button should never get stuck
- [ ] Rapid-click disconnect multiple times — button should not freeze
- [ ] Disconnect during a network timeout (kill the backend mid-disconnect) — button should reset after finally block
- [ ] After disconnect + reconnect, button should show SVG icon + "Disconnect" text (not flat text)
- [ ] Stream a response from an Anthropic model via LLMChat — tokens should appear incrementally
- [ ] Stream a response from a non-Anthropic model — should still work (no regression)