### PR TITLE
[FIX]: Increase health check timeout from 5s to 30s and reset failure counter on recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -588,7 +588,7 @@ DATAPLANE_PUBLISHER_INTERVAL_SECONDS = 60
 
 # Health checks
 # HEALTH_CHECK_INTERVAL=60
-# HEALTH_CHECK_TIMEOUT=5
+# HEALTH_CHECK_TIMEOUT=30
 # UNHEALTHY_THRESHOLD=3
 # GATEWAY_VALIDATION_TIMEOUT=5
 # MAX_CONCURRENT_HEALTH_CHECKS=10
@@ -2479,11 +2479,11 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # Project defaults block sets HEALTH_CHECK_INTERVAL=300 for local dev
 # HEALTH_CHECK_INTERVAL=60
 
-# Health check timeout in seconds (default: 5)
-# HEALTH_CHECK_TIMEOUT=5
+# Health check timeout in seconds (default: 30)
+# HEALTH_CHECK_TIMEOUT=30
 
-# Per-check timeout (seconds) to bound total time of one gateway health check (default: 5.0)
-# GATEWAY_HEALTH_CHECK_TIMEOUT=5.0
+# Per-check timeout (seconds) to bound total time of one gateway health check (default: 30.0)
+# GATEWAY_HEALTH_CHECK_TIMEOUT=30.0
 
 # Consecutive failures before marking gateway offline (default: 3)
 # UNHEALTHY_THRESHOLD=3

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-22T10:27:33Z",
+  "generated_at": "2026-07-23T12:29:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1889,
+        "line_number": 1902,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1977,
+        "line_number": 1990,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2327,
+        "line_number": 2340,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3692,
+        "line_number": 3705,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3783,
+        "line_number": 3796,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3826,
+        "line_number": 3839,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3831,
+        "line_number": 3844,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3836,
+        "line_number": 3849,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -342,7 +342,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 521,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 987,
+        "line_number": 977,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 989,
+        "line_number": 979,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1641,
+        "line_number": 1631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1860,
+        "line_number": 1850,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5963,
+        "line_number": 5931,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6460,
+        "line_number": 6428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6472,
+        "line_number": 6440,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6544,
+        "line_number": 6512,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7611,
+        "line_number": 7579,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -562,7 +562,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1119,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -570,7 +570,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1433,
+        "line_number": 1426,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -580,7 +580,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 305,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 61,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 824,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 979,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1083,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1086,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1253,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1292,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1365,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1460,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1831,
+        "line_number": 1813,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 258,
+        "line_number": 243,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 403,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 411,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 459,
+        "line_number": 444,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 998,
+        "line_number": 947,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1101,
+        "line_number": 1050,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1107,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1216,
+        "line_number": 1165,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1251,
+        "line_number": 1200,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1787,
+        "line_number": 1736,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2035,
+        "line_number": 1984,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2510,
+        "line_number": 2459,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2510,
+        "line_number": 2459,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2523,
+        "line_number": 2472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2671,
+        "line_number": 2620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2692,
+        "line_number": 2641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2700,
+        "line_number": 2649,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2705,
+        "line_number": 2654,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1644,7 +1644,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 617,
+        "line_number": 604,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1850,7 +1850,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1432,
+        "line_number": 1559,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1858,7 +1858,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1473,
+        "line_number": 1600,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1930,7 +1930,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 820,
+        "line_number": 821,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +1938,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1327,
+        "line_number": 1328,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +1946,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1332,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2218,7 +2218,7 @@
         "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 127,
+        "line_number": 144,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2226,7 +2226,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 179,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2234,7 +2234,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 181,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2770,7 +2770,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 827,
+        "line_number": 636,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4221,24 +4221,6 @@
         "verified_result": null
       }
     ],
