### PR TITLE
fix(ui): Add app_root_path when exporting virtual server

### DIFF
--- a/mcpgateway/admin_ui/configExport.js
+++ b/mcpgateway/admin_ui/configExport.js
@@ -46,10 +46,11 @@ export const getCatalogUrl = function (server) {
     window.location.port ||
     (window.location.protocol === "https:" ? "443" : "80");
   const protocol = window.location.protocol;
+  const rootPath = window.ROOT_PATH || "";
 
   const baseUrl = `${protocol}//${currentHost}${
     currentPort !== "80" && currentPort !== "443" ? ":" + currentPort : ""
-  }`;
+  }${rootPath}`;
 
   return `${baseUrl}/servers/${server.id}`;
 };
@@ -145,7 +146,8 @@ export const generateConfig = function (server, configType) {
     window.location.port ||
     (window.location.protocol === "https:" ? "443" : "80");
   const protocol = window.location.protocol;
-  const baseUrl = `${protocol}//${currentHost}${currentPort !== "80" && currentPort !== "443" ? ":" + currentPort : ""}`;
+  const rootPath = window.ROOT_PATH || "";
+  const baseUrl = `${protocol}//${currentHost}${currentPort !== "80" && currentPort !== "443" ? ":" + currentPort : ""}${rootPath}`;
 
   // Clean server name for use as config key (alphanumeric and hyphens only)
   const cleanServerName = server.name

--- a/tests/js/admin-dom.test.js
+++ b/tests/js/admin-dom.test.js
@@ -288,6 +288,19 @@ describe("getCatalogUrl", () => {
     expect(result).toContain("/servers/srv-123");
     expect(result).toMatch(/^https?:\/\//);
   });
+
+  test("includes ROOT_PATH in catalog URL", () => {
+    window.ROOT_PATH = "/api/v1";
+    const result = getCatalogUrl({ id: "srv-456" });
+    expect(result).toContain("/api/v1/servers/srv-456");
+  });
+
+  test("handles empty ROOT_PATH in catalog URL", () => {
+    window.ROOT_PATH = "";
+    const result = getCatalogUrl({ id: "srv-789" });
+    expect(result).toContain("/servers/srv-789");
+    expect(result).not.toContain("//servers");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -330,6 +343,47 @@ describe("generateConfig", () => {
     expect(() => generateConfig({ id: "s1", name: "x" }, "unknown")).toThrow(
       /Unknown config type/
     );
+  });
+
+  test("includes ROOT_PATH in stdio config URLs", () => {
+    window.ROOT_PATH = "/api/v1";
+    const result = generateConfig({ id: "s1", name: "My Server" }, "stdio");
+    expect(
+      result.mcpServers["mcpgateway-wrapper"].env.MCP_SERVER_URL
+    ).toContain("/api/v1/servers/s1");
+  });
+
+  test("includes ROOT_PATH in sse config URLs", () => {
+    window.ROOT_PATH = "/gateway";
+    const result = generateConfig({ id: "s1", name: "My Server" }, "sse");
+    const key = Object.keys(result.servers)[0];
+    expect(result.servers[key].url).toContain("/gateway/servers/s1/sse");
+  });
+
+  test("includes ROOT_PATH in http config URLs", () => {
+    window.ROOT_PATH = "/mcp-proxy";
+    const result = generateConfig({ id: "s1", name: "My Server" }, "http");
+    const key = Object.keys(result.servers)[0];
+    expect(result.servers[key].url).toContain("/mcp-proxy/servers/s1/mcp");
+  });
+
+  test("handles empty ROOT_PATH gracefully", () => {
+    window.ROOT_PATH = "";
+    const result = generateConfig({ id: "s1", name: "My Server" }, "sse");
+    const key = Object.keys(result.servers)[0];
+    expect(result.servers[key].url).toContain("/servers/s1/sse");
+    expect(result.servers[key].url).not.toContain("//servers");
+  });
+
+  test("handles undefined ROOT_PATH gracefully", () => {
+    delete window.ROOT_PATH;
+    const result = generateConfig({ id: "s1", name: "My Server" }, "stdio");
+    expect(
+      result.mcpServers["mcpgateway-wrapper"].env.MCP_SERVER_URL
+    ).toContain("/servers/s1");
+    expect(
+      result.mcpServers["mcpgateway-wrapper"].env.MCP_SERVER_URL
+    ).not.toContain("//servers");
   });
 });
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4827

---

## 📝 Summary
Fixes a bug where the "Export Config" feature in the Admin UI generated URLs without the `APP_ROOT_PATH` prefix, causing incorrect/incomplete URLs when the application is deployed with a custom path prefix.

**What Changed:**
- Modified `getCatalogUrl()` and `generateConfig()` functions to include `window.ROOT_PATH` in all generated URLs
- Added test coverage for ROOT_PATH handling in both functions

---

## 🏷️ Type of Change
- [ x ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    pass    |
| Unit tests                | `make test`     |    pass    |
| Coverage ≥ 80%            | `make coverage` |    pass    |

---

## ✅ Checklist
- [ x ] Code formatted (`make black isort pre-commit`)
- [ x ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ x ] No secrets or credentials committed