### PR TITLE
Fix/rbac admin bypass token teams upsert

### DIFF
--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -44,10 +44,23 @@ def _allowed_teams_from_ctx(ctx: Dict[str, Any]) -> Optional[set[str]]:
 
     Returns ``None`` for unrestricted admins (full bypass).
     Returns an empty set for public-only callers (nothing allowed).
+
+    Admin tokens that do not carry an explicit ``teams`` claim are treated as
+    unrestricted (full bypass). Only when an admin's token is *explicitly*
+    scoped to a non-empty list of teams is the admin restricted to that list.
+    This preserves the historical admin bypass behaviour while still allowing
+    intentionally team-scoped admin tokens.
     """
     is_admin: bool = ctx.get("is_admin", False)
     token_teams = ctx.get("token_teams")
-    return None if (is_admin and token_teams is None) else set(token_teams or [])
+    # Admin bypass: full bypass unless the token is explicitly scoped to teams.
+    # ``token_teams`` is None when the JWT's ``teams`` claim is absent/null for
+    # an admin (admin bypass), and [] when the claim is missing for a regular
+    # token mint where ``normalize_token_teams`` returns the secure default.
+    # In both of those cases an admin should retain the historical bypass.
+    if is_admin and not token_teams:
+        return None
+    return set(token_teams or [])
 
 
 async def _invalidate_and_broadcast(bindings: List[ToolPluginBindingResponse]) -> None:

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -44,20 +44,10 @@ def _allowed_teams_from_ctx(ctx: Dict[str, Any]) -> Optional[set[str]]:
 
     Returns ``None`` for unrestricted admins (full bypass).
     Returns an empty set for public-only callers (nothing allowed).
-
-    Admin tokens that do not carry an explicit ``teams`` claim are treated as
-    unrestricted (full bypass). Only when an admin's token is *explicitly*
-    scoped to a non-empty list of teams is the admin restricted to that list.
-    This preserves the historical admin bypass behaviour while still allowing
-    intentionally team-scoped admin tokens.
     """
     is_admin: bool = ctx.get("is_admin", False)
     token_teams = ctx.get("token_teams")
     # Admin bypass: full bypass unless the token is explicitly scoped to teams.
-    # ``token_teams`` is None when the JWT's ``teams`` claim is absent/null for
-    # an admin (admin bypass), and [] when the claim is missing for a regular
-    # token mint where ``normalize_token_teams`` returns the secure default.
-    # In both of those cases an admin should retain the historical bypass.
     if is_admin and not token_teams:
         return None
     return set(token_teams or [])

--- a/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
+++ b/tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py
@@ -330,6 +330,49 @@ class TestToolPluginBindingsRouter:
         )
         assert result.total == 2
 
+    @pytest.mark.asyncio
+    async def test_upsert_admin_with_empty_token_teams_can_target_any_team(self, db_session):
+        """
+        ``mcpgateway.auth.normalize_token_teams`` returns ``[]`` (not ``None``)
+        when the JWT lacks a ``teams`` claim — which is the case for every
+        normal admin token mint. The bypass must also fire when
+        ``token_teams`` is falsy (empty list).
+        """
+        admin_no_teams_claim_ctx = {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "token_teams": [],  # JWT had no "teams" claim → secure default []
+            "db": db_session,
+            "permissions": ["tools.manage_plugins", "tools.read"],
+        }
+        result = await upsert_tool_plugin_bindings(
+            request=_two_team_request(),
+            current_user_ctx=admin_no_teams_claim_ctx,
+            db=db_session,
+        )
+        assert result.total == 2
+
+    @pytest.mark.asyncio
+    async def test_upsert_narrowed_admin_still_restricted(self, db_session):
+        """Admin with an *explicitly* team-scoped token is still restricted to those teams."""
+        narrowed_admin_ctx = {
+            "email": "admin@example.com",
+            "full_name": "Admin User",
+            "is_admin": True,
+            "token_teams": ["team-b"],  # explicitly scoped — does NOT include team-a
+            "db": db_session,
+            "permissions": ["tools.manage_plugins", "tools.read"],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            await upsert_tool_plugin_bindings(
+                request=_simple_request(),  # targets team-a
+                current_user_ctx=narrowed_admin_ctx,
+                db=db_session,
+            )
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        assert exc_info.value.detail == "Not authorized to configure bindings for team(s): team-a"
+
     # ------------------------------------------------------------------
     # GET / — list_tool_plugin_bindings
     # ------------------------------------------------------------------


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4825

---

## 📝 Summary
PR #4405 tightened `_allowed_teams_from_ctx` to only grant the admin bypass when `is_admin=True` **and** `token_teams is None`. However, `normalize_token_teams` in auth.py returns `[]` (not `None`) for any JWT that lacks a `"teams"` claim — which includes every normal admin token minted by the gateway (claim set: `sub`, `exp`, `iat`, `aud`, `iss`, `jti`, `token_use`, `user` — no `teams`). This caused `POST /v1/tools/plugin_bindings/` to return 403 for all admin users, a regression from pre-#4405 behaviour.

Fix: change the bypass condition to `is_admin and not token_teams`, so admins are bypassed when `token_teams` is either `None` or `[]` (i.e. not explicitly scoped). Admins carrying a non-empty `token_teams` list are still restricted to those teams, preserving the intent of #4405 for explicitly scoped tokens.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Two regression tests added in `tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py`:
- `test_upsert_admin_with_empty_token_teams_can_target_any_team` — admin with `token_teams=[]` (JWT missing `teams` claim) can upsert bindings for any team. This test **fails** against the #4405 code and passes after this fix.
- `test_upsert_narrowed_admin_still_restricted` — admin with `token_teams=["team-b"]` is still blocked from creating bindings in `team-a`, preserving the scoped-admin restriction.