### PR TITLE
fix(ci): supply CI env vars so playwright-ci-smoke gateway starts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -38,6 +38,9 @@ jobs:
       # Disable forced password-change on bootstrap so Playwright tests can
       # access /admin/ without being redirected to /admin/change-password-required
       ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: "false"
+      # Override .env.example placeholders — env vars take precedence over .env in pydantic-settings
+      JWT_SECRET_KEY: "ci-playwright-smoke-jwt-secret-not-for-production-use"
+      AUTH_ENCRYPTION_SECRET: "ci-playwright-smoke-auth-enc-secret-not-for-production"
 
     steps:
       - name: ⬇️ Checkout source

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,8 +39,8 @@ jobs:
       # access /admin/ without being redirected to /admin/change-password-required
       ADMIN_REQUIRE_PASSWORD_CHANGE_ON_BOOTSTRAP: "false"
       # Override .env.example placeholders — env vars take precedence over .env in pydantic-settings
-      JWT_SECRET_KEY: "ci-playwright-smoke-jwt-secret-not-for-production-use"
-      AUTH_ENCRYPTION_SECRET: "ci-playwright-smoke-auth-enc-secret-not-for-production"
+      JWT_SECRET_KEY: "ci-playwright-smoke-jwt-secret-not-for-production-use"  # pragma: allowlist secret
+      AUTH_ENCRYPTION_SECRET: "ci-playwright-smoke-auth-enc-secret-not-for-production"  # pragma: allowlist secret
 
     steps:
       - name: ⬇️ Checkout source


### PR DESCRIPTION
## Summary

- `playwright-ci-smoke` crashes on startup because the workflow copies `.env.example` to `.env`, which ships with `__REPLACE_ME__` placeholder values for `JWT_SECRET_KEY` and `AUTH_ENCRYPTION_SECRET`
- `validate_security_combinations()` (`config.py:1468`) hard-fails on any value starting with `__REPLACE_ME__` — gunicorn exits before binding, gateway never starts, all Playwright tests time out
- Fix adds the two vars to the workflow job-level `env:` block; pydantic-settings env vars always override `.env` file values so the placeholders are never evaluated

Closes #4869