### PR TITLE
fix: update Rust dependency pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ pyo3-stub-gen = "0.19"
 rand = "0.8"
 redis = { version = "0.32.7", features = ["aio", "tokio-comp", "connection-manager"] }
 regex = "1.12.2"
-rmcp = { version = "1.4.0", default-features = false }
+rmcp = { version = "1.7.0", default-features = false }
 sha2 = "0.10.9"
 
 # HTTP client (native-tls to avoid CDLA-Permissive-2.0 from rustls-platform-verifier)

--- a/crates/mcp_runtime/Cargo.toml
+++ b/crates/mcp_runtime/Cargo.toml
@@ -28,7 +28,7 @@ rand.workspace = true
 regex.workspace = true
 redis.workspace = true
 reqwest.workspace = true
-reqwest-rmcp = { package = "reqwest", version = "0.13.2", default-features = false, features = ["json", "stream", "rustls"], optional = true }
+reqwest-rmcp = { package = "reqwest", version = "0.13.3", default-features = false, features = ["json", "stream", "rustls"], optional = true }
 rmcp = { workspace = true, optional = true, features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 rustls = "0.23.37"
 rustls-native-certs = "0.8.3"

--- a/mcp-servers/rust/filesystem-server/Cargo.toml
+++ b/mcp-servers/rust/filesystem-server/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.54", features = ["derive"] }
 futures = "0.3.31"
 globset = "0.4.18"
 ignore = "0.4.25"
-openssl = "0.10.78"
+openssl = "0.10.79"
 rmcp = { version = "0.14.0", features = ["transport-streamable-http-server"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -32,8 +32,8 @@ axum-test = "18.7.0"
 bytes = "1.11.0"
 http = "1.4.0"
 hyper = "1.8.1"
-openssl = "0.10.78"
-reqwest = { version = "0.13.1", default-features = false, features = [
+openssl = "0.10.79"
+reqwest = { version = "0.13.3", default-features = false, features = [
     "native-tls",
     "json",
 ] }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -217,8 +217,8 @@ user-login = "newpavlov"
 user-name = "Artyom Pavlov"
 
 [[publisher.h2]]
-version = "0.4.13"
-when = "2026-01-05"
+version = "0.4.14"
+when = "2026-05-04"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -230,8 +230,8 @@ user-id = 55123
 user-login = "rust-lang-owner"
 
 [[publisher.hashbrown]]
-version = "0.17.0"
-when = "2026-04-09"
+version = "0.17.1"
+when = "2026-05-09"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -584,8 +584,8 @@ user-login = "briansmith"
 user-name = "Brian Smith"
 
 [[publisher.rmcp]]
-version = "1.2.0"
-when = "2026-03-11"
+version = "1.7.0"
+when = "2026-05-13"
 user-id = 341684
 user-login = "alexhancock"
 user-name = "Alex Hancock"
@@ -772,6 +772,13 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
+[[publisher.tokio]]
+version = "1.52.3"
+when = "2026-05-08"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
 [[publisher.tokio-macros]]
 version = "2.7.0"
 when = "2026-04-03"
@@ -864,8 +871,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.tower-http]]
-version = "0.6.8"
-when = "2025-12-08"
+version = "0.6.10"
+when = "2026-05-06"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -2554,7 +2561,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -2572,7 +2579,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## 🔗 Related Issue
N/A

---

## 📝 Summary
Updates selected Rust dependency pins and lock metadata for the RMCP client path and filesystem server.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Rust workspace check | `cargo check --workspace --all-features` | Passed |
| Filesystem server check | `cargo check --manifest-path mcp-servers/rust/filesystem-server/Cargo.toml` | Passed |
| Cargo audit | `cargo audit --file Cargo.lock` | Passed |
| Cargo audit | `cargo audit --file mcp-servers/rust/filesystem-server/Cargo.lock` | Passed |
| Cargo audit | `cargo audit --file mcp-servers/rust/fast-test-server/Cargo.lock` | Passed |
| Cargo vet | `cargo vet check` | Passed |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Dependency-only change. No runtime code changes.