### PR TITLE
perf: speed up team visibility listings

### DIFF
--- a/mcpgateway/alembic/versions/8d0f7c2a9b31_add_visibility_listing_order_indexes.py
+++ b/mcpgateway/alembic/versions/8d0f7c2a9b31_add_visibility_listing_order_indexes.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/alembic/versions/8d0f7c2a9b31_add_visibility_listing_order_indexes.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+add visibility listing order indexes
+
+Revision ID: 8d0f7c2a9b31
+Revises: 351b43e1d273
+Create Date: 2026-05-18 14:25:00.000000
+
+The Alembic environment runs migrations inside a transaction, so PostgreSQL
+CONCURRENTLY cannot be used here. A short lock timeout prevents indefinite
+blocking; very large production tables can create these indexes concurrently
+before running this migration.
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "8d0f7c2a9b31"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "351b43e1d273"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+VISIBILITY_TABLES = ("tools", "resources", "prompts", "servers", "gateways", "a2a_agents")
+REQUIRED_COLUMNS = {"id", "team_id", "owner_email", "visibility", "enabled", "created_at"}
+
+
+def _index_specs(table_name: str) -> tuple[tuple[str, list[str], str], ...]:
+    """Return ordered partial index definitions for one visibility table."""
+    return (
+        (
+            f"idx_{table_name}_private_owner_team_order",
+            ["team_id", "owner_email", "created_at", "id"],
+            "enabled AND visibility = 'private'",
+        ),
+    )
+
+
+def upgrade() -> None:
+    """Add ordered partial indexes for visibility-filtered list queries."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    for table_name in VISIBILITY_TABLES:
+        if table_name not in tables:
+            continue
+
+        columns = {column["name"] for column in inspector.get_columns(table_name)}
+        if not REQUIRED_COLUMNS.issubset(columns):
+            continue
+
+        existing_indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+        for index_name, index_columns, predicate in _index_specs(table_name):
+            if index_name in existing_indexes:
+                continue
+
+            op.create_index(
+                index_name,
+                table_name,
+                index_columns,
+                unique=False,
+                postgresql_where=sa.text(predicate),
+            )
+
+
+def downgrade() -> None:
+    """Drop ordered partial indexes for visibility-filtered list queries."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    inspector = sa.inspect(bind)
+    tables = set(inspector.get_table_names())
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    for table_name in VISIBILITY_TABLES:
+        if table_name not in tables:
+            continue
+
+        existing_indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+        for index_name, _, _ in _index_specs(table_name):
+            if index_name in existing_indexes:
+                op.drop_index(index_name, table_name=table_name)

--- a/mcpgateway/services/base_service.py
+++ b/mcpgateway/services/base_service.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql import Select
 from mcpgateway.plugins import get_plugin_manager
 from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.admin_check import is_user_admin
+from mcpgateway.utils.pagination import with_team_visibility_fast_filter
 
 
 class BaseService(ABC):
@@ -163,9 +164,18 @@ class BaseService(ABC):
                 and_(model_cls.team_id == team_id, model_cls.visibility.in_(["team", "public"])),
                 model_cls.visibility == "public",  # globally public items from any team are always visible
             ]
+            fast_branches = [
+                (model_cls.visibility == "public",),
+                (model_cls.team_id == team_id, model_cls.visibility == "team"),
+            ]
             if user_email:
-                access_conditions.append(and_(model_cls.team_id == team_id, model_cls.owner_email == user_email, model_cls.visibility == "private"))
-            return query.where(or_(*access_conditions))
+                private_condition = and_(model_cls.team_id == team_id, model_cls.owner_email == user_email, model_cls.visibility == "private")
+                access_conditions.append(private_condition)
+                fast_branches.append((private_condition,))
+            filtered_query = query.where(or_(*access_conditions))
+            if not hasattr(filtered_query, "execution_options"):
+                return filtered_query
+            return with_team_visibility_fast_filter(filtered_query, model_cls, fast_branches)
 
         access_conditions = [model_cls.visibility == "public"]
 

