### PR TITLE
docs: clarify contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -13,18 +13,32 @@ Before opening this PR please:
 ---
 
 ## 📌 Summary
+
 _What problem does this PR fix and **why**?_
 
 ## 🔁 Reproduction Steps
+
 _Link the issue and minimal steps to reproduce the bug._
 
 ## 🐞 Root Cause
+
 _What was wrong and where?_
 
 ## 💡 Fix Description
+
 _How did you solve it?  Key design points._
 
+## 📏 Reviewability
+
+- [ ] This PR has one clear purpose
+- [ ] The linked issue is not labeled `triage`
+- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
+- [ ] Tests are included with the code they validate
+- [ ] If AI-assisted, I understand and can explain the generated changes
+
 ## 🧪 Verification
+
+_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._
 
 | Check                                 | Command              | Status |
 |---------------------------------------|----------------------|--------|
@@ -34,9 +48,11 @@ _How did you solve it?  Key design points._
 | Manual regression no longer fails     | steps / screenshots  |        |
 
 ## 📐 MCP Compliance (if relevant)
+
 - [ ] Matches current MCP spec
 - [ ] No breaking change to MCP clients
 
 ## ✅ Checklist
+
 - [ ] Code formatted (`make black isort pre-commit`)
 - [ ] No secrets/credentials committed

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -7,17 +7,30 @@
 ---
 
 ## 🔗 Related Issue / Epic
+
 _Link to the doc bug or epic this PR addresses:_
 Closes #
 
 ---
 
 ## 📝 Summary (1-2 sentences)
+
 _What section of the docs is changing and why?_
 
 ---
 
+## 📏 Reviewability
+
+- [ ] This PR has one clear purpose
+- [ ] The linked issue is not labeled `triage`
+- [ ] Unrelated docs fixes or improvements are tracked in separate issues/PRs
+- [ ] Generated files are separated where that improves reviewability
+- [ ] If AI-assisted, I understand and can explain the generated changes
+
+---
+
 ## ✏️ Type of Change
+
 - [ ] Typo / formatting
 - [ ] Outdated or incorrect info
 - [ ] Missing explanation / example
@@ -26,3 +39,7 @@ _What section of the docs is changing and why?_
 - [ ] Other (describe)
 
 ---
+
+## 🧪 Verification
+
+_List exact commands, screenshots, preview links, logs, or manual validation. If evidence is not feasible, explain why._

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,17 +1,31 @@
 # ✨ Feature / Enhancement PR
 
 ## 🔗 Epic / Issue
+
 _Link to the epic or parent issue:_
 Closes #
 
 ---
 
 ## 🚀 Summary (1-2 sentences)
+
 _What does this PR add or change?_
 
 ---
 
+## 📏 Reviewability
+
+- [ ] This PR has one clear purpose
+- [ ] The linked issue is not labeled `triage`
+- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
+- [ ] Tests are included with the code they validate
+- [ ] If AI-assisted, I understand and can explain the generated changes
+
+---
+
 ## 🧪 Checks
+
+_List exact commands, screenshots, videos, logs, validation steps, or explain why evidence is not feasible._
 
 - [ ] `make lint` passes
 - [ ] `make test` passes
@@ -20,7 +34,8 @@ _What does this PR add or change?_
 ---
 
 ## 📓 Notes (optional)
-_Design sketch, screenshots, or extra context._
+
+_Design sketch or extra context._
 
 If the change introduces or alters an architectural decision, add or update an ADR in **`docs/docs/adr/`** and link it here._
 

--- a/.github/PULL_REQUEST_TEMPLATE/plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin.md
@@ -1,16 +1,26 @@
 # 🧱 New Plugin
 
 ## 🔗 Closes
+
 _Link to the epic or parent issue:_
 
 Closes #
 
-
 ## 🚀 Summary
-_Describe the new plugin_
 
+Describe the new plugin.
+
+## 📏 Reviewability
+
+- [ ] This PR has one clear purpose
+- [ ] The linked issue is not labeled `triage`
+- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
+- [ ] Tests are included with the code they validate
+- [ ] If AI-assisted, I understand and can explain the generated changes
 
 ## 🧪 Checks
