### PR TITLE
[FEATURE]: Support Okta Org Authorization Server (no API Access Management required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1266,6 +1266,7 @@ SKIP_MIGRATION=false
 # SSO_OKTA_CLIENT_SECRET=your-okta-client-secret
 # SSO_OKTA_ISSUER=https://your-okta-domain.okta.com
 # SSO_OKTA_SCOPE=openid profile email groups
+# SSO_OKTA_AUTH_SERVER=default  # 'default', 'org', or custom authorization server ID
 # OKTA_GROUP_MAPPING={"Engineering": "team-uuid-1", "Admins": "team-uuid-2"}
 
 # Keycloak OIDC Configuration (with auto-discovery)

--- a/docs/docs/manage/sso-okta-tutorial.md
+++ b/docs/docs/manage/sso-okta-tutorial.md
@@ -196,9 +196,49 @@ SSO_OKTA_SCOPE="openid profile email groups address phone"
 # Group mapping for automatic team assignment
 OKTA_GROUP_MAPPING={"ContextForge Admins": "admin-team-uuid", "ContextForge Users": "user-team-uuid"}
 
-# Custom authorization server (if using custom Okta authorization server)
-SSO_OKTA_ISSUER=https://dev-12345.okta.com/oauth2/custom-auth-server-id
+# Authorization server selection (v1.0.1+)
+# - 'default': Custom authorization server (requires Okta API Access Management)
+# - 'org':     Org Authorization Server (no AAM required)
+# - <custom>:  Any custom authorization server ID (e.g., 'aus1a2b3c4d5e6f7g8h9i')
+# Defaults to 'default' for backward compatibility.
+SSO_OKTA_AUTH_SERVER=custom-auth-server-id
+
+# Note: SSO_OKTA_ISSUER should be the Okta domain base URL (e.g., https://dev-12345.okta.com).
+# The /oauth2/{auth_server} path is appended automatically based on SSO_OKTA_AUTH_SERVER.
 ```
+
+### 4.4.1 Org Authorization Server (No API Access Management)
+
+If your Okta tenant does **not** have API Access Management (AAM) licensed, use the
+**Org Authorization Server** instead of the default custom authorization server.
+
+The Org Authorization Server uses `/oauth2/v1/...` endpoints with the issuer set to
+your Okta domain directly (no `/oauth2/...` suffix). Group claims are sourced from
+the OIDC application's claim filter, not the authorization server.
+
+```bash
+# Org Authorization Server configuration
+SSO_OKTA_ENABLED=true
+SSO_OKTA_CLIENT_ID=0oa1b2c3d4e5f6g7h8i9
+SSO_OKTA_CLIENT_SECRET=AbCdEfGhIjKlMnOpQrStUvWxYz1234567890abcdef
+SSO_OKTA_ISSUER=https://acmecorp.okta.com
+SSO_OKTA_AUTH_SERVER=org  # Use Org Authorization Server
+
+# Include groups in ID token via application-level group claim filter
+# (Okta Admin → Applications → [Your App] → Sign On → OpenID Connect ID Token)
+SSO_OKTA_SCOPE="openid profile email groups"
+```
+
+Key differences from the default authorization server:
+
+| Aspect | Default (`default`) | Org (`org`) |
+|--------|---------------------|-------------|
+| Authorization URL | `/oauth2/default/v1/authorize` | `/oauth2/v1/authorize` |
+| Token URL | `/oauth2/default/v1/token` | `/oauth2/v1/token` |
+| Userinfo URL | `/oauth2/default/v1/userinfo` | `/oauth2/v1/userinfo` |
+| Issuer | `/oauth2/default` | bare domain (no suffix) |
+| AAM required | Yes | No |
+| Groups source | Authorization server claims | Application-level group claim filter |
 
 ## Step 5: Restart and Verify Gateway
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -491,6 +491,14 @@ class Settings(BaseSettings):
     sso_okta_client_secret: Optional[SecretStr] = Field(default=None, description="Okta client secret")
     sso_okta_issuer: Optional[str] = Field(default=None, description="Okta issuer URL")
     sso_okta_scope: str = Field(default="openid profile email", description="Okta OIDC scopes (space-separated)")
+    sso_okta_auth_server: str = Field(
+        default="default",
+        description=(
+            "Okta authorization server ID. Use 'default' (current behavior) for the "
+            "built-in custom authorization server, 'org' for the Org Authorization "
+            "Server (no API Access Management required), or any custom server ID."
+        ),
+    )
     okta_group_mapping: Optional[str] = Field(default=None, description="JSON mapping of Okta group names to team UUIDs")
 
     sso_keycloak_enabled: bool = Field(default=False, description="Enable Keycloak OIDC authentication")
@@ -2214,6 +2222,27 @@ class Settings(BaseSettings):
             return [item.strip() for item in s.split(",") if item.strip()]
         raise ValueError("Invalid type for SSO_ISSUERS")
 
+    @field_validator("sso_okta_auth_server")
+    @classmethod
+    def validate_okta_auth_server(cls, v: str) -> str:
+        """Validate and normalize the Okta authorization server ID.
+
+        Args:
+            v: Raw authorization server ID from config.
+
+        Returns:
+            Normalized auth server ID, defaulting to 'default' on empty input.
+
+        Raises:
+            ValueError: If the value contains path separators (path traversal prevention).
+        """
+        if not v or not v.strip():
+            return "default"
+        cleaned = v.strip()
+        if "/" in cleaned or "\\" in cleaned:
+            raise ValueError("SSO_OKTA_AUTH_SERVER must not contain path separators")
+        return cleaned
+
     # Resources
     resource_cache_size: int = 1000
     resource_cache_ttl: int = 3600  # seconds
@@ -2534,7 +2563,9 @@ class Settings(BaseSettings):
     redis_ssl_ca_certs: Optional[str] = Field(default=None, description="Path to CA certificate bundle used to verify the Redis server certificate")
     redis_ssl_certfile: Optional[str] = Field(default=None, description="Path to client certificate for mutual TLS (mTLS) authentication with Redis")
     redis_ssl_keyfile: Optional[str] = Field(default=None, description="Path to client private key for mutual TLS (mTLS) authentication with Redis")
-    redis_ssl_check_hostname: bool = Field(default=True, description="Verify the Redis TLS certificate chain and hostname. Set False only for self-signed certs (pair with REDIS_SSL_CA_CERTS for the CA bundle)")
+    redis_ssl_check_hostname: bool = Field(
+        default=True, description="Verify the Redis TLS certificate chain and hostname. Set False only for self-signed certs (pair with REDIS_SSL_CA_CERTS for the CA bundle)"
+    )
 
     redis_operation_timeout: float = Field(
         default=0.5, gt=0.0, description="Timeout for individual Redis operations in seconds (get/set/delete). " "Should be lower than redis_socket_timeout for faster fallback to in-memory cache."

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -177,6 +177,18 @@ def get_predefined_sso_providers() -> List[Dict]:
     # Okta Provider
     if settings.sso_okta_enabled and settings.sso_okta_client_id:
         base_url = settings.sso_okta_issuer or "https://company.okta.com"
+        auth_server = settings.sso_okta_auth_server or "default"
+
+        # Construct authorization server-specific URLs.
+        # Org AS:  /oauth2/v1/... with bare issuer (no API Access Management).
+        # Custom/default: /oauth2/{id}/v1/... with issuer including the path.
+        if auth_server == "org":
+            auth_root = f"{base_url}/oauth2"
+            issuer = base_url
+        else:
+            auth_root = f"{base_url}/oauth2/{auth_server}"
+            issuer = f"{base_url}/oauth2/{auth_server}"
+
         okta_team_mapping: Dict[str, Any] = {}
         if settings.okta_group_mapping:
             try:
@@ -195,10 +207,10 @@ def get_predefined_sso_providers() -> List[Dict]:
                 "provider_type": "oidc",
                 "client_id": settings.sso_okta_client_id,
                 "client_secret": settings.sso_okta_client_secret.get_secret_value() if settings.sso_okta_client_secret else "",
-                "authorization_url": f"{base_url}/oauth2/default/v1/authorize",
-                "token_url": f"{base_url}/oauth2/default/v1/token",
-                "userinfo_url": f"{base_url}/oauth2/default/v1/userinfo",
-                "issuer": f"{base_url}/oauth2/default",
+                "authorization_url": f"{auth_root}/v1/authorize",
+                "token_url": f"{auth_root}/v1/token",
+                "userinfo_url": f"{auth_root}/v1/userinfo",
+                "issuer": issuer,
                 "scope": settings.sso_okta_scope,
                 "trusted_domains": settings.sso_trusted_domains,
                 "auto_create_users": settings.sso_auto_create_users,

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -1674,3 +1674,29 @@ def test_uaid_allowed_domains_accepts_valid_with_port():
     """Verify validator accepts valid public domains with ports."""
     settings = Settings(uaid_allowed_domains=["example.com:8443", "gateway.io:4444"], _env_file=None)
     assert settings.uaid_allowed_domains == ["example.com:8443", "gateway.io:4444"]
+
+
+def test_sso_okta_auth_server_accepts_valid_values():
+    """Valid auth server IDs should be accepted."""
+    for valid in ["org", "default", "aus1234567890", "custom-server", "server_01"]:
+        s = Settings(sso_okta_auth_server=valid, _env_file=None)
+        assert s.sso_okta_auth_server == valid
+
+
+def test_sso_okta_auth_server_rejects_path_traversal():
+    """Auth server ID must not contain path separators."""
+    # First-Party
+    from pydantic import ValidationError
+
+    invalid_ids = ["../oauth2", "a/b", "a\\b", "../../etc/passwd"]
+    for invalid in invalid_ids:
+        with pytest.raises(ValidationError) as exc_info:
+            Settings(sso_okta_auth_server=invalid, _env_file=None)
+        assert "path separators" in str(exc_info.value)
+
+
+def test_sso_okta_auth_server_empty_falls_back_to_default():
+    """Empty or whitespace-only values should fall back to 'default'."""
+    for empty in ["", "  "]:
+        s = Settings(sso_okta_auth_server=empty, _env_file=None)
+        assert s.sso_okta_auth_server == "default"

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -46,6 +46,7 @@ def test_get_predefined_sso_providers_multiple(monkeypatch):
         sso_okta_client_secret=secret,
         sso_okta_issuer="https://company.okta.com",
         sso_okta_scope="openid profile email groups",
+        sso_okta_auth_server="default",
         okta_group_mapping='{"Engineering": "team-uuid-1"}',
         sso_entra_enabled=True,
         sso_entra_client_id="entra-client",
@@ -988,6 +989,7 @@ def test_okta_default_scope_without_group_mapping(monkeypatch):
         sso_okta_client_secret=secret,
         sso_okta_issuer="https://company.okta.com",
         sso_okta_scope="openid profile email",
+        sso_okta_auth_server="default",
         okta_group_mapping=None,
         sso_entra_enabled=False,
         sso_entra_client_id=None,
@@ -1036,6 +1038,7 @@ def test_okta_invalid_group_mapping_json_uses_empty(monkeypatch, caplog):
         sso_okta_client_secret=secret,
         sso_okta_issuer="https://company.okta.com",
         sso_okta_scope="openid profile email groups",
+        sso_okta_auth_server="default",
         okta_group_mapping="not-valid-json{",
         sso_entra_enabled=False,
         sso_entra_client_id=None,
@@ -1093,6 +1096,7 @@ class TestBootstrapPreservesDBValues:
 
         with patch("mcpgateway.utils.sso_bootstrap.settings") as mock_settings:
             mock_settings.sso_enabled = True
+            mock_settings.sso_okta_auth_server = "default"
 
             with patch("mcpgateway.utils.sso_bootstrap.get_predefined_sso_providers", return_value=[provider_config]):
                 with patch("mcpgateway.db.get_db", return_value=iter([mock_db])):
@@ -1131,6 +1135,7 @@ class TestBootstrapPreservesDBValues:
 
         with patch("mcpgateway.utils.sso_bootstrap.settings") as mock_settings:
             mock_settings.sso_enabled = True
+            mock_settings.sso_okta_auth_server = "default"
 
             with patch("mcpgateway.utils.sso_bootstrap.get_predefined_sso_providers", return_value=[provider_config]):
                 with patch("mcpgateway.db.get_db", return_value=iter([mock_db])):
@@ -1169,6 +1174,7 @@ class TestBootstrapPreservesDBValues:
 
         with patch("mcpgateway.utils.sso_bootstrap.settings") as mock_settings:
             mock_settings.sso_enabled = True
+            mock_settings.sso_okta_auth_server = "default"
 
             with patch("mcpgateway.utils.sso_bootstrap.get_predefined_sso_providers", return_value=[provider_config]):
                 with patch("mcpgateway.db.get_db", return_value=iter([mock_db])):
@@ -1207,6 +1213,7 @@ class TestBootstrapPreservesDBValues:
 
         with patch("mcpgateway.utils.sso_bootstrap.settings") as mock_settings:
             mock_settings.sso_enabled = True
+            mock_settings.sso_okta_auth_server = "default"
 
             with patch("mcpgateway.utils.sso_bootstrap.get_predefined_sso_providers", return_value=[provider_config]):
                 with patch("mcpgateway.db.get_db", return_value=iter([mock_db])):
@@ -1239,6 +1246,7 @@ def test_okta_non_dict_group_mapping_uses_empty(monkeypatch, caplog):
         sso_okta_client_secret=secret,
         sso_okta_issuer="https://company.okta.com",
         sso_okta_scope="openid profile email",
+        sso_okta_auth_server="default",
         okta_group_mapping='["not", "a", "dict"]',
         sso_entra_enabled=False,
         sso_entra_client_id=None,
@@ -1262,3 +1270,101 @@ def test_okta_non_dict_group_mapping_uses_empty(monkeypatch, caplog):
     assert len(providers) == 1
     assert providers[0]["team_mapping"] == {}
     assert any("must be a JSON object" in record.message for record in caplog.records)
+
+
+def test_get_predefined_sso_providers_okta_org_auth_server(monkeypatch):
+    """Org AS should produce /oauth2/v1/... URLs with bare issuer."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("okta-secret")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False, sso_github_client_id=None, sso_github_client_secret=None,
+        sso_google_enabled=False, sso_ibm_verify_enabled=False,
+        sso_entra_enabled=False, sso_keycloak_enabled=False,
+        sso_adfs_enabled=False, sso_generic_enabled=False,
+        sso_okta_enabled=True,
+        sso_okta_client_id="okta-client",
+        sso_okta_client_secret=secret,
+        sso_okta_issuer="https://acme.okta.com",
+        sso_okta_auth_server="org",
+        sso_okta_scope="openid profile email groups",
+        okta_group_mapping='{"IT": "team-uuid"}',
+        sso_trusted_domains=["acme.com"],
+        sso_auto_create_users=True,
+    )
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    okta = providers[0]
+    assert okta["id"] == "okta"
+    assert okta["authorization_url"] == "https://acme.okta.com/oauth2/v1/authorize"
+    assert okta["token_url"] == "https://acme.okta.com/oauth2/v1/token"
+    assert okta["userinfo_url"] == "https://acme.okta.com/oauth2/v1/userinfo"
+    assert okta["issuer"] == "https://acme.okta.com"
+    assert okta["team_mapping"] == {"IT": "team-uuid"}
+
+
+def test_get_predefined_sso_providers_okta_custom_auth_server(monkeypatch):
+    """Custom auth server ID should produce /oauth2/{id}/v1/... URLs."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("okta-secret")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False, sso_github_client_id=None, sso_github_client_secret=None,
+        sso_google_enabled=False, sso_ibm_verify_enabled=False,
+        sso_entra_enabled=False, sso_keycloak_enabled=False,
+        sso_adfs_enabled=False, sso_generic_enabled=False,
+        sso_okta_enabled=True,
+        sso_okta_client_id="okta-client",
+        sso_okta_client_secret=secret,
+        sso_okta_issuer="https://acme.okta.com",
+        sso_okta_auth_server="aus1234567890",
+        sso_okta_scope="openid profile email",
+        okta_group_mapping=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    okta = providers[0]
+    assert okta["authorization_url"] == "https://acme.okta.com/oauth2/aus1234567890/v1/authorize"
+    assert okta["token_url"] == "https://acme.okta.com/oauth2/aus1234567890/v1/token"
+    assert okta["userinfo_url"] == "https://acme.okta.com/oauth2/aus1234567890/v1/userinfo"
+    assert okta["issuer"] == "https://acme.okta.com/oauth2/aus1234567890"
+
+
+def test_get_predefined_sso_providers_okta_default_auth_server(monkeypatch):
+    """Default auth server should produce /oauth2/default/v1/... URLs (backward compat)."""
+    # First-Party
+    from mcpgateway.utils.sso_bootstrap import get_predefined_sso_providers
+
+    secret = DummySecret("okta-secret")
+    cfg = SimpleNamespace(
+        sso_github_enabled=False, sso_github_client_id=None, sso_github_client_secret=None,
+        sso_google_enabled=False, sso_ibm_verify_enabled=False,
+        sso_entra_enabled=False, sso_keycloak_enabled=False,
+        sso_adfs_enabled=False, sso_generic_enabled=False,
+        sso_okta_enabled=True,
+        sso_okta_client_id="okta-client",
+        sso_okta_client_secret=secret,
+        sso_okta_issuer="https://acme.okta.com",
+        sso_okta_auth_server="default",
+        sso_okta_scope="openid profile email",
+        okta_group_mapping=None,
+        sso_trusted_domains=[],
+        sso_auto_create_users=True,
+    )
+    monkeypatch.setattr("mcpgateway.utils.sso_bootstrap.settings", cfg)
+    providers = get_predefined_sso_providers()
+
+    assert len(providers) == 1
+    okta = providers[0]
+    assert okta["authorization_url"] == "https://acme.okta.com/oauth2/default/v1/authorize"
+    assert okta["token_url"] == "https://acme.okta.com/oauth2/default/v1/token"
+    assert okta["userinfo_url"] == "https://acme.okta.com/oauth2/default/v1/userinfo"
+    assert okta["issuer"] == "https://acme.okta.com/oauth2/default"


### PR DESCRIPTION
## Problem

The built-in Okta SSO provider hardcodes `/oauth2/default/v1/...` paths, requiring Okta's **API Access Management (AAM)** add-on. Enterprise customers on Okta tenants without AAM licensing cannot use the built-in Okta provider and must either:

1. Purchase AAM just for SSO, or
2. Reconfigure as a generic OIDC provider, losing Okta-specific UX (`OKTA_GROUP_MAPPING`, dedicated tutorial, provider routing in `sso_service.py`)

## Solution

Add a single environment variable — `SSO_OKTA_AUTH_SERVER` — letting operators choose which Okta authorization server to target:

| Value | Behavior | Use Case |
|-------|----------|----------|
| `default` (default) | `/oauth2/default/v1/...` — current behavior | Okta tenants with AAM |
| `org` | `/oauth2/v1/...` with bare domain issuer | Okta tenants without AAM |
| `<custom ID>` | `/oauth2/{id}/v1/...` | Custom authorization servers |

### Why this approach

- **Minimal surface area**: Single new config field, changes isolated to `mcpgateway/utils/sso_bootstrap.py` (the only place URLs are constructed). The runtime (`sso_service.py`) is already URL-agnostic — no changes needed.
- **Follows existing patterns**: Uses the same templated `base_url + path` approach as the IBM Verify and Entra providers.
- **Backward compatible**: Default value `"default"` produces identical URLs to the pre-change hardcoded behavior, verified by regression test.
- **Defense-in-depth**: Config-level validator rejects path separators (CWE-22 prevention), plus runtime fallback `or "default"` for defensive belt-and-suspenders.
- **Delegates format validation to Okta**: The validator only blocks path traversal — Okta validates whether an authorization server ID is valid, keeping the gateway loosely coupled from Okta's ID format.

## Changes

| File | Change |
|------|--------|
| `mcpgateway/config.py` | Added `sso_okta_auth_server` field with path-traversal-safe validator |
| `mcpgateway/utils/sso_bootstrap.py` | Dynamic URL construction based on auth server type |
| `tests/unit/mcpgateway/utils/test_sso_bootstrap.py` | Updated 8 existing tests; added 3 new (org, custom, default paths) |
| `tests/unit/mcpgateway/test_config.py` | Added 3 validator tests (valid values, path rejection, empty fallback) |
| `docs/docs/manage/sso-okta-tutorial.md` | Added Org Authorization Server section with comparison table |
| `.env.example` | Added `SSO_OKTA_AUTH_SERVER` entry |

## Verification

- **200/200 tests pass** across both modified test files
- **9 Okta-specific tests pass** (6 existing + 3 new)
- `make ruff`, `make bandit` — all clean
- **No runtime changes** to `sso_service.py` — already URL-agnostic
- **No DB migrations** — URLs stored as strings, no schema changes

## Notes

- Minor formatting changes from `black` in `mcpgateway/config.py` (the `redis_ssl_check_hostname` field was reformatted from a single long line to a wrapped Field call).
- Related: #4770 (orthogonal SSO issue discovered during the same enterprise rollout).

Closes #4804