--- a/mcpgateway/utils/pagination.py
+++ b/mcpgateway/utils/pagination.py
@@ -46,7 +46,7 @@ from urllib.parse import urlencode
 # Third-Party
 from fastapi import Request
 import orjson
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, union_all
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import Select
 
@@ -55,6 +55,20 @@ from mcpgateway.config import settings
 from mcpgateway.schemas import PaginationLinks, PaginationMeta
 
 logger = logging.getLogger(__name__)
+
+_TEAM_VISIBILITY_FAST_FILTER = "team_visibility_fast_filter"
+
+
+def with_team_visibility_fast_filter(query: Select, model: Any, branches: List[Tuple[Any, ...]]) -> Select:
+    """Attach metadata used by the Postgres team visibility fast path."""
+    return query.execution_options(
+        **{
+            _TEAM_VISIBILITY_FAST_FILTER: {
+                "model": model,
+                "branches": branches,
+            }
+        }
+    )
 
 
 def encode_cursor(data: Dict[str, Any]) -> str:
@@ -646,6 +660,66 @@ async def paginate_query(
     )
 
 
+def _team_visibility_filter(query: Select) -> Optional[Dict[str, Any]]:
+    """Return team visibility fast-filter metadata attached by BaseService."""
+    return query.get_execution_options().get(_TEAM_VISIBILITY_FAST_FILTER)
+
+
+def _supports_team_visibility_union(db: Session) -> bool:
+    """Return True when the dialect supports ordered branch UNION fast path."""
+    try:
+        return db.bind.dialect.name == "postgresql"
+    except Exception:
+        return False
+
+
+def _run_team_visibility_union_page(
+    db: Session,
+    query: Select,
+    page_size: int,
+    last_id: Optional[str] = None,
+    last_created: Any = None,
+) -> Tuple[List[Any], Optional[str]]:
+    """Fetch one cursor page with a branch-limited UNION ALL ID subquery."""
+    fast_filter = _team_visibility_filter(query)
+    if not fast_filter:
+        raise ValueError("team visibility fast filter missing")
+
+    model = fast_filter["model"]
+    fast_branches = fast_filter["branches"]
+
+    cursor_filter = None
+    if last_id and last_created:
+        cursor_filter = or_(model.created_at < last_created, and_(model.created_at == last_created, model.id < last_id))
+
+    branch_limit = page_size + 1
+
+    def branch(*branch_criteria: Any) -> Select:
+        """Build one ordered, limited visibility branch."""
+        branch_query = query.with_only_columns(model.id.label("id"), model.created_at.label("created_at"), maintain_column_froms=True).order_by(None).where(*branch_criteria)
+        if cursor_filter is not None:
+            branch_query = branch_query.where(cursor_filter)
+        return branch_query.order_by(model.created_at.desc(), model.id.desc()).limit(branch_limit)
+
+    branches = [branch(*branch_criteria) for branch_criteria in fast_branches]
+
+    id_page = union_all(*branches).order_by(model.created_at.desc(), model.id.desc()).limit(branch_limit).subquery()
+    items = db.execute(query.where(model.id.in_(select(id_page.c.id)))).scalars().all()
+
+    has_more = len(items) > page_size
+    if has_more:
+        items = items[:page_size]
+
+    next_cursor = None
+    if has_more and items:
+        item_created_at = getattr(items[-1], "created_at", None)
+        item_id = getattr(items[-1], "id", None)
+        cursor_data = {"created_at": item_created_at.isoformat() if item_created_at else None, "id": item_id}
+        next_cursor = encode_cursor(cursor_data)
+
+    return items, next_cursor
+
+
 async def unified_paginate(
     db: Session,
     query: Select,
@@ -750,6 +824,10 @@ async def unified_paginate(
                 last_created = datetime.fromisoformat(created_str)
         except (ValueError, TypeError) as e:
             logger.warning(f"Invalid cursor, ignoring: {e}")
+
+    if page_size is not None and _team_visibility_filter(query):
+        if _supports_team_visibility_union(db):
+            return _run_team_visibility_union_page(db, query, page_size, last_id, last_created)
 
     # Apply cursor filter with keyset pagination (assumes query already has ORDER BY)
     if last_id and last_created:

--- a/tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py
+++ b/tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Tests for visibility listing index migration."""
+
+# Standard
+import importlib
+import os
+
+# Third-Party
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import pytest
+import sqlalchemy as sa
+
+MODULE_NAME = "mcpgateway.alembic.versions.8d0f7c2a9b31_add_visibility_listing_order_indexes"
+
+
+def _postgres_url(test_db_url):
+    """Return the configured Postgres URL, if this test run has one."""
+    if os.environ.get("TEST_POSTGRES_URL"):
+        return os.environ["TEST_POSTGRES_URL"]
+    if test_db_url.startswith("postgresql"):
+        return test_db_url
+    return None
+
+
+def _migration_context(conn):
+    """Return an Alembic migration context bound to conn."""
+    return MigrationContext.configure(conn, opts={"as_sql": False})
+
+
+def _pg_engine(postgres_url):
+    """Return a PostgreSQL engine for migration tests."""
+    return sa.create_engine(postgres_url)
+
+
+def _create_visibility_table(conn, table_name):
+    """Create a minimal visibility table that satisfies migration preconditions."""
+    conn.execute(sa.text(f"DROP TABLE IF EXISTS {table_name} CASCADE"))
+    conn.execute(sa.text("""
+            CREATE TABLE {table_name} (
+                id VARCHAR PRIMARY KEY,
+                team_id VARCHAR,
+                owner_email VARCHAR,
+                visibility VARCHAR NOT NULL,
+                enabled BOOLEAN NOT NULL,
+                created_at TIMESTAMP NOT NULL
+            )
+            """.format(table_name=table_name)))
+    conn.commit()
+
+
+def _drop_visibility_tables(conn, table_names):
+    """Drop minimal visibility tables."""
+    for table_name in table_names:
+        conn.execute(sa.text(f"DROP TABLE IF EXISTS {table_name} CASCADE"))
+    conn.commit()
+
+
+def _index_name(table_name):
+    """Return the migration index name for table_name."""
+    return f"idx_{table_name}_private_owner_team_order"
+
+
+def _index_names(conn, table_name):
+    """Return indexes on table_name."""
+    return {index["name"] for index in sa.inspect(conn).get_indexes(table_name)}
+
+
+def _index_definition(conn, table_name):
+    """Return the PostgreSQL index definition for the migration index."""
+    row = conn.execute(
+        sa.text("SELECT indexdef FROM pg_indexes WHERE tablename = :table_name AND indexname = :name"),
+        {"table_name": table_name, "name": _index_name(table_name)},
+    ).one_or_none()
+    return row[0] if row else None
+
+
+def test_visibility_listing_index_upgrade_is_idempotent_and_downgrades(test_db_url):
+    """Migration creates private owner/team indexes once and drops them."""
+    postgres_url = _postgres_url(test_db_url)
+    if not postgres_url:
+        pytest.skip("PostgreSQL test database not configured")
+
+    module = importlib.import_module(MODULE_NAME)
+    table_names = module.VISIBILITY_TABLES
+    engine = _pg_engine(postgres_url)
+    try:
+        with engine.connect() as conn:
+            for table_name in table_names:
+                _create_visibility_table(conn, table_name)
+
+            ctx = _migration_context(conn)
+            with Operations.context(ctx):
+                module.upgrade()
+                module.upgrade()
+
+            for table_name in table_names:
+                assert _index_name(table_name) in _index_names(conn, table_name)
+                index_definition = _index_definition(conn, table_name)
+                assert "team_id" in index_definition
+                assert "owner_email" in index_definition
+                assert "enabled" in index_definition
+                assert "visibility" in index_definition
+                assert "private" in index_definition
+
+            with Operations.context(ctx):
+                module.downgrade()
+
+            for table_name in table_names:
+                assert _index_name(table_name) not in _index_names(conn, table_name)
+    finally:
+        with engine.connect() as conn:
+            _drop_visibility_tables(conn, table_names)
+        engine.dispose()

--- a/tests/unit/mcpgateway/utils/test_pagination_team_visibility.py
+++ b/tests/unit/mcpgateway/utils/test_pagination_team_visibility.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+"""Tests for team visibility pagination fast path."""
+
+# Standard
+import asyncio
+from datetime import datetime
+import os
+
+# Third-Party
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+# First-Party
+from mcpgateway.services.base_service import BaseService
+from mcpgateway.utils.pagination import encode_cursor, unified_paginate
+
+
+class _Base(DeclarativeBase):
+    """Base class for local test mappings."""
+
+    pass
+
+
+class _VisibleItem(_Base):
+    """Minimal mapped item for compiling visibility pagination SQL."""
+
+    __tablename__ = "visible_items"
+
+    id: Mapped[str] = mapped_column(sa.String, primary_key=True)
+    team_id: Mapped[str] = mapped_column(sa.String)
+    owner_email: Mapped[str] = mapped_column(sa.String)
+    name: Mapped[str] = mapped_column(sa.String)
+    visibility: Mapped[str] = mapped_column(sa.String)
+    enabled: Mapped[bool] = mapped_column(sa.Boolean)
+    created_at: Mapped[datetime] = mapped_column(sa.DateTime)
+
+
+class _Item:
+    """Simple row object returned by the DB stub."""
+
+    def __init__(self, item_id: str, created_at: datetime):
+        """Initialize an item with cursor fields."""
+        self.id = item_id
+        self.created_at = created_at
+
+
+class _Result:
+    """Minimal SQLAlchemy result stub."""
+
+    def __init__(self, rows):
+        """Store rows returned by the stub."""
+        self._rows = rows
+
+    def all(self):
+        """Return all rows."""
+        return self._rows
+
+    def scalars(self):
+        """Return the scalar-result stub."""
+        return self
+
+
+class _Dialect:
+    """DB dialect stub."""
+
+    name = "postgresql"
+
+
+class _Bind:
+    """DB bind stub."""
+
+    def __init__(self, dialect_name="postgresql"):
+        """Initialize the bind with a dialect name."""
+        self.dialect = _Dialect()
+        self.dialect.name = dialect_name
+
+
+class _Db:
+    """Capture executed statements without touching a real database."""
+
+    def __init__(self, dialect_name="postgresql"):
+        """Initialize captured statement storage."""
+        self.bind = _Bind(dialect_name)
+        self.statements = []
+        self._created = datetime(2026, 1, 1, 12, 0, 0)
+
+    def execute(self, statement):
+        """Capture the statement and return one extra ordered object."""
+        self.statements.append(statement)
+        return _Result([_Item("3", self._created), _Item("2", self._created), _Item("1", self._created)])
+
+
+class _VisibleItemService(BaseService):
+    """Minimal service that produces real fast-path metadata."""
+
+    _visibility_model_cls = _VisibleItem
+
+
+def _base_query():
+    """Build a representative team-scoped query through BaseService."""
+    base_query = sa.select(_VisibleItem).where(_VisibleItem.enabled).order_by(_VisibleItem.created_at.desc(), _VisibleItem.id.desc())
+    return _VisibleItemService()._apply_visibility_filter(base_query, "owner@test.com", ["team-1"], "team-1").where(_VisibleItem.name == "kept")
+
+
+def _postgres_url(test_db_url):
+    """Return the configured Postgres URL, if this test run has one."""
+    if os.environ.get("TEST_POSTGRES_URL"):
+        return os.environ["TEST_POSTGRES_URL"]
+    if test_db_url.startswith("postgresql"):
+        return test_db_url
+    return None
+
+
+def test_team_visibility_fast_path_uses_branch_limited_union_and_scoped_fetch():
+    """Postgres fast path uses a branch-limited ID subquery in a scoped fetch."""
+    db = _Db()
+    unified_result = asyncio.run(unified_paginate(db, _base_query(), limit=2))
+    items, next_cursor = unified_result
+
+    assert [item.id for item in items] == ["3", "2"]
+    assert next_cursor is not None
+    assert len(unified_result) == 2
+    assert len(db.statements) == 1
+
+    compiled = str(db.statements[0].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert compiled.count("UNION ALL") == 2
+    assert compiled.count("LIMIT 3") == 4
+    assert "visible_items.id IN (SELECT" in compiled
+    assert "visible_items.visibility = 'public'" in compiled
+    assert "visible_items.visibility = 'team'" in compiled
+    assert "visible_items.visibility = 'private'" in compiled
+    assert compiled.count("visible_items.name = 'kept'") >= 3
+
+
+def test_team_visibility_fast_path_applies_cursor_to_union_branches():
+    """Cursor continuation is pushed into every visibility branch."""
+    db = _Db()
+    cursor = encode_cursor({"created_at": datetime(2026, 1, 1, 12, 0, 0).isoformat(), "id": "3"})
+
+    asyncio.run(unified_paginate(db, _base_query(), cursor=cursor, limit=2))
+
+    compiled = str(db.statements[0].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert compiled.count("visible_items.created_at < '2026-01-01 12:00:00'") == 3
+    assert compiled.count("visible_items.id < '3'") == 3
+
+
+def test_team_visibility_fast_path_falls_back_for_non_postgres():
+    """Non-Postgres dialects use the regular cursor path."""
+    db = _Db(dialect_name="sqlite")
+
+    items, next_cursor = asyncio.run(unified_paginate(db, _base_query(), limit=2))
+
+    compiled = str(db.statements[0].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+    assert [item.id for item in items] == ["3", "2"]
+    assert next_cursor is not None
+    assert "LIMIT 3" in compiled
+    assert "UNION ALL" not in compiled
+
+
+def test_team_visibility_fast_path_executes_on_postgres(test_db_url):
+    """Postgres fast path returns ordered filtered rows across cursor pages."""
+    postgres_url = _postgres_url(test_db_url)
+    if not postgres_url:
+        pytest.skip("PostgreSQL test database not configured")
+
+    engine = sa.create_engine(postgres_url)
+    try:
+        _Base.metadata.drop_all(engine, tables=[_VisibleItem.__table__])
+        _Base.metadata.create_all(engine, tables=[_VisibleItem.__table__])
+        created = datetime(2026, 1, 1, 12, 0, 0)
+        rows = [
+            _VisibleItem(
+                id=f"drop-{idx}",
+                name="drop",
+                enabled=True,
+                visibility="public",
+                team_id="team-x",
+                owner_email="other@test.com",
+                created_at=created.replace(minute=idx),
+            )
+            for idx in range(5)
+        ]
+        rows.extend(
+            [
+                _VisibleItem(
+                    id="keep-4",
+                    name="kept",
+                    enabled=True,
+                    visibility="private",
+                    team_id="team-1",
+                    owner_email="owner@test.com",
+                    created_at=created.replace(second=4),
+                ),
+                _VisibleItem(
+                    id="keep-3",
+                    name="kept",
+                    enabled=True,
+                    visibility="private",
+                    team_id="team-1",
+                    owner_email="owner@test.com",
+                    created_at=created.replace(second=3),
+                ),
+                _VisibleItem(
+                    id="keep-2",
+                    name="kept",
+                    enabled=True,
+                    visibility="team",
+                    team_id="team-1",
+                    owner_email="other@test.com",
+                    created_at=created.replace(second=2),
+                ),
+                _VisibleItem(
+                    id="keep-1b",
+                    name="kept",
+                    enabled=True,
+                    visibility="public",
+                    team_id="team-x",
+                    owner_email="other@test.com",
+                    created_at=created.replace(second=1),
+                ),
+                _VisibleItem(
+                    id="keep-1a",
+                    name="kept",
+                    enabled=True,
+                    visibility="public",
+                    team_id="team-x",
+                    owner_email="other@test.com",
+                    created_at=created.replace(second=1),
+                ),
+            ]
+        )
+        with Session(engine) as db:
+            db.add_all(rows)
+            db.commit()
+
+            page_one, cursor = asyncio.run(unified_paginate(db, _base_query(), limit=2))
+            assert [item.id for item in page_one] == ["keep-4", "keep-3"]
+            assert cursor is not None
+
+            page_two, cursor = asyncio.run(unified_paginate(db, _base_query(), cursor=cursor, limit=2))
+            assert [item.id for item in page_two] == ["keep-2", "keep-1b"]
+            assert cursor is not None
+
+            page_three, next_cursor = asyncio.run(unified_paginate(db, _base_query(), cursor=cursor, limit=2))
+            assert [item.id for item in page_three] == ["keep-1a"]
+            assert next_cursor is None
+    finally:
+        _Base.metadata.drop_all(engine, tables=[_VisibleItem.__table__])
+        engine.dispose()


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue
Closes #4802

---

## 🚀 Summary (1-2 sentences)
Speeds up PostgreSQL team-scoped registry listings by using a branch-limited `UNION ALL` ID subquery inside the normal scoped ORM query. Adds PostgreSQL-only private owner/team ordered partial indexes; public and team branches continue to use existing listing indexes.

---

## 🧪 Checks

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] CHANGELOG updated (if user-facing)

Focused checks run locally:
- `uv run ruff check mcpgateway/services/base_service.py mcpgateway/utils/pagination.py mcpgateway/alembic/versions/8d0f7c2a9b31_add_visibility_listing_order_indexes.py tests/unit/mcpgateway/utils/test_pagination_team_visibility.py tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py`
- `uv run black --check mcpgateway/services/base_service.py mcpgateway/utils/pagination.py tests/unit/mcpgateway/utils/test_pagination_team_visibility.py tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py`
- `uv run pytest tests/unit/mcpgateway/services/test_base_service.py tests/unit/mcpgateway/utils/test_pagination_team_visibility.py tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py tests/unit/mcpgateway/services/test_a2a_service.py::TestA2AAgentService::test_apply_visibility_filter -q`
- `TEST_POSTGRES_URL=postgresql+psycopg://postgres:mysecretpassword@127.0.0.1:5433/mcp uv run --with psycopg pytest tests/unit/mcpgateway/utils/test_pagination_team_visibility.py tests/unit/mcpgateway/db/test_visibility_listing_indexes_migration.py -q`
- `cd mcpgateway && uv run alembic heads`
- `git diff --check`
- fresh SQLite `python -m mcpgateway.bootstrap_db`
- fresh PostgreSQL `python -m mcpgateway.bootstrap_db` using local `postgres:18`

---

## 📓 Notes (optional)

PostgreSQL benchmark on a local 200k-row synthetic table with the reduced index surface and the production-style bare boolean predicate:

| Path | Mean | p95 |
| --- | ---: | ---: |
| Current OR predicate | 10.312 ms | 11.325 ms |
| Fast path | 4.807 ms | 5.567 ms |

The fast path is 2.15x faster by mean and 2.03x faster at p95 in this run.

The fast path keeps `_apply_access_control()` returning a filtered query. Fast-path metadata carries service-built visibility branch criteria, so visibility policy remains beside the service filter while pagination only executes the branch-limited query. The branch-limited subquery is derived from the final query passed to pagination, so later service filters are included before branch limits are applied. Final rows are still loaded through the normal scoped ORM query so existing eager-load options and visibility filters remain in force.

The new indexes are PostgreSQL-only and limited to the private owner/team branch. The migration sets a short `lock_timeout` so it fails fast rather than waiting indefinitely behind production writes; very large production tables can create the same indexes concurrently before running the migration.
