### PR TITLE
fix(auth): allow cookie auth for same-origin OAuth callback fetch requests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-04T10:56:44Z",
+  "generated_at": "2026-05-26T08:35:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,7 +90,6 @@
     ".env.example": [
       {
         "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
@@ -116,7 +115,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 690,
+        "line_number": 676,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +123,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 918,
+        "line_number": 871,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +131,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1158,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +139,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +147,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1239,
+        "line_number": 1192,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +155,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1318,
+        "line_number": 1271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +163,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1276,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +171,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1281,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +179,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1287,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +187,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1299,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +195,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1364,
+        "line_number": 1317,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +203,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1425,
+        "line_number": 1378,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -274,7 +273,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1336,
+        "line_number": 1217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +281,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1305,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +289,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1655,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +297,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3140,
+        "line_number": 3021,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +305,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3231,
+        "line_number": 3112,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +313,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3274,
+        "line_number": 3155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +321,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3279,
+        "line_number": 3160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +329,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3284,
+        "line_number": 3165,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -350,7 +349,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 525,
+        "line_number": 523,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +357,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 962,
+        "line_number": 991,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +365,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 964,
+        "line_number": 993,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +373,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1616,
+        "line_number": 1645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +381,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1835,
+        "line_number": 1864,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +389,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6381,
+        "line_number": 6389,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +397,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6878,
+        "line_number": 6886,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +405,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6890,
+        "line_number": 6898,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +413,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6962,
+        "line_number": 6970,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +421,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8043,
+        "line_number": 8051,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -570,7 +569,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -578,7 +577,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1433,
+        "line_number": 1373,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -588,7 +587,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 301,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -634,7 +633,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +641,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 984,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +649,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +657,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1090,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +665,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +673,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +681,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1360,
+        "line_number": 1344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +689,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1455,
+        "line_number": 1439,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +697,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1810,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1323,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1331,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1794,7 +1793,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2412,7 +2411,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1218,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2419,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2828,7 +2827,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 320,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4282,7 +4281,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 752,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4348,7 +4347,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14971,
+        "line_number": 15099,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4392,7 +4391,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 665,
+        "line_number": 667,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5093,16 +5092,6 @@
         "verified_result": null
       }
     ],