-    "run-granian.sh": [
-      {
-        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 291,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 406,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "run-gunicorn.sh": [
       {
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
@@ -4682,7 +4664,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1463,
+        "line_number": 1470,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-23T10:17:07Z",
+  "generated_at": "2026-07-17T04:46:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1902,
+        "line_number": 1746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1990,
+        "line_number": 1834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2340,
+        "line_number": 2184,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3705,
+        "line_number": 3549,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3796,
+        "line_number": 3640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3839,
+        "line_number": 3683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3844,
+        "line_number": 3688,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3849,
+        "line_number": 3693,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -342,7 +342,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 521,
+        "line_number": 531,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -350,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 977,
+        "line_number": 987,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 989,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1631,
+        "line_number": 1641,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1850,
+        "line_number": 1860,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5931,
+        "line_number": 5953,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6428,
+        "line_number": 6450,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6440,
+        "line_number": 6462,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6512,
+        "line_number": 6534,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7579,
+        "line_number": 7601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -562,7 +562,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1119,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -570,7 +570,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1426,
+        "line_number": 1433,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -580,7 +580,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 305,
+        "line_number": 286,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -626,7 +626,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 824,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -634,7 +634,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 1000,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1083,
+        "line_number": 1103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1086,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1253,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1311,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1813,
+        "line_number": 1831,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -756,7 +756,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 243,
+        "line_number": 258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,7 +764,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -772,7 +772,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 388,
+        "line_number": 403,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -780,7 +780,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 411,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -788,7 +788,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 444,
+        "line_number": 459,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -796,7 +796,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 947,
+        "line_number": 998,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,7 +804,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1050,
+        "line_number": 1101,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -812,7 +812,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -820,7 +820,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1165,
+        "line_number": 1216,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -828,7 +828,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1200,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -836,7 +836,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1736,
+        "line_number": 1787,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -844,7 +844,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1984,
+        "line_number": 2035,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -852,7 +852,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2459,
+        "line_number": 2510,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -860,7 +860,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2459,
+        "line_number": 2510,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -868,7 +868,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2472,
+        "line_number": 2523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -876,7 +876,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2620,
+        "line_number": 2671,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -884,7 +884,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2641,
+        "line_number": 2692,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -892,7 +892,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2649,
+        "line_number": 2700,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -900,7 +900,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2654,
+        "line_number": 2705,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1191,6 +1191,216 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 184,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/architecture/roadmap.md": [
+      {
+        "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 106,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 107,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 115,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 144,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 397,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 398,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 399,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 417,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 516,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 551,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 552,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 566,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 573,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 582,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 587,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 599,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 620,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 622,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 625,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a603075604516de626cda903868e457fad826533",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 632,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 633,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 671,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 682,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 684,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 716,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1644,7 +1854,7 @@
         "hashed_secret": "4729dd879b70a5a3ae4fa180ccbb4bea7b1d4ce2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 604,
+        "line_number": 617,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1850,7 +2060,7 @@
         "hashed_secret": "91174c4e6859da80df4e7ce9d45b35501f591210",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1432,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1858,7 +2068,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1600,
+        "line_number": 1473,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1930,7 +2140,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 821,
+        "line_number": 820,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1938,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1327,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -1946,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1332,
+        "line_number": 1331,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2218,7 +2428,7 @@
         "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 144,
+        "line_number": 127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2226,7 +2436,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 179,
+        "line_number": 162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2234,7 +2444,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 181,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2770,7 +2980,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 636,
+        "line_number": 827,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4221,6 +4431,24 @@
         "verified_result": null
       }
     ],
+    "run-granian.sh": [
+      {
+        "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 291,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 406,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "run-gunicorn.sh": [
       {
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
@@ -4624,7 +4852,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 460,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4634,7 +4862,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17920,
+        "line_number": 17940,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4654,7 +4882,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2805,
+        "line_number": 2804,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4664,7 +4892,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1470,
+        "line_number": 1463,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-17T04:46:09Z",
+  "generated_at": "2026-07-22T10:27:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1746,
+        "line_number": 1889,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1834,
+        "line_number": 1977,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2327,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3549,
+        "line_number": 3692,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3640,
+        "line_number": 3783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3683,
+        "line_number": 3826,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
+        "line_number": 3831,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3693,
+        "line_number": 3836,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5953,
+        "line_number": 5963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6450,
+        "line_number": 6460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6462,
+        "line_number": 6472,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6534,
+        "line_number": 6544,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7601,
+        "line_number": 7611,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1191,216 +1191,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 184,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/docs/architecture/roadmap.md": [
-      {
-        "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 106,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 107,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 144,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 397,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 398,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 399,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 417,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 516,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 551,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 552,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 566,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 573,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 582,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 587,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 599,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 620,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 622,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 625,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a603075604516de626cda903868e457fad826533",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 632,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 633,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 671,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 682,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 684,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 716,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 719,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4852,7 +4642,7 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 460,
+        "line_number": 398,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4862,7 +4652,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17940,
+        "line_number": 17920,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4882,7 +4672,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2804,
+        "line_number": 2805,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -946,8 +946,8 @@ The gateway includes built-in observability features for tracking HTTP requests,
 | Setting                 | Description                               | Default | Options |
 | ----------------------- | ----------------------------------------- | ------- | ------- |
 | `HEALTH_CHECK_INTERVAL` | Health poll interval (secs)               | `60`    | int > 0 |
-| `HEALTH_CHECK_TIMEOUT`  | Health request timeout (secs)             | `5`     | int > 0 |
-| `GATEWAY_HEALTH_CHECK_TIMEOUT` | Per-check timeout for gateway health check (secs) | `5.0` | float > 0 |
+| `HEALTH_CHECK_TIMEOUT`  | Health request timeout (secs)             | `30`    | int > 0 |
+| `GATEWAY_HEALTH_CHECK_TIMEOUT` | Per-check timeout for gateway health check (secs) | `30.0` | float > 0 |
 | `UNHEALTHY_THRESHOLD`   | Fail-count before peer deactivation (-1 to disable) | `3`     | int     |
 | `GATEWAY_VALIDATION_TIMEOUT` | Gateway URL validation timeout (secs) | `5`     | int > 0 |
 | `MAX_CONCURRENT_HEALTH_CHECKS` | Max concurrent health checks        | `20`    | int > 0 |

--- a/docs/docs/manage/scale.md
+++ b/docs/docs/manage/scale.md
@@ -1237,11 +1237,11 @@ RETRY_MAX_DELAY=60
 
 # Health check intervals
 HEALTH_CHECK_INTERVAL=60
-HEALTH_CHECK_TIMEOUT=5
+HEALTH_CHECK_TIMEOUT=30
 UNHEALTHY_THRESHOLD=3
 
 # Gateway health check timeout (seconds)
-GATEWAY_HEALTH_CHECK_TIMEOUT=5.0
+GATEWAY_HEALTH_CHECK_TIMEOUT=30.0
 
 # Auto-refresh tools during health checks
 # When enabled, tools/resources/prompts are fetched and synced during health checks

--- a/docs/docs/manage/tuning.md
+++ b/docs/docs/manage/tuning.md
@@ -279,7 +279,7 @@ Pool staleness checks use `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` (default 30s) for
 | Check Type | Timeout Used | Default |
 |------------|--------------|---------|
 | Pool staleness check (idle > interval) | `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` | 30s |
-| Explicit health RPC (when enabled) | `HEALTH_CHECK_TIMEOUT` | 5s |
+| Explicit health RPC (when enabled) | `HEALTH_CHECK_TIMEOUT` | 30s |
 | Session creation | `MCP_SESSION_POOL_CREATE_TIMEOUT` | 30s |
 
 **Trade-off**: The 30s transport timeout allows long-running tools to complete but means unhealthy sessions may take longer to detect. If you need faster failure detection:
@@ -287,7 +287,7 @@ Pool staleness checks use `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` (default 30s) for
 ```bash
 # Stricter health checks (5s timeout for explicit RPC)
 MCP_SESSION_POOL_EXPLICIT_HEALTH_RPC=true
-HEALTH_CHECK_TIMEOUT=5
+HEALTH_CHECK_TIMEOUT=30
 
 # Or reduce transport timeout (affects all operations)
 MCP_SESSION_POOL_TRANSPORT_TIMEOUT=10

--- a/docs/docs/manage/tuning.md
+++ b/docs/docs/manage/tuning.md
@@ -272,7 +272,7 @@ MCP_SESSION_POOL_TRANSPORT_TIMEOUT=120
 
 ### Health Check Timeout Trade-offs
 
-Pool staleness checks use `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` (default 30s) for session acquisition. When `MCP_SESSION_POOL_EXPLICIT_HEALTH_RPC=true`, the explicit RPC call uses `HEALTH_CHECK_TIMEOUT` (default 5s).
+Pool staleness checks use `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` (default 30s) for session acquisition. When `MCP_SESSION_POOL_EXPLICIT_HEALTH_RPC=true`, the explicit RPC call uses `HEALTH_CHECK_TIMEOUT` (default 30s).
 
 **Behavior summary:**
 
@@ -285,7 +285,7 @@ Pool staleness checks use `MCP_SESSION_POOL_TRANSPORT_TIMEOUT` (default 30s) for
 **Trade-off**: The 30s transport timeout allows long-running tools to complete but means unhealthy sessions may take longer to detect. If you need faster failure detection:
 
 ```bash
-# Stricter health checks (5s timeout for explicit RPC)
+# Stricter health checks (30s timeout for explicit RPC)
 MCP_SESSION_POOL_EXPLICIT_HEALTH_RPC=true
 HEALTH_CHECK_TIMEOUT=30
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2505,10 +2505,10 @@ class Settings(BaseSettings):
     # Interval in seconds between gateway health checks.
     health_check_interval: int = 60
     # Timeout in seconds for each health check request
-    health_check_timeout: int = 5
+    health_check_timeout: int = 30
     # Per-check timeout (seconds) to bound total time of one gateway health check
     # Env: GATEWAY_HEALTH_CHECK_TIMEOUT
-    gateway_health_check_timeout: float = 5.0
+    gateway_health_check_timeout: float = 30.0
     # Consecutive failures before marking gateway offline
     unhealthy_threshold: int = 3
     # Max concurrent health checks per worker

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -4721,6 +4721,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             async with ClientSession(read_stream, write_stream) as session:
                                 response = await session.initialize()
 
+                    # Reset failure counter on any successful health check
+                    self._gateway_failure_counts[gateway_id] = 0
+
                     # Reactivate / update last_seen (success path)
                     await self._mark_gateway_reachable(gateway_id, gateway_name, gateway_enabled, gateway_reachable)
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -6475,6 +6475,59 @@ class TestCheckSingleGatewayHealth:
         call_kw = mock_ssl.call_args
         assert call_kw[1]["client_key"] == "raw-unencrypted-key"
 
+    @pytest.mark.asyncio
+    async def test_successful_health_check_resets_failure_counter(self, gateway_service, monkeypatch):
+        """Successful health check resets the failure counter even when gateway is reachable."""
+        gw = _make_gateway(
+            id="gw-reset",
+            name="reset-gw",
+            url="http://example.com/sse",
+            enabled=True,
+            reachable=True,
+            transport="sse",
+            auth_type=None,
+            auth_value=None,
+            auth_query_params=None,
+            ca_certificate=None,
+            ca_certificate_sig=None,
+            oauth_config=None,
+            last_refresh_at=None,
+            refresh_interval_seconds=None,
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        mock_stream_response = AsyncMock()
+        mock_stream_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_response.__aexit__ = AsyncMock(return_value=False)
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_response)
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.get_isolated_http_client", lambda **kw: mock_ctx)
+        monkeypatch.setattr("mcpgateway.services.gateway_service.fresh_db_session", MagicMock())
+        monkeypatch.setattr(
+            "mcpgateway.services.gateway_service.settings",
+            MagicMock(
+                enable_ed25519_signing=False,
+                health_check_timeout=5,
+                auto_refresh_servers=False,
+                httpx_admin_read_timeout=5,
+                mcp_session_pool_enabled=False,
+            ),
+        )
+        monkeypatch.setattr("mcpgateway.services.gateway_service.create_span", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock()), __exit__=MagicMock(return_value=False))))
+
+        # Pre-populate failure counter
+        gateway_service._gateway_failure_counts = {"gw-reset": 2}
+
+        await gateway_service._check_single_gateway_health(gw)
+
+        # Counter must be reset after successful health check
+        assert gateway_service._gateway_failure_counts["gw-reset"] == 0
+
 
 # ---------------------------------------------------------------------------
 # list_gateways_for_user tests


### PR DESCRIPTION
## Problem

Users report that MCP servers show as "Offline" in the UI with tooltip "Gateway not reachable", but the Test button succeeds for the same server. This creates confusion as the gateway is clearly reachable. The issue manifests after approximately 3-5 minutes of operation, suggesting a timeout-related problem.

**Issue:** #4785

## Root Cause

The problem is a **24x timeout mismatch** between periodic health checks and the Test button:

| Aspect | Periodic Health Check | Test Button |
|--------|----------------------|-------------|
| Code | `_check_single_gateway_health()` (`gateway_service.py:3688`) | `admin_test_gateway()` (`admin.py:14002`) |
| Timeout | `health_check_timeout` = **5s** (`config.py:2409`) | `federation_timeout` = **120s** (`config.py:2172`) |
| Wrapper timeout | `gateway_health_check_timeout` = **5.0s** (`config.py:2412`) | N/A |
| Failure behavior | After **3 consecutive failures** (~3 min), sets `reachable=False` | Returns result, does NOT modify DB state |
| Recovery | Next successful health check sets `reachable=True` (up to 60s later) | N/A |

**The failure sequence:**
1. Gateway is slow to respond (e.g., 6-10s due to auth, cold start, or network latency)
2. Health check times out at 5s → failure count increments
3. After 3 consecutive failures (~3 minutes), `reachable` is set to `False`
4. UI shows yellow "Offline" badge — but gateway is actually healthy
5. Test button uses 120s timeout and succeeds every time

## Solution

### 1. Increase Health Check Timeout from 5s → 30s

`config.py`:
- `health_check_timeout`: `5` → `30`
- `gateway_health_check_timeout`: `5.0` → `30.0`

**Why 30s and not 120s (to match Test button)?**

- **30s aligns with existing `httpx_admin_read_timeout`** — the httpx client at `gateway_service.py:3807` was already configured with this value as its default timeout. The 5s override at line 3876 was contradicting the intended design.
- **30s is a 6x improvement** over 5s, covering the vast majority of slow-responder scenarios (cold starts, auth token exchange, TLS negotiation, moderate network latency).
- **Failure detection remains reasonable** — at 30s + 60s interval + threshold 3, a truly dead gateway is detected in ~4.5 min vs ~3 min at 5s. This ~90s tradeoff is acceptable for ops response.
- **120s detection time** would mean a dead gateway takes up to 6+ minutes to detect, which is too slow for practical operations.

**Resource impact analysis:**
- Max 10 concurrent health checks (semaphore-limited)
- At 30s each: 300 connection-seconds per cycle
- With 50 gateways at 30s worst case: ~150s cycle time vs 60s interval → at most 2-3 overlapping cycles → 20-30 concurrent HTTP connections
- DB pool is 200+10 connections — **negligible impact**

### 2. Reset Failure Counter on Gateway Recovery

`gateway_service.py:3900` — Added:
```python
self._gateway_failure_counts[gateway_id] = 0
```

**Why?** Before this fix, a flickering gateway that briefly recovers then has a single slow response would retain its pre-recovery failure count (e.g., 2). On the next failure, it would immediately hit the threshold of 3 and be marked offline. Resetting the counter on recovery ensures a clean slate.

### 3. Documentation Updates

- `docs/docs/manage/configuration.md` — Updated documented defaults
- `docs/docs/manage/scale.md` — Updated example config values
- `docs/docs/manage/tuning.md` — Updated health check timeout table
- `.env.example` — Updated commented-out examples

## Verification

- **`make test`**: 18735 passed, 591 skipped (pre-existing)
- **`make ruff`**: All checks passed
- **`make bandit`**: 0 issues
- **`make pylint`**: 10.00/10
- **`make interrogate`**: 100.0% docstring coverage
- **`make pre-commit`**: All 20 hooks passed

No test regressions — all health check tests explicitly mock their own timeout values and are unaffected by the default change.

Closes #4785