### PR TITLE
fix(api): add JSON support and RESTful endpoints for admin gateway CRUD operations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-28T15:39:50Z",
+  "generated_at": "2026-05-19T08:34:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,14 +89,6 @@
     ],
     ".env.example": [
       {
-        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
@@ -116,7 +108,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 690,
+        "line_number": 657,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +116,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 885,
+        "line_number": 852,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +124,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1125,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +132,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1198,
+        "line_number": 1151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +140,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1206,
+        "line_number": 1159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +148,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1285,
+        "line_number": 1238,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +156,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1290,
+        "line_number": 1243,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +164,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1248,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +172,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1301,
+        "line_number": 1254,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +180,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1313,
+        "line_number": 1266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +188,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1284,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +196,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1392,
+        "line_number": 1345,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -232,7 +224,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +232,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +240,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 211,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -256,7 +248,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 283,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -264,7 +256,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 284,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -274,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1336,
+        "line_number": 1217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1305,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1655,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3140,
+        "line_number": 3021,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3231,
+        "line_number": 3112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3274,
+        "line_number": 3155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3279,
+        "line_number": 3160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3284,
+        "line_number": 3165,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -350,7 +342,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 525,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 964,
+        "line_number": 993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1616,
+        "line_number": 1645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1835,
+        "line_number": 1864,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6360,
+        "line_number": 6302,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6857,
+        "line_number": 6799,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6869,
+        "line_number": 6811,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6941,
+        "line_number": 6883,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8022,
+        "line_number": 7964,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -994,47 +986,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 364,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 412,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 420,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 468,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1004,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1107,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +994,47 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 359,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 401,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 457,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 973,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1073,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1042,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1137,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1050,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1257,
+        "line_number": 1172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1066,7 +1058,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1796,
+        "line_number": 1711,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1066,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1873,
+        "line_number": 1788,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1074,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2189,
+        "line_number": 2104,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1082,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1090,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2561,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1098,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2659,
+        "line_number": 2574,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1106,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2722,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1114,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2828,
+        "line_number": 2743,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1122,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2836,
+        "line_number": 2751,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1130,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2841,
+        "line_number": 2756,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2412,7 +2404,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1210,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1214,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4257,6 +4249,82 @@
         "verified_result": null
       }
     ],