-    "tests/playwright/security/test_team_selector_e2e.py": [
-      {
-        "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 283,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -5126,9 +5115,8 @@
     "tests/unit/mcpgateway/test_admin.py": [
       {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 11204,
+        "line_number": 10661,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5138,18 +5126,8 @@
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2745,
+        "line_number": 2716,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_auth_ratelimiter_redis.py": [
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 228,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5158,7 +5136,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2731,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-26T08:35:20Z",
+  "generated_at": "2026-05-27T09:02:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,6 +90,7 @@
     ".env.example": [
       {
         "hashed_secret": "15ab6d87c10ed359ba98e6a578764fa53954fdfc",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
@@ -273,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1217,
+        "line_number": 1336,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -281,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1305,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -289,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1655,
+        "line_number": 1774,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -297,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3021,
+        "line_number": 3140,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -305,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3112,
+        "line_number": 3231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -313,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3155,
+        "line_number": 3274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -321,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3160,
+        "line_number": 3279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -329,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3165,
+        "line_number": 3284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5092,6 +5093,16 @@
         "verified_result": null
       }
     ],
+    "tests/playwright/security/test_team_selector_e2e.py": [
+      {
+        "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -5115,6 +5126,7 @@
     "tests/unit/mcpgateway/test_admin.py": [
       {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 10661,
         "type": "Hex High Entropy String",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-27T09:02:44Z",
+  "generated_at": "2026-06-04T16:06:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 676,
+        "line_number": 690,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 871,
+        "line_number": 918,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1158,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1184,
+        "line_number": 1231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1192,
+        "line_number": 1239,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1271,
+        "line_number": 1318,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1323,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1281,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1287,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1299,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1317,
+        "line_number": 1364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1378,
+        "line_number": 1425,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -350,7 +350,7 @@
         "hashed_secret": "844c398e469ef3fb919da3778944365ab2175fb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 525,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 991,
+        "line_number": 962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 993,
+        "line_number": 964,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1645,
+        "line_number": 1616,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1864,
+        "line_number": 1835,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6389,
+        "line_number": 6381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6886,
+        "line_number": 6878,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6898,
+        "line_number": 6890,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6970,
+        "line_number": 6962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8051,
+        "line_number": 8043,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -570,7 +570,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1066,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -578,7 +578,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1373,
+        "line_number": 1433,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -588,7 +588,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 286,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -634,7 +634,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 984,
+        "line_number": 1000,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1090,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1256,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1311,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1344,
+        "line_number": 1360,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1455,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +698,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1810,
+        "line_number": 1826,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1324,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1332,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1794,7 +1794,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2412,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1275,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2828,7 +2828,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 320,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4282,7 +4282,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 752,
+        "line_number": 753,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4348,7 +4348,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15099,
+        "line_number": 14971,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4392,7 +4392,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 667,
+        "line_number": 665,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5128,7 +5128,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10661,
+        "line_number": 11204,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5138,8 +5138,18 @@
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2716,
+        "line_number": 2745,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_auth_ratelimiter_redis.py": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 228,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5148,7 +5158,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2731,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4805,13 +4805,29 @@ async def _admin_logout(request: Request) -> Response:
 
     # For GET requests, distinguish between browser navigation and OIDC front-channel logout
     if request.method == "GET":
-        # Check if request is from a browser (Accept: text/html, HX-Request header, or admin referer)
+        # Check if request is from a browser (Accept: text/html, HX-Request header, or same-origin admin/oauth referer)
         # Detection must match auth_middleware.py and rbac.py patterns to ensure consistent behavior
         # Browser navigation should redirect to login, OIDC callbacks should return 200 OK
         accept_header = request.headers.get("accept", "")
         is_htmx = request.headers.get("hx-request") == "true"
         referer = request.headers.get("referer", "")
-        is_browser_request = "text/html" in accept_header or is_htmx or "/admin" in referer
+
+        # Check if referer is from same origin (for admin UI and OAuth callback pages)
+        is_same_origin_referer = False
+        if referer:
+            try:
+                # Standard
+                from urllib.parse import urlparse
+
+                referer_parsed = urlparse(referer)
+                request_host = request.headers.get("host", "")
+                # Match if referer host matches request host and path contains /admin or /oauth/callback
+                if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
+                    is_same_origin_referer = True
+            except Exception:
+                pass  # Invalid referer URL, treat as not same-origin
+
+        is_browser_request = "text/html" in accept_header or is_htmx or is_same_origin_referer
 
         if is_browser_request:
             # Browser navigation - redirect to login (cookies cleared below)

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -271,11 +271,27 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
                 # without user context so the RBAC layer can redirect to /admin/login.
                 # API requests: return a hard JSON 401/403 deny.
                 # Detection must match rbac.py's is_browser_request logic (Accept,
-                # HX-Request, and Referer: /admin) to avoid breaking admin UI flows.
+                # HX-Request, and same-origin Referer: /admin or /oauth/callback) to avoid breaking admin UI flows.
                 accept_header = request.headers.get("accept", "")
                 is_htmx = request.headers.get("hx-request") == "true"
                 referer = request.headers.get("referer", "")
-                is_browser = "text/html" in accept_header or is_htmx or "/admin" in referer
+
+                # Check if referer is from same origin (for admin UI and OAuth callback pages)
+                is_same_origin_referer = False
+                if referer:
+                    try:
+                        # Standard
+                        from urllib.parse import urlparse
+
+                        referer_parsed = urlparse(referer)
+                        request_host = request.headers.get("host", "")
+                        # Match if referer host matches request host and path contains /admin or /oauth/callback
+                        if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
+                            is_same_origin_referer = True
+                    except Exception:
+                        pass  # Invalid referer URL, treat as not same-origin
+
+                is_browser = "text/html" in accept_header or is_htmx or is_same_origin_referer
                 if is_browser:
                     logger.debug("Browser request with rejected auth — continuing without user for redirect")
                     return await call_next(request)

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -351,11 +351,26 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     accept_header = request.headers.get("accept", "")
     is_htmx = request.headers.get("hx-request") == "true"
     referer = request.headers.get("referer", "")
-    is_admin_ui_request = "/admin" in referer
-    is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request
+
+    # Check if referer is from same origin (for admin UI and OAuth callback pages)
+    is_same_origin_referer = False
+    if referer:
+        try:
+            # Standard
+            from urllib.parse import urlparse
+
+            referer_parsed = urlparse(referer)
+            request_host = request.headers.get("host", "")
+            # Match if referer host matches request host and path contains /admin or /oauth/callback
+            if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
+                is_same_origin_referer = True
+        except Exception:
+            pass  # Invalid referer URL, treat as not same-origin
+
+    is_browser_request = "text/html" in accept_header or is_htmx or is_same_origin_referer
 
     # SECURITY: Reject cookie-only authentication for API requests
-    # Cookies should only be used for browser/HTML requests (including admin UI fetch calls)
+    # Cookies should only be used for browser/HTML requests (including admin UI and OAuth callback fetch calls)
     if token_from_cookie and not is_browser_request:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/unit/mcpgateway/middleware/test_auth_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_auth_middleware.py
@@ -49,6 +49,59 @@ async def test_no_token_continues(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_invalid_referer_url_treated_as_api_request():
+    """Invalid referer URL that causes urlparse exception should be treated as not same-origin and trigger hard deny for cookie auth."""
+    from fastapi import HTTPException
+
+    middleware = AuthContextMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/data"
+    request.cookies = {"jwt_token": "invalid_token"}
+    request.headers = {
+        "accept": "application/json",
+        "referer": "http://example.com/admin",  # Valid URL but will be mocked to raise exception
+        "host": "localhost:4444"
+    }
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    # Mock urlparse to raise an exception to test exception handling (lines 289-290)
+    # Mock get_current_user to raise a hard-deny exception (simulating revoked token)
+    with patch("urllib.parse.urlparse", side_effect=ValueError("Invalid URL")):
+        with patch("mcpgateway.middleware.auth_middleware.get_current_user", side_effect=HTTPException(status_code=401, detail="Token has been revoked")):
+            response = await middleware.dispatch(request, call_next)
+            # Should return hard deny (401) because exception means not a browser request
+            assert response.status_code == 401
+            assert "Token has been revoked" in response.body.decode()
+
+@pytest.mark.asyncio
+async def test_oauth_callback_referer_allows_browser_continuation():
+    """OAuth callback referer should be treated as same-origin and allow browser request to continue."""
+    from fastapi import HTTPException
+
+    middleware = AuthContextMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok"))
+    request = MagicMock(spec=Request)
+    request.url.path = "/api/data"
+    request.cookies = {"jwt_token": "invalid_token"}
+    request.headers = {
+        "accept": "application/json",
+        "referer": "http://localhost:4444/oauth/callback?code=abc123",
+        "host": "localhost:4444"
+    }
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    # Mock get_current_user to raise a hard-deny exception (simulating revoked token)
+    with patch("mcpgateway.middleware.auth_middleware.get_current_user", side_effect=HTTPException(status_code=401, detail="Token has been revoked")):
+        response = await middleware.dispatch(request, call_next)
+        # Should continue to call_next (browser request) instead of returning hard deny
+        call_next.assert_awaited_once_with(request)
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_token_from_cookie(monkeypatch):
     """Token extracted from cookie triggers authentication."""
     middleware = AuthContextMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -114,7 +114,7 @@ async def test_cookie_auth_allowed_with_admin_referer():
     """/admin referer marks the request as a browser/UI request; cookie auth must be accepted."""
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
-    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin#gateways"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin#gateways", "host": "localhost:4444"}
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-admin", token_teams=["team-1"])
@@ -142,6 +142,34 @@ async def test_cookie_auth_allowed_with_accept_text_html():
 
 
 @pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_oauth_callback_referer():
+    """OAuth callback referer with Accept: application/json must be treated as a browser request.
+
+    This test covers the scenario where the OAuth callback success page makes a fetch
+    request to /oauth/fetch-tools with Accept: application/json. The referer header
+    indicates it's from the OAuth callback page, so cookie authentication should be allowed.
+
+    Regression test for issue where OAuth tool fetching failed after PR #2680 added
+    cookie authentication restrictions for API requests.
+    """
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "http://localhost:4444/oauth/callback?code=abc&state=xyz",
+        "host": "localhost:4444"
+    }
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-oauth-fetch", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
 async def test_cookie_auth_rejected_with_cross_origin_oauth_referer():
     """Cross-origin /oauth/ referer without browser headers must NOT grant cookie auth."""
     mock_request = MagicMock(spec=Request)
@@ -155,6 +183,30 @@ async def test_cookie_auth_rejected_with_cross_origin_oauth_referer():
         await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Cookie authentication not allowed" in exc.value.detail
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_with_invalid_referer_url():
+    """Invalid referer URL that causes urlparse exception should be treated as not same-origin and reject cookie auth."""
+    from unittest.mock import patch
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "http://example.com/admin",  # Valid URL but will be mocked to raise exception
+        "host": "localhost:4444"
+    }
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-invalid")
+
+    # Mock urlparse to raise an exception to test exception handling
+    with patch("urllib.parse.urlparse", side_effect=ValueError("Invalid URL")):
+        with pytest.raises(HTTPException) as exc:
+            await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+        assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "Cookie authentication not allowed" in exc.value.detail
+
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -507,7 +507,7 @@ async def test_admin_logout_paths():
     # GET request with admin referer should redirect to login
     get_referer_request = _make_request(root_path="/root")
     get_referer_request.method = "GET"
-    get_referer_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin/users"}
+    get_referer_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin/users", "host": "localhost:4444"}
     response = await admin._admin_logout(get_referer_request)
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 303


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4867

---

## 📝 Summary

OAuth-configured MCP servers (ClickUp, Gamma, Granola, Notion) failed to fetch tools after a successful OAuth authorization flow. The "Fetch Tools from MCP Server" button on the OAuth callback success page returned:

`Cookie authentication not allowed for API requests. Use Authorization header.`

**Root cause:** The browser detection logic in `rbac.py`, `auth_middleware.py`, and `admin.py` identified a request as a legitimate browser/UI request if the `Referer` header contained `/admin`. However, the OAuth callback page (`/oauth/callback`) makes a `fetch()` call with `Accept: application/json`, which matched none of the browser signals, causing the security middleware introduced in #2680 to incorrectly reject it as an external API request.

**Fix:** Replaced the loose `"/admin" in referer` substring check with a structured same-origin referer validation using `urlparse`. The check now verifies that the referer's host matches the request host **and** that its path contains either `/admin` or `/oauth/callback`. This correctly identifies OAuth callback fetch requests as same-origin browser requests while preserving the CSRF protection for cross-origin requests.

The fix is applied consistently across all three locations where browser detection logic lives:
- `mcpgateway/middleware/rbac.py`
- `mcpgateway/middleware/auth_middleware.py`
- `mcpgateway/admin.py`

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification
| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |  ✅ Pass      |
| Unit tests                | `make test`     |     ✅ Pass   |
| Coverage ≥ 80%            | `make coverage` |    ✅ Pass    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Tests added:**
- `test_oauth_callback_referer_allows_browser_continuation` — verifies OAuth callback referer is treated as a same-origin browser request and continues to `call_next` instead of hard-denying
- `test_cookie_auth_allowed_with_oauth_callback_referer` — verifies cookie auth is accepted when the referer is an OAuth callback URL from the same host
- `test_cookie_auth_rejected_with_invalid_referer_url` — verifies that a malformed referer URL that raises a `urlparse` exception is safely caught and treated as not same-origin, preserving the CSRF rejection
- `test_invalid_referer_url_treated_as_api_request` — same exception-path coverage for `auth_middleware.py`

Existing tests for the `/admin` referer path (`test_cookie_auth_allowed_with_admin_referer`, `test_admin_logout_paths`) were updated to include the `host` header, which is now required for the same-origin host comparison.