### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,18 +6,18 @@
 /mcpgateway/plugins @araujof @terylt @jonpspri
 
 # Rust projects
-/crates/ @lucarlig @dima-zakharov @dawid-nowak
-/mcp-servers/rust/ @lucarlig @dima-zakharov @dawid-nowak
-/Cargo.toml @lucarlig @dima-zakharov @dawid-nowak
-/Cargo.lock @lucarlig @dima-zakharov @dawid-nowak
-/deny.toml @lucarlig @dima-zakharov @dawid-nowak
-/rust-toolchain.toml @lucarlig @dima-zakharov @dawid-nowak
-/supply-chain/ @lucarlig @dima-zakharov @dawid-nowak
-/.github/workflows/rust.yml @lucarlig @dima-zakharov @dawid-nowak
-/.github/workflows/pytest-rust.yml @lucarlig @dima-zakharov @dawid-nowak
+/crates/ @lucarlig @dawid-nowak
+/mcp-servers/rust/ @lucarlig @dawid-nowak
+/Cargo.toml @lucarlig @dawid-nowak
+/Cargo.lock @lucarlig @dawid-nowak
+/deny.toml @lucarlig @dawid-nowak
+/rust-toolchain.toml @lucarlig @dawid-nowak
+/supply-chain/ @lucarlig @dawid-nowak
+/.github/workflows/rust.yml @lucarlig @dawid-nowak
+/.github/workflows/pytest-rust.yml @lucarlig @dawid-nowak
 
 # Ownership for all tests
-/tests/ @crivetimihai @kevalmahajan @madhav165
+/tests/ @crivetimihai @madhav165
 
 # Tests for plugin framework
 /tests/unit/mcpgateway/plugins @araujof @terylt @jonpspri


### PR DESCRIPTION
## 🔗 Related Issue
N/A

---

## 📝 Summary
Removes @kevalmahajan and @dima-zakharov from CODEOWNERS ownership entries.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Not run; CODEOWNERS-only change |
| Unit tests                | `make test`     | Not run; CODEOWNERS-only change |
| Coverage ≥ 80%            | `make coverage` | Not run; CODEOWNERS-only change |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Remaining repo-wide references after this change: @kevalmahajan appears in CHANGELOG.md; no remaining matches for @dima-zakharov.