+
+_List exact commands, screenshots, videos, logs, validation steps, or explain why evidence is not feasible._
 
 - [ ] Plugin was [bootstrapped with the CLI](https://ibm.github.io/mcp-context-forge/using/plugins/lifecycle/) (native or external template)
 - [ ] Unit tests created for the new plugin

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,17 +8,32 @@ For specialized templates, append to your PR URL:
 Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
 -->
 
+# Pull Request
+
 ## 🔗 Related Issue
+
 Closes #
 
 ---
 
 ## 📝 Summary
+
 _What does this PR do and why?_
 
 ---
 
+## 📏 Reviewability
+
+- [ ] This PR has one clear purpose
+- [ ] The linked issue is not labeled `triage`
+- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
+- [ ] Tests are included with the code they validate
+- [ ] If AI-assisted, I understand and can explain the generated changes
+
+---
+
 ## 🏷️ Type of Change
+
 - [ ] Bug fix
 - [ ] Feature / Enhancement
 - [ ] Documentation
@@ -30,6 +45,8 @@ _What does this PR do and why?_
 
 ## 🧪 Verification
 
+_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._
+
 | Check                     | Command         | Status |
 |---------------------------|-----------------|--------|
 | Lint suite                | `make lint`     |        |
@@ -39,6 +56,7 @@ _What does this PR do and why?_
 ---
 
 ## ✅ Checklist
+
 - [ ] Code formatted (`make black isort pre-commit`)
 - [ ] Tests added/updated for changes
 - [ ] Documentation updated (if applicable)
@@ -47,4 +65,5 @@ _What does this PR do and why?_
 ---
 
 ## 📓 Notes (optional)
+
 _Screenshots, design decisions, or additional context._

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,20 @@ are not interested in accepting into the code base.
 If you would like to fix a bug, please [raise an issue](https://github.com/ibm/mcp-context-forge/issues) before sending a
 pull request so it can be tracked.
 
+## Before Contributing
+
+### Setup
+
+For setup instructions, please see the [Quick Start sections](README.md#quick-start---pypi) in the README, or refer to the [Installation](README.md#installation) section for detailed instructions.
+
+### Testing
+
+Before submitting changes, run the test suite as outlined in the [Bug-fix PR template](.github/PULL_REQUEST_TEMPLATE/bug_fix.md):
+
+1. `make lint` - passes all linters
+2. `make test` - all unit + integration tests green
+3. `make coverage` - >= 90%
+
 ## ✅ Pull Request Standards
 
 All pull requests must be reviewable by a human maintainer. The same standard
@@ -109,6 +123,36 @@ bulk generated code that you cannot explain or validate.
 The project maintainers use LGTM (Looks Good To Me) in comments on the code
 review to indicate acceptance. A change requires an LGTM from at least one
 maintainer.
+
+## Coding Standards
+
+- **Python >= 3.11** with type hints
+- **Formatting**: Black (line length 200), isort (profile=black)
+- **Linting**: Ruff, Pylint per `pyproject.toml`
+- **Naming**: `snake_case` functions, `PascalCase` classes, `UPPER_CASE` constants
+
+See [CLAUDE.md](CLAUDE.md#code-style--standards) for complete coding standards.
+
+### Python File Headers
+
+All Python source files (`.py`) must begin with the following standardized header. This ensures consistency and proper licensing across the codebase.
+
+The header format is as follows:
+
+```python
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Module Description.
+Location: ./path/to/your/file.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+Authors: "Author One, Author Two"
+
+Your detailed module documentation begins here...
+"""
+```
+
+You can automatically check and fix file headers using the provided `make` targets. For detailed usage and examples, please see the [File Header Management section](docs/docs/development/module-documentation.md) in our development documentation.
 
 ## Legal
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,16 @@ To contribute code or documentation, please submit a [pull request](https://gith
 
 A good way to familiarize yourself with the codebase and contribution process is
 to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/ibm/mcp-context-forge/issues).
-Before embarking on a more ambitious contribution, please quickly [get in touch](#communication) with us.
 
 **Note: We appreciate your effort, and want to avoid a situation where a contribution
 requires extensive rework (by you or by us), sits in backlog for a long time, or
 cannot be accepted at all!**
+
+### 🚦 Issue readiness
+
+Do not start implementation on issues labeled `triage`, including issues you
+opened. Wait until maintainers accept or scope the issue, remove the `triage`
+label, or explicitly invite contributions.
 
 ### Proposing new features
 
@@ -27,24 +32,85 @@ are not interested in accepting into the code base.
 If you would like to fix a bug, please [raise an issue](https://github.com/ibm/mcp-context-forge/issues) before sending a
 pull request so it can be tracked.
 
+## ✅ Pull Request Standards
+
+All pull requests must be reviewable by a human maintainer. The same standard
+applies to hand-written, AI-assisted, and agentic changes.
+
+### ✅ Before opening a PR
+
+- Link the issue the PR addresses.
+- Confirm the issue is not labeled `triage`.
+- Keep the PR focused on one concern.
+- Include testing evidence, or explain why testing evidence is not feasible.
+- Use `Closes #123` only when the PR fully resolves that issue.
+
+### 📏 Scope and reviewability
+
+Be considerate of reviewer time. A PR is too large when it mixes unrelated
+concerns or would take a reviewer too long to understand with confidence.
+Thousands of lines of AI-assisted or agent-generated changes can make a PR
+effectively unreviewable, even when the intent is good.
+
+If you expect work to become large, open an issue or draft PR before starting.
+Describe the intended sequence of changes and ask maintainers how they want the
+work split. Large initiatives should be planned as a sequence of reviewable PRs
+instead of one broad PR.
+
+Keep tests with the code they validate. Tests should usually be in the same PR
+as the behavior change, bug fix, or refactor they cover.
+
+If you find an unrelated bug or improvement while working on a PR, open a new
+issue and handle it in a separate PR. Do not expand the current PR to include
+unrelated work.
+
+### 🧪 Evidence and description
+
+Every PR must include a clear summary and testing evidence. Provide the commands
+you ran and their results. Include screenshots, videos, logs, reproduction steps,
+or validation steps where they help reviewers verify the change.
+
+If testing evidence is not feasible, say why in the PR and describe the risk.
+Maintainers may ask for more evidence before reviewing or merging.
+
+Keep commits understandable. Squash noisy fixups when they do not help reviewers
+or future readers.
+
+### 👀 Maintainer review process
+
+Draft PRs are useful for early feedback, but CI does not run until the PR is
+marked ready for review.
+
+All PRs require manual review. Maintainers generally will not review PRs when:
+
+- the issue is still labeled `triage`;
+- CI is failing;
+- the PR has merge conflicts;
+- the scope is unclear or too broad;
+- testing evidence is missing;
+- unrelated concerns are mixed together.
+
+In these cases, maintainers should ask the author to split, clarify, or update
+the PR before doing a detailed review.
+
+### 🌱 First-time contributors
+
+Good first issues are the best place to start. If an issue is unclear, ask on
+the issue before investing heavily in an implementation.
+
+### 🤖 AI-assisted and agentic development
+
+AI-assisted and agentic development are allowed. PR owners remain responsible for
+understanding, testing, and explaining every change they submit. Do not submit
+bulk generated code that you cannot explain or validate.
+
 ### Merge approval
 
 The project maintainers use LGTM (Looks Good To Me) in comments on the code
-review to indicate acceptance. A change requires LGTMs from two of the
-maintainers of each component affected.
-
-For a list of the maintainers, see the [MAINTAINERS.md](MAINTAINERS.md) page.
+review to indicate acceptance. A change requires an LGTM from at least one
+maintainer.
 
 ## Legal
-
-Each source file must include a license header for the Apache
-Software License 2.0. Using the SPDX format is the simplest approach.
-e.g.
-
-```python
-# Copyright <holder> All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-```
 
 We have tried to make it as easy as possible to make contributions. This
 applies to how we handle the legal aspects of contribution. We use the
@@ -67,49 +133,3 @@ local git repository using the following command:
 ```bash
 git commit -s
 ```
-
-## Communication
-
-Please feel free to connect with us through the [issue tracker](https://github.com/ibm/mcp-context-forge/issues).
-
-## Setup
-
-For setup instructions, please see the [Quick Start sections](README.md#quick-start---pypi) in the README, or refer to the [Installation](README.md#installation) section for detailed instructions.
-
-## Testing
-
-Before submitting changes, run the test suite as outlined in the [Bug-fix PR template](.github/PULL_REQUEST_TEMPLATE/bug_fix.md):
-
-1. `make lint` - passes all linters
-2. `make test` - all unit + integration tests green
-3. `make coverage` - ≥ 90%
-
-## Coding style guidelines
-
-- **Python >= 3.11** with type hints
-- **Formatting**: Black (line length 200), isort (profile=black)
-- **Linting**: Ruff, Pylint per `pyproject.toml`
-- **Naming**: `snake_case` functions, `PascalCase` classes, `UPPER_CASE` constants
-
-See [CLAUDE.md](CLAUDE.md#code-style--standards) for complete coding standards.
-
-### Python File Headers
-
-All Python source files (`.py`) must begin with the following standardized header. This ensures consistency and proper licensing across the codebase.
-
-The header format is as follows:
-
-```python
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""Module Description.
-Location: ./path/to/your/file.py
-Copyright 2025
-SPDX-License-Identifier: Apache-2.0
-Authors: "Author One, Author Two"
-
-Your detailed module documentation begins here...
-"""
-```
-
-You can automatically check and fix file headers using the provided `make` targets. For detailed usage and examples, please see the [File Header Management section](docs/docs/development/module-documentation.md) in our development documentation.

--- a/crates/mcp_runtime/DEVELOPING.md
+++ b/crates/mcp_runtime/DEVELOPING.md
@@ -91,6 +91,15 @@ Notes:
 - `make doctest test htmlcov`
   - this is the main broad backend confidence pass
 
+### Python File Headers
+
+If you add or edit Python files while working on the runtime integration, keep
+their standardized headers valid:
+
+```bash
+make check-headers
+```
+
 Important behavior:
 
 - `make test` is a broad Python test run against the `tests/` tree with


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #4428

---

## 📝 Summary

Clarifies contribution guidance for triaged issues, reviewable PR scope, testing evidence, AI-assisted changes, and maintainer review expectations. Updates PR templates so contributors provide the same reviewability details when opening PRs.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [x] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Markdown lint | `markdownlint-cli2 CONTRIBUTING.md .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE/bug_fix.md .github/PULL_REQUEST_TEMPLATE/feature.md .github/PULL_REQUEST_TEMPLATE/docs.md .github/PULL_REQUEST_TEMPLATE/plugin.md` | Passed |
| Diff whitespace | `git diff --check` | Passed |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Testing evidence included, or explained why it is not feasible
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Docs-only change. Repository-wide `make markdownlint` was not used as final evidence because it reports pre-existing markdown issues outside this PR scope.