+    "mcp-servers/python/mcp_eval_server/test_all_providers.py": [
+      {
+        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "58e0b5360036b03c093c01fe6e95242a83b12ff7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3658a95db0b214e73694335448df084f979c526f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcp-servers/python/mcp_eval_server/validate_models.py": [
+      {
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 204,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "mcp-servers/python/output_schema_test_server/CURL_TESTING.md": [
       {
         "hashed_secret": "df82ebbbe5479d4e322f4c35f4740804751a53fa",
@@ -4264,6 +4332,40 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/admin.py": [
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4314,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4956,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4958,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 15586,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4277,17 +4379,657 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/alembic/versions/04cda6733305_add_admin_types_to_email_users.py": [
+      {
+        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/0f81d4a5efe0_new_table_email_team_member_history_for_.py": [
+      {
+        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/14ac971cee42_add_user_context_to_oauth_tokens.py": [
+      {
+        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py": [
+      {
+        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/1fc1795f6983_merge_a2a_and_custom_name_changes.py": [
+      {
+        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/34492f99a0c4_add_comprehensive_metadata_to_all_.py": [
+      {
+        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py": [
+      {
+        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/3b17fdc40a8d_add_passthrough_headers_to_gateways_and_.py": [
+      {
+        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/3c89a45f32e5_add_grpc_services_table.py": [
+      {
+        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/43c07ed25a24_add_oauth_fields_to_servers.py": [
+      {
+        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/4e6273136e56_normalize_registered_oauth_client_issuer.py": [
+      {
+        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/5f3c681b05e1_add_index_for_team_name.py": [
+      {
+        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/61ee11c482d6_add_code_verifier_to_oauth_states_for_.py": [
+      {
+        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/64acf94cb7f2_cleanup_inactive_duplicate_user_roles.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/733159a4fa74_add_display_name_to_tools.py": [
+      {
+        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/77243f5bfce5_add_tool_id_to_a2a_agents.py": [
+      {
+        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/8a16a77260f0_adding_original_description_column_to_.py": [
+      {
+        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/8a2934be50c0_rest_pass_api_fld_tools.py": [
+      {
+        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py": [
+      {
+        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/9f5d93ced2b3_add_llm_permissions_to_default_roles.py": [
+      {
+        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a23a08d61eb0_add_observability_tables.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a3c38b6c2437_fix_a2a_agents_auth_value.py": [
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a4f1c7d8e9b0_add_app_user_email_to_oauth_states.py": [
+      {
+        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/a8f3b2c1d4e5_add_gateway_refresh_fields.py": [
+      {
+        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/aac21d6f9522_merge_ca_cert_and_observability_heads.py": [
+      {
+        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/abf8ac3b6008_add_admin_overview_and_servers_use_to_.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/add_oauth_tokens_table.py": [
+      {
+        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/b2d9c6e4f1a7_add_explicit_team_and_token_permissions.py": [
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/b9e496e91e71_merge_gateway_refresh_and_sso_provider_.py": [
+      {
+        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/c96c11c111b4_create_index_on_user_name.py": [
+      {
+        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/cbedf4e580e0_add_tools_execute_to_viewer_role.py": [
+      {
+        "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/cfc3d6aa0fb2_consolidated_multiuser_team_rbac_.py": [
+      {
+        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/d9e0f1a2b3c4_change_token_uniqueness_to_per_team.py": [
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py": [
+      {
+        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e1f2a3b4c5d6_add_grant_source_to_user_roles.py": [
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e5a59c16e041_unique_const_changes_for_prompt_and_.py": [
+      {
+        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/eb17fd368f9d_merge_passthrough_headers_and_tags_.py": [
+      {
+        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/ee288b094280_add_auth_query_params_to_gateways.py": [
+      {
+        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f1a2b3c4d5e6_add_auth_query_params_to_a2a_agents.py": [
+      {
+        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f3a3a3d901b8_remove_gateway_url_unique_constraint.py": [
+      {
+        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/f8c9d3e2a1b4_add_oauth_config_to_gateways.py": [
+      {
+        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/g1a2b3c4d5e6_add_pagination_indexes.py": [
+      {
+        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py": [
+      {
+        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/i3c4d5e6f7g8_add_observability_performance_indexes.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/k5e6f7g8h9i0_add_structured_logging_tables.py": [
+      {
+        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/u5f6g7h8i9j0_add_provider_metadata_to_sso_providers.py": [
+      {
+        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/v1a2b3c4d5e6_assign_default_viewer_role_to_existing_users.py": [
+      {
+        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py": [
+      {
+        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/cache/session_registry.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 752,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
+    "mcpgateway/config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 249,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2933,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 80,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/llm_provider_configs.py": [
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 308,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 316,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/middleware/request_logging_middleware.py": [
+      {
+        "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -4313,12 +5055,48 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/routers/auth.py": [
+      {
+        "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/routers/email_auth.py": [
+      {
+        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 429,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 711,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/routers/oauth_router.py": [
       {
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 720,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4328,18 +5106,202 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4317,
+        "line_number": 4314,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5446,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5795,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5852,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5890,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5891,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/scripts/validate_env.py": [
+      {
+        "hashed_secret": "b0fb9e3dbf6beca57a1e203dddab80910598ec3d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/argon2_service.py": [
+      {
+        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/email_auth_service.py": [
+      {
+        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 669,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/services/mcp_client_chat_service.py": [
       {
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 526,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "94b778a67d72bc0e8fa5838e7fa48b37739a9e30",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 624,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 719,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 590,
+        "line_number": 1796,
         "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1809,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/oauth_manager.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "819ef87051ee2837fefbb462d846b8d282d3b756",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 110,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/observability_service.py": [
+      {
+        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/resource_service.py": [
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 366,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3526,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/sso_service.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 785,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/support_bundle_service.py": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -4348,7 +5310,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15099,
+        "line_number": 15051,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4358,7 +5320,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4366,7 +5328,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 193,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4374,7 +5336,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4382,7 +5344,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 586,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4394,6 +5356,70 @@
         "is_verified": false,
         "line_number": 667,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/toolops_altk_service.py": [
+      {
+        "hashed_secret": "772fabfec4c6f068c046e516ab0b946909697d32",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/utils/db_util.py": [
+      {
+        "hashed_secret": "e2eea31cf61d791c922b110554ce1f0a6ed046e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 178,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/toolops/utils/llm_util.py": [
+      {
+        "hashed_secret": "e6a51c968d41fd1d3437e6b7d9101e527ee1b83f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9c4006403b5388cd34ccfe3ed1b1d3e53cf35700",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d01e71e4c47a4022acd25c74bffedd2641a60c70",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 96,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "39fc8e4accd6a3563c4be159e507195ad3d7274c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/tools/builder/common.py": [
+      {
+        "hashed_secret": "2a1027e8abaef8567159c09ddca81604fb1ba8c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -4425,6 +5451,14 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 261,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
@@ -4433,7 +5467,87 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/utils/create_jwt_token.py": [
+      {
+        "hashed_secret": "2fcd9b91b955db1627d18720cb7395ef2893a497",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/generate_keys.py": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/services_auth.py": [
+      {
+        "hashed_secret": "a2fe5a0cdcbf2e84dbf868a11c5f2ca79f2d7b8d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 218,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/sso_bootstrap.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b44bf05d644c15c4d84f78771de011e3cce924c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "999a3419d9959d3c39b11dcc67d79c7888b4b765",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bacac952b5cb942687d38a9eda6531d570f88b22",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 85,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cd1ecfcd67c8b85800a483d77e550d36727e8925",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/utils/url_auth.py": [
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -4455,6 +5569,42 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 138,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/utils/verify_credentials.py": [
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 810,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/version.py": [
+      {
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 850,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 912,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4549,6 +5699,34 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 295,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "plugins/examples/custom_auth_example/custom_auth.py": [
+      {
+        "hashed_secret": "79acc7201378a3d075db4c3b716187b65d4369ba",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 260,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "plugins/examples/simple_token_auth/simple_token_auth.py": [
+      {
+        "hashed_secret": "8a9e9e42f8e154a255c1455267654ab4ec13528b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 157,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3d75cbdb604907851e109e4ced7161c178648532",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4733,6 +5911,16 @@
         "verified_result": null
       }
     ],
+    "scripts/demo_a2a_agent_auth.py": [
+      {
+        "hashed_secret": "e415dfafffe0c1859396cee8659521eaeb789ced",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "scripts/lib/common.sh": [
       {
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
@@ -4763,10 +5951,150 @@
     ],
     "scripts/test_email_auth_api.py": [
       {
+        "hashed_secret": "55ae024ac61278627948dc9375b31bbbbfd7b442",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 304,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 329,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0378e32875a5f7f922d2cce11b0741096d61c5f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8b5f2dff4edd3be66dd04ef8f9b6da4f6a4d0463",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 517,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1c5d7338a53cbdce0a6d26c4572e9725eb94ffc0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 530,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "673563640ec0c172e8d6f1316ae097269e3986c4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0269ac00d06201bd7bcf234fed607b713469d2d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 562,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 341,
+        "line_number": 753,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "scripts/test_mcp_client.py": [
+      {
+        "hashed_secret": "1ee61ed8e67eecf5f1e97c4786b6728b478b8fae",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "scripts/test_mcp_token_scoping.py": [
+      {
+        "hashed_secret": "ae28b10c8c7ef67658ef1de7b29ee23556a32eef",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 348,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/conftest.py": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_admin_apis.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_main_apis.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 766,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/e2e/test_oauth_protected_resource.py": [
+      {
+        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 59,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4776,7 +6104,55 @@
         "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 58,
+        "line_number": 62,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_dcr_flow_integration.py": [
+      {
+        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_integration.py": [
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 218,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_password_change_bypass.py": [
+      {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 94,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd85a682a37a0e311eaff728d69c0af050a68158",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_translate_dynamic_env.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4814,6 +6190,70 @@
         "is_verified": false,
         "line_number": 80,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile.py": [
+      {
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3780,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6623,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6979,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7003,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_baseline.py": [
+      {
+        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_echo_delay.py": [
+      {
+        "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/loadtest/locustfile_mcp_isolation.py": [
+      {
+        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4993,12 +6433,22 @@
         "verified_result": null
       }
     ],
+    "tests/migration/conftest.py": [
+      {
+        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 273,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "tests/migration/docker-compose.test.yml": [
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 18,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5006,8 +6456,18 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 35,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/migration/utils/container_manager.py": [
+      {
+        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 398,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -5057,6 +6517,26 @@
         "verified_result": null
       }
     ],
+    "tests/performance/test_postgresql_percentile_performance.py": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/performance/utils/generate_docker_compose.py": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "tests/playwright/README.md": [
       {
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
@@ -5083,12 +6563,42 @@
         "verified_result": null
       }
     ],
+    "tests/playwright/conftest.py": [
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 637,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/operations/test_llm_config.py": [
+      {
+        "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 137,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/playwright/pytest.ini": [
       {
         "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
         "is_secret": false,
         "is_verified": false,
         "line_number": 8,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/playwright/security/test_sso_management.py": [
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5103,63 +6613,3067 @@
         "verified_result": null
       }
     ],
+    "tests/playwright/test_agents.py": [
+      {
+        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 264,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/cleanup.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/populators/users.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/populate/verify.py": [
+      {
+        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/security/test_input_validation.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 288,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "120340c3d011e9621b9bb88b5884221b25251b88",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2070,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_a2a_agents_auth_value_migration.py": [
+      {
+        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_observability_migrations.py": [
+      {
+        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_rbac_permission_backfill_migration.py": [
+      {
+        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/db/test_token_uniqueness_migration.py": [
+      {
+        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_auth_method_propagation.py": [
+      {
+        "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_http_auth_headers.py": [
+      {
+        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "35e6ca489e73a8991165cdcfc2b79eb0d25ed0a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 105,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "59df6723fb54fd8dde6dcf51034e51491bfbff24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 947,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 955,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_http_auth_integration.py": [
+      {
+        "hashed_secret": "6f865e7e20c773e3483eaa74a07d03cec02bde2e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 159,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 180,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 250,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 262,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 443,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 464,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 502,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 658,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_rbac.py": [
+      {
+        "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1397,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1484,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/middleware/test_request_logging_middleware.py": [
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 116,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 214,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation.py": [
+      {
+        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 199,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation_integration.py": [
+      {
+        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 260,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 323,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py": [
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "83ff9f4e0d16d61727cbdf47d769fb707b652217",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 462,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py": [
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/virus_total_checker/test_virus_total_checker.py": [
+      {
+        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 403,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_integration.py": [
+      {
+        "hashed_secret": "a8ae1520ce69381a9cf8dbd5082d8512fcace493",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_notification.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 186,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_auth.py": [
+      {
+        "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 353,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_email_auth_router.py": [
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 206,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 566,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 724,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1488,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1557,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1661,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1692,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1709,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1743,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2202,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_llm_admin_router.py": [
+      {
+        "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 550,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 558,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_llmchat_router.py": [
+      {
+        "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 132,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_oauth_router.py": [
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 373,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2151,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_reverse_proxy.py": [
+      {
+        "hashed_secret": "c56486f8b638f63e04251d0c8ab0b4fbfee8e06b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 796,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/routers/test_teams.py": [
+      {
+        "hashed_secret": "1e418031f4ec8505cff3cde4f41efc0ee83ec2d1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 321,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_a2a_query_param_auth.py": [
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 279,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 344,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 345,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 432,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 563,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_a2a_service.py": [
+      {
+        "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 217,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 218,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 413,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 414,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 450,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 477,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 829,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 831,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2445,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2454,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3314,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3475,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3507,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_argon2_service.py": [
+      {
+        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4be80aee9bf2223071eedfc002ba2546abd1f5ea",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 487,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 538,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_async_crypto_wrappers.py": [
+      {
+        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 74,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d4bb297c014026ace455b1ad5926033d795bf016",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_catalog_service.py": [
+      {
+        "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 578,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_correlation_id_json_formatter.py": [
+      {
+        "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 135,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 136,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_dcr_service.py": [
+      {
+        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 453,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 699,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 834,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_basic.py": [
+      {
+        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "927ab42cfc3a3f3409f66221d8e37442f3b188e3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 691,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d076928bfade831b34f9af755506cd06e8b4dd1b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 718,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 923,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 955,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1030,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1244,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "39d0a63a567ae11fcf8695abfe19656aa1cbc0ed",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1303,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f302e5128922d4e7acf42d7e22f95a2f001eb14d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1524,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1597,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "18d2caf3d1bac7ecb05d4e510dd021477ab55b9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1622,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a4c1e340613dfefc9b4d4980394879d136e2fbc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1664,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1681,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b94e256b5a8102d04799792b284dc44dd58b6609",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2392,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b0ee0c442a1a6ea3ecce064786c038eb5c285c24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3152,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3331f962763e9b59c985f0c18407811ccee92e72",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3187,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f13d82146ff9aa3b08420f15eec4c7a5aab44769",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3221,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_service.py": [
+      {
+        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 366,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4cf5ead1df6b23c1309a1eac48fe32ffc6c9ab1d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 395,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
+      {
+        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dff88ddbf282dc1477e1e419a7706371e7afba27",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 321,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79caf88021d840cf3544d1aae14ae84f58310f8f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 365,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f71ca03855f95d7df834ece97c9e09fc34ce89b9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 493,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_email_notification_service.py": [
+      {
+        "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 155,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_encryption_service.py": [
+      {
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 378,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 380,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 418,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 419,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 420,
+        "type": "AWS Access Key",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 734,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 735,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 797,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 798,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 819,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_export_service.py": [
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1162,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6578fca8b62f49457e4cd7e66554a310a1a64be8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1753,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_query_param_auth.py": [
+      {
+        "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 203,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 227,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service.py": [
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 639,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 640,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1528,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5185,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6731,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7328,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7347,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7553,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7572,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_extended.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 183,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py": [
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 502,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py": [
+      {
+        "hashed_secret": "ee131046fbfad0f5fac08926f9b928539da950cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 616,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 638,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_import_service.py": [
+      {
+        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 288,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 491,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1390,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1543,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1554,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2384,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2401,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2550,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_llm_provider_service.py": [
+      {
+        "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 275,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 545,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 555,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 773,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 779,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_llm_proxy_service.py": [
+      {
+        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 440,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 453,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 466,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_mcp_client_chat_service.py": [
+      {
+        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 69,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 123,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 146,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 165,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
+      {
+        "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 266,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 346,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 821,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1229,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1335,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1412,
+        "line_number": 1601,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_metrics.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 169,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
+      {
+        "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 516,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 535,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 624,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 847,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 923,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 926,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager_pkce.py": [
+      {
+        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 371,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_observability_service.py": [
+      {
+        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 410,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 411,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_resource_service.py": [
       {
+        "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4133,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 883,
+        "line_number": 4831,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_server_service.py": [
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1494,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1495,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1635,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1636,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "498e738c70c40fb156a240d26f866f2d50e9cb51",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1848,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a6bf0a0e01efe836c52ef316f030bf50ac2f716c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1866,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_sso_service.py": [
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 177,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 198,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 335,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_support_bundle_service.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 83,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 107,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 197,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 211,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 254,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_token_storage_service.py": [
+      {
+        "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 337,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 545,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_tool_service.py": [
+      {
+        "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 548,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 549,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 565,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1984,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3570,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4204,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7588,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8080,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9427,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9571,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10052,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_tool_service_coverage.py": [
+      {
+        "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2985,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3671,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3680,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4130,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7057,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7075,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7099,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7163,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7174,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7215,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7221,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8415,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10670,
-        "type": "Hex High Entropy String",
+        "line_number": 1605,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1777,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5536,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6189,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6271,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6527,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9634,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9683,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9722,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9779,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14850,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17682,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17701,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_admin_catalog_htmx.py": [
+      {
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 239,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_admin_module.py": [
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 451,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1106,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_auth.py": [
       {
+        "hashed_secret": "b5920aa41ccde1341077fdb2636afc16d6da0e1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "467be688b21f5d43370f5dc983fe5ed58dea4b00",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d955debea8e960a293ecbb257048680898cc9d94",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 231,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ee9e7b8482f6e0282b0117eb81651c98b537589",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 282,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "500886a66d19ebfe2d5c0ee86cf4612f9458ee4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 355,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2169f1a808382eb7b521206debaef01c91f1b60",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 394,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cd61d9f689e9992aec40aeec7210b45a681309f9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 428,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae97d9e9201a9bc1806069d80e5809ab745a91e8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 463,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eb2344b0e2d6529ced74f8b09be362a460defa15",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 500,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "89be7e8e88bc7b0cdb5ddaa01dab1cd1728541e2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 564,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5a539b200edec3aaa5167e1cde5d8fd0e8cf4aee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 577,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8be6db326ca95f74590bd09c9c328fc9a3db3b6c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 715,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2368055dc74fca43f2f9c849dbbaaa04616670cf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 764,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8ce647089e0614d3b924f4a0b8fb78268562ec7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1453,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dc6f6cc49f767ae38db110a9e6c1adf5c651ecbf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1497,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7939ea1cdfc6d73115b0d736fa04012be2b25b18",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1588,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "91014bcbf183cf77807b4bd24f2e8652f67b56a0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2096,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61ac75f7e6677b79c219ce819d954e05f61b5d2c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8223fafd35f399e55c3cf611c3d6ebbf43d68d71",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2760,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "dfd99b5f25f839608a3c275c0f8ceb363f8f0bc0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3555,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2716,
+        "line_number": 3664,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f5cd573c18bf811f82a886ceb6866b05d5ef02cd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3742,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "79bead8e6d65862a00cffaa12ccde1189ec34d29",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4125,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_cli_export_import_coverage.py": [
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 685,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_config.py": [
+      {
+        "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 256,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 640,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 653,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 659,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 728,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 788,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1158,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1410,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_db.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2407,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_db_isready.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 72,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 224,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_display_name_uuid_features.py": [
+      {
+        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 620,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 621,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_final_coverage_push.py": [
+      {
+        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 200,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_llm_schemas.py": [
+      {
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_main.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 68,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 152,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 165,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "759ea996d3686cbca80b6d412c3cee3faf60c272",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3821,
+        "type": "JSON Web Token",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_main_error_handlers.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_main_extended.py": [
       {
+        "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2630,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2919,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_multi_auth_headers.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 298,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_oauth_manager.py": [
       {
+        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 70,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1313,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1540,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1484,
+        "line_number": 2008,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_observability.py": [
+      {
+        "hashed_secret": "8f1b63868b5d31deb06a0ff740b192aa490e8950",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 373,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1fb844731bf1e5928ae606915b54e21264da4768",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 802,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_password_policy.py": [
+      {
+        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas.py": [
+      {
+        "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1292,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas_auth_validation.py": [
+      {
+        "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 339,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 358,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 377,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 388,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_schemas_validators_extra.py": [
+      {
+        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 779,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 975,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 980,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1006,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1024,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1235,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1351,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_team_governance_flags.py": [
+      {
+        "hashed_secret": "8ac21c6ecda35ffb18d58264aeb43ca800b3d758",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 586,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_toolops_utils.py": [
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 141,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_translate_stdio_endpoint.py": [
+      {
+        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 276,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_version.py": [
+      {
+        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 210,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/tools/builder/test_common.py": [
+      {
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 673,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 961,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/tools/builder/test_schema.py": [
+      {
+        "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 172,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/transports/test_streamablehttp_transport.py": [
+      {
+        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13172,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14347,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_create_jwt_token.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_db_isready.py": [
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_generate_keys.py": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_proxy_auth.py": [
+      {
+        "hashed_secret": "b2d898cda25886738c0cd002eb080745b09e2332",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_sso_bootstrap.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 379,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 463,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_trace_redaction.py": [
+      {
+        "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_url_auth.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 66,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 154,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 156,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 216,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/utils/test_verify_credentials.py": [
+      {
+        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "29534257453ead25854695b1b7c95e3857a7238d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 114,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1045,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1194,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/validation/test_validators_advanced.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1142,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/plugins/test_encoded_exfil_detector.py": [
+      {
+        "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 140,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 453,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 497,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 510,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 879,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/plugins/test_jwt_claims_extraction.py": [
+      {
+        "hashed_secret": "dccfe30496fb85f5bb560ea18b582b9aa50372bb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/plugins/test_secrets_detection.py": [
+      {
+        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 149,
+        "type": "AWS Access Key",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/test_conc_01_helpers.py": [
+      {
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 167,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-02T09:51:15Z",
+  "generated_at": "2026-06-02T11:09:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5125,10 +5125,18 @@
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10823,
+        "line_number": 11229,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-19T08:34:28Z",
+  "generated_at": "2026-06-02T09:51:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -89,6 +89,14 @@
     ],
     ".env.example": [
       {
+        "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
@@ -108,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 657,
+        "line_number": 690,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -116,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 885,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -124,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1125,
+        "line_number": 1172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1151,
+        "line_number": 1198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1159,
+        "line_number": 1206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 1285,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1243,
+        "line_number": 1290,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1248,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1254,
+        "line_number": 1301,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1266,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1345,
+        "line_number": 1392,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -224,7 +232,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 120,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -232,7 +240,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 209,
+        "line_number": 217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +248,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 211,
+        "line_number": 219,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +256,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 291,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -256,7 +264,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 284,
+        "line_number": 292,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -266,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1217,
+        "line_number": 1336,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1305,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1655,
+        "line_number": 1774,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3021,
+        "line_number": 3140,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3112,
+        "line_number": 3231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3155,
+        "line_number": 3274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3160,
+        "line_number": 3279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3165,
+        "line_number": 3284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -342,7 +350,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 525,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +358,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 991,
+        "line_number": 962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +366,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 993,
+        "line_number": 964,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +374,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +382,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1864,
+        "line_number": 1835,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6302,
+        "line_number": 6360,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6799,
+        "line_number": 6857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6811,
+        "line_number": 6869,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6883,
+        "line_number": 6941,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7964,
+        "line_number": 8022,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -986,15 +994,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 359,
+        "line_number": 364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 412,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 457,
+        "line_number": 468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 973,
+        "line_number": 1004,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,15 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1073,
+        "line_number": 1107,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1050,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1137,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1058,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1066,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1711,
+        "line_number": 1796,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1066,7 +1074,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1788,
+        "line_number": 1873,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2104,
+        "line_number": 2189,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2561,
+        "line_number": 2646,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1090,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2561,
+        "line_number": 2646,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1098,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2574,
+        "line_number": 2659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1106,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2722,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2743,
+        "line_number": 2828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2751,
+        "line_number": 2836,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2756,
+        "line_number": 2841,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2404,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1210,
+        "line_number": 1218,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2412,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1214,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4249,82 +4257,6 @@
         "verified_result": null
       }
     ],
-    "mcp-servers/python/mcp_eval_server/test_all_providers.py": [
-      {
-        "hashed_secret": "69dba6dfc0be932d10cdbfaae770c300cd7e0e3c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "58e0b5360036b03c093c01fe6e95242a83b12ff7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "60dae6886103a20b3fd75814ece38eb861246083",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 54,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 57,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61590b1c314aea752829602c7e0d653e51d52738",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3658a95db0b214e73694335448df084f979c526f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcp-servers/python/mcp_eval_server/validate_models.py": [
-      {
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 204,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 207,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "mcp-servers/python/output_schema_test_server/CURL_TESTING.md": [
       {
         "hashed_secret": "df82ebbbe5479d4e322f4c35f4740804751a53fa",
@@ -4332,40 +4264,6 @@
         "is_verified": false,
         "line_number": 15,
         "type": "JSON Web Token",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/admin.py": [
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4314,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "559b05f1b2863e725b76e216ac3dadecbf92e244",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4956,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a8af4759392d4f7496d613174f33afe2074a4b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4958,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "85b60d811d16ff56b3654587d4487f713bfa33b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 15586,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4379,657 +4277,17 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/alembic/versions/04cda6733305_add_admin_types_to_email_users.py": [
-      {
-        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/0f81d4a5efe0_new_table_email_team_member_history_for_.py": [
-      {
-        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/14ac971cee42_add_user_context_to_oauth_tokens.py": [
-      {
-        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/191a2def08d7_resource_rename_template_to_uri_template.py": [
-      {
-        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/1fc1795f6983_merge_a2a_and_custom_name_changes.py": [
-      {
-        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/34492f99a0c4_add_comprehensive_metadata_to_all_.py": [
-      {
-        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/356a2d4eed6f_uuid_change_for_prompt_and_resources.py": [
-      {
-        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/3b17fdc40a8d_add_passthrough_headers_to_gateways_and_.py": [
-      {
-        "hashed_secret": "044c1c4f5cc1f89969f46018b2bacbe8918aaf1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/3c89a45f32e5_add_grpc_services_table.py": [
-      {
-        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/43c07ed25a24_add_oauth_fields_to_servers.py": [
-      {
-        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/4e6273136e56_normalize_registered_oauth_client_issuer.py": [
-      {
-        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/5f3c681b05e1_add_index_for_team_name.py": [
-      {
-        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/61ee11c482d6_add_code_verifier_to_oauth_states_for_.py": [
-      {
-        "hashed_secret": "aeaf4ea9e7c81ad714da7db03735fd1d053414c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/64acf94cb7f2_cleanup_inactive_duplicate_user_roles.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/733159a4fa74_add_display_name_to_tools.py": [
-      {
-        "hashed_secret": "b6d082a6cc1261d009b34cddd19dca4828f1cb7d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/77243f5bfce5_add_tool_id_to_a2a_agents.py": [
-      {
-        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/8a16a77260f0_adding_original_description_column_to_.py": [
-      {
-        "hashed_secret": "10b36c8089b5791d82f0700828fd23a9c782101f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/8a2934be50c0_rest_pass_api_fld_tools.py": [
-      {
-        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py": [
-      {
-        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9f5d93ced2b3_add_llm_permissions_to_default_roles.py": [
-      {
-        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a23a08d61eb0_add_observability_tables.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a3c38b6c2437_fix_a2a_agents_auth_value.py": [
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 37,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a4f1c7d8e9b0_add_app_user_email_to_oauth_states.py": [
-      {
-        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99927e177522cd7b4b713ac9fe99968d2f71b829",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/a8f3b2c1d4e5_add_gateway_refresh_fields.py": [
-      {
-        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/aac21d6f9522_merge_ca_cert_and_observability_heads.py": [
-      {
-        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/abf8ac3b6008_add_admin_overview_and_servers_use_to_.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 37,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/add_oauth_tokens_table.py": [
-      {
-        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/b2d9c6e4f1a7_add_explicit_team_and_token_permissions.py": [
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ebf53ef06815a59e9fd0378d3a19dff8b0ac28a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/b9e496e91e71_merge_gateway_refresh_and_sso_provider_.py": [
-      {
-        "hashed_secret": "19c9ebc4037f02acb15d950b258d51e9eb249966",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/c96c11c111b4_create_index_on_user_name.py": [
-      {
-        "hashed_secret": "21562fcd9707470b4fa7cec05458e86caeb25fda",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/cbedf4e580e0_add_tools_execute_to_viewer_role.py": [
-      {
-        "hashed_secret": "f89c8b868b1f89c02134b0cae17608852b6ec609",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 33,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2e6b7b27cad43ed0908be745231a98936aad5293",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/cfc3d6aa0fb2_consolidated_multiuser_team_rbac_.py": [
-      {
-        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/d9e0f1a2b3c4_change_token_uniqueness_to_per_team.py": [
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 35,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e182847d89e6_unique_constraints_changes_for_gateways_.py": [
-      {
-        "hashed_secret": "8e70fb96660fbce85c4be348188c03c3d98a5e95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f216ad54219955ae0c4c306010eee4c60b0ec6e1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e1f2a3b4c5d6_add_grant_source_to_user_roles.py": [
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e5a59c16e041_unique_const_changes_for_prompt_and_.py": [
-      {
-        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c84583fef8c1325676bd098d09cfc64f185792f7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/eb17fd368f9d_merge_passthrough_headers_and_tags_.py": [
-      {
-        "hashed_secret": "9743f9059c52643b7cc917663462e853fb36f69d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/ee288b094280_add_auth_query_params_to_gateways.py": [
-      {
-        "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f1a2b3c4d5e6_add_auth_query_params_to_a2a_agents.py": [
-      {
-        "hashed_secret": "2d40811ded1703d949aca3c40d77175a5c568c05",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f3a3a3d901b8_remove_gateway_url_unique_constraint.py": [
-      {
-        "hashed_secret": "0c1c30eba610778ef5e68a58883a052733a22bd4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74cf584eb4fffdfa472c808000adb71841786f3e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/f8c9d3e2a1b4_add_oauth_config_to_gateways.py": [
-      {
-        "hashed_secret": "3333a8285ac54459f46f2ef561184275586dd1a7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/g1a2b3c4d5e6_add_pagination_indexes.py": [
-      {
-        "hashed_secret": "81d89c741bbf0978e92cb9852870242cc88c7db2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/h2b3c4d5e6f7_add_oauth_config_to_a2a_agents.py": [
-      {
-        "hashed_secret": "83af00f2e79329f549c1438dec118e0cba4ad111",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/i3c4d5e6f7g8_add_observability_performance_indexes.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/k5e6f7g8h9i0_add_structured_logging_tables.py": [
-      {
-        "hashed_secret": "c81482140a7bf22e957d89f358479e90adef80dc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/u5f6g7h8i9j0_add_provider_metadata_to_sso_providers.py": [
-      {
-        "hashed_secret": "e6ec1410341b496819aeb85882509889c33017af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/v1a2b3c4d5e6_assign_default_viewer_role_to_existing_users.py": [
-      {
-        "hashed_secret": "c052f9f7b5b94886b423384e4938ed8388cd77b4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/z1a2b3c4d5e6_add_password_change_required.py": [
-      {
-        "hashed_secret": "36b0556065adc2fdd8a15b7ffac028a043c34595",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/cache/session_registry.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/common/validators.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 753,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
-    "mcpgateway/config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 249,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff37a98a9963d347e9749a5c1b3936a4a245a6ff",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2933,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 80,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/llm_provider_configs.py": [
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 308,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 316,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/middleware/request_logging_middleware.py": [
-      {
-        "hashed_secret": "e9fe51f94eadabf54dbf2fbbd57188b9abee436e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -5055,48 +4313,12 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/routers/auth.py": [
-      {
-        "hashed_secret": "aa1a82fe15c74459f1261961b07ae924e2b94ab2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 202,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/routers/email_auth.py": [
-      {
-        "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 428,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 429,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 711,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/routers/oauth_router.py": [
       {
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 720,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5106,202 +4328,18 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4314,
+        "line_number": 4317,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5446,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5795,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5852,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b85788b459aa4d67e1070930dae6d0827756aadb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5890,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5891,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/scripts/validate_env.py": [
-      {
-        "hashed_secret": "b0fb9e3dbf6beca57a1e203dddab80910598ec3d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/argon2_service.py": [
-      {
-        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/email_auth_service.py": [
-      {
-        "hashed_secret": "f42a3fabe1e9bed059d727f47eb752e3aa61b977",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 669,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "mcpgateway/services/mcp_client_chat_service.py": [
       {
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 526,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "94b778a67d72bc0e8fa5838e7fa48b37739a9e30",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 624,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 719,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1157,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1796,
+        "line_number": 590,
         "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1809,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/oauth_manager.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 107,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "819ef87051ee2837fefbb462d846b8d282d3b756",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 110,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/observability_service.py": [
-      {
-        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/resource_service.py": [
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 366,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3526,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/sso_service.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 785,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/support_bundle_service.py": [
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 157,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5310,7 +4348,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15051,
+        "line_number": 15099,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5320,7 +4358,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5328,7 +4366,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 193,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5336,7 +4374,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 221,
+        "line_number": 223,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -5344,7 +4382,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 586,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5356,70 +4394,6 @@
         "is_verified": false,
         "line_number": 667,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/toolops_altk_service.py": [
-      {
-        "hashed_secret": "772fabfec4c6f068c046e516ab0b946909697d32",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 283,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/utils/db_util.py": [
-      {
-        "hashed_secret": "e2eea31cf61d791c922b110554ce1f0a6ed046e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 178,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/toolops/utils/llm_util.py": [
-      {
-        "hashed_secret": "e6a51c968d41fd1d3437e6b7d9101e527ee1b83f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 67,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9c4006403b5388cd34ccfe3ed1b1d3e53cf35700",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 81,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d01e71e4c47a4022acd25c74bffedd2641a60c70",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 96,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "39fc8e4accd6a3563c4be159e507195ad3d7274c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/tools/builder/common.py": [
-      {
-        "hashed_secret": "2a1027e8abaef8567159c09ddca81604fb1ba8c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 428,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5451,14 +4425,6 @@
         "verified_result": null
       },
       {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 261,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
@@ -5467,87 +4433,7 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/utils/create_jwt_token.py": [
-      {
-        "hashed_secret": "2fcd9b91b955db1627d18720cb7395ef2893a497",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 36,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/generate_keys.py": [
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 89,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/services_auth.py": [
-      {
-        "hashed_secret": "a2fe5a0cdcbf2e84dbf868a11c5f2ca79f2d7b8d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/sso_bootstrap.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 43,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b44bf05d644c15c4d84f78771de011e3cce924c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "999a3419d9959d3c39b11dcc67d79c7888b4b765",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bacac952b5cb942687d38a9eda6531d570f88b22",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 85,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cd1ecfcd67c8b85800a483d77e550d36727e8925",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 99,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/utils/url_auth.py": [
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -5569,42 +4455,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 138,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 203,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/utils/verify_credentials.py": [
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 810,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/version.py": [
-      {
-        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 850,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9addbf544119efa4a64223b649750a510f0d463f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 912,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5699,34 +4549,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 295,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "plugins/examples/custom_auth_example/custom_auth.py": [
-      {
-        "hashed_secret": "79acc7201378a3d075db4c3b716187b65d4369ba",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 260,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "plugins/examples/simple_token_auth/simple_token_auth.py": [
-      {
-        "hashed_secret": "8a9e9e42f8e154a255c1455267654ab4ec13528b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 157,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3d75cbdb604907851e109e4ced7161c178648532",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5911,16 +4733,6 @@
         "verified_result": null
       }
     ],
-    "scripts/demo_a2a_agent_auth.py": [
-      {
-        "hashed_secret": "e415dfafffe0c1859396cee8659521eaeb789ced",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 45,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "scripts/lib/common.sh": [
       {
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
@@ -5951,150 +4763,10 @@
     ],
     "scripts/test_email_auth_api.py": [
       {
-        "hashed_secret": "55ae024ac61278627948dc9375b31bbbbfd7b442",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 304,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 329,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0378e32875a5f7f922d2cce11b0741096d61c5f2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8b5f2dff4edd3be66dd04ef8f9b6da4f6a4d0463",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 517,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1c5d7338a53cbdce0a6d26c4572e9725eb94ffc0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 530,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "673563640ec0c172e8d6f1316ae097269e3986c4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 538,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0269ac00d06201bd7bcf234fed607b713469d2d0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 562,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "scripts/test_mcp_client.py": [
-      {
-        "hashed_secret": "1ee61ed8e67eecf5f1e97c4786b6728b478b8fae",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 30,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "scripts/test_mcp_token_scoping.py": [
-      {
-        "hashed_secret": "ae28b10c8c7ef67658ef1de7b29ee23556a32eef",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 325,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 348,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/conftest.py": [
-      {
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 154,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 203,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_admin_apis.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 60,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_main_apis.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4dfad2d5130a5bcaf2716c495de92da13f4389e0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 766,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/e2e/test_oauth_protected_resource.py": [
-      {
-        "hashed_secret": "ba9cdae9b74942b8ac45ec20dfc3803a07fe6de9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 59,
+        "line_number": 341,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6104,55 +4776,7 @@
         "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_dcr_flow_integration.py": [
-      {
-        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 149,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_integration.py": [
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_password_change_bypass.py": [
-      {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 94,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fd85a682a37a0e311eaff728d69c0af050a68158",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 154,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_translate_dynamic_env.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
+        "line_number": 58,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6190,70 +4814,6 @@
         "is_verified": false,
         "line_number": 80,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile.py": [
-      {
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3780,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d73bccb432c5c7b1b166cfa603b3b99af63fd580",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6623,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "20d22126242b5c7e253d84dd6ff0ed7a6d2662a2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6979,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7003,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_baseline.py": [
-      {
-        "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 87,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_echo_delay.py": [
-      {
-        "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/loadtest/locustfile_mcp_isolation.py": [
-      {
-        "hashed_secret": "07b7b454e840ca79e1582edcf973b051fc56e079",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -6433,22 +4993,12 @@
         "verified_result": null
       }
     ],
-    "tests/migration/conftest.py": [
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 273,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "tests/migration/docker-compose.test.yml": [
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -6456,18 +5006,8 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 34,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/migration/utils/container_manager.py": [
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 398,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -6517,26 +5057,6 @@
         "verified_result": null
       }
     ],
-    "tests/performance/test_postgresql_percentile_performance.py": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 63,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/performance/utils/generate_docker_compose.py": [
-      {
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 74,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "tests/playwright/README.md": [
       {
         "hashed_secret": "0df7be1bea60575a7469f5e07e13124ce428d263",
@@ -6563,42 +5083,12 @@
         "verified_result": null
       }
     ],
-    "tests/playwright/conftest.py": [
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 637,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/operations/test_llm_config.py": [
-      {
-        "hashed_secret": "2a3575e3c0abe9772b3f98c92e7d530d7f131514",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 137,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/playwright/pytest.ini": [
       {
         "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
         "is_secret": false,
         "is_verified": false,
         "line_number": 8,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/playwright/security/test_sso_management.py": [
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 41,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -6613,3067 +5103,63 @@
         "verified_result": null
       }
     ],
-    "tests/playwright/test_agents.py": [
-      {
-        "hashed_secret": "03f5e2d670af3e9183f3fe790785b0d41291a17d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 264,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/cleanup.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 47,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/populators/users.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/populate/verify.py": [
-      {
-        "hashed_secret": "c871a5b8b2e511a525b09edea0b9a4d9f46401e5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 125,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/security/test_input_validation.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 288,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "120340c3d011e9621b9bb88b5884221b25251b88",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2070,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_a2a_agents_auth_value_migration.py": [
-      {
-        "hashed_secret": "52294c20155b397fbf140baa0cfb6d9400c82c25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 28,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b094435d625c9385a1bb083604f87fa7c225da0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 29,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_observability_migrations.py": [
-      {
-        "hashed_secret": "9d88d7eece452a76b2955ecfbb251f23cf7b7905",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 126,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_rbac_permission_backfill_migration.py": [
-      {
-        "hashed_secret": "dc7c15edd98c7c7ce4cd107fb4ccb17329510002",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/db/test_token_uniqueness_migration.py": [
-      {
-        "hashed_secret": "45fc9ab5f41816c6979df8bc85ffdc160a0e696a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c4770f062e9bfa8ec054475f98315913da1d16fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 26,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_auth_method_propagation.py": [
-      {
-        "hashed_secret": "e7c4d1ba7ce017155823536efd57843fa15ef759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_http_auth_headers.py": [
-      {
-        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 83,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "35e6ca489e73a8991165cdcfc2b79eb0d25ed0a3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 105,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "59df6723fb54fd8dde6dcf51034e51491bfbff24",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 947,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 955,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_http_auth_integration.py": [
-      {
-        "hashed_secret": "6f865e7e20c773e3483eaa74a07d03cec02bde2e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 159,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 180,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 250,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 262,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4155f3a6f21409ec6066b6c974b058d3ea4a2c5c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 443,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "84a36e47e8bfcca13318bca53cdcb1270e2c4b9e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 464,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c48ea9182291ca3f527914fd7d35a698830931d0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 502,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "534c8ebac109fde87e1eb0c6e35249fc8a38278a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 658,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_rbac.py": [
-      {
-        "hashed_secret": "ab73a3eaca01a7059dcdff6f95556ec7fd83de96",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1397,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "92dd4a2de441b63e6ac51fdb81a05a416dffd182",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1484,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/middleware/test_request_logging_middleware.py": [
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 116,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 117,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 214,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation.py": [
-      {
-        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 40,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 199,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/content_moderation/test_content_moderation_integration.py": [
-      {
-        "hashed_secret": "0bc02c6c973caffbda3e15adcb2f39c41634c728",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 260,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8cdf8b16b80c4f3f6e6af135b3c72efd706723c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 323,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/header_filter/test_header_filter_plugin.py": [
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 417,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "83ff9f4e0d16d61727cbdf47d769fb707b652217",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 462,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/tools_telemetry_exporter/test_tools_telemetry_exporter.py": [
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 63,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cc84fa5a361f86a589169fde1e4e6d62bc786e6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 144,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/virus_total_checker/test_virus_total_checker.py": [
-      {
-        "hashed_secret": "829c3804401b0727f70f73d4415e162400cbe57b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 403,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_integration.py": [
-      {
-        "hashed_secret": "a8ae1520ce69381a9cf8dbd5082d8512fcace493",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 202,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/plugins/plugins/webhook_notification/test_webhook_notification.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 100,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 186,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_auth.py": [
-      {
-        "hashed_secret": "6eb67d95dba1a614971e31e78146d44bd4a3ada3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 192,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 353,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_email_auth_router.py": [
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 206,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de14fdc5a7f3843d8db79053625a2169a4eed921",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 566,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f3e12d2b914fae6510cff60e40b097c0962654a1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 724,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e6b6afbd6d76bb5d2041542d7d2e3fac5bb05593",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1488,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "23ace7331ef30c45051de4e683719db7391b9980",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1557,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6aa6f10deee84f739ae8aca12a2755a2d0e103ac",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1661,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e577bc0464e5dd0052fc9ab532b0630e58173f92",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1692,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ef7d0dca079f43e7952971148dfaba10fbcce609",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1709,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "789b49606c321c8cf228d17942608eff0ccc4171",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1743,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc8002865f92070749b264e76045b04fa3b8de71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2202,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_llm_admin_router.py": [
-      {
-        "hashed_secret": "f7a75342741955b2b9b66b55a78e5061f321ff44",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 550,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61ba747fe2f5b3d513c40550084c6284fbbc1094",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 558,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_llmchat_router.py": [
-      {
-        "hashed_secret": "baf4e5770bde2def49611ed9c852b518038db759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 132,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_oauth_router.py": [
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 373,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2151,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_reverse_proxy.py": [
-      {
-        "hashed_secret": "c56486f8b638f63e04251d0c8ab0b4fbfee8e06b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 796,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/routers/test_teams.py": [
-      {
-        "hashed_secret": "1e418031f4ec8505cff3cde4f41efc0ee83ec2d1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 321,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_a2a_query_param_auth.py": [
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 279,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f4cbfd23b14432ac406aacc683f2a6485e52f356",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 344,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f5e6c51ff9f3703a753cde41e4cc8f506bc809db",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 345,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6108f529090a823e5cbaefba71604ccecc021ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 432,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e3de258032685ca3a157e704090921039ff7f0b3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 563,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_a2a_service.py": [
-      {
-        "hashed_secret": "41db7c65f665e40b44178f95f5f86473ca17160e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 99,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 217,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 413,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "94c9325c8ade4f6327d87e240713c2fd7fdbfc63",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 414,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7bb0c6efd2edb1ae20dab6dd260895ad8895e07e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 450,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ddbeee31dc29b74fcede0bea4d3fc5276d9148c8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 477,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "122758dd535bc6d246f36a686b29c7c40fab1315",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 829,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fa727f587e9f6115da6d4eb600dd8b6fe06cf69a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 831,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "250cdef3ce09000fa9a939a13e5f73433d96a852",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2445,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2454,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3314,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a343c9b5b1abfcf385d5c6f6dc0282f4d88a416e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3475,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3507,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_argon2_service.py": [
-      {
-        "hashed_secret": "f13733f6dd9f1ed3118e2da31428c71eab5ffd99",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 79,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 152,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4be80aee9bf2223071eedfc002ba2546abd1f5ea",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 230,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 388,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 487,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 538,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_async_crypto_wrappers.py": [
-      {
-        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 44,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 74,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d4bb297c014026ace455b1ad5926033d795bf016",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 98,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d512cc3d1a73d1f0a7331746483447a60b9bd98",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 112,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_catalog_service.py": [
-      {
-        "hashed_secret": "816cc20437d859538736e1ef46558b7bda486c06",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 578,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_correlation_id_json_formatter.py": [
-      {
-        "hashed_secret": "125fbc14773f228e72f16d55be21bad750d30b19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 135,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ff998abc1ce6d8f01a675fa197368e44c8916e9c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 136,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_dcr_service.py": [
-      {
-        "hashed_secret": "352b2a4120b46b2e0221e753a1272cd34a6aa0da",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 453,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 699,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 834,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_basic.py": [
-      {
-        "hashed_secret": "5a0aee0f3af308cd6d74d617fde6592c2bc94fa3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 276,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "927ab42cfc3a3f3409f66221d8e37442f3b188e3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 691,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d076928bfade831b34f9af755506cd06e8b4dd1b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 718,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8662cfb96bd9c7fe84c31d76819ec3a92c80e63",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 923,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b5bc013af872265e389b3abee36dd4932a206ab8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 955,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "be57d8e1a2a7a4e5c034e7790659309f5e5539c0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1030,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b4edd1d6f455752e0b214407e561d8d3823204fe",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1244,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "39d0a63a567ae11fcf8695abfe19656aa1cbc0ed",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1303,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "562c20a72724744e2529d163c304a3ec32d09c0a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f302e5128922d4e7acf42d7e22f95a2f001eb14d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1524,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1597,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "18d2caf3d1bac7ecb05d4e510dd021477ab55b9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1622,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a4c1e340613dfefc9b4d4980394879d136e2fbc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1664,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "36abac195cd57009a1013913a7ec5b2677faf5fd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1681,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b94e256b5a8102d04799792b284dc44dd58b6609",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2392,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b0ee0c442a1a6ea3ecce064786c038eb5c285c24",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3152,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3331f962763e9b59c985f0c18407811ccee92e72",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3187,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f13d82146ff9aa3b08420f15eec4c7a5aab44769",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3221,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_service.py": [
-      {
-        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 366,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4cf5ead1df6b23c1309a1eac48fe32ffc6c9ab1d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 395,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_auth_service_admin_role_sync.py": [
-      {
-        "hashed_secret": "c0bded6fb5bf2c0aea508ec30d353a42ddd8b8f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 50,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dff88ddbf282dc1477e1e419a7706371e7afba27",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 321,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "79caf88021d840cf3544d1aae14ae84f58310f8f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 365,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f71ca03855f95d7df834ece97c9e09fc34ce89b9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 493,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_email_notification_service.py": [
-      {
-        "hashed_secret": "584db8632ab5718672aab8670add109a862fff0c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 155,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_encryption_service.py": [
-      {
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 378,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c6c580101c1bdaaad4e360d0679d7a8cac514e4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 380,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "755f997eb6296e47fd6d145e1b541b9e98a4fab1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 418,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2538fa47a21f3a58be26e62c63b6dd0a6e87dae5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 419,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 420,
-        "type": "AWS Access Key",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 734,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 735,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "290180f809e70dd1bc99a4c65bd669f43dde426d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 797,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "eea0d9a29d51f43612c303ff2f64b57f56dad885",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 798,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2cee75752f97573ff8cae445096cc30e992b55c7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 819,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_export_service.py": [
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1162,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6578fca8b62f49457e4cd7e66554a310a1a64be8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1753,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_query_param_auth.py": [
-      {
-        "hashed_secret": "67ece584ee3884563e532a35b1616e5aefc2c121",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 203,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 227,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service.py": [
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 639,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 640,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "104c9bb58d7eb1aa5ab82080cd06f1134ac6040b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1528,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5185,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6731,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2a23dd4f2e8b50315e601a2867ea7b7bf5a43b8c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7328,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7347,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b55c6dc4705dba8b151c59566175ad845d5a9104",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7553,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7572,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_extended.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 183,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_health_oauth.py": [
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 502,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py": [
-      {
-        "hashed_secret": "ee131046fbfad0f5fac08926f9b928539da950cd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 102,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 616,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "752cb354d4d101b52581dc820d6fa3f29e87a776",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 638,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_import_service.py": [
-      {
-        "hashed_secret": "9b4cd28c8ecd18d533601bbb7d3345b9d007bd80",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 288,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8d974e916edd2f663f202c91a1d775f32f7c8d62",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 491,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4b0873b633484d5de20b2d8f852a8c07b43336bc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1390,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2d6e80602a17e8309ee0317358582a1207e2fd44",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1543,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "bfbb13b4405a850385a367a1cb668c0fa8b00f3c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1554,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2384,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1073ab6cda4b991cd29f9e83a307f34004ae9327",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2401,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2550,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_llm_provider_service.py": [
-      {
-        "hashed_secret": "51af665d1afaf4f399863df27521b41e6ac2484e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 118,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "133e3d6b775613651eaedbf7e609d244f2f852af",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 275,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 545,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "54ec81ecf625d2640f2d27dbb8343cb6ee1b7348",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 555,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 773,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 779,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_llm_proxy_service.py": [
-      {
-        "hashed_secret": "a5645bb67778c147a3b366da521477d254f5c4e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 440,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 453,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 466,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_mcp_client_chat_service.py": [
-      {
-        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 69,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 99,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 123,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "76ce15edd5a8548603b6fd281d185f323234758f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 146,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e2c786c60e8fb4620403ebbd4ec4fd8e8766370e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 165,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
-      {
-        "hashed_secret": "0474aee45985f5ae829f53849df476200e876990",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 266,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 346,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a022de4a00e7998ae897308ffaaf884fabb9ee1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 821,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "766a6e8998aefe2117d62c2d48411e43161ffa11",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "64bd05d89142566144bce27f4904a322d8d9e836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1229,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1335,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1601,
+        "line_number": 1412,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_metrics.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 169,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
-      {
-        "hashed_secret": "34e587c8f9ba011db386d719d66ffe3cfaea5447",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 516,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 535,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 624,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 847,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 923,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "355e7ab792a8403301eb0732bab9d2b3950ac048",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 926,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager_pkce.py": [
-      {
-        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 67,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 371,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_observability_service.py": [
-      {
-        "hashed_secret": "0a24796d4c71ce722a92f450f69dc36c60b21de4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 410,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8750a512f22c55598175aee8790ae2470ec88d16",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 411,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_resource_service.py": [
       {
-        "hashed_secret": "b0beaa298b4c296ba29df08b919548d17e68d6c8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4118,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4133,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4831,
+        "line_number": 883,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_server_service.py": [
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1494,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1495,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e8af0e18ff4805f4efd84f58b0fa69e3780f35a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1635,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1636,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "498e738c70c40fb156a240d26f866f2d50e9cb51",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1848,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a6bf0a0e01efe836c52ef316f030bf50ac2f716c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1866,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_sso_service.py": [
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 177,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3340ad734a33028b9498d58dc8b49e9c02157b19",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 198,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ec09a041656818107eb855453ffbf7327d3bbc9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 335,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_support_bundle_service.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 83,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 107,
-        "type": "JSON Web Token",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 197,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 211,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 254,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_token_storage_service.py": [
-      {
-        "hashed_secret": "f7cfcf33b07a640de88cca1a41a681d98213a43c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 31,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "920a25ef686c4f7ca6ad23dd109d3ad653161832",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 337,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "48004e013423b89217e65eca07df9574fcd092a6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 545,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_tool_service.py": [
-      {
-        "hashed_secret": "d63b39580934e062f89aae63426d2f2c77c3e258",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 548,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "586a55a9b8b97f0cd88e24ce8279ebc955949688",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 549,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "00cafd126182e8a9e7c01bb2f0dfd00496be724f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 565,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7b1552c7c7ffb8bd70b5666e5997c8e017630aab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1984,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3570,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4204,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7588,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8080,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4a249743d4d2241bd2ae085b4fe654d089488295",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9427,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0c8d051d3c7eada5d31b53d9936fce6bcc232ae2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9571,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 10052,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_tool_service_coverage.py": [
-      {
-        "hashed_secret": "2dd2850bcc4ae4e74154aed99ee5f68292ecfec5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2985,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d92342976d720ff38cf5dcb329be41959ab1ba6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3671,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f93640458964af294a485bc6d597694cf3308e1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3680,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0857abc2d90c5d9821229fc0a880f1c38ffb0e04",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4130,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99834bc4eff3f1e1c1e4692d2476b593b501d045",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7057,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7075,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b8cec023ad982a1355abb9e7c7700e42d7e6fac3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7099,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0614eb27c6e0d2f4ed9a1cce2a5bcbbbc17aa556",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7163,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a38fea79a043f0c9a62f851659d459dc3b716ea9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7174,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a50da1fb101595ac5158f2c9394a65a84061b56c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7215,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ed3e0017cb8e4b06a59af1a441f62cbe58d2ef59",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7221,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9bdc408babb4c5740aa9ee42e65b9308bd01f5f9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8415,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1605,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5cbd0bf2db07a8f50fa9bbcc5ac720b1911c6380",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1777,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5536,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6189,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2878cbdbbcfa6feafc04b8889f5ecc8c470ba32e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6271,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 6527,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9634,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a75a7c7b31474f3f04f3a395228ded8d61ee1ae3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9683,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "02c593fd9af8254b859d426a76b6cd42847fbec1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9722,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 9779,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14850,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17682,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17701,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_admin_catalog_htmx.py": [
-      {
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 239,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_admin_module.py": [
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 451,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c00dbbc9dadfbe1e232e93a729dd4752fade0abf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1106,
-        "type": "Secret Keyword",
+        "line_number": 10823,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_auth.py": [
       {
-        "hashed_secret": "b5920aa41ccde1341077fdb2636afc16d6da0e1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "467be688b21f5d43370f5dc983fe5ed58dea4b00",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 216,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d955debea8e960a293ecbb257048680898cc9d94",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 231,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ee9e7b8482f6e0282b0117eb81651c98b537589",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 282,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "500886a66d19ebfe2d5c0ee86cf4612f9458ee4f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 355,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2169f1a808382eb7b521206debaef01c91f1b60",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 394,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cd61d9f689e9992aec40aeec7210b45a681309f9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 428,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae97d9e9201a9bc1806069d80e5809ab745a91e8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 463,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "eb2344b0e2d6529ced74f8b09be362a460defa15",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 500,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "89be7e8e88bc7b0cdb5ddaa01dab1cd1728541e2",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 564,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5a539b200edec3aaa5167e1cde5d8fd0e8cf4aee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 577,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8be6db326ca95f74590bd09c9c328fc9a3db3b6c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 715,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2368055dc74fca43f2f9c849dbbaaa04616670cf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 764,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8ce647089e0614d3b924f4a0b8fb78268562ec7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1453,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dc6f6cc49f767ae38db110a9e6c1adf5c651ecbf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1497,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7939ea1cdfc6d73115b0d736fa04012be2b25b18",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1588,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "91014bcbf183cf77807b4bd24f2e8652f67b56a0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2096,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61ac75f7e6677b79c219ce819d954e05f61b5d2c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8223fafd35f399e55c3cf611c3d6ebbf43d68d71",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2760,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "dfd99b5f25f839608a3c275c0f8ceb363f8f0bc0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3555,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3664,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f5cd573c18bf811f82a886ceb6866b05d5ef02cd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3742,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "79bead8e6d65862a00cffaa12ccde1189ec34d29",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 4125,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_cli_export_import_coverage.py": [
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 685,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_config.py": [
-      {
-        "hashed_secret": "7952d9e777d5fa3933a6132f35493b970e1c8828",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 256,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "78466ed9a08daa9faf88434c1dd6bb8761e98a61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 640,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "51beb0ccb2d6f1365ed1278c636dabcd8797db95",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 653,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "95bb8a28fc0d18320a4d8deae3bd9c043709a22f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 659,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 728,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0f0ab1d14970dea160a53133a1b2487ba464fda3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 788,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1158,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ef4eb24299c517306652ffee61e05934f2224914",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1410,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_db.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2407,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_db_isready.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 224,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_display_name_uuid_features.py": [
-      {
-        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 620,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "99c962e8c62296bdc9a17f5caf91ce9bb4c7e0e6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 621,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_final_coverage_push.py": [
-      {
-        "hashed_secret": "5ef3af6cd9b5aa907fa618fac829baaec6763b42",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 200,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_llm_schemas.py": [
-      {
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_main.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 68,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 152,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a10b98d7340036e9c8c301704f623eddd733cc1a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 165,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "759ea996d3686cbca80b6d412c3cee3faf60c272",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 3821,
-        "type": "JSON Web Token",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_main_error_handlers.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 25,
+        "line_number": 2716,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_main_extended.py": [
       {
-        "hashed_secret": "6745fa570d36be08400efa1cbc2f057bb001290e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2630,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2919,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_multi_auth_headers.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 298,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_oauth_manager.py": [
       {
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 70,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1313,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "233243ef95e736679cb1d5664a4c71ba89c10664",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1540,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2008,
+        "line_number": 1484,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_observability.py": [
-      {
-        "hashed_secret": "8f1b63868b5d31deb06a0ff740b192aa490e8950",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 373,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1fb844731bf1e5928ae606915b54e21264da4768",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 802,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_password_policy.py": [
-      {
-        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 185,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_postgresql_schema_config.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 171,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas.py": [
-      {
-        "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1292,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas_auth_validation.py": [
-      {
-        "hashed_secret": "40461afdef055768f498c9f11ca7d42beaf667b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 339,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "364d84ed2a75ef4c9a3cba031109db88e504511b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 358,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 377,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "379b59bcc5d7088a11af63318381a83709402009",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 388,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_schemas_validators_extra.py": [
-      {
-        "hashed_secret": "277fd76456880437641f76de1bfa6d7ef61ae861",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 779,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4ea8d2335b430796cf3f500368c5b0f5b1dc90f5",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 975,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "57b2ad99044d337197c0c39fd3823568ff81e48a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 980,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "3d12349760de61e8070eea4704d2c471731bdd15",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1006,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "640d87e741e6aa4c669a82a4cd304787960513ab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1024,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1235,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8db15e8ba2f571ba5d630b4edf3a52d265668f0a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1351,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_team_governance_flags.py": [
-      {
-        "hashed_secret": "8ac21c6ecda35ffb18d58264aeb43ca800b3d758",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 586,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_toolops_utils.py": [
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 141,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_translate_stdio_endpoint.py": [
-      {
-        "hashed_secret": "528ceffb33609fca3a5646ec64a032d4362d301b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 276,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_version.py": [
-      {
-        "hashed_secret": "516b9783fca517eecbd1d064da2d165310b19759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 210,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/tools/builder/test_common.py": [
-      {
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 673,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 961,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/tools/builder/test_schema.py": [
-      {
-        "hashed_secret": "fd858ef1e811e28a823d60908b38df56e9e359e7",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 172,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/transports/test_streamablehttp_transport.py": [
-      {
-        "hashed_secret": "b4c9248600a42f8c38c01b632f392dbcb4c7b19a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 13172,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 14347,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_create_jwt_token.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 42,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_db_isready.py": [
-      {
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 81,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_generate_keys.py": [
-      {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 38,
-        "type": "Private Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_proxy_auth.py": [
-      {
-        "hashed_secret": "b2d898cda25886738c0cd002eb080745b09e2332",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_sso_bootstrap.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 379,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "945db841c03e42eef2f3d0a4ff310e2f3b3e59ec",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 463,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_trace_redaction.py": [
-      {
-        "hashed_secret": "36c3eaa0e1e290f41e2810bae8d9502c785e92d9",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 56,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_url_auth.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 41,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e48c47f1431afd3bb030deea266b4309e2228c5b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 48,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fd0ef1fb9f5dbc367c4ec061500002a22d109bab",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 66,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de9f9d75dc3dd5f8f16d484e569b75fd2e69c86f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 81,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 154,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b02dff0ec9d24823e77c27c281a852247896b86d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 156,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9bebe8d61ea4965d1205e9e0f8f0c6bf5262880f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 216,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/utils/test_verify_credentials.py": [
-      {
-        "hashed_secret": "cd024c09e5784e941e833bd8fabf1dcfc3fb6cd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 53,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "29534257453ead25854695b1b7c95e3857a7238d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 114,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1045,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1194,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/validation/test_validators_advanced.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1142,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/plugins/test_encoded_exfil_detector.py": [
-      {
-        "hashed_secret": "55d2534ed6ad4f269b428160428fa2f6f541ba7b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 140,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cf743b3a58a4d0f91c1d7f5825c0b1b5f7758174",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 453,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8e42b03e460b2cf358ffbcf4da3bc5d14a22c86e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 497,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2093dd9cf307518cfe1d2fa5a3985d6fec4e995e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 510,
-        "type": "Base64 High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "caa924f200b35ceb6f0e33878faff75203bdccb4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 879,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f16da2820437f3c703ff5b95c813f310ce8e67a4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1128,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/plugins/test_jwt_claims_extraction.py": [
-      {
-        "hashed_secret": "dccfe30496fb85f5bb560ea18b582b9aa50372bb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 153,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/plugins/test_secrets_detection.py": [
-      {
-        "hashed_secret": "86de8c52637ec530fe39b0a8471da9b8764d5242",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 149,
-        "type": "AWS Access Key",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/test_conc_01_helpers.py": [
-      {
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 167,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ]

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12617,6 +12617,17 @@ async def admin_delete_gateway_rest(
 ) -> Response:
     """Delete a gateway via REST API (DELETE).
 
+    **Example Request:**
+    ```bash
+    curl -X DELETE http://localhost:4444/admin/gateways/gw-123 \
+         -H "Authorization: Bearer $TOKEN"
+    ```
+
+    **Example Response (204):**
+    ```
+    (No content - empty response body)
+    ```
+
     Args:
         gateway_id: The ID of the gateway to delete.
         db: Database session.

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12313,7 +12313,6 @@ async def admin_discover_oauth(
 @require_permission("gateways.create", allow_admin_bypass=False)
 async def admin_add_gateway(
     request: Request,
-    gateway_data: Optional[GatewayCreate] = None,
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user_with_permissions),
 ) -> JSONResponse:
@@ -12356,17 +12355,17 @@ async def admin_add_gateway(
     LOGGER.debug(f"User {get_user_email(user)} is adding a new gateway")
 
     # Parse request data (supports both JSON and form-data)
-    if gateway_data is None:
+    try:
         data = await _parse_gateway_data_from_request(request)
-        team_id = data.get("team_id")
-        if team_id and isinstance(team_id, str):
-            team_id = team_id.strip() or None
-        visibility = str(data.get("visibility", "private"))
-    else:
-        # JSON request with Pydantic model
-        data = gateway_data.model_dump(exclude_unset=True)
-        team_id = data.get("team_id")
-        visibility = str(data.get("visibility", "private"))
+    except HTTPException:
+        raise
+    except Exception as e:
+        return ORJSONResponse(content={"message": f"Invalid request data: {e}", "success": False}, status_code=400)
+
+    team_id = data.get("team_id")
+    if team_id and isinstance(team_id, str):
+        team_id = team_id.strip() or None
+    visibility = str(data.get("visibility", "private"))
 
     _check_public_visibility_allowed(visibility, team_id=team_id)
 
@@ -12406,9 +12405,6 @@ async def admin_add_gateway(
 
         # Create GatewayCreate model from data
         gateway = GatewayCreate(**data)
-    except KeyError as e:
-        # Convert KeyError to ValidationError-like response
-        return ORJSONResponse(content={"message": f"Missing required field: {e}", "success": False}, status_code=422)
 
     except ValidationError as ex:
         # --- Getting only the custom message from the ValueError ---
@@ -12490,7 +12486,6 @@ async def admin_add_gateway(
 async def admin_update_gateway_rest(
     gateway_id: str,
     request: Request,
-    gateway_data: Optional[GatewayUpdate] = None,
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user_with_permissions),
 ) -> JSONResponse:
@@ -12520,17 +12515,17 @@ async def admin_update_gateway_rest(
     LOGGER.debug(f"User {get_user_email(user)} is updating gateway ID {gateway_id}")
 
     # Parse request data (supports both JSON and form-data)
-    if gateway_data is None:
+    try:
         data = await _parse_gateway_data_from_request(request)
-        team_id = data.get("team_id")
-        if team_id and isinstance(team_id, str):
-            team_id = team_id.strip() or None
-        visibility = str(data.get("visibility", "private"))
-    else:
-        # JSON request with Pydantic model
-        data = gateway_data.model_dump(exclude_unset=True)
-        team_id = data.get("team_id")
-        visibility = str(data.get("visibility", "private"))
+    except HTTPException:
+        raise
+    except Exception as e:
+        return ORJSONResponse(content={"message": f"Invalid request data: {e}", "success": False}, status_code=400)
+
+    team_id = data.get("team_id")
+    if team_id and isinstance(team_id, str):
+        team_id = team_id.strip() or None
+    visibility = str(data.get("visibility", "private"))
 
     _check_public_visibility_allowed(visibility, team_id=team_id)
 
@@ -12550,18 +12545,26 @@ async def admin_update_gateway_rest(
 
         user_email = get_user_email(user)
 
+        # Fetch existing gateway to preserve owner_email and team_id
+        existing_gateway = db.get(DbGateway, gateway_id)
+        if not existing_gateway:
+            return ORJSONResponse(content={"message": "Gateway not found", "success": False}, status_code=404)
+
+        # Preserve existing owner_email (don't transfer ownership)
+        existing_owner = getattr(existing_gateway, "owner_email", None)
+        if existing_owner:
+            data["owner_email"] = existing_owner
+
         # Preserve existing gateway's team_id when no explicit team_id is provided
         if not team_id:
-            existing_gateway = db.get(DbGateway, gateway_id)
-            existing_team = getattr(existing_gateway, "team_id", None) if existing_gateway else None
+            existing_team = getattr(existing_gateway, "team_id", None)
             if isinstance(existing_team, str) and existing_team:
                 team_id = existing_team
 
         team_service = TeamManagementService(db)
         team_id = await team_service.verify_team_for_user(user_email, team_id)
 
-        # Add ownership fields
-        data["owner_email"] = user_email
+        # Set team_id (but not owner_email, which was preserved above)
         data["team_id"] = team_id
 
         # Create GatewayUpdate model from data
@@ -12587,6 +12590,8 @@ async def admin_update_gateway_rest(
         return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
     except HTTPException:
         raise
+    except GatewayNotFoundError as e:
+        return ORJSONResponse(content={"message": str(e), "success": False}, status_code=404)
     except Exception as ex:
         if isinstance(ex, GatewayConnectionError):
             return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=502)
@@ -12603,13 +12608,13 @@ async def admin_update_gateway_rest(
 
 
 # RESTful DELETE endpoint for gateway deletion
-@admin_router.delete("/gateways/{gateway_id}", response_model=None)
+@admin_router.delete("/gateways/{gateway_id}", response_model=None, status_code=204)
 @require_permission("gateways.delete", allow_admin_bypass=False)
 async def admin_delete_gateway_rest(
     gateway_id: str,
     db: Session = Depends(get_db),
     user: dict[str, Any] = Depends(get_current_user_with_permissions),
-) -> JSONResponse:
+) -> Response:
     """Delete a gateway via REST API (DELETE).
 
     Args:
@@ -12618,20 +12623,19 @@ async def admin_delete_gateway_rest(
         user: Authenticated user.
 
     Returns:
-        JSON response with success status and message.
+        204 No Content on success, or error response with appropriate status code.
     """
     user_email = get_user_email(user)
     LOGGER.debug(f"User {user_email} is deleting gateway ID {gateway_id}")
 
     try:
         await gateway_service.delete_gateway(db, gateway_id, user_email=user_email)
-        return ORJSONResponse(
-            content={"message": "Gateway deleted successfully!", "success": True},
-            status_code=200,
-        )
+        return Response(status_code=204)
     except PermissionError as e:
         LOGGER.warning(f"Permission denied for user {user_email} deleting gateway {gateway_id}: {e}")
         return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
+    except GatewayNotFoundError as e:
+        return ORJSONResponse(content={"message": str(e), "success": False}, status_code=404)
     except Exception as e:
         LOGGER.error(f"Error deleting gateway: {e}")
         return ORJSONResponse(

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -849,6 +849,138 @@ def _form_team_id(form: Any) -> Optional[str]:
     return str(raw).strip() or None
 
 
+async def _parse_gateway_data_from_request(request: Request) -> dict[str, Any]:
+    """Parse gateway data from either JSON body or form data.
+
+    This helper function enables endpoints to accept both application/json and
+    multipart/form-data content types, supporting both API clients and the HTMX UI.
+
+    Args:
+        request: FastAPI request object.
+
+    Returns:
+        Dictionary containing parsed gateway data.
+
+    Raises:
+        HTTPException: If content type is unsupported or data is malformed.
+    """
+    content_type = request.headers.get("content-type", "").lower()
+
+    # Handle JSON requests
+    if "application/json" in content_type:
+        try:
+            data = await request.json()
+            # Normalize tags if provided as string
+            if isinstance(data.get("tags"), str):
+                data["tags"] = [tag.strip() for tag in data["tags"].split(",") if tag.strip()]
+            return data
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON body: {e}")
+
+    # Handle form data requests (multipart/form-data or application/x-www-form-urlencoded)
+    elif "multipart/form-data" in content_type or "application/x-www-form-urlencoded" in content_type:
+        form = await request.form()
+        data: dict[str, Any] = {}
+
+        # Extract all form fields
+        for key in form.keys():
+            value = form.get(key)
+            if value is not None:
+                data[key] = value
+
+        # Parse tags from comma-separated string
+        if "tags" in data and isinstance(data["tags"], str):
+            tags_str = str(data["tags"])
+            data["tags"] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
+
+        # Parse auth_headers JSON if present
+        if "auth_headers" in data and isinstance(data["auth_headers"], str):
+            try:
+                data["auth_headers"] = orjson.loads(data["auth_headers"])
+            except (orjson.JSONDecodeError, ValueError):
+                data["auth_headers"] = []
+
+        # Parse passthrough_headers
+        if "passthrough_headers" in data and isinstance(data["passthrough_headers"], str):
+            passthrough_str = str(data["passthrough_headers"]).strip()
+            if passthrough_str:
+                try:
+                    data["passthrough_headers"] = orjson.loads(passthrough_str)
+                except (orjson.JSONDecodeError, ValueError):
+                    # Fallback to comma-separated parsing
+                    data["passthrough_headers"] = [h.strip() for h in passthrough_str.split(",") if h.strip()]
+            else:
+                data["passthrough_headers"] = None
+
+        # Parse OAuth configuration - support both JSON string and individual form fields
+        oauth_config: Optional[dict[str, Any]] = None
+        oauth_config_json = str(data.get("oauth_config", ""))
+
+        # Option 1: Pre-assembled oauth_config JSON (from API calls)
+        # If oauth_config field is present (even if invalid), don't fall back to Option 2
+        oauth_config_field_provided = "oauth_config" in data
+        if oauth_config_json and oauth_config_json != "None":
+            try:
+                oauth_config = orjson.loads(oauth_config_json)
+            except (orjson.JSONDecodeError, ValueError):
+                # Invalid JSON - set to None in data and don't try Option 2
+                oauth_config = None
+                data["oauth_config"] = None
+        elif oauth_config_json == "None":
+            # Explicit "None" string - set to None in data
+            oauth_config = None
+            data["oauth_config"] = None
+
+        # Option 2: Assemble from individual UI form fields
+        # Only try this if oauth_config field was NOT provided
+        if not oauth_config and not oauth_config_field_provided:
+            oauth_grant_type = str(data.get("oauth_grant_type", ""))
+            oauth_issuer = str(data.get("oauth_issuer", ""))
+            oauth_token_url = str(data.get("oauth_token_url", ""))
+            oauth_authorization_url = str(data.get("oauth_authorization_url", ""))
+            oauth_redirect_uri = str(data.get("oauth_redirect_uri", ""))
+            oauth_client_id = str(data.get("oauth_client_id", ""))
+            oauth_client_secret = str(data.get("oauth_client_secret", ""))
+            oauth_username = str(data.get("oauth_username", ""))
+            oauth_password = str(data.get("oauth_password", ""))
+            oauth_scopes_str = str(data.get("oauth_scopes", ""))
+
+            # If any OAuth field is provided, assemble oauth_config
+            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
+                oauth_config = {}
+                if oauth_grant_type:
+                    oauth_config["grant_type"] = oauth_grant_type
+                if oauth_issuer:
+                    oauth_config["issuer"] = oauth_issuer
+                if oauth_token_url:
+                    oauth_config["token_url"] = oauth_token_url
+                if oauth_authorization_url:
+                    oauth_config["authorization_url"] = oauth_authorization_url
+                if oauth_redirect_uri:
+                    oauth_config["redirect_uri"] = oauth_redirect_uri
+                if oauth_client_id:
+                    oauth_config["client_id"] = oauth_client_id
+                if oauth_client_secret:
+                    oauth_config["client_secret"] = oauth_client_secret
+                if oauth_username:
+                    oauth_config["username"] = oauth_username
+                if oauth_password:
+                    oauth_config["password"] = oauth_password
+                if oauth_scopes_str:
+                    scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
+                    if scopes:
+                        oauth_config["scopes"] = scopes
+
+        # Only set oauth_config if it's a non-empty dict
+        if oauth_config:
+            data["oauth_config"] = oauth_config
+
+        return data
+
+    else:
+        raise HTTPException(status_code=415, detail=f"Unsupported content type: {content_type}. Use application/json or multipart/form-data")
+
+
 def _build_admin_redirect(root_path: str, fragment: str, *, error: Optional[str] = None, include_inactive: bool = False, team_id: Optional[str] = None) -> str:
     """Build an admin redirect URL preserving query parameters.
 
@@ -12177,194 +12309,110 @@ async def admin_discover_oauth(
         )
 
 
-@admin_router.post("/gateways")
+@admin_router.post("/gateways", response_model=None)
 @require_permission("gateways.create", allow_admin_bypass=False)
-async def admin_add_gateway(request: Request, db: Session = Depends(get_db), user: dict[str, Any] = Depends(get_current_user_with_permissions)) -> JSONResponse:
-    """Add a gateway via the admin UI.
+async def admin_add_gateway(
+    request: Request,
+    gateway_data: Optional[GatewayCreate] = None,
+    db: Session = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> JSONResponse:
+    """Add a gateway via Admin API.
 
-    Expects form fields:
-      - name
-      - url
-      - description (optional)
-      - tags (optional, comma-separated)
+    Accepts both JSON (application/json) and form data (multipart/form-data).
+
+    **JSON Example:**
+    ```json
+    {
+      "name": "my-gateway",
+      "url": "http://localhost:9000/sse",
+      "transport": "SSE",
+      "description": "My gateway",
+      "tags": ["tag1", "tag2"],
+      "visibility": "private"
+    }
+    ```
+
+    **Form Data Example:**
+    ```
+    name=my-gateway
+    url=http://localhost:9000/sse
+    transport=SSE
+    tags=tag1,tag2
+    ```
 
     Args:
-        request: FastAPI request containing form data.
+        request: FastAPI request containing JSON or form data.
+        gateway_data: Optional pre-parsed Pydantic model (for JSON requests).
         db: Database session.
         user: Authenticated user.
 
     Returns:
-        A redirect response to the admin dashboard.
+        JSON response with success status and message.
 
     Raises:
         HTTPException: 422 when public visibility is disabled and request is team-scoped.
-
-    Examples:
-        >>> callable(admin_add_gateway)
-        True
-        >>> admin_add_gateway.__name__
-        'admin_add_gateway'
     """
     LOGGER.debug(f"User {get_user_email(user)} is adding a new gateway")
-    form = await request.form()
-    team_id = _form_team_id(form)
-    visibility = str(form.get("visibility", "private"))
+
+    # Parse request data (supports both JSON and form-data)
+    if gateway_data is None:
+        data = await _parse_gateway_data_from_request(request)
+        team_id = data.get("team_id")
+        if team_id and isinstance(team_id, str):
+            team_id = team_id.strip() or None
+        visibility = str(data.get("visibility", "private"))
+    else:
+        # JSON request with Pydantic model
+        data = gateway_data.model_dump(exclude_unset=True)
+        team_id = data.get("team_id")
+        visibility = str(data.get("visibility", "private"))
+
     _check_public_visibility_allowed(visibility, team_id=team_id)
+
     try:
-        # Parse tags from comma-separated string
-        tags_str = str(form.get("tags", ""))
-        tags: list[str] = [tag.strip() for tag in tags_str.split(",") if tag.strip()] if tags_str else []
+        # Handle OAuth client secret encryption if present
+        oauth_config = data.get("oauth_config")
+        if oauth_config and isinstance(oauth_config, dict) and "client_secret" in oauth_config:
+            client_secret = oauth_config.get("client_secret")
+            if client_secret and isinstance(client_secret, str):
+                encryption = get_encryption_service(settings.auth_encryption_secret)
+                oauth_config["client_secret"] = await encryption.encrypt_secret_async(client_secret)
+                data["oauth_config"] = oauth_config
 
-        # Parse auth_headers JSON if present
-        auth_headers_json = form.get("auth_headers") or ""
-        auth_headers: list[dict[str, Any]] = []
-        if auth_headers_json:
-            try:
-                auth_headers = orjson.loads(auth_headers_json)
-            except (orjson.JSONDecodeError, ValueError):
-                auth_headers = []
-
-        # Parse OAuth configuration - support both JSON string and individual form fields
-        oauth_config_json = str(form.get("oauth_config"))
-        oauth_config: Optional[dict[str, Any]] = None
-
-        LOGGER.info(f"DEBUG: oauth_config_json from form = '{oauth_config_json}'")
-        LOGGER.info(f"DEBUG: Individual OAuth fields - grant_type='{form.get('oauth_grant_type')}', issuer='{form.get('oauth_issuer')}'")
-
-        # Option 1: Pre-assembled oauth_config JSON (from API calls)
-        if oauth_config_json and oauth_config_json != "None":
-            try:
-                oauth_config = orjson.loads(oauth_config_json)
-                # Encrypt the client secret if present
-                if oauth_config and "client_secret" in oauth_config:
-                    encryption = get_encryption_service(settings.auth_encryption_secret)
-                    oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_config["client_secret"])
-            except (orjson.JSONDecodeError, ValueError) as e:
-                LOGGER.error(f"Failed to parse OAuth config: {e}")
-                oauth_config = None
-
-        # Option 2: Assemble from individual UI form fields
-        if not oauth_config:
-            oauth_grant_type = str(form.get("oauth_grant_type", ""))
-            oauth_issuer = str(form.get("oauth_issuer", ""))
-            oauth_token_url = str(form.get("oauth_token_url", ""))
-            oauth_authorization_url = str(form.get("oauth_authorization_url", ""))
-            oauth_redirect_uri = str(form.get("oauth_redirect_uri", ""))
-            oauth_client_id = str(form.get("oauth_client_id", ""))
-            oauth_client_secret = str(form.get("oauth_client_secret", ""))
-            oauth_username = str(form.get("oauth_username", ""))
-            oauth_password = str(form.get("oauth_password", ""))
-            oauth_scopes_str = str(form.get("oauth_scopes", ""))
-
-            # If any OAuth field is provided, assemble oauth_config
-            if any([oauth_grant_type, oauth_issuer, oauth_token_url, oauth_authorization_url, oauth_client_id]):
-                oauth_config = {}
-
-                if oauth_grant_type:
-                    oauth_config["grant_type"] = oauth_grant_type
-                if oauth_issuer:
-                    oauth_config["issuer"] = oauth_issuer
-                if oauth_token_url:
-                    oauth_config["token_url"] = oauth_token_url  # OAuthManager expects 'token_url', not 'token_endpoint'
-                if oauth_authorization_url:
-                    oauth_config["authorization_url"] = oauth_authorization_url  # OAuthManager expects 'authorization_url', not 'authorization_endpoint'
-                if oauth_redirect_uri:
-                    oauth_config["redirect_uri"] = oauth_redirect_uri
-                if oauth_client_id:
-                    oauth_config["client_id"] = oauth_client_id
-                if oauth_client_secret:
-                    # Encrypt the client secret
-                    encryption = get_encryption_service(settings.auth_encryption_secret)
-                    oauth_config["client_secret"] = await encryption.encrypt_secret_async(oauth_client_secret)
-
-                # Add username and password for password grant type
-                if oauth_username:
-                    oauth_config["username"] = oauth_username
-                if oauth_password:
-                    oauth_config["password"] = oauth_password
-
-                # Parse scopes (comma or space separated)
-                if oauth_scopes_str:
-                    scopes = [s.strip() for s in oauth_scopes_str.replace(",", " ").split() if s.strip()]
-                    if scopes:
-                        oauth_config["scopes"] = scopes
-
-                LOGGER.info(f"✅ Assembled OAuth config from UI form fields: grant_type={oauth_grant_type}, issuer={oauth_issuer}")
-                LOGGER.info(f"DEBUG: Complete oauth_config = {oauth_config}")
-
-        # Handle passthrough_headers
-        passthrough_headers = str(form.get("passthrough_headers"))
-        if passthrough_headers and passthrough_headers.strip():
-            try:
-                passthrough_headers = orjson.loads(passthrough_headers)
-            except (orjson.JSONDecodeError, ValueError):
-                # Fallback to comma-separated parsing
-                passthrough_headers = [h.strip() for h in passthrough_headers.split(",") if h.strip()]
-        else:
-            passthrough_headers = None
-
-        # Auto-detect OAuth: if oauth_config is present and auth_type not explicitly set, use "oauth"
-        auth_type_from_form = str(form.get("auth_type", ""))
-        LOGGER.info(f"DEBUG: auth_type from form: '{auth_type_from_form}', oauth_config present: {oauth_config is not None}")
-        if oauth_config and not auth_type_from_form:
-            auth_type_from_form = "oauth"
-            LOGGER.info("✅ Auto-detected OAuth configuration, setting auth_type='oauth'")
-        elif oauth_config and auth_type_from_form:
-            LOGGER.info(f"✅ OAuth config present with explicit auth_type='{auth_type_from_form}'")
-
-        ca_certificate: Optional[str] = None
+        # Handle CA certificate signing
+        ca_certificate = data.get("ca_certificate")
         sig: Optional[str] = None
+        if ca_certificate and isinstance(ca_certificate, str) and ca_certificate.strip():
+            ca_certificate = ca_certificate.strip()
+            if settings.enable_ed25519_signing:
+                try:
+                    private_key_pem = settings.ed25519_private_key.get_secret_value()
+                    sig = sign_data(ca_certificate.encode(), private_key_pem)
+                    data["ca_certificate_sig"] = sig
+                    data["signing_algorithm"] = "ed25519"
+                except Exception as e:
+                    LOGGER.error(f"Error signing CA certificate: {e}")
+                    raise RuntimeError("Failed to sign CA certificate") from e
+            else:
+                # Explicitly set to None when signing is disabled
+                data["ca_certificate_sig"] = None
+                data["signing_algorithm"] = None
 
-        # CA certificate(s) handled by JavaScript validation (supports single or multiple files)
-        # JavaScript validates, orders (root→intermediate→leaf), and concatenates into hidden field
-        if "ca_certificate" in form:
-            ca_cert_value = form["ca_certificate"]
-            if isinstance(ca_cert_value, str) and ca_cert_value.strip():
-                ca_certificate = ca_cert_value.strip()
-                LOGGER.info("✅ CA certificate(s) received and validated by frontend")
+        # Auto-detect OAuth auth_type
+        if oauth_config and not data.get("auth_type"):
+            data["auth_type"] = "oauth"
+            LOGGER.info("✅ Auto-detected OAuth configuration, setting auth_type='oauth'")
 
-                if settings.enable_ed25519_signing:
-                    try:
-                        private_key_pem = settings.ed25519_private_key.get_secret_value()
-                        sig = sign_data(ca_certificate.encode(), private_key_pem)
-                    except Exception as e:
-                        LOGGER.error(f"Error signing CA certificate: {e}")
-                        sig = None
-                        raise RuntimeError("Failed to sign CA certificate") from e
-                else:
-                    LOGGER.warning("⚠️  Ed25519 signing is disabled; CA certificate will be stored without signature")
-                    sig = None
-
-        gateway = GatewayCreate(
-            name=str(form["name"]),
-            url=str(form["url"]),
-            description=str(form.get("description")),
-            tags=tags,
-            transport=str(form.get("transport", "SSE")),
-            auth_type=auth_type_from_form,
-            auth_username=str(form.get("auth_username", "")),
-            auth_password=str(form.get("auth_password", "")),
-            auth_token=str(form.get("auth_token", "")),
-            auth_header_key=str(form.get("auth_header_key", "")),
-            auth_header_value=str(form.get("auth_header_value", "")),
-            auth_headers=auth_headers if auth_headers else None,
-            auth_query_param_key=str(form.get("auth_query_param_key", "")) or None,
-            auth_query_param_value=str(form.get("auth_query_param_value", "")) or None,
-            oauth_config=oauth_config,
-            one_time_auth=form.get("one_time_auth", False),
-            passthrough_headers=passthrough_headers,
-            visibility=visibility,
-            ca_certificate=ca_certificate,
-            ca_certificate_sig=sig if sig else None,
-            signing_algorithm="ed25519" if sig else None,
-        )
+        # Create GatewayCreate model from data
+        gateway = GatewayCreate(**data)
     except KeyError as e:
         # Convert KeyError to ValidationError-like response
         return ORJSONResponse(content={"message": f"Missing required field: {e}", "success": False}, status_code=422)
 
     except ValidationError as ex:
         # --- Getting only the custom message from the ValueError ---
-        error_ctx = [str(err["ctx"]["error"]) for err in ex.errors()]
+        error_ctx = [str(err.get("ctx", {}).get("error", err.get("msg", str(err)))) for err in ex.errors()]
         return ORJSONResponse(content={"success": False, "message": "; ".join(error_ctx)}, status_code=422)
 
     except RuntimeError as err:
@@ -12436,6 +12484,163 @@ async def admin_add_gateway(request: Request, db: Session = Depends(get_db), use
         return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
 
 
+# RESTful PUT endpoint for gateway updates (JSON/form-data support)
+@admin_router.put("/gateways/{gateway_id}", response_model=None)
+@require_permission("gateways.update", allow_admin_bypass=False)
+async def admin_update_gateway_rest(
+    gateway_id: str,
+    request: Request,
+    gateway_data: Optional[GatewayUpdate] = None,
+    db: Session = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> JSONResponse:
+    """Update a gateway via REST API (PUT).
+
+    Accepts both JSON (application/json) and form data (multipart/form-data).
+
+    **JSON Example:**
+    ```json
+    {
+      "name": "updated-gateway",
+      "url": "http://localhost:9001/sse",
+      "description": "Updated description"
+    }
+    ```
+
+    Args:
+        gateway_id: Gateway ID to update.
+        request: FastAPI request containing JSON or form data.
+        gateway_data: Optional pre-parsed Pydantic model (for JSON requests).
+        db: Database session.
+        user: Authenticated user.
+
+    Returns:
+        JSON response with success status and message.
+    """
+    LOGGER.debug(f"User {get_user_email(user)} is updating gateway ID {gateway_id}")
+
+    # Parse request data (supports both JSON and form-data)
+    if gateway_data is None:
+        data = await _parse_gateway_data_from_request(request)
+        team_id = data.get("team_id")
+        if team_id and isinstance(team_id, str):
+            team_id = team_id.strip() or None
+        visibility = str(data.get("visibility", "private"))
+    else:
+        # JSON request with Pydantic model
+        data = gateway_data.model_dump(exclude_unset=True)
+        team_id = data.get("team_id")
+        visibility = str(data.get("visibility", "private"))
+
+    _check_public_visibility_allowed(visibility, team_id=team_id)
+
+    try:
+        # Handle OAuth client secret encryption if present
+        oauth_config = data.get("oauth_config")
+        if oauth_config and isinstance(oauth_config, dict) and "client_secret" in oauth_config:
+            client_secret = oauth_config.get("client_secret")
+            if client_secret and isinstance(client_secret, str):
+                encryption = get_encryption_service(settings.auth_encryption_secret)
+                oauth_config["client_secret"] = await encryption.encrypt_secret_async(client_secret)
+                data["oauth_config"] = oauth_config
+
+        # Auto-detect OAuth auth_type
+        if oauth_config and not data.get("auth_type"):
+            data["auth_type"] = "oauth"
+
+        user_email = get_user_email(user)
+
+        # Preserve existing gateway's team_id when no explicit team_id is provided
+        if not team_id:
+            existing_gateway = db.get(DbGateway, gateway_id)
+            existing_team = getattr(existing_gateway, "team_id", None) if existing_gateway else None
+            if isinstance(existing_team, str) and existing_team:
+                team_id = existing_team
+
+        team_service = TeamManagementService(db)
+        team_id = await team_service.verify_team_for_user(user_email, team_id)
+
+        # Add ownership fields
+        data["owner_email"] = user_email
+        data["team_id"] = team_id
+
+        # Create GatewayUpdate model from data
+        gateway = GatewayUpdate(**data)
+
+        mod_metadata = MetadataCapture.extract_modification_metadata(request, user, 0)
+        await gateway_service.update_gateway(
+            db,
+            gateway_id,
+            gateway,
+            modified_by=mod_metadata["modified_by"],
+            modified_from_ip=mod_metadata["modified_from_ip"],
+            modified_via=mod_metadata["modified_via"],
+            modified_user_agent=mod_metadata["modified_user_agent"],
+            user_email=user_email,
+        )
+        return ORJSONResponse(
+            content={"message": "Gateway updated successfully!", "success": True},
+            status_code=200,
+        )
+    except PermissionError as e:
+        LOGGER.info(f"Permission denied for user {get_user_email(user)}: {e}")
+        return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
+    except HTTPException:
+        raise
+    except Exception as ex:
+        if isinstance(ex, GatewayConnectionError):
+            return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=502)
+        if isinstance(ex, RuntimeError):
+            return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
+        if isinstance(ex, ValidationError):
+            return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
+        if isinstance(ex, IntegrityError):
+            return ORJSONResponse(status_code=409, content=ErrorFormatter.format_database_error(ex))
+        if isinstance(ex, ValueError):
+            return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=400)
+        LOGGER.exception(f"Unexpected error in admin_update_gateway_rest: {ex}")
+        return ORJSONResponse(content={"message": "An unexpected error occurred. Please try again or contact support.", "success": False}, status_code=500)
+
+
+# RESTful DELETE endpoint for gateway deletion
+@admin_router.delete("/gateways/{gateway_id}", response_model=None)
+@require_permission("gateways.delete", allow_admin_bypass=False)
+async def admin_delete_gateway_rest(
+    gateway_id: str,
+    db: Session = Depends(get_db),
+    user: dict[str, Any] = Depends(get_current_user_with_permissions),
+) -> JSONResponse:
+    """Delete a gateway via REST API (DELETE).
+
+    Args:
+        gateway_id: The ID of the gateway to delete.
+        db: Database session.
+        user: Authenticated user.
+
+    Returns:
+        JSON response with success status and message.
+    """
+    user_email = get_user_email(user)
+    LOGGER.debug(f"User {user_email} is deleting gateway ID {gateway_id}")
+
+    try:
+        await gateway_service.delete_gateway(db, gateway_id, user_email=user_email)
+        return ORJSONResponse(
+            content={"message": "Gateway deleted successfully!", "success": True},
+            status_code=200,
+        )
+    except PermissionError as e:
+        LOGGER.warning(f"Permission denied for user {user_email} deleting gateway {gateway_id}: {e}")
+        return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
+    except Exception as e:
+        LOGGER.error(f"Error deleting gateway: {e}")
+        return ORJSONResponse(
+            content={"message": "Failed to delete gateway. Please try again.", "success": False},
+            status_code=500,
+        )
+
+
+# Legacy POST endpoint for backward compatibility with HTMX UI
 # OAuth callback is now handled by the dedicated OAuth router at /oauth/callback
 # This route has been removed to avoid conflicts with the complete implementation
 @admin_router.post("/gateways/{gateway_id}/edit")

--- a/scripts/test_rest_api_endpoints.py
+++ b/scripts/test_rest_api_endpoints.py
@@ -194,21 +194,22 @@ class GatewayAPITester:
             print(f"❌ Error: {e}")
             return False
 
-    async def test_json_vs_form_endpoints(self) -> bool:
-        """Test that JSON endpoint works and form endpoint is separate."""
+    async def test_form_data_acceptance(self) -> bool:
+        """Test that the endpoint accepts both JSON and form-data."""
         print("\n" + "="*60)
-        print("TEST 4: Verify JSON-only REST Endpoint Behavior")
+        print("TEST 4: Verify Form-Data Acceptance")
         print("="*60)
 
-        # Test that form data to REST endpoint returns 422 (expected behavior)
+        # Test that form data to REST endpoint is accepted (backward compatibility)
         form_data = {
             "name": "test-form-gateway",
             "url": "http://httpbin.org/delay/0",
             "transport": "SSE",
-            "description": "Test gateway created via form data"
+            "description": "Test gateway created via form data",
+            "skip_initialization": "true"
         }
 
-        print(f"\n📤 Sending form data to JSON-only endpoint (should fail with 422)")
+        print(f"\n📤 Sending form data to endpoint (should succeed)")
         print(f"📦 Form Data: {form_data}")
 
         try:
@@ -225,13 +226,26 @@ class GatewayAPITester:
                 )
 
                 print(f"\n📥 Response Status: {response.status_code}")
+                print(f"📥 Response Body: {response.text}")
 
-                if response.status_code == 422:
-                    print("✅ Correctly rejected form data (JSON-only endpoint working as expected)")
-                    return True
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("success"):
+                        print("✅ Form data accepted successfully (backward compatibility maintained)")
+                        # Clean up the created gateway if we got an ID
+                        if "gateway_id" in data:
+                            gateway_id = data["gateway_id"]
+                            await client.delete(
+                                f"{self.base_url}/admin/gateways/{gateway_id}",
+                                headers={"Authorization": f"Bearer {self.token}"} if self.token else {},
+                                timeout=10.0
+                            )
+                        return True
+                    else:
+                        print(f"❌ Form data rejected: {data.get('message')}")
+                        return False
                 else:
-                    print(f"❌ Unexpected status code: {response.status_code} (expected 422)")
-                    print(f"📥 Response Body: {response.text}")
+                    print(f"❌ Unexpected status code: {response.status_code}")
                     return False
 
         except Exception as e:
@@ -273,9 +287,9 @@ class GatewayAPITester:
             results.append(("Update Gateway (JSON)", False))
             results.append(("Delete Gateway", False))
 
-        # Test 4: JSON-only endpoint behavior
-        result4 = await self.test_json_vs_form_endpoints()
-        results.append(("JSON-only Endpoint Behavior", result4))
+        # Test 4: Form-data acceptance
+        result4 = await self.test_form_data_acceptance()
+        results.append(("Form-Data Acceptance", result4))
 
         # Print summary
         print("\n" + "="*60)

--- a/scripts/test_rest_api_endpoints.py
+++ b/scripts/test_rest_api_endpoints.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Test script for REST API gateway endpoints.
+
+This script tests the new RESTful endpoints for gateway CRUD operations:
+- POST /admin/gateways (create with JSON)
+- PUT /admin/gateways/{id} (update with JSON)
+- DELETE /admin/gateways/{id} (delete)
+
+Usage:
+    uv run scripts/test_rest_api_endpoints.py
+"""
+
+import asyncio
+import os
+import sys
+from typing import Dict, Optional, Tuple
+
+import httpx
+
+
+class GatewayAPITester:
+    """Test the gateway REST API endpoints."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", token: Optional[str] = None):
+        """Initialize the tester.
+
+        Args:
+            base_url: Base URL of the gateway API
+            token: JWT token for authentication (if None, checks $TOKEN env var, then creates one)
+        """
+        self.base_url = base_url.rstrip("/")
+        # Check environment variable if token not provided
+        self.token = token or os.environ.get("TOKEN")
+        self.created_gateway_id: Optional[str] = None
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get request headers with authentication."""
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    async def _create_test_token(self) -> str:
+        """Create a test JWT token using the utility."""
+        try:
+            # Try to import and use the token creation utility
+            from mcpgateway.utils.create_jwt_token import create_jwt_token
+
+            # Create token with admin user data
+            token = await create_jwt_token(
+                data={"sub": "test-admin@example.com"},
+                expires_in_minutes=60,
+                user_data={
+                    "email": "test-admin@example.com",
+                    "full_name": "Test Admin",
+                    "is_admin": True,
+                    "auth_provider": "test"
+                },
+                teams=None  # Admin bypass
+            )
+            print("✅ Created test JWT token")
+            return token
+        except Exception as e:
+            print(f"❌ Failed to create test token: {e}")
+            print("Please set a valid JWT token manually or ensure the server is configured correctly")
+            sys.exit(1)
+
+    async def test_create_gateway_json(self) -> bool:
+        """Test creating a gateway with JSON payload."""
+        print("\n" + "="*60)
+        print("TEST 1: Create Gateway with JSON (POST /admin/gateways)")
+        print("="*60)
+
+        payload = {
+            "name": "test-rest-gateway",
+            "url": "http://httpbin.org/delay/0",  # Use a real endpoint for testing
+            "transport": "SSE",
+            "description": "Test gateway created via REST API",
+            "tags": ["test", "rest-api"],
+            "skip_initialization": True  # Skip validation for testing
+        }
+
+        print(f"\n📤 Sending POST request to {self.base_url}/admin/gateways")
+        print(f"📦 Payload: {payload}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.base_url}/admin/gateways",
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=10.0
+                )
+
+                print(f"\n📥 Response Status: {response.status_code}")
+                print(f"📥 Response Body: {response.text}")
+
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("success"):
+                        print("✅ Gateway created successfully!")
+                        # Try to extract gateway ID from response
+                        if "gateway_id" in data:
+                            self.created_gateway_id = data["gateway_id"]
+                            print(f"   Gateway ID: {self.created_gateway_id}")
+                        return True
+                    else:
+                        print(f"❌ Creation failed: {data.get('message')}")
+                        return False
+                else:
+                    print(f"❌ Request failed with status {response.status_code}")
+                    return False
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            return False
+
+    async def test_update_gateway_json(self, gateway_id: str) -> bool:
+        """Test updating a gateway with JSON payload."""
+        print("\n" + "="*60)
+        print(f"TEST 2: Update Gateway with JSON (PUT /admin/gateways/{gateway_id})")
+        print("="*60)
+
+        payload = {
+            "name": "test-rest-gateway-updated",
+            "description": "Updated via REST API PUT endpoint",
+            "tags": ["test", "rest-api", "updated"]
+        }
+
+        print(f"\n📤 Sending PUT request to {self.base_url}/admin/gateways/{gateway_id}")
+        print(f"📦 Payload: {payload}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.put(
+                    f"{self.base_url}/admin/gateways/{gateway_id}",
+                    json=payload,
+                    headers=self._get_headers(),
+                    timeout=10.0
+                )
+
+                print(f"\n📥 Response Status: {response.status_code}")
+                print(f"📥 Response Body: {response.text}")
+
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("success"):
+                        print("✅ Gateway updated successfully!")
+                        return True
+                    else:
+                        print(f"❌ Update failed: {data.get('message')}")
+                        return False
+                else:
+                    print(f"❌ Request failed with status {response.status_code}")
+                    return False
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            return False
+
+    async def test_delete_gateway(self, gateway_id: str) -> bool:
+        """Test deleting a gateway."""
+        print("\n" + "="*60)
+        print(f"TEST 3: Delete Gateway (DELETE /admin/gateways/{gateway_id})")
+        print("="*60)
+
+        print(f"\n📤 Sending DELETE request to {self.base_url}/admin/gateways/{gateway_id}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.delete(
+                    f"{self.base_url}/admin/gateways/{gateway_id}",
+                    headers=self._get_headers(),
+                    timeout=10.0
+                )
+
+                print(f"\n📥 Response Status: {response.status_code}")
+                print(f"📥 Response Body: {response.text}")
+
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("success"):
+                        print("✅ Gateway deleted successfully!")
+                        return True
+                    else:
+                        print(f"❌ Deletion failed: {data.get('message')}")
+                        return False
+                else:
+                    print(f"❌ Request failed with status {response.status_code}")
+                    return False
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            return False
+
+    async def test_json_vs_form_endpoints(self) -> bool:
+        """Test that JSON endpoint works and form endpoint is separate."""
+        print("\n" + "="*60)
+        print("TEST 4: Verify JSON-only REST Endpoint Behavior")
+        print("="*60)
+
+        # Test that form data to REST endpoint returns 422 (expected behavior)
+        form_data = {
+            "name": "test-form-gateway",
+            "url": "http://httpbin.org/delay/0",
+            "transport": "SSE",
+            "description": "Test gateway created via form data"
+        }
+
+        print(f"\n📤 Sending form data to JSON-only endpoint (should fail with 422)")
+        print(f"📦 Form Data: {form_data}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                headers: Dict[str, str] = {}
+                if self.token:
+                    headers["Authorization"] = f"Bearer {self.token}"
+
+                response = await client.post(
+                    f"{self.base_url}/admin/gateways",
+                    data=form_data,
+                    headers=headers,
+                    timeout=10.0
+                )
+
+                print(f"\n📥 Response Status: {response.status_code}")
+
+                if response.status_code == 422:
+                    print("✅ Correctly rejected form data (JSON-only endpoint working as expected)")
+                    return True
+                else:
+                    print(f"❌ Unexpected status code: {response.status_code} (expected 422)")
+                    print(f"📥 Response Body: {response.text}")
+                    return False
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+            return False
+
+    async def run_all_tests(self) -> bool:
+        """Run all tests in sequence."""
+        print("\n" + "🚀 " + "="*58)
+        print("🚀 REST API Gateway Endpoints Test Suite")
+        print("🚀 " + "="*58)
+        print(f"\n🌐 Base URL: {self.base_url}")
+
+        # Create token if not provided
+        if not self.token:
+            print("\n🔑 No token provided (not in --token or $TOKEN env var), creating test token...")
+            self.token = await self._create_test_token()
+        else:
+            # Determine source: if TOKEN env var exists, it came from there; otherwise from command line
+            token_source = "TOKEN environment variable" if os.environ.get("TOKEN") else "command line"
+            print(f"\n🔑 Using token from {token_source}")
+
+        results: list[Tuple[str, bool]] = []
+
+        # Test 1: Create gateway with JSON
+        result1 = await self.test_create_gateway_json()
+        results.append(("Create Gateway (JSON)", result1))
+
+        if result1 and self.created_gateway_id:
+            # Test 2: Update gateway with JSON
+            result2 = await self.test_update_gateway_json(self.created_gateway_id)
+            results.append(("Update Gateway (JSON)", result2))
+
+            # Test 3: Delete gateway
+            result3 = await self.test_delete_gateway(self.created_gateway_id)
+            results.append(("Delete Gateway", result3))
+        else:
+            print("\n⚠️  Skipping update and delete tests (no gateway ID)")
+            results.append(("Update Gateway (JSON)", False))
+            results.append(("Delete Gateway", False))
+
+        # Test 4: JSON-only endpoint behavior
+        result4 = await self.test_json_vs_form_endpoints()
+        results.append(("JSON-only Endpoint Behavior", result4))
+
+        # Print summary
+        print("\n" + "="*60)
+        print("📊 TEST SUMMARY")
+        print("="*60)
+
+        for test_name, passed in results:
+            status = "✅ PASS" if passed else "❌ FAIL"
+            print(f"{status} - {test_name}")
+
+        total_passed = sum(1 for _, passed in results if passed)
+        total_tests = len(results)
+
+        print(f"\n📈 Results: {total_passed}/{total_tests} tests passed")
+
+        if total_passed == total_tests:
+            print("\n🎉 All tests passed!")
+            return True
+        else:
+            print(f"\n⚠️  {total_tests - total_passed} test(s) failed")
+            return False
+
+
+async def main():
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Test REST API gateway endpoints")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8000",
+        help="Base URL of the gateway API (default: http://localhost:8000)"
+    )
+    parser.add_argument(
+        "--token",
+        help="JWT token for authentication (if not provided, checks $TOKEN env var, then creates one)"
+    )
+
+    args = parser.parse_args()
+
+    tester = GatewayAPITester(base_url=args.url, token=args.token)
+    success = await tester.run_all_tests()
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_rest_api_endpoints.py
+++ b/scripts/test_rest_api_endpoints.py
@@ -178,10 +178,14 @@ class GatewayAPITester:
                 print(f"\n📥 Response Status: {response.status_code}")
                 print(f"📥 Response Body: {response.text}")
 
-                if response.status_code == 200:
+                if response.status_code == 204:
+                    print("✅ Gateway deleted successfully (204 No Content)!")
+                    return True
+                elif response.status_code == 200:
+                    # Legacy behavior - still accept but warn
                     data = response.json()
                     if data.get("success"):
-                        print("✅ Gateway deleted successfully!")
+                        print("⚠️  Gateway deleted (200 OK - should return 204 No Content)")
                         return True
                     else:
                         print(f"❌ Deletion failed: {data.get('message')}")

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3181,8 +3181,9 @@ class TestAdminGatewayRoutes:
         for auth_config in auth_configs:
             form_data = FakeForm({"name": f"Gateway_{auth_config.get('auth_type', 'none')}", "url": "http://example.com", **auth_config})
             mock_request.form = AsyncMock(return_value=form_data)
+            mock_request.headers = {"content-type": "multipart/form-data"}
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -3198,8 +3199,9 @@ class TestAdminGatewayRoutes:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, JSONResponse)
         assert result.status_code == 200
 
@@ -3207,8 +3209,11 @@ class TestAdminGatewayRoutes:
     async def test_admin_add_gateway_connection_error(self, mock_register_gateway, mock_request, mock_db):
         """Test adding gateway with connection error."""
         mock_register_gateway.side_effect = GatewayConnectionError("Cannot connect to gateway")
+        form_data = FakeForm({"name": "Test_Gateway", "url": "http://example.com"})
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 502
@@ -3223,8 +3228,9 @@ class TestAdminGatewayRoutes:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
@@ -6230,6 +6236,7 @@ class TestOAuthFunctionality:
 
         form_data = FakeForm({"name": "OAuth_Gateway", "url": "https://oauth.example.com", "oauth_config": json.dumps(oauth_config)})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         # Mock OAuth encryption
         with patch("mcpgateway.admin.get_encryption_service") as mock_get_encryption:
@@ -6237,7 +6244,7 @@ class TestOAuthFunctionality:
             mock_encryption.encrypt_secret_async = AsyncMock(return_value="encrypted-secret")
             mock_get_encryption.return_value = mock_encryption
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             body = json.loads(result.body)
@@ -6254,8 +6261,9 @@ class TestOAuthFunctionality:
         """Test adding gateway with invalid OAuth JSON."""
         form_data = FakeForm({"name": "Invalid_OAuth_Gateway", "url": "https://example.com", "oauth_config": "invalid-json{"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         # Should still succeed but oauth_config will be None due to JSON error
@@ -6272,17 +6280,33 @@ class TestOAuthFunctionality:
         """Test adding gateway with oauth_config as 'None' string."""
         form_data = FakeForm({"name": "No_OAuth_Gateway", "url": "https://example.com", "oauth_config": "None"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta,
+        ):
+            mock_meta.return_value = {
+                "created_by": "u@example.com",
+                "created_from_ip": None,
+                "created_via": "ui",
+                "created_user_agent": None,
+                "import_batch_id": None,
+                "federation_source": None,
+            }
 
-        assert isinstance(result, JSONResponse)
-        body = json.loads(result.body)
-        assert body["success"] is True
-        mock_register_gateway.assert_called_once()
-        # Verify oauth_config was set to None
-        call_args = mock_register_gateway.call_args[0]
-        gateway_create = call_args[1]
-        assert gateway_create.oauth_config is None
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+
+            assert isinstance(result, JSONResponse)
+            body = json.loads(result.body)
+            assert body["success"] is True
+            mock_register_gateway.assert_called_once()
+            # Verify oauth_config was set to None
+            call_args = mock_register_gateway.call_args[0]
+            gateway_create = call_args[1]
+            assert gateway_create.oauth_config is None
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_with_oauth_config(self, mock_update_gateway, mock_request, mock_db):
@@ -6387,6 +6411,7 @@ class TestOAuthFunctionality:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6407,7 +6432,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6439,6 +6464,7 @@ class TestOAuthFunctionality:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6455,7 +6481,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6477,6 +6503,7 @@ class TestOAuthFunctionality:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6493,7 +6520,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6507,6 +6534,7 @@ class TestOAuthFunctionality:
         oauth_config = {"grant_type": "client_credentials", "client_id": "cid"}
         form_data = FakeForm({"name": "OAuth_NoSecret_Gateway", "url": "https://example.com", "auth_headers": "", "oauth_config": json.dumps(oauth_config)})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6523,7 +6551,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6650,6 +6678,7 @@ class TestOAuthFunctionality:
 
         form_data = FakeForm({"name": "Gateway_With_CA", "url": "https://example.com", "ca_certificate": "CERT"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6666,7 +6695,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6682,6 +6711,7 @@ class TestOAuthFunctionality:
 
         form_data = FakeForm({"name": "Gateway_With_CA", "url": "https://example.com", "ca_certificate": "CERT"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6698,7 +6728,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6720,7 +6750,9 @@ class TestOAuthFunctionality:
         form_data = FakeForm({"name": "Gateway_With_CA", "url": "https://example.com", "ca_certificate": "CERT"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
         body = json.loads(result.body)
@@ -6737,6 +6769,7 @@ class TestOAuthFunctionality:
 
         form_data = FakeForm({"name": "Gateway", "url": "https://example.com"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         team_service = MagicMock()
         team_service.verify_team_for_user = AsyncMock(return_value=None)
@@ -6758,7 +6791,7 @@ class TestOAuthFunctionality:
 
         for exc, expected in cases:
             mock_register_gateway.side_effect = exc
-            response = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            response = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
             assert response.status_code == expected
 
     @patch.object(GatewayService, "update_gateway")
@@ -6791,6 +6824,111 @@ class TestOAuthFunctionality:
             response = await admin_edit_gateway("gateway-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert response.status_code == expected
 
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_invalid_json_body(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with invalid JSON body (covers line 876)."""
+        mock_request.headers = {"content-type": "application/json"}
+        # Mock request.json() to raise an exception
+        mock_request.json = AsyncMock(side_effect=ValueError("Invalid JSON"))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid JSON body" in str(exc_info.value.detail)
+
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_empty_tags_string(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with empty tags string (covers lines 891-892)."""
+        form_data = FakeForm({"name": "Test_Gateway", "url": "https://example.com", "tags": ""})
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.MetadataCapture.extract_creation_metadata") as mock_meta,
+        ):
+            mock_meta.return_value = {
+                "created_by": "u@example.com",
+                "created_from_ip": None,
+                "created_via": "ui",
+                "created_user_agent": None,
+                "import_batch_id": None,
+                "federation_source": None,
+            }
+
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+
+            assert isinstance(result, JSONResponse)
+            body = json.loads(result.body)
+            assert body["success"] is True
+
+            # Verify tags is an empty list
+            gateway_create = mock_register_gateway.call_args.args[1]
+            assert gateway_create.tags == []
+
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_unsupported_content_type(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with unsupported content type (covers line 979)."""
+        mock_request.headers = {"content-type": "text/plain"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert exc_info.value.status_code == 415
+        assert "Unsupported content type" in str(exc_info.value.detail)
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_form_success(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway via form data (covers line 12547)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        # Mock existing gateway
+        existing_gateway = MagicMock()
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        form_data = FakeForm({
+            "name": "Updated_Gateway",
+            "url": "https://updated.example.com",
+            "description": "Updated description"
+        })
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.MetadataCapture.extract_modification_metadata") as mock_meta,
+        ):
+            mock_meta.return_value = {
+                "modified_by": "u@example.com",
+                "modified_from_ip": None,
+                "modified_via": "ui",
+                "modified_user_agent": None,
+            }
+
+            result = await admin_update_gateway_rest(
+                "gateway-123",
+                mock_request,
+                None,
+                mock_db,
+                user={"email": "test-user", "db": mock_db}
+            )
+
+            assert isinstance(result, JSONResponse)
+            body = json.loads(result.body)
+            assert body["success"] is True
+
+            # Verify update_gateway was called
+            mock_update_gateway.assert_called_once()
+            gateway_update = mock_update_gateway.call_args.args[2]
+            assert gateway_update.name == "Updated_Gateway"
+            assert gateway_update.url == "https://updated.example.com"
+
 
 class TestPassthroughHeadersParsing:
     """Test passthrough headers parsing functionality."""
@@ -6803,7 +6941,9 @@ class TestPassthroughHeadersParsing:
         form_data = FakeForm({"name": "Gateway_With_Headers", "url": "https://example.com", "passthrough_headers": json.dumps(passthrough_headers)})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -6820,7 +6960,9 @@ class TestPassthroughHeadersParsing:
         form_data = FakeForm({"name": "Gateway_With_CSV_Headers", "url": "https://example.com", "passthrough_headers": "X-Header-1, X-Header-2 , X-Header-3"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -6844,7 +6986,9 @@ class TestPassthroughHeadersParsing:
         )
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -6869,14 +7013,15 @@ class TestErrorHandlingPaths:
             }
         )
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
         body = json.loads(result.body)
         assert body["success"] is False
-        assert "Missing required field" in body["message"]
+        assert "required" in body["message"].lower() or "missing" in body["message"].lower()
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_runtime_error(self, mock_register_gateway, mock_request, mock_db):
@@ -6886,7 +7031,9 @@ class TestErrorHandlingPaths:
         form_data = FakeForm({"name": "Runtime_Error_Gateway", "url": "https://example.com"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
@@ -6902,7 +7049,9 @@ class TestErrorHandlingPaths:
         form_data = FakeForm({"name": "Value_Error_Gateway", "url": "invalid-url"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
@@ -6918,7 +7067,9 @@ class TestErrorHandlingPaths:
         form_data = FakeForm({"name": "Exception_Gateway", "url": "https://example.com"})
         mock_request.form = AsyncMock(return_value=form_data)
 
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
@@ -6939,12 +7090,13 @@ class TestErrorHandlingPaths:
         # Mock form parsing to raise ValidationError
         form_data = FakeForm({"name": "", "url": "https://example.com"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         # Mock the GatewayCreate validation to raise the error
         with patch("mcpgateway.admin.GatewayCreate") as mock_gateway_create:
             mock_gateway_create.side_effect = validation_error
 
-            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             assert result.status_code == 422
@@ -23006,8 +23158,9 @@ class TestPublicVisibilityGuard:
         monkeypatch.setattr("mcpgateway.admin.settings.allow_public_visibility", False)
         form_data = FakeForm({"name": "G", "url": "http://g", "visibility": "public", "team_id": "team-abc"})
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
         with pytest.raises(HTTPException) as exc_info:
-            await admin_add_gateway(mock_request, mock_db, user={"email": "u@e.com", "db": mock_db})
+            await admin_add_gateway(mock_request, None, mock_db, user={"email": "u@e.com", "db": mock_db})
         assert exc_info.value.status_code == 422
 
     @pytest.mark.asyncio
@@ -23100,7 +23253,8 @@ class TestPublicVisibilityGuard:
         monkeypatch.setattr("mcpgateway.admin.settings.allow_public_visibility", False)
         form_data = FakeForm({"name": "G", "url": "http://g", "visibility": "public"})
         mock_request.form = AsyncMock(return_value=form_data)
-        result = await admin_add_gateway(mock_request, mock_db, user={"email": "u@e.com", "db": mock_db})
+        mock_request.headers = {"content-type": "multipart/form-data"}
+        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "u@e.com", "db": mock_db})
         assert result.status_code != 422
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3183,7 +3183,7 @@ class TestAdminGatewayRoutes:
             mock_request.form = AsyncMock(return_value=form_data)
             mock_request.headers = {"content-type": "multipart/form-data"}
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -3201,7 +3201,7 @@ class TestAdminGatewayRoutes:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, JSONResponse)
         assert result.status_code == 200
 
@@ -3213,7 +3213,7 @@ class TestAdminGatewayRoutes:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 502
@@ -3230,7 +3230,7 @@ class TestAdminGatewayRoutes:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
@@ -6244,7 +6244,7 @@ class TestOAuthFunctionality:
             mock_encryption.encrypt_secret_async = AsyncMock(return_value="encrypted-secret")
             mock_get_encryption.return_value = mock_encryption
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             body = json.loads(result.body)
@@ -6263,7 +6263,7 @@ class TestOAuthFunctionality:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         # Should still succeed but oauth_config will be None due to JSON error
@@ -6297,7 +6297,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             body = json.loads(result.body)
@@ -6432,7 +6432,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6481,7 +6481,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6520,7 +6520,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6551,7 +6551,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6695,7 +6695,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6728,7 +6728,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert isinstance(result, JSONResponse)
             assert result.status_code == 200
 
@@ -6752,7 +6752,7 @@ class TestOAuthFunctionality:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
         body = json.loads(result.body)
@@ -6791,7 +6791,7 @@ class TestOAuthFunctionality:
 
         for exc, expected in cases:
             mock_register_gateway.side_effect = exc
-            response = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            response = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
             assert response.status_code == expected
 
     @patch.object(GatewayService, "update_gateway")
@@ -6832,7 +6832,7 @@ class TestOAuthFunctionality:
         mock_request.json = AsyncMock(side_effect=ValueError("Invalid JSON"))
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert exc_info.value.status_code == 400
         assert "Invalid JSON body" in str(exc_info.value.detail)
@@ -6859,7 +6859,7 @@ class TestOAuthFunctionality:
                 "federation_source": None,
             }
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             body = json.loads(result.body)
@@ -6875,7 +6875,7 @@ class TestOAuthFunctionality:
         mock_request.headers = {"content-type": "text/plain"}
 
         with pytest.raises(HTTPException) as exc_info:
-            await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert exc_info.value.status_code == 415
         assert "Unsupported content type" in str(exc_info.value.detail)
@@ -6888,6 +6888,7 @@ class TestOAuthFunctionality:
         # Mock existing gateway
         existing_gateway = MagicMock()
         existing_gateway.team_id = "team-123"
+        existing_gateway.owner_email = "original-owner@example.com"
         mock_db.get = MagicMock(return_value=existing_gateway)
 
         form_data = FakeForm({
@@ -6914,7 +6915,6 @@ class TestOAuthFunctionality:
             result = await admin_update_gateway_rest(
                 "gateway-123",
                 mock_request,
-                None,
                 mock_db,
                 user={"email": "test-user", "db": mock_db}
             )
@@ -6943,7 +6943,7 @@ class TestPassthroughHeadersParsing:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -6962,7 +6962,7 @@ class TestPassthroughHeadersParsing:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -6988,7 +6988,7 @@ class TestPassthroughHeadersParsing:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         body = json.loads(result.body)
@@ -7015,13 +7015,14 @@ class TestErrorHandlingPaths:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
         body = json.loads(result.body)
         assert body["success"] is False
-        assert "required" in body["message"].lower() or "missing" in body["message"].lower()
+        # Verify Pydantic ValidationError message format (field validation errors)
+        assert "field required" in body["message"].lower() or "missing" in body["message"].lower()
 
     @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_runtime_error(self, mock_register_gateway, mock_request, mock_db):
@@ -7033,7 +7034,7 @@ class TestErrorHandlingPaths:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
@@ -7051,7 +7052,7 @@ class TestErrorHandlingPaths:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 422
@@ -7069,7 +7070,7 @@ class TestErrorHandlingPaths:
 
         mock_request.headers = {"content-type": "multipart/form-data"}
 
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
         assert isinstance(result, JSONResponse)
         assert result.status_code == 500
@@ -7096,7 +7097,7 @@ class TestErrorHandlingPaths:
         with patch("mcpgateway.admin.GatewayCreate") as mock_gateway_create:
             mock_gateway_create.side_effect = validation_error
 
-            result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "test-user", "db": mock_db})
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
 
             assert isinstance(result, JSONResponse)
             assert result.status_code == 422
@@ -23160,7 +23161,7 @@ class TestPublicVisibilityGuard:
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
         with pytest.raises(HTTPException) as exc_info:
-            await admin_add_gateway(mock_request, None, mock_db, user={"email": "u@e.com", "db": mock_db})
+            await admin_add_gateway(mock_request, mock_db, user={"email": "u@e.com", "db": mock_db})
         assert exc_info.value.status_code == 422
 
     @pytest.mark.asyncio
@@ -23254,7 +23255,7 @@ class TestPublicVisibilityGuard:
         form_data = FakeForm({"name": "G", "url": "http://g", "visibility": "public"})
         mock_request.form = AsyncMock(return_value=form_data)
         mock_request.headers = {"content-type": "multipart/form-data"}
-        result = await admin_add_gateway(mock_request, None, mock_db, user={"email": "u@e.com", "db": mock_db})
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "u@e.com", "db": mock_db})
         assert result.status_code != 422
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -7105,6 +7105,412 @@ class TestErrorHandlingPaths:
             assert body["success"] is False
             assert "Name cannot be empty" in body["message"]
 
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_tags_as_comma_string_json(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with tags as comma-separated string in JSON (covers lines 874-876)."""
+        mock_request.json = AsyncMock(return_value={
+            "name": "test-gateway",
+            "url": "https://example.com",
+            "tags": "tag1, tag2, tag3"  # String instead of array
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["success"] is True
+
+        # Verify tags were parsed correctly (tags are converted to dict format)
+        mock_register_gateway.assert_called_once()
+        gateway_create = mock_register_gateway.call_args[0][1]
+        assert len(gateway_create.tags) == 3
+        assert gateway_create.tags[0]["id"] == "tag1"
+        assert gateway_create.tags[1]["id"] == "tag2"
+        assert gateway_create.tags[2]["id"] == "tag3"
+
+    @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_parse_exception(self, mock_register_gateway, mock_request, mock_db):
+        """Test adding gateway with parsing exception after successful parse (covers lines 12362-12363)."""
+        # Mock successful JSON parsing but raise exception during processing
+        mock_request.json = AsyncMock(return_value={
+            "name": "test-gateway",
+            "url": "https://example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        # Mock _parse_gateway_data_from_request to raise a generic exception
+        with patch("mcpgateway.admin._parse_gateway_data_from_request", side_effect=Exception("Processing failed")):
+            result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "Invalid request data" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_parse_exception(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with parsing exception (covers lines 12520-12523)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        # Mock _parse_gateway_data_from_request to raise exception
+        with patch("mcpgateway.admin._parse_gateway_data_from_request", side_effect=Exception("Parsing failed")):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "Invalid request data" in body["message"]
+        assert "Parsing failed" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_with_team_id_whitespace(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with team_id containing whitespace (covers line 12527)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com",
+            "team_id": "  "  # Whitespace only
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value=None)
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["success"] is True
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_with_oauth_secret(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with OAuth client secret (covers lines 12536-12540)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "oauth-gateway",
+            "url": "https://oauth.example.com",
+            "oauth_config": {
+                "client_id": "client123",
+                "client_secret": "secret123",
+                "token_url": "https://oauth.example.com/token"
+            }
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with (
+            patch("mcpgateway.admin.TeamManagementService", lambda db: team_service),
+            patch("mcpgateway.admin.get_encryption_service") as mock_encryption,
+        ):
+            mock_enc_service = MagicMock()
+            mock_enc_service.encrypt_secret_async = AsyncMock(return_value="encrypted_secret")
+            mock_encryption.return_value = mock_enc_service
+
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["success"] is True
+        mock_enc_service.encrypt_secret_async.assert_called_once_with("secret123")
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_auto_detect_oauth(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with OAuth auto-detection (covers line 12544)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "oauth-gateway",
+            "url": "https://oauth.example.com",
+            "oauth_config": {
+                "client_id": "client123",
+                "token_url": "https://oauth.example.com/token"
+            }
+            # No auth_type specified
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        body = json.loads(result.body)
+        assert body["success"] is True
+        # Verify auth_type was auto-detected
+        mock_update_gateway.assert_called_once()
+        gateway_update = mock_update_gateway.call_args[0][2]
+        assert gateway_update.auth_type == "oauth"
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_permission_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with permission error (covers lines 12588-12590)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = PermissionError("User does not have permission")
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 403
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "does not have permission" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_gateway_connection_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with connection error (covers lines 12596-12597)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = GatewayConnectionError("Connection failed")
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 502
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "Connection failed" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_runtime_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with runtime error (covers lines 12598-12599)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = RuntimeError("Service unavailable")
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "Service unavailable" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_validation_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with validation error (covers lines 12600-12601)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+        from pydantic import ValidationError
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        # Create a proper Pydantic ValidationError by trying to validate invalid data
+        try:
+            from mcpgateway.schemas import GatewayUpdate
+            GatewayUpdate(url="not-a-valid-url")  # This will raise ValidationError
+        except ValidationError as e:
+            validation_error = e
+
+        mock_update_gateway.side_effect = validation_error
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+        body = json.loads(result.body)
+        assert body["success"] is False
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_integrity_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with integrity error (covers lines 12602-12603)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = IntegrityError("statement", {}, None)
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 409
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_value_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with value error (covers lines 12604-12605)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = ValueError("Invalid value")
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "Invalid value" in body["message"]
+
+    @patch.object(GatewayService, "update_gateway")
+    async def test_admin_update_gateway_rest_unexpected_error(self, mock_update_gateway, mock_request, mock_db):
+        """Test updating gateway with unexpected error (covers lines 12606-12607)."""
+        from mcpgateway.admin import admin_update_gateway_rest
+
+        existing_gateway = MagicMock()
+        existing_gateway.owner_email = "owner@example.com"
+        existing_gateway.team_id = "team-123"
+        mock_db.get = MagicMock(return_value=existing_gateway)
+
+        mock_request.json = AsyncMock(return_value={
+            "name": "updated-gateway",
+            "url": "https://updated.example.com"
+        })
+        mock_request.headers = {"content-type": "application/json"}
+
+        mock_update_gateway.side_effect = Exception("Unexpected error")
+
+        team_service = MagicMock()
+        team_service.verify_team_for_user = AsyncMock(return_value="team-123")
+
+        with patch("mcpgateway.admin.TeamManagementService", lambda db: team_service):
+            result = await admin_update_gateway_rest("gateway-123", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 500
+        body = json.loads(result.body)
+        assert body["success"] is False
+        assert "An unexpected error occurred" in body["message"]
+
+    async def test_admin_delete_gateway_rest_permission_error(self, mock_db):
+        """Test deleting gateway with permission error (covers lines 12634-12636)."""
+        from mcpgateway.admin import admin_delete_gateway_rest
+
+        with patch("mcpgateway.admin.gateway_service.delete_gateway", new_callable=AsyncMock) as mock_delete:
+            mock_delete.side_effect = PermissionError("User does not have permission")
+
+            result = await admin_delete_gateway_rest("gateway-123", mock_db, user={"email": "test-user", "db": mock_db})
+
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 403
+            body = json.loads(result.body)
+            assert body["success"] is False
+            assert "does not have permission" in body["message"]
+
+    async def test_admin_delete_gateway_rest_unexpected_error(self, mock_db):
+        """Test deleting gateway with unexpected error (covers lines 12639-12641)."""
+        from mcpgateway.admin import admin_delete_gateway_rest
+
+        with patch("mcpgateway.admin.gateway_service.delete_gateway", new_callable=AsyncMock) as mock_delete:
+            mock_delete.side_effect = Exception("Unexpected error")
+
+            result = await admin_delete_gateway_rest("gateway-123", mock_db, user={"email": "test-user", "db": mock_db})
+
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 500
+            body = json.loads(result.body)
+            assert body["success"] is False
+            assert "Failed to delete gateway" in body["message"]
+
+
 
 class TestImportConfigurationEndpoints:
     """Test import configuration functionality."""

--- a/tests/unit/mcpgateway/test_multi_auth_headers.py
+++ b/tests/unit/mcpgateway/test_multi_auth_headers.py
@@ -163,6 +163,7 @@ class TestMultiAuthHeaders:
 
         mock_request = MagicMock(spec=Request)
         mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
 
         with patch("mcpgateway.admin.gateway_service.register_gateway", AsyncMock()):
             response = await admin_add_gateway(mock_request, mock_db, user=mock_user)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #3517

---

## 📝 Summary
Implements JSON payload support and RESTful HTTP verbs for gateway CRUD operations in the Admin API. Previously, `/admin/gateways` endpoints only accepted `multipart/form-data` and used non-standard POST routes for updates/deletes. This PR adds proper REST endpoints with Pydantic schema validation and Swagger documentation.

**Key Changes:**
- Added JSON support via Pydantic models (`GatewayCreate`, `GatewayUpdate`)
- Implemented RESTful endpoints: `PUT /admin/gateways/{id}` and `DELETE /admin/gateways/{id}`
- Maintained backward compatibility with existing form-data endpoints
- Fixed OAuth config parsing to handle invalid JSON and "None" string values
- Fixed CA certificate signing to properly set `signing_algorithm` to None when disabled
- Added comprehensive unit tests for new functionality (22 tests total)

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass    |
| Unit tests                | `make test`     | ✅ Pass    |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Testing:**
A test script is included at `scripts/test_rest_api_endpoints.py` to verify the new REST endpoints:
```bash
export TOKEN=$(curl -s -X POST "http://localhost:8000/auth/email/login" \
  -H "Content-Type: application/json" \
  -d '{"email": "admin@example.com", "password": "yourpass"}' | jq -r '.access_token')
uv run scripts/test_rest_api_endpoints.py
```

**Backward Compatibility:**
- Existing form-data endpoints continue to work unchanged
- New JSON endpoints are additive and don't break existing clients
- Both content types are supported via `_parse_gateway_data_from_request()` helper

**Fixed Tests (3):**
- `test_admin_add_gateway_with_invalid_oauth_json` - now properly handles invalid OAuth JSON
- `test_admin_add_gateway_oauth_config_none_string` - now properly handles "None" string
- `test_admin_add_gateway_ca_certificate_signing_disabled` - verifies `signing_algorithm=None` when disabled

**New Coverage Tests (7 in `TestRESTAPIEndpointsCoverage`):**
- `test_admin_add_gateway_json_tags_string` - covers tag string-to-list conversion (lines 872-874)
- `test_admin_add_gateway_pydantic_with_team_id_strip` - covers Pydantic model path with team_id stripping
- `test_admin_update_gateway_rest_http_exception` - covers HTTPException re-raising (line 12565)
- `test_admin_delete_gateway_rest_success` - covers successful deletion path (line 12604)
- `test_admin_update_gateway_rest_form_data_team_id_strip` - covers team_id stripping in form-data (line 12503)
- `test_admin_update_gateway_rest_oauth_client_secret_encryption` - covers OAuth secret encryption (lines 12517-12521)
- `test_admin_update_gateway_rest_oauth_auto_detect_auth_type` - covers OAuth auth_type auto-detection (line 12525)

**Test Results:**
All 22 tests pass (3 originally failing + 19 new tests including 12 from previous coverage work + 7 new)