### PR TITLE
Update alembic history files to pass pre-commit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-19T12:25:29Z",
+  "generated_at": "2026-05-19T16:38:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4579,16 +4579,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 22,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py": [
-      {
-        "hashed_secret": "c561aac847538846232699cfaed7fc7fabd1d134",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 23,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/alembic/versions/59028d2263b1_add_toolops_test_cases_table.py
+++ b/mcpgateway/alembic/versions/59028d2263b1_add_toolops_test_cases_table.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Location: ./mcpgateway/alembic/versions/add_toolops_test_cases_table.py
+"""Location: ./mcpgateway/alembic/versions/59028d2263b1_add_toolops_test_cases_table.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Jay Bandlamudi
 
-add_toolops_test_cases_table
+59028d2263b1_add_toolops_test_cases_table
 
-Revision ID: add_toolops_test_cases_table
+Revision ID: 59028d2263b1
 Revises: add_oauth_tokens_table
 Create Date: 2025-11-27 10:00:00.000000
 """
@@ -19,8 +19,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "add_toolops_test_cases_table"
-down_revision: Union[str, Sequence[str], None] = "z1a2b3c4d5e6"
+revision: str = "59028d2263b1"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "z1a2b3c4d5e6"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/90cc4b5a96e7_add_a2a_agents_and_metrics.py
+++ b/mcpgateway/alembic/versions/90cc4b5a96e7_add_a2a_agents_and_metrics.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
-"""Location: ./mcpgateway/alembic/versions/add_a2a_agents_and_metrics.py
+"""Location: ./mcpgateway/alembic/versions/90cc4b5a96e7_add_a2a_agents_and_metrics.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Mihai Criveti
 
-add_a2a_agents_and_metrics
+90cc4b5a96e7_add_a2a_agents_and_metrics
 
-Revision ID: add_a2a_agents_and_metrics
-Revises: add_oauth_tokens_table
+Revision ID: 90cc4b5a96e7
+Revises: 94f64b8e282f
 Create Date: 2025-08-19 10:00:00.000000
 """
 
@@ -19,8 +19,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "add_a2a_agents_and_metrics"
-down_revision: Union[str, Sequence[str], None] = "add_oauth_tokens_table"
+revision: str = "90cc4b5a96e7"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "94f64b8e282f"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/94f64b8e282f_add_oauth_tokens_table.py
+++ b/mcpgateway/alembic/versions/94f64b8e282f_add_oauth_tokens_table.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Location: ./mcpgateway/alembic/versions/add_oauth_tokens_table.py
+"""Location: ./mcpgateway/alembic/versions/94f64b8e282f_add_oauth_tokens_table.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 Authors: Mihai Criveti
 
 add oauth tokens table
 
-Revision ID: add_oauth_tokens_table
+Revision ID: 94f64b8e282f
 Revises: f8c9d3e2a1b4
 Create Date: 2024-12-20 11:00:00.000000
 """
@@ -19,8 +19,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "add_oauth_tokens_table"
-down_revision: Union[str, Sequence[str], None] = "f8c9d3e2a1b4"
+revision: str = "94f64b8e282f"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "f8c9d3e2a1b4"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py
+++ b/mcpgateway/alembic/versions/9e028ecf59c4_tag_records_changes_list_str_to_list_.py
@@ -7,7 +7,7 @@ Authors: Mihai Criveti
 tag records changes list[str] to list[Dict[str,str]]
 
 Revision ID: 9e028ecf59c4
-Revises: add_toolops_test_cases_table
+Revises: 59028d2263b1
 Create Date: 2025-11-26 18:15:07.113528
 """
 
@@ -20,8 +20,8 @@ import orjson
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "9e028ecf59c4"
-down_revision: Union[str, Sequence[str], None] = "add_toolops_test_cases_table"
+revision: str = "9e028ecf59c4"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "59028d2263b1"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/c9dd86c0aac9_remove_original_name_slug_and_added_.py
+++ b/mcpgateway/alembic/versions/c9dd86c0aac9_remove_original_name_slug_and_added_.py
@@ -7,7 +7,7 @@ Authors: Mihai Criveti
 remove original_name_slug and added custom_name
 
 Revision ID: c9dd86c0aac9
-Revises: add_a2a_agents_and_metrics
+Revises: 90cc4b5a96e7
 Create Date: 2025-08-19 15:15:26.509036
 """
 
@@ -19,8 +19,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "c9dd86c0aac9"
-down_revision: Union[str, Sequence[str], None] = "add_a2a_agents_and_metrics"
+revision: str = "c9dd86c0aac9"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "90cc4b5a96e7"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #4817 

---

## 📝 Summary
Renames some of the historical corrections to alembic that are currently failing pre-commit checks when touched.

Currently pre-commit checks fail if executing, particularly the "check-migration-patterns" which only fails in the install pre-commit checks.
The command that is executed is `python3 scripts/pre-commit/check_migration_patterns.py` which turns up these files as causing issues because they don't adhere to the alembic standard we're abiding by.

```
 . ./.venv/bin/activate
[brian@dogmatix] ➜ [.venv] mcp-context-forge_main git:(bh/correct_alembic) ✗ python3 scripts/pre-commit/check_migration_patterns.py mcpgateway/alembic/versions/*
Migration pattern violations:
  add_a2a_agents_and_metrics.py: filename must match <12-char-alphanumeric>_<description>.py
  add_oauth_tokens_table.py: filename must match <12-char-alphanumeric>_<description>.py
  add_toolops_test_cases_table.py: filename must match <12-char-alphanumeric>_<description>.py
```

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
