### PR TITLE
fix(ui): replace htmx.ajax() with element-based trigger in loadSearchablePanel

### DIFF
--- a/mcpgateway/admin_ui/search.js
+++ b/mcpgateway/admin_ui/search.js
@@ -102,12 +102,23 @@ export const loadSearchablePanel = function (entityType) {
   }
 
   const url = `${window.ROOT_PATH}/admin/${panelConfig.partialPath}?${params.toString()}`;
-  if (window.htmx && window.htmx.ajax) {
-    window.htmx.ajax("GET", url, {
-      target: panelConfig.targetSelector,
-      swap: "outerHTML",
-      indicator: panelConfig.indicatorSelector,
-    });
+  // Use element-based HTMX trigger instead of htmx.ajax() to ensure OOB swaps
+  // (e.g. pagination controls) are reliably processed.  htmx.ajax() can silently
+  // skip hx-swap-oob elements in the response, causing a null-querySelector crash
+  // on every search after the first one.  The tokens panel already uses this same
+  // pattern (tokens.js:63-68).
+  if (window.htmx) {
+    const targetEl = document.querySelector(panelConfig.targetSelector);
+    if (targetEl) {
+      targetEl.setAttribute("hx-get", url);
+      targetEl.setAttribute("hx-swap", "outerHTML");
+      targetEl.setAttribute("hx-trigger", "searchReload");
+      if (panelConfig.indicatorSelector) {
+        targetEl.setAttribute("hx-indicator", panelConfig.indicatorSelector);
+      }
+      window.htmx.process(targetEl);
+      window.htmx.trigger(targetEl, "searchReload");
+    }
   }
 };
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Panel search (tools, servers, resources, prompts, gateways, agents) works on first use but breaks on every subsequent search with `htmx:swapError` / `TypeError: null is not an object (evaluating 'o.querySelector')` in the browser console.

The root cause is that `loadSearchablePanel()` uses `window.htmx.ajax()`, which silently skips `hx-swap-oob` elements in the response. The partial responses for all these panels return an out-of-band `<div id="*-pagination-controls" hx-swap-oob="true">` alongside the main table fragment. When HTMX fails to process the OOB swap, it tries to call `.querySelector()` on a null target reference and throws.

## 🔁 Reproduction Steps

Fixes #4822.

1. Open the Admin UI → **Tools** tab (or Servers, Resources, Prompts, Gateways, Agents).
2. Type any term in the search input — results update correctly.
3. Type a second search term (or clear and type again).
4. Observe: table does not update; browser console shows `htmx:swapError` and `TypeError: null is not an object (evaluating 'o.querySelector')`.

## 🐞 Root Cause

`loadSearchablePanel()` in `mcpgateway/admin_ui/search.js` calls `window.htmx.ajax()` to fetch and swap the panel partial. The server response contains both the main table fragment and an OOB pagination-controls fragment (`hx-swap-oob="true"`). `htmx.ajax()` does not reliably process OOB elements — this is already documented in the codebase at `tokens.js:63–65`:

> _"This ensures OOB swaps (pagination controls) are properly processed, unlike `htmx.ajax()` which can silently skip OOB handling."_

When OOB processing is skipped, HTMX internally resolves the OOB target to `null` and crashes with `o.querySelector` on the second and subsequent invocations.

## 💡 Fix Description

Replace `htmx.ajax()` with the element-based trigger pattern already used by the tokens panel (`tokens.js:63–68`):

1. Set `hx-get`, `hx-swap`, `hx-trigger`, and `hx-indicator` directly on the target element.
2. Call `htmx.process(targetEl)` to register HTMX handlers on the updated attributes.
3. Call `htmx.trigger(targetEl, "searchReload")` to fire the request through HTMX's full declarative pipeline.

This ensures OOB swap elements in the response are correctly processed on every search invocation, not just the first.

The fix is a one-function change with no template or backend modifications required.

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | JS-only change; no Python linting impact |
| Unit tests | `make test` | No Python logic changed |
| Coverage ≥ 80 % | `make coverage` | Unaffected |
| Manual regression no longer fails | Type in search box twice on Tools page | Fixed |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed