### PR TITLE
chore: add Slack failure notification for main branch builds

### DIFF
--- a/.github/workflows/notify-slack-failure.yml
+++ b/.github/workflows/notify-slack-failure.yml
@@ -1,0 +1,75 @@
+# ======================================================================
+# Notify Slack on Post-Merge Build Failure
+# ======================================================================
+#
+# Listens for the completion of main-branch build workflows and sends
+# a single Slack notification to #contextforge-ci-alerts when any of
+# them fail.  No changes are needed in the watched workflow files.
+#
+# Watched workflows (matched by the workflow `name:` field):
+#   - Multiplatform Docker Build    → docker-multiplatform.yml
+#   - Helm chart - lint and publish → helm-publish.yml
+#   - linting-full                  → linting-full.yml
+#
+# Required secret (repo Settings → Secrets and variables → Actions):
+#   SLACK_WEBHOOK_URL — Slack Incoming Webhook URL for #contextforge-build-notifications
+#
+# To add more workflows to the watch list, append their `name:` values
+# to the `workflows:` list below.
+#
+# ======================================================================
+
+name: Notify Slack on Build Failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Multiplatform Docker Build"
+      - "Helm chart - lint and publish"
+      - "linting-full"
+    types: [completed]
+    branches: [main]
+  # workflow_dispatch allows manually triggering this workflow from any branch
+  # to verify the Slack integration (secret + action) works before merging to main.
+  # Remove after confirming end-to-end delivery.
+  workflow_dispatch:
+
+# Each workflow_run completion event is unique — do not cancel in-progress
+# notifications so every failure produces exactly one Slack message.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Send Slack failure notification
+    # Only fire when the upstream workflow actually failed, or when manually dispatched for testing
+    if: github.event.workflow_run.conclusion == 'failure' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": ":x: *${{ github.event.workflow_run.name || 'Manual test dispatch' }}* failed on `main`",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *${{ github.event.workflow_run.name || 'Manual test dispatch' }}* failed on `main`\n• *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}|`${{ github.event.workflow_run.head_sha || github.sha }}`>\n• *Actor:* `${{ github.event.workflow_run.actor.login || github.actor }}`\n• *Run:* <${{ github.event.workflow_run.html_url || github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4852

---

## 📝 Summary
Adds a single centralized GitHub Actions workflow (notify-slack-failure.yml) that listens for failures in the three main post-merge build workflows (`Multiplatform Docker Build`, `Helm chart - lint and publish`, `linting-full`) on the `main` branch and sends a Slack notification to `#contextforge-build-notifications`.

No changes are made to any existing workflow files — the `workflow_run` trigger handles everything from one place.

A `workflow_dispatch` trigger is also included to allow manual end-to-end testing from this branch before merging (requires the `SLACK_WEBHOOK_URL` secret to be added by a repo admin).

---

## 🏷️ Type of Change
- [x] Chore (deps, CI, tooling)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | N/A — workflow YAML only |
| Unit tests                | `make test`     | N/A — workflow YAML only |
| Coverage ≥ 80%            | `make coverage` | N/A — workflow YAML only |

YAML validated locally via `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/notify-slack-failure.yml'))"`.

---

## ✅ Checklist
- [x] No secrets or credentials committed
- [x] `SLACK_WEBHOOK_URL` secret added to repo Settings → Secrets and variables → Actions (requires repo admin)
- [ ] End-to-end test via **Actions → Notify Slack on Build Failure → Run workflow** after secret is added

---

## 📓 Notes

**Prerequisite before testing:** A repo admin must add the `SLACK_WEBHOOK_URL` secret (Slack Incoming Webhook URL for `#contextforge-build-notifications`) to the repository.

**How it works:** Each watched workflow completion fires an independent `workflow_run` event. If the conclusion is `failure`, one Slack message is sent immediately — no waiting for other workflows. One failure = one notification.

**`workflow_run` limitation:** The trigger only activates when this file is on the default branch (`main`). The `workflow_dispatch` trigger exists solely for testing notifications and should be removed in a follow-up once delivery is confirmed.