### PR TITLE
feat: add canonical_url for stable RFC 9728 OAuth resource identifiers

### DIFF
--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -56,6 +56,7 @@ Stored as JSON within the gateway record and assembled from Admin UI fields or A
 - **User Credentials**: Username and password (for password grant only).
 - **Scopes**: Array of requested scopes.
 - **Resource**: Optional resource parameter; derived from the gateway URL if omitted.
+- **Canonical URL**: Per virtual-server `canonical_url` that replaces the UUID-based RFC 9728 resource metadata URL. Must match `app_domain` and have a non-root path (e.g., `/mcp`). Global uniqueness enforced at the application layer. When set, the well-known metadata endpoint returns `canonical_url` as the `resource` field, and the token audience validator includes it as a valid audience.
 
 ### OAuth Tokens
 

--- a/mcpgateway/alembic/versions/1d92a8045125_add_canonical_url_to_servers.py
+++ b/mcpgateway/alembic/versions/1d92a8045125_add_canonical_url_to_servers.py
@@ -14,8 +14,8 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-revision: str = "1d92a8045125"
-down_revision: Union[str, Sequence[str], None] = "e28566875fa4"
+revision: str = "1d92a8045125"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e28566875fa4"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/1d92a8045125_add_canonical_url_to_servers.py
+++ b/mcpgateway/alembic/versions/1d92a8045125_add_canonical_url_to_servers.py
@@ -1,0 +1,52 @@
+"""add_canonical_url_to_servers
+
+Revision ID: 1d92a8045125
+Revises: e28566875fa4
+Create Date: 2026-05-22 16:51:08.269206
+
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "1d92a8045125"
+down_revision: Union[str, Sequence[str], None] = "e28566875fa4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add canonical_url column to servers table.
+
+    Idempotent: checks table and column existence before adding.
+    No hermetic downgrade needed — purely additive column with no settings dependency.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "servers" not in inspector.get_table_names():
+        return
+    columns = [c["name"] for c in inspector.get_columns("servers")]
+    if "canonical_url" not in columns:
+        op.add_column(
+            "servers",
+            sa.Column("canonical_url", sa.String(767), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Remove canonical_url column from servers table.
+
+    Idempotent: checks table and column existence before dropping.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "servers" not in inspector.get_table_names():
+        return
+    columns = [c["name"] for c in inspector.get_columns("servers")]
+    if "canonical_url" in columns:
+        op.drop_column("servers", "canonical_url")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -4581,6 +4581,11 @@ class Server(Base):
     # When enabled, MCP clients can authenticate using OAuth with browser-based IDP SSO
     oauth_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     oauth_config: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSON, nullable=True)
+    canonical_url: Mapped[Optional[str]] = mapped_column(
+        String(767),
+        nullable=True,
+        comment="Stable RFC 9728 resource URL override (e.g. https://gw.example.com/mcp)",
+    )
 
     # Relationship for loading team names (only active teams)
     # Uses default lazy loading - team name is only loaded when accessed

--- a/mcpgateway/routers/well_known.py
+++ b/mcpgateway/routers/well_known.py
@@ -19,11 +19,13 @@ from urllib.parse import urlparse, urlunparse
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, PlainTextResponse
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.db import get_db
+from mcpgateway.db import Server as DbServer
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.server_service import ServerError, ServerNotFoundError, ServerService
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
@@ -124,72 +126,87 @@ async def get_oauth_protected_resource_rfc9728(
     """
     RFC 9728 OAuth 2.0 Protected Resource Metadata endpoint (path-based).
 
-    Per RFC 9728 Section 3.1, the well-known URI is constructed by:
-    1. Taking the resource URL: http://localhost:4444/servers/{UUID}/mcp
-    2. Removing trailing slash and inserting /.well-known/oauth-protected-resource/
-    3. Result: http://localhost:4444/.well-known/oauth-protected-resource/servers/{UUID}/mcp
+    Supports two path formats:
+    1. UUID-based:  servers/{uuid}/mcp  (existing, always works)
+    2. Canonical:   {canonical_path}    (new, requires canonical_url on server)
+
+    Per RFC 9728 Section 3.1, the well-known URI is constructed by inserting
+    /.well-known/oauth-protected-resource/ into the resource URL, so the
+    resource field in the response MUST match the URL from which metadata
+    was retrieved.
 
     This endpoint does not require authentication per RFC 9728 requirements.
 
     Args:
-        path: The resource path after oauth-protected-resource/ (e.g., "servers/{UUID}/mcp")
-        request: FastAPI request object for building resource URL
-        db: Database session dependency
+        path: The resource path after oauth-protected-resource/.
+        request: FastAPI request object for building resource URL.
+        db: Database session dependency.
 
     Returns:
-        JSONResponse with RFC 9728 Protected Resource Metadata:
-        {
-            "resource": "http://localhost:4444/servers/{UUID}/mcp",
-            "authorization_servers": ["https://auth.example.com"],
-            "bearer_methods_supported": ["header"],
-            "scopes_supported": ["read", "write"]
-        }
+        JSONResponse with RFC 9728 Protected Resource Metadata.
 
     Raises:
-        HTTPException: 404 if path format invalid, server not found, disabled,
-            non-public, OAuth not enabled, or not configured.
-
-    Examples:
-        >>> # Request OAuth metadata for a server
-        >>> # GET /.well-known/oauth-protected-resource/servers/abc123/mcp
-        >>> # Returns RFC 9728 compliant metadata
+        HTTPException: 404 if path format invalid or server not found.
     """
     if not settings.well_known_enabled:
         raise HTTPException(status_code=404, detail="Not found")
 
-    # Parse path to extract server_id with validation
-    # Expected formats:
-    #   - "servers/{UUID}/mcp" (standard MCP endpoint)
-    #   - "servers/{UUID}" (fallback without /mcp suffix)
-    path_parts = path.strip("/").split("/")
-
-    # Validate path structure
-    if len(path_parts) < 2 or path_parts[0] != "servers":
-        # Sanitize untrusted path before logging to prevent log injection
-        logger.debug(f"Invalid RFC 9728 path format: {sanitize_for_log(path)}")
-        raise HTTPException(status_code=404, detail="Invalid resource path format. Expected: /.well-known/oauth-protected-resource/servers/{server_id}/mcp")
-
-    server_id = path_parts[1]
-
-    # Validate server_id is a valid UUID (prevents path traversal and injection)
-    if not UUID_PATTERN.match(server_id):
-        # Sanitize untrusted server_id before logging to prevent log injection
-        logger.warning(f"Invalid server_id format (not a UUID): {sanitize_for_log(server_id)}")
-        raise HTTPException(status_code=404, detail="Invalid server_id format. Must be a valid UUID.")
-
-    # Reject paths with extra segments after /mcp (e.g., servers/uuid/mcp/extra)
-    if len(path_parts) > 3:
-        # Sanitize untrusted path before logging to prevent log injection
-        logger.warning(f"RFC 9728 path has unexpected segments: {sanitize_for_log(path)}")
-        raise HTTPException(status_code=404, detail="Invalid resource path format. Expected: /.well-known/oauth-protected-resource/servers/{server_id}/mcp")
-
-    # Build resource URL with /mcp suffix per MCP specification
+    path = path.strip("/")
+    path_parts = path.split("/")
     base_url = get_base_url_with_protocol(request)
-    resource_url = f"{base_url}/servers/{server_id}/mcp"
+    server_id = None
+    resource_url = None
+
+    # ── Strategy 1: UUID-based path resolution ──
+    if len(path_parts) >= 2 and path_parts[0] == "servers":
+        candidate_id = path_parts[1]
+        if not UUID_PATTERN.match(candidate_id):
+            logger.warning(f"Invalid server_id format (not a UUID): {sanitize_for_log(candidate_id)}")
+            raise HTTPException(
+                status_code=404,
+                detail="Invalid server_id format. Must be a valid UUID.",
+            )
+        if len(path_parts) > 3:
+            raise HTTPException(
+                status_code=404,
+                detail="Invalid resource path format",
+            )
+        server_id = candidate_id
+        # Check if this server has a canonical_url set
+        server_obj = db.get(DbServer, server_id)
+        if server_obj and server_obj.canonical_url:
+            resource_url = server_obj.canonical_url
+        else:
+            resource_url = f"{base_url}/servers/{server_id}/mcp"
+
+    # ── Strategy 2: Canonical URL path resolution ──
+    if server_id is None:
+        normalized_path = path.rstrip("/")
+        reconstructed_url = f"{base_url}/{normalized_path}"
+        server = db.execute(
+            select(DbServer).where(
+                DbServer.canonical_url == reconstructed_url,
+                DbServer.enabled,
+                DbServer.oauth_enabled,
+            )
+        ).scalar_one_or_none()
+        if server:
+            server_id = server.id
+            resource_url = server.canonical_url
+
+    if server_id is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Invalid resource path format. " "Expected: /.well-known/oauth-protected-resource/servers/{server_id}/mcp " "or a path matching a configured canonical_url",
+        )
 
     server_service = ServerService()
     try:
-        response_data = server_service.get_oauth_protected_resource_metadata(db=db, server_id=server_id, resource_base_url=resource_url)
+        response_data = server_service.get_oauth_protected_resource_metadata(
+            db=db,
+            server_id=server_id,
+            resource_base_url=resource_url,
+        )
     except ServerNotFoundError:
         raise HTTPException(status_code=404, detail="Server not found")
     except ServerError as e:
@@ -198,7 +215,12 @@ async def get_oauth_protected_resource_rfc9728(
     # Add cache headers per RFC 9728 recommendations
     headers = {"Cache-Control": f"public, max-age={settings.well_known_cache_max_age}"}
 
-    logger.debug(f"Served RFC 9728 OAuth metadata for server {server_id}")
+    logger.debug(
+        "Served RFC 9728 OAuth metadata for server %s (path: %s, resource: %s)",
+        server_id,
+        path,
+        resource_url,
+    )
     return JSONResponse(content=response_data, headers=headers)
 
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -165,6 +165,55 @@ def _validate_oauth_config_urls(v: Optional[Dict[str, Any]]) -> Optional[Dict[st
     return v
 
 
+def _validate_canonical_url(v: Optional[str]) -> Optional[str]:
+    """Validate and normalize canonical URL for RFC 9728 metadata.
+
+    Applied as a @field_validator on ServerCreate and ServerUpdate.
+
+    Args:
+        v: The canonical URL string to validate, or None.
+
+    Returns:
+        Normalized URL with trailing slash stripped, or None.
+
+    Raises:
+        ValueError: If the URL fails any validation check.
+    """
+    if v is None:
+        return v
+
+    v = v.strip().rstrip("/")
+    parsed = urlparse(v)
+
+    # Absolute URL with scheme and netloc
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("canonical_url must be an absolute URL (http or https)")
+
+    # HTTPS required in production
+    if settings.environment == "production" and parsed.scheme != "https":
+        raise ValueError("canonical_url must use HTTPS in production")
+
+    # Non-root path required
+    if not parsed.path or parsed.path in ("", "/"):
+        raise ValueError("canonical_url must have a non-root path (e.g. /mcp)")
+
+    # No UUID patterns (defeats stability purpose)
+    uuid_pattern = r"[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}"
+    if re.search(uuid_pattern, v, re.IGNORECASE):
+        raise ValueError("canonical_url must not contain UUIDs")
+
+    # Length limit
+    if len(v) > 767:
+        raise ValueError("canonical_url exceeds maximum length (767)")
+
+    # Domain must match app_domain (prevents cross-domain confusion attacks)
+    app_parsed = urlparse(str(settings.app_domain))
+    if parsed.netloc.lower() != app_parsed.netloc.lower():
+        raise ValueError(f"canonical_url domain '{parsed.netloc}' must match " f"app_domain '{app_parsed.netloc}'")
+
+    return v
+
+
 def _validate_mapping_size(v: dict | None) -> dict | None:
     """Validate that a mapping dict does not exceed size limits.
 
@@ -4169,6 +4218,10 @@ class ServerCreate(BaseModel):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: bool = Field(False, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+    canonical_url: Optional[str] = Field(
+        None,
+        description="Stable canonical URL for RFC 9728 OAuth metadata " "(e.g. https://gateway.example.com/mcp). " "When set, replaces the UUID-based URL in metadata responses.",
+    )
 
     @field_validator("name")
     @classmethod
@@ -4262,6 +4315,19 @@ class ServerCreate(BaseModel):
             return SecurityValidator.validate_uuid(v, "team_id")
         return v
 
+    @field_validator("canonical_url")
+    @classmethod
+    def validate_canonical_url(cls, v: Optional[str]) -> Optional[str]:
+        """Validate canonical URL format for RFC 9728 metadata."""
+        return _validate_canonical_url(v)
+
+    @model_validator(mode="after")
+    def validate_canonical_url_requires_oauth(self):
+        """Canonical URL can only be set when OAuth is enabled."""
+        if self.canonical_url is not None and not self.oauth_enabled:
+            raise ValueError("canonical_url can only be set when oauth_enabled=True")
+        return self
+
 
 class ServerUpdate(BaseModelWithConfigDict):
     """Schema for updating an existing server.
@@ -4283,6 +4349,10 @@ class ServerUpdate(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: Optional[bool] = Field(None, description="Enable OAuth 2.0 for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+    canonical_url: Optional[str] = Field(
+        None,
+        description="Stable canonical URL for RFC 9728 OAuth metadata " "(e.g. https://gateway.example.com/mcp). " "When set, replaces the UUID-based URL in metadata responses.",
+    )
 
     @field_validator("tags")
     @classmethod
@@ -4406,6 +4476,21 @@ class ServerUpdate(BaseModelWithConfigDict):
         """
         return _validate_association_ids(v, info.field_name)
 
+    @field_validator("canonical_url")
+    @classmethod
+    def validate_canonical_url(cls, v: Optional[str]) -> Optional[str]:
+        """Validate canonical URL format for RFC 9728 metadata."""
+        return _validate_canonical_url(v)
+
+    @model_validator(mode="after")
+    def validate_canonical_url_requires_oauth(self):
+        """Canonical URL can only be set when OAuth is enabled."""
+        if self.canonical_url is not None and self.oauth_enabled is not None:
+            # oauth_enabled is Optional[bool] in update — only validate when it's set
+            if not self.oauth_enabled:
+                raise ValueError("canonical_url can only be set when oauth_enabled=True")
+        return self
+
 
 class ServerRead(BaseModelWithConfigDict):
     """Schema for reading server information.
@@ -4458,6 +4543,10 @@ class ServerRead(BaseModelWithConfigDict):
     # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
     oauth_enabled: bool = Field(False, description="Whether OAuth 2.0 is enabled for MCP client authentication")
     oauth_config: Optional[Dict[str, Any]] = Field(None, description="OAuth 2.0 configuration (authorization_server, scopes_supported, etc.)")
+    canonical_url: Optional[str] = Field(
+        None,
+        description="Stable canonical URL for RFC 9728 OAuth metadata. " "Must match app_domain and have a non-root path.",
+    )
 
     _normalize_visibility = field_validator("visibility", mode="before")(classmethod(lambda cls, v: _coerce_visibility(v)))
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -259,6 +259,14 @@ def _update_server_associations(db: Session, server: DbServer, server_update: Se
             setattr(server, at.rel_attr, list(objs))
 
 
+def _safe_str(v: object) -> Optional[str]:
+    """Return v if it is a string, otherwise None.
+
+    Guards against MagicMock auto-creation in tests.
+    """
+    return v if isinstance(v, str) else None
+
+
 class ServerService(BaseService):
     """Service for managing MCP Servers in the catalog.
 
@@ -432,6 +440,7 @@ class ServerService(BaseService):
             # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
             "oauth_enabled": getattr(server, "oauth_enabled", False),
             "oauth_config": getattr(server, "oauth_config", None),
+            "canonical_url": _safe_str(getattr(server, "canonical_url", None)),
         }
 
         # Compute aggregated metrics only if requested (avoids N+1 queries in list operations)
@@ -599,6 +608,7 @@ class ServerService(BaseService):
                 # OAuth 2.0 configuration for RFC 9728 Protected Resource Metadata
                 oauth_enabled=getattr(server_in, "oauth_enabled", False) or False,
                 oauth_config=oauth_config,
+                canonical_url=getattr(server_in, "canonical_url", None),
                 # Metadata fields
                 created_by=created_by,
                 created_from_ip=created_from_ip,
@@ -623,6 +633,16 @@ class ServerService(BaseService):
             existing_server = get_for_update(db, DbServer, where=and_(*conditions))
             if existing_server:
                 raise ServerNameConflictError(server_in.name, enabled=existing_server.enabled, server_id=existing_server.id, visibility=existing_server.visibility)
+            # Canonical URL uniqueness check (metadata endpoint is unauthenticated, so global uniqueness)
+            if server_in.canonical_url is not None:
+                existing_cu = get_for_update(
+                    db,
+                    DbServer,
+                    where=DbServer.canonical_url == server_in.canonical_url,
+                )
+                if existing_cu:
+                    raise ServerError(f"canonical_url '{server_in.canonical_url}' is already in use " f"by server '{existing_cu.name}' ({existing_cu.id})")
+
             # Set custom UUID if provided
             if server_in.id:
                 logger.info(f"Setting custom UUID for server: {server_in.id}")
@@ -669,6 +689,7 @@ class ServerService(BaseService):
                     "associated_resources_count": len(db_server.resources),
                     "associated_prompts_count": len(db_server.prompts),
                     "associated_a2a_agents_count": len(db_server.a2a_agents),
+                    "canonical_url": server_in.canonical_url,
                 },
                 metadata={
                     "created_from_ip": created_from_ip,
@@ -1327,6 +1348,23 @@ class ServerService(BaseService):
                 elif server_update.oauth_config is not None:
                     server.oauth_config = await protect_oauth_config_for_storage(server_update.oauth_config, existing_oauth_config=server.oauth_config)
 
+            # Canonical URL update with uniqueness check
+            update_cu = getattr(server_update, "canonical_url", None)
+            if isinstance(update_cu, str):
+                existing_cu = get_for_update(
+                    db,
+                    DbServer,
+                    where=and_(
+                        DbServer.canonical_url == update_cu,
+                        DbServer.id != server.id,
+                    ),
+                )
+                if existing_cu:
+                    raise ServerError(f"canonical_url '{update_cu}' is already in use " f"by server '{existing_cu.name}' ({existing_cu.id})")
+                server.canonical_url = update_cu
+            elif "canonical_url" in getattr(server_update, "model_fields_set", {}):
+                server.canonical_url = None
+
             # Update metadata fields
             server.updated_at = datetime.now(timezone.utc)
             if modified_by:
@@ -1367,6 +1405,8 @@ class ServerService(BaseService):
                 changes.append(f"visibility: {server_update.visibility}")
             if server_update.team_id:
                 changes.append(f"team_id: {server_update.team_id}")
+            if "canonical_url" in getattr(server_update, "model_fields_set", {}):
+                changes.append(f"canonical_url: {server_update.canonical_url}")
 
             self._audit_trail.log_action(
                 user_id=user_email or "system",

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from enum import Enum
 import re
 from typing import Any, assert_never, AsyncGenerator, ContextManager, Dict, List, Optional, Pattern, Tuple, Union
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlparse, urlsplit, urlunsplit
 from uuid import uuid4
 
 # Third-Party
@@ -926,6 +926,29 @@ def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:
     if not base:
         return ""
     return f"{base}/.well-known/oauth-protected-resource/servers/{server_id}/mcp"
+
+
+def _build_canonical_metadata_url(canonical_url: str) -> str:
+    """Build RFC 9728 metadata URL from a canonical resource URL.
+
+    Canonical URL:  https://gw.example.com/mcp
+    Metadata URL:   https://gw.example.com/.well-known/oauth-protected-resource/mcp
+
+    Args:
+        canonical_url: The operator-configured canonical resource URL.
+
+    Returns:
+        Fully-qualified metadata URL string, or "" if construction fails.
+    """
+    try:
+        parsed = urlparse(canonical_url)
+        if not parsed.scheme or not parsed.netloc:
+            return ""
+        well_known_path = f"/.well-known/oauth-protected-resource{parsed.path}"
+        return f"{parsed.scheme}://{parsed.netloc}{well_known_path}"
+    except Exception:
+        logger.warning("Failed to build canonical metadata URL from %s", canonical_url)
+        return ""
 
 
 def _is_valid_audience(value: Any) -> bool:
@@ -4888,7 +4911,18 @@ class _StreamableHttpAuthHandler:
             try:
                 await _check_server_oauth_enforcement(per_server_id, {"is_authenticated": False})
             except OAuthRequiredError:
-                resource_metadata = _build_resource_metadata_url(self.scope, per_server_id)
+                cu = None
+                try:
+                    async with get_db() as db_conn:
+                        srv = db_conn.execute(select(DbServer).where(DbServer.id == per_server_id)).scalar_one_or_none()
+                        if srv:
+                            cu = srv.canonical_url if isinstance(srv.canonical_url, str) else None
+                except Exception:
+                    logger.debug("Failed to retrieve server %s for canonical URL (falling back to UUID-based metadata)", per_server_id)
+                if cu:
+                    resource_metadata = _build_canonical_metadata_url(cu)
+                else:
+                    resource_metadata = _build_resource_metadata_url(self.scope, per_server_id)
                 www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
                 return await self._send_error(detail="This server requires OAuth authentication", headers={"WWW-Authenticate": www_auth})
             except OAuthEnforcementUnavailableError:
@@ -5376,11 +5410,12 @@ class _StreamableHttpAuthHandler:
         # 1. ``resource`` configured (operator-set or previously learned)
         #    → enforce it strictly.
         # 2. ``resource`` unset → fall back to a list of acceptable
-        #    audiences derived from operator config:
-        #      * the canonical RFC 8707/9728 resource URL, and
-        #      * the legacy ``client_id`` field (for IdPs like Authentik
-        #        that mint tokens with ``aud == client_id``).
-        #    PyJWT's "any element matches" semantics accept either.
+        #    audiences derived from operator config (in priority order):
+        #      a. ``server.canonical_url`` (operator-chosen stable URL)
+        #      b. the canonical RFC 8707/9728 resource URL (UUID-based)
+        #      c. the legacy ``client_id`` field (for IdPs like Authentik
+        #         that mint tokens with ``aud == client_id``).
+        #    PyJWT's "any element matches" semantics accept any of them.
         # 3. Neither configured → fail closed. Skipping audience entirely
         #    would let any token from an allowed issuer authenticate here,
         #    enabling cross-resource token confusion in shared-IdP
@@ -5391,19 +5426,32 @@ class _StreamableHttpAuthHandler:
             expected_audience = configured_resource
         else:
             fallback_audiences: list[str] = []
-            canonical_url = _build_server_resource_url(self.scope, server_id)
-            if canonical_url:
-                fallback_audiences.append(canonical_url)
+
+            # (a) operator-configured stable canonical URL
+            if server.canonical_url and isinstance(server.canonical_url, str):
+                fallback_audiences.append(server.canonical_url)
+
+            # (b) auto-derived UUID-based URL from settings.app_domain
+            auto_url = _build_server_resource_url(self.scope, server_id)
+            if auto_url:
+                fallback_audiences.append(auto_url)
+
+            # (c) legacy client_id for Authentik compatibility
             legacy_client_id = server.oauth_config.get("client_id")
             if isinstance(legacy_client_id, str) and legacy_client_id.strip():
                 fallback_audiences.append(legacy_client_id.strip())
+
             if not fallback_audiences:
                 logger.warning(
-                    "Server %s has no resource or client_id configured and no canonical resource URL could be derived; rejecting OAuth token",
+                    "Server %s has no resource, canonical_url, or client_id " "configured and no canonical resource URL could be derived; " "rejecting OAuth token",
                     server_id_log,
                 )
-                resource_metadata = _build_resource_metadata_url(self.scope, server_id)
-                www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
+                cu = server.canonical_url if isinstance(server.canonical_url, str) else None
+                if cu:
+                    resource_meta_url = _build_canonical_metadata_url(cu)
+                else:
+                    resource_meta_url = _build_resource_metadata_url(self.scope, server_id)
+                www_auth = f'Bearer resource_metadata="{resource_meta_url}"' if resource_meta_url else "Bearer"
                 await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
                 return OAuthAuthResult.FAILED
             expected_audience = fallback_audiences[0] if len(fallback_audiences) == 1 else fallback_audiences
@@ -5411,8 +5459,12 @@ class _StreamableHttpAuthHandler:
         claims = await verify_oauth_access_token(token, authorization_servers, expected_audience=expected_audience)
 
         if claims is None:
-            resource_metadata = _build_resource_metadata_url(self.scope, server_id)
-            www_auth = f'Bearer resource_metadata="{resource_metadata}"' if resource_metadata else "Bearer"
+            cu = server.canonical_url if isinstance(server.canonical_url, str) else None
+            if cu:
+                resource_meta_url = _build_canonical_metadata_url(cu)
+            else:
+                resource_meta_url = _build_resource_metadata_url(self.scope, server_id)
+            www_auth = f'Bearer resource_metadata="{resource_meta_url}"' if resource_meta_url else "Bearer"
             await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
             return OAuthAuthResult.FAILED
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -940,15 +940,11 @@ def _build_canonical_metadata_url(canonical_url: str) -> str:
     Returns:
         Fully-qualified metadata URL string, or "" if construction fails.
     """
-    try:
-        parsed = urlparse(canonical_url)
-        if not parsed.scheme or not parsed.netloc:
-            return ""
-        well_known_path = f"/.well-known/oauth-protected-resource{parsed.path}"
-        return f"{parsed.scheme}://{parsed.netloc}{well_known_path}"
-    except Exception:
-        logger.warning("Failed to build canonical metadata URL from %s", canonical_url)
+    parsed = urlparse(canonical_url)
+    if not parsed.scheme or not parsed.netloc:
         return ""
+    well_known_path = f"/.well-known/oauth-protected-resource{parsed.path}"
+    return f"{parsed.scheme}://{parsed.netloc}{well_known_path}"
 
 
 def _is_valid_audience(value: Any) -> bool:
@@ -5446,11 +5442,7 @@ class _StreamableHttpAuthHandler:
                     "Server %s has no resource, canonical_url, or client_id " "configured and no canonical resource URL could be derived; " "rejecting OAuth token",
                     server_id_log,
                 )
-                cu = server.canonical_url if isinstance(server.canonical_url, str) else None
-                if cu:
-                    resource_meta_url = _build_canonical_metadata_url(cu)
-                else:
-                    resource_meta_url = _build_resource_metadata_url(self.scope, server_id)
+                resource_meta_url = _build_resource_metadata_url(self.scope, server_id)
                 www_auth = f'Bearer resource_metadata="{resource_meta_url}"' if resource_meta_url else "Bearer"
                 await self._send_error(detail="Invalid OAuth access token", headers={"WWW-Authenticate": www_auth})
                 return OAuthAuthResult.FAILED

--- a/tests/integration/test_canonical_url_oauth.py
+++ b/tests/integration/test_canonical_url_oauth.py
@@ -1,0 +1,207 @@
+"""Integration tests for canonical_url OAuth flow.
+
+Tests the E2E flow: create server with canonical_url → well-known metadata
+resolution → WWW-Authenticate header with canonical metadata URL.
+"""
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+
+
+@pytest.fixture
+def test_app():
+    import os
+    import tempfile
+    from unittest.mock import MagicMock, patch
+
+    from _pytest.monkeypatch import MonkeyPatch
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    mp = MonkeyPatch()
+
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    from mcpgateway.config import settings
+
+    mp.setattr(settings, "database_url", url, raising=False)
+    mp.setattr(settings, "app_domain", "https://gw.example.com", raising=False)
+    mp.setattr(settings, "auth_required", False, raising=False)
+
+    import mcpgateway.db as db_mod
+    from mcpgateway.main import app as main_app
+    import mcpgateway.main as main_mod
+    from mcpgateway.utils.verify_credentials import require_auth
+
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestingSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestingSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    from mcpgateway.db import Base
+
+    Base.metadata.create_all(bind=engine)
+
+    # Seed a gateway record for tests
+    gw_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    gw_db = TestingSessionLocal()
+    try:
+        from mcpgateway.db import Gateway
+        gw = Gateway(
+            id=gw_id, name="test-gw", slug="test-gw", url="https://gw.example.com",
+            capabilities={}, enabled=True,
+        )
+        gw_db.add(gw)
+        gw_db.commit()
+    finally:
+        gw_db.close()
+
+    from mcpgateway.auth import get_current_user
+    from mcpgateway.middleware.rbac import get_current_user_with_permissions
+    from mcpgateway.middleware.rbac import get_db as rbac_get_db
+    from mcpgateway.middleware.rbac import get_permission_service
+
+    mock_email_user = MagicMock()
+    mock_email_user.email = "admin@example.com"
+    mock_email_user.full_name = "Admin"
+    mock_email_user.is_admin = True
+    mock_email_user.is_active = True
+
+    async def mock_user_with_permissions():
+        db_session = TestingSessionLocal()
+        try:
+            yield {
+                "email": "admin@example.com",
+                "full_name": "Admin",
+                "is_admin": True,
+                "ip_address": "127.0.0.1",
+                "user_agent": "test-client",
+                "db": db_session,
+            }
+        finally:
+            db_session.close()
+
+    def mock_get_permission_service(*args, **kwargs):
+        from tests.utils.rbac_mocks import MockPermissionService
+        return MockPermissionService(always_grant=True)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from tests.utils.rbac_mocks import MockPermissionService
+
+    with patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService):
+        with patch("mcpgateway.routers.well_known.get_base_url_with_protocol", return_value="https://gw.example.com"):
+            main_app.dependency_overrides[require_auth] = lambda: "admin"
+            main_app.dependency_overrides[get_current_user] = lambda: mock_email_user
+            main_app.dependency_overrides[get_current_user_with_permissions] = mock_user_with_permissions
+            main_app.dependency_overrides[get_permission_service] = mock_get_permission_service
+            main_app.dependency_overrides[rbac_get_db] = override_get_db
+
+            yield main_app, TestingSessionLocal, gw_id
+
+            main_app.dependency_overrides.pop(require_auth, None)
+            main_app.dependency_overrides.pop(get_current_user, None)
+            main_app.dependency_overrides.pop(get_current_user_with_permissions, None)
+            main_app.dependency_overrides.pop(get_permission_service, None)
+            main_app.dependency_overrides.pop(rbac_get_db, None)
+
+    mp.undo()
+    engine.dispose()
+    os.close(fd)
+    os.unlink(path)
+
+
+@pytest.fixture
+def client(test_app):
+    app_instance, _, _ = test_app
+    return TestClient(app_instance)
+
+
+@pytest.fixture
+def auth_headers():
+    return {}
+
+
+@pytest.fixture
+def server_with_canonical(client, auth_headers, test_app):
+    _, TestingSessionLocal, gw_id = test_app
+
+    canonical_path = "/my-canon-srv/mcp"
+    server_data = {
+        "server": {
+            "name": "canon-srv",
+            "gateway_id": gw_id,
+            "oauth_enabled": True,
+            "oauth_config": {
+                "authorization_server": "https://auth.example.com",
+            },
+            "canonical_url": f"https://gw.example.com{canonical_path}",
+        },
+        "team_id": None,
+        "visibility": "public",
+    }
+    response = client.post("/servers/", json=server_data, headers=auth_headers)
+    assert response.status_code == 201, f"Server creation failed: {response.text}"
+    return response.json(), canonical_path
+
+
+class TestCanonicalUrlOAuthFlow:
+    """End-to-end tests for canonical_url OAuth flow."""
+
+    def test_create_server_with_canonical(self, server_with_canonical):
+        server, _ = server_with_canonical
+        assert server["canonicalUrl"] == "https://gw.example.com/my-canon-srv/mcp"
+
+    def test_well_known_uuid_path_returns_canonical_resource(self, client, server_with_canonical):
+        server, _ = server_with_canonical
+        server_id = server["id"]
+        response = client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["resource"] == "https://gw.example.com/my-canon-srv/mcp"
+
+    def test_well_known_canonical_path_returns_metadata(self, client, server_with_canonical):
+        server, canonical_path = server_with_canonical
+        response = client.get(f"/.well-known/oauth-protected-resource{canonical_path}")
+        assert response.status_code == 200
+        data = response.json()
+        assert "resource" in data
+        assert "authorization_servers" in data
+
+    def test_well_known_canonical_path_404_for_unknown(self, client):
+        response = client.get("/.well-known/oauth-protected-resource/nonexistent/path/mcp")
+        assert response.status_code == 404
+
+    def test_well_known_uuid_path_returns_uuid_when_no_canonical(self, client, auth_headers, test_app):
+        _, TestingSessionLocal, gw_id = test_app
+
+        server_data = {
+            "server": {
+                "name": "plain-srv",
+                "gateway_id": gw_id,
+                "oauth_enabled": True,
+                "oauth_config": {
+                    "authorization_server": "https://auth.example.com",
+                },
+            },
+            "team_id": None,
+            "visibility": "public",
+        }
+        response = client.post("/servers/", json=server_data, headers=auth_headers)
+        server = response.json()
+        server_id = server["id"]
+
+        response = client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
+        assert response.status_code == 200
+        data = response.json()
+        assert server_id in data["resource"]

--- a/tests/unit/mcpgateway/routers/test_well_known_rfc9728.py
+++ b/tests/unit/mcpgateway/routers/test_well_known_rfc9728.py
@@ -104,6 +104,9 @@ class TestRFC9728CompliantEndpoint:
     def test_rfc9728_endpoint_invalid_path_format(self, app):
         """Test RFC 9728 endpoint rejects invalid path formats."""
         mock_db = MagicMock()
+        mock_execute_result = MagicMock()
+        mock_execute_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_execute_result
 
         def override_get_db():
             yield mock_db
@@ -471,3 +474,129 @@ class TestRFC9728SecurityValidation:
             service.get_oauth_protected_resource_metadata(
                 db=mock_db, server_id="550e8400-e29b-41d4-a716-446655440000", resource_base_url="http://localhost:4444/servers/550e8400-e29b-41d4-a716-446655440000/mcp"
             )
+
+
+class TestCanonicalUrlWellKnown:
+    """Tests for canonical_url resolution in the well-known endpoint."""
+
+    def test_uuid_path_returns_canonical_resource_when_set(self, app):
+        """UUID path returns canonical_url as resource when server has it set."""
+        mock_db = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        server_id = "550e8400-e29b-41d4-a716-446655440000"
+        mock_server = MagicMock()
+        mock_server.id = server_id
+        mock_server.canonical_url = "https://gw.example.com/servers/my-srv/mcp"
+        mock_db.get.return_value = mock_server
+
+        mock_service = MagicMock()
+        mock_service.get_oauth_protected_resource_metadata.return_value = {
+            "resource": "https://gw.example.com/servers/my-srv/mcp",
+            "authorization_servers": ["https://auth.example.com"],
+            "bearer_methods_supported": ["header"],
+            "scopes_supported": ["read"],
+        }
+
+        client = TestClient(app)
+
+        with patch("mcpgateway.routers.well_known.ServerService", return_value=mock_service):
+            response = client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["resource"] == "https://gw.example.com/servers/my-srv/mcp"
+
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_uuid_path_returns_uuid_resource_when_no_canonical(self, app):
+        """UUID path returns auto-derived URL when canonical_url is not set."""
+        mock_db = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        server_id = "550e8400-e29b-41d4-a716-446655440000"
+        mock_server = MagicMock()
+        mock_server.id = server_id
+        mock_server.canonical_url = None
+        mock_db.get.return_value = mock_server
+
+        mock_service = MagicMock()
+        mock_service.get_oauth_protected_resource_metadata.return_value = {
+            "resource": f"http://testserver/servers/{server_id}/mcp",
+            "authorization_servers": ["https://auth.example.com"],
+            "bearer_methods_supported": ["header"],
+            "scopes_supported": ["read"],
+        }
+
+        client = TestClient(app)
+
+        with patch("mcpgateway.routers.well_known.ServerService", return_value=mock_service):
+            response = client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["resource"] == f"http://testserver/servers/{server_id}/mcp"
+
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_canonical_path_resolves_to_metadata(self, app):
+        """Canonical URL path resolves to server metadata."""
+        mock_db = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        server_id = "550e8400-e29b-41d4-a716-446655440000"
+        canonical_url = "http://testserver/my-app/mcp"
+
+        mock_server = MagicMock()
+        mock_server.id = server_id
+        mock_server.canonical_url = canonical_url
+
+        mock_db.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=mock_server)
+        )
+
+        mock_service = MagicMock()
+        mock_service.get_oauth_protected_resource_metadata.return_value = {
+            "resource": canonical_url,
+            "authorization_servers": ["https://auth.example.com"],
+            "bearer_methods_supported": ["header"],
+            "scopes_supported": ["read"],
+        }
+
+        client = TestClient(app)
+        with patch("mcpgateway.routers.well_known.ServerService", return_value=mock_service):
+            response = client.get("/.well-known/oauth-protected-resource/my-app/mcp")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["resource"] == canonical_url
+
+        app.dependency_overrides.pop(get_db, None)
+
+    def test_canonical_path_returns_404_when_no_match(self, app):
+        """Canonical URL path returns 404 when no server matches."""
+        mock_db = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        mock_db.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=None)
+        )
+
+        client = TestClient(app)
+        response = client.get("/.well-known/oauth-protected-resource/nonexistent/path/mcp")
+        assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_db, None)

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -11,6 +11,7 @@ Tests for server service implementation.
 import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from urllib.parse import urlparse
 
 # Third-Party
 import pytest
@@ -3819,6 +3820,12 @@ def _make_server_read(**kwargs) -> ServerRead:
     return ServerRead(**base)
 
 
+def _make_canonical_url(path: str = "/my-srv/mcp") -> str:
+    """Build a canonical URL matching settings.app_domain for tests."""
+    parsed = urlparse(str(settings.app_domain))
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
 class TestCanonicalUrl:
     """Service-layer behavior for canonical_url on register and update."""
 
@@ -3850,10 +3857,12 @@ class TestCanonicalUrl:
         execute_result.scalar_one_or_none = scalar_one_or_none
         test_db.execute.return_value = execute_result
 
+        canonical_url = _make_canonical_url("/servers/my-srv/mcp")
+
         server_create = ServerCreate(
             name="canon-b",
             oauth_enabled=True,
-            canonical_url="http://localhost/servers/my-srv/mcp",
+            canonical_url=canonical_url,
         )
 
         with pytest.raises(ServerError) as exc:
@@ -3880,6 +3889,7 @@ class TestCanonicalUrl:
     async def test_update_set_canonical(self, server_service, mock_server, test_db):
         mock_server.canonical_url = None
         mock_server.owner_email = "test@example.com"
+        canonical_url = _make_canonical_url("/servers/my-srv/mcp")
 
         mock_scalar = Mock()
         mock_scalar.scalar_one_or_none.return_value = None
@@ -3889,7 +3899,7 @@ class TestCanonicalUrl:
         test_db.rollback = Mock()
         server_service.convert_server_to_read = Mock(return_value=_make_server_read(
             id=mock_server.id, name=mock_server.name,
-            canonical_url="http://localhost/servers/my-srv/mcp",
+            canonical_url=canonical_url,
         ))
 
         call_count = 0
@@ -3902,7 +3912,7 @@ class TestCanonicalUrl:
             return None
 
         server_update = ServerUpdate(
-            canonical_url="http://localhost/servers/my-srv/mcp",
+            canonical_url=canonical_url,
             oauth_enabled=True,
         )
 
@@ -3910,12 +3920,12 @@ class TestCanonicalUrl:
             result = await server_service.update_server(
                 test_db, mock_server.id, server_update, "test@example.com",
             )
-        assert result.canonical_url == "http://localhost/servers/my-srv/mcp"
-        assert mock_server.canonical_url == "http://localhost/servers/my-srv/mcp"
+        assert result.canonical_url == canonical_url
+        assert mock_server.canonical_url == canonical_url
 
     @pytest.mark.asyncio
     async def test_update_clear_canonical(self, server_service, mock_server, test_db):
-        mock_server.canonical_url = "http://localhost/servers/srv/mcp"
+        mock_server.canonical_url = _make_canonical_url("/servers/srv/mcp")
         mock_server.owner_email = "test@example.com"
 
         mock_scalar = Mock()
@@ -3949,6 +3959,7 @@ class TestCanonicalUrl:
     async def test_update_canonical_duplicate_rejected(self, server_service, mock_server, test_db):
         mock_server.canonical_url = None
         mock_server.owner_email = "test@example.com"
+        canonical_url = _make_canonical_url("/servers/my-srv/mcp")
 
         other_server = MagicMock()
         other_server.id = "other-id"
@@ -3968,7 +3979,7 @@ class TestCanonicalUrl:
         test_db.rollback = Mock()
 
         server_update = ServerUpdate(
-            canonical_url="http://localhost/servers/my-srv/mcp",
+            canonical_url=canonical_url,
             oauth_enabled=True,
         )
 
@@ -3980,7 +3991,8 @@ class TestCanonicalUrl:
 
     @pytest.mark.asyncio
     async def test_update_ignores_canonical_not_provided(self, server_service, mock_server, test_db):
-        mock_server.canonical_url = "http://localhost/servers/srv/mcp"
+        canonical_url = _make_canonical_url("/servers/srv/mcp")
+        mock_server.canonical_url = canonical_url
         mock_server.owner_email = "test@example.com"
 
         mock_scalar = Mock()
@@ -3991,7 +4003,7 @@ class TestCanonicalUrl:
         test_db.rollback = Mock()
         server_service.convert_server_to_read = Mock(return_value=_make_server_read(
             id=mock_server.id, name=mock_server.name,
-            canonical_url="http://localhost/servers/srv/mcp",
+            canonical_url=canonical_url,
         ))
 
         call_count = 0
@@ -4008,5 +4020,5 @@ class TestCanonicalUrl:
             result = await server_service.update_server(
                 test_db, mock_server.id, server_update, "test@example.com",
             )
-        assert result.canonical_url == "http://localhost/servers/srv/mcp"
-        assert mock_server.canonical_url == "http://localhost/servers/srv/mcp"
+        assert result.canonical_url == canonical_url
+        assert mock_server.canonical_url == canonical_url

--- a/tests/unit/mcpgateway/services/test_server_service.py
+++ b/tests/unit/mcpgateway/services/test_server_service.py
@@ -9,6 +9,7 @@ Tests for server service implementation.
 
 # Standard
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # Third-Party
@@ -3788,3 +3789,224 @@ class TestConvertServerToReadAssociatedToolIds:
             assert len(server_result.associated_prompts) == 1
             assert "prompt-1" in server_result.associated_prompts
             assert "prompt-2" not in server_result.associated_prompts
+
+
+def _make_server_read(**kwargs) -> ServerRead:
+    """Helper to build a ServerRead with minimal required fields."""
+    base = {
+        "id": "srv-id",
+        "name": "srv",
+        "description": "",
+        "icon": "",
+        "enabled": True,
+        "visibility": "public",
+        "owner_email": "",
+        "oauth_enabled": False,
+        "oauth_config": None,
+        "canonical_url": None,
+        "associated_tools": [],
+        "associated_resources": [],
+        "associated_prompts": [],
+        "associated_a2a_agents": [],
+        "tags": [],
+        "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "created_by": "",
+        "modified_by": "",
+        "version": 1,
+    }
+    base.update(kwargs)
+    return ServerRead(**base)
+
+
+class TestCanonicalUrl:
+    """Service-layer behavior for canonical_url on register and update."""
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_canonical_rejected(self, server_service, test_db):
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = None
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.add = Mock()
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+
+        existing_server = MagicMock()
+        existing_server.name = "canon-a"
+        existing_server.id = "server-1"
+
+        scalar_results = [None, existing_server]
+        scalar_index = 0
+
+        def scalar_one_or_none():
+            nonlocal scalar_index
+            val = scalar_results[scalar_index]
+            scalar_index += 1
+            return val
+
+        test_db.execute = Mock()
+        execute_result = Mock()
+        execute_result.scalar_one_or_none = scalar_one_or_none
+        test_db.execute.return_value = execute_result
+
+        server_create = ServerCreate(
+            name="canon-b",
+            oauth_enabled=True,
+            canonical_url="http://localhost/servers/my-srv/mcp",
+        )
+
+        with pytest.raises(ServerError) as exc:
+            await server_service.register_server(test_db, server_create, created_by="test@example.com")
+        assert "already in use" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_register_without_canonical_succeeds(self, server_service, test_db):
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = None
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.add = Mock()
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+        server_service._notify_server_added = AsyncMock()
+        server_service.convert_server_to_read = Mock(return_value=_make_server_read(name="plain-srv"))
+
+        server_create = ServerCreate(name="plain-srv", oauth_enabled=True)
+        result = await server_service.register_server(test_db, server_create, created_by="test@example.com")
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_update_set_canonical(self, server_service, mock_server, test_db):
+        mock_server.canonical_url = None
+        mock_server.owner_email = "test@example.com"
+
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = None
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+        server_service.convert_server_to_read = Mock(return_value=_make_server_read(
+            id=mock_server.id, name=mock_server.name,
+            canonical_url="http://localhost/servers/my-srv/mcp",
+        ))
+
+        call_count = 0
+
+        def get_for_update_side_effect(db, model, entity_id=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_server
+            return None
+
+        server_update = ServerUpdate(
+            canonical_url="http://localhost/servers/my-srv/mcp",
+            oauth_enabled=True,
+        )
+
+        with patch("mcpgateway.services.server_service.get_for_update", side_effect=get_for_update_side_effect):
+            result = await server_service.update_server(
+                test_db, mock_server.id, server_update, "test@example.com",
+            )
+        assert result.canonical_url == "http://localhost/servers/my-srv/mcp"
+        assert mock_server.canonical_url == "http://localhost/servers/my-srv/mcp"
+
+    @pytest.mark.asyncio
+    async def test_update_clear_canonical(self, server_service, mock_server, test_db):
+        mock_server.canonical_url = "http://localhost/servers/srv/mcp"
+        mock_server.owner_email = "test@example.com"
+
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = None
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+        server_service.convert_server_to_read = Mock(return_value=_make_server_read(
+            id=mock_server.id, name=mock_server.name, canonical_url=None,
+        ))
+
+        call_count = 0
+
+        def get_for_update_side_effect(db, model, entity_id=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_server
+            return None
+
+        server_update = ServerUpdate.model_validate({"canonical_url": None})
+        with patch("mcpgateway.services.server_service.get_for_update", side_effect=get_for_update_side_effect):
+            result = await server_service.update_server(
+                test_db, mock_server.id, server_update, "test@example.com",
+            )
+        assert result.canonical_url is None
+        assert mock_server.canonical_url is None
+
+    @pytest.mark.asyncio
+    async def test_update_canonical_duplicate_rejected(self, server_service, mock_server, test_db):
+        mock_server.canonical_url = None
+        mock_server.owner_email = "test@example.com"
+
+        other_server = MagicMock()
+        other_server.id = "other-id"
+        other_server.name = "other-server"
+
+        call_count = 0
+
+        def get_for_update_side_effect(db, model, entity_id=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_server
+            return other_server
+
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+
+        server_update = ServerUpdate(
+            canonical_url="http://localhost/servers/my-srv/mcp",
+            oauth_enabled=True,
+        )
+
+        with patch("mcpgateway.services.server_service.get_for_update", side_effect=get_for_update_side_effect):
+            with pytest.raises(ServerError, match="already in use"):
+                await server_service.update_server(
+                    test_db, mock_server.id, server_update, "test@example.com",
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_ignores_canonical_not_provided(self, server_service, mock_server, test_db):
+        mock_server.canonical_url = "http://localhost/servers/srv/mcp"
+        mock_server.owner_email = "test@example.com"
+
+        mock_scalar = Mock()
+        mock_scalar.scalar_one_or_none.return_value = None
+        test_db.execute = Mock(return_value=mock_scalar)
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+        test_db.rollback = Mock()
+        server_service.convert_server_to_read = Mock(return_value=_make_server_read(
+            id=mock_server.id, name=mock_server.name,
+            canonical_url="http://localhost/servers/srv/mcp",
+        ))
+
+        call_count = 0
+
+        def get_for_update_side_effect(db, model, entity_id=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_server
+            return None
+
+        server_update = ServerUpdate(oauth_enabled=True)
+        with patch("mcpgateway.services.server_service.get_for_update", side_effect=get_for_update_side_effect):
+            result = await server_service.update_server(
+                test_db, mock_server.id, server_update, "test@example.com",
+            )
+        assert result.canonical_url == "http://localhost/servers/srv/mcp"
+        assert mock_server.canonical_url == "http://localhost/servers/srv/mcp"

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1740,3 +1740,30 @@ class TestCanonicalUrlValidation:
             s = ServerUpdate(canonical_url="https://gw.example.com/mcp",
                              oauth_enabled=True)
         assert s.canonical_url == "https://gw.example.com/mcp"
+
+    def test_https_production_rejects_http(self):
+        """Rejects HTTP URL in production environment."""
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            with patch.object(settings, "environment", "production"):
+                with pytest.raises(ValueError, match="HTTPS"):
+                    ServerCreate(
+                        name="srv", oauth_enabled=True,
+                        canonical_url="http://gw.example.com/mcp",
+                    )
+
+    def test_length_exceeds_limit(self):
+        """Rejects canonical URL exceeding 767 character limit."""
+        long_path = "/" + "x" * 767
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            with pytest.raises(ValueError, match="length"):
+                ServerCreate(
+                    name="srv", oauth_enabled=True,
+                    canonical_url=f"https://gw.example.com{long_path}",
+                )
+
+    def test_update_requires_oauth(self):
+        """Rejects canonical_url on ServerUpdate when oauth_enabled is False."""
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            with pytest.raises(ValueError, match="oauth_enabled"):
+                ServerUpdate(canonical_url="https://gw.example.com/mcp",
+                             oauth_enabled=False)

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -48,6 +48,7 @@ from mcpgateway.common.models import (
     ToolResult,
 )
 from mcpgateway.common.validators import SecurityValidator
+from mcpgateway.config import settings
 from mcpgateway.schemas import (
     AdminGatewayCreate,
     AdminToolCreate,
@@ -1660,3 +1661,82 @@ class TestTitleSchemas:
             ),
         )
         assert prompt_read.title == "Read Prompt Title"
+
+
+class TestCanonicalUrlValidation:
+    """Validate canonical_url field validators on ServerCreate and ServerUpdate."""
+
+    def test_valid_url(self):
+        """Accepts valid HTTPS URL with non-root path."""
+        data = {"name": "srv", "oauth_enabled": True,
+                "canonical_url": "https://gateway.example.com/mcp"}
+        with patch.object(settings, "app_domain", "https://gateway.example.com"):
+            s = ServerCreate(**data)
+        assert s.canonical_url == "https://gateway.example.com/mcp"
+
+    def test_trailing_slash_stripped(self):
+        """Strips trailing slash from URL."""
+        data = {"name": "srv", "oauth_enabled": True,
+                "canonical_url": "https://gw.example.com/mcp/"}
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            s = ServerCreate(**data)
+        assert s.canonical_url == "https://gw.example.com/mcp"
+
+    def test_no_scheme_rejected(self):
+        """Rejects URL without scheme."""
+        with pytest.raises(ValueError, match="absolute URL"):
+            with patch.object(settings, "app_domain", "https://gw.example.com"):
+                ServerCreate(name="srv", oauth_enabled=True,
+                             canonical_url="gw.example.com/mcp")
+
+    def test_no_path_rejected(self):
+        """Rejects URL with no path component."""
+        with pytest.raises(ValueError, match="non-root path"):
+            with patch.object(settings, "app_domain", "https://gw.example.com"):
+                ServerCreate(name="srv", oauth_enabled=True,
+                             canonical_url="https://gw.example.com")
+
+    def test_root_path_rejected(self):
+        """Rejects URL with root path only."""
+        with pytest.raises(ValueError, match="non-root path"):
+            with patch.object(settings, "app_domain", "https://gw.example.com"):
+                ServerCreate(name="srv", oauth_enabled=True,
+                             canonical_url="https://gw.example.com/")
+
+    def test_uuid_rejected(self):
+        """Rejects URL containing UUID pattern."""
+        with pytest.raises(ValueError, match="UUID"):
+            with patch.object(settings, "app_domain", "https://gw.example.com"):
+                ServerCreate(
+                    name="srv", oauth_enabled=True,
+                    canonical_url="https://gw.example.com/servers/550e8400e29b41d4a716446655440000/mcp",
+                )
+
+    def test_domain_mismatch_rejected(self):
+        """Rejects URL whose domain does not match app_domain."""
+        with patch.object(settings, "app_domain", "https://real.example.com"):
+            with pytest.raises(ValueError, match="domain"):
+                ServerCreate(
+                    name="srv", oauth_enabled=True,
+                    canonical_url="https://evil.com/mcp",
+                )
+
+    def test_requires_oauth(self):
+        """Rejects canonical_url when oauth_enabled is False."""
+        with pytest.raises(ValueError, match="oauth_enabled"):
+            with patch.object(settings, "app_domain", "https://gw.example.com"):
+                ServerCreate(name="srv", oauth_enabled=False,
+                             canonical_url="https://gw.example.com/mcp")
+
+    def test_update_accepts_none(self):
+        """None means don't change — valid for partial updates."""
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            s = ServerUpdate(canonical_url=None)
+        assert s.canonical_url is None
+
+    def test_update_accepts_url(self):
+        """Accepts valid canonical URL on ServerUpdate."""
+        with patch.object(settings, "app_domain", "https://gw.example.com"):
+            s = ServerUpdate(canonical_url="https://gw.example.com/mcp",
+                             oauth_enabled=True)
+        assert s.canonical_url == "https://gw.example.com/mcp"

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -2309,6 +2309,77 @@ async def test_streamable_http_auth_oauth_server_returns_resource_metadata_in_st
 
 
 @pytest.mark.asyncio
+async def test_streamable_http_auth_oauth_server_returns_canonical_resource_metadata(monkeypatch):
+    """WWW-Authenticate header includes canonical resource_metadata when server.canonical_url is set."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", True)
+
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+    mock_server.canonical_url = "https://gw.example.com/my-canon/mcp"
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _make_fake_get_db(mock_db))
+
+    scope = _make_scope("/servers/abc123def/mcp")
+    called = []
+
+    async def send(msg):
+        called.append(msg)
+
+    token = tr._oauth_checked_var.set(False)
+    try:
+        result = await streamable_http_auth(scope, None, send)
+    finally:
+        tr._oauth_checked_var.reset(token)
+    assert result is False
+    assert called[0]["status"] == 401
+    www_auth = dict(called[0].get("headers", [])).get(b"www-authenticate", b"").decode()
+    assert "resource_metadata=" in www_auth
+    assert "gw.example.com/.well-known/oauth-protected-resource/my-canon/mcp" in www_auth
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_auth_oauth_server_handles_db_failure_for_canonical_url(monkeypatch):
+    """Falls back gracefully (resource_metadata without canonical URL) when DB lookup fails."""
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcp_require_auth", True)
+
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+
+    call_count = [0]
+
+    @asynccontextmanager
+    async def _get_db():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            mock_db = MagicMock()
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+            yield mock_db
+        else:
+            raise RuntimeError("DB connection lost")
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _get_db)
+
+    scope = _make_scope("/servers/abc123def/mcp")
+    called = []
+
+    async def send(msg):
+        called.append(msg)
+
+    token = tr._oauth_checked_var.set(False)
+    try:
+        result = await streamable_http_auth(scope, None, send)
+    finally:
+        tr._oauth_checked_var.reset(token)
+    assert result is False
+    assert called[0]["status"] == 401
+    www_auth = dict(called[0].get("headers", [])).get(b"www-authenticate", b"").decode()
+    assert "resource_metadata=" in www_auth
+
+
+@pytest.mark.asyncio
 async def test_streamable_http_auth_wrong_scheme(monkeypatch):
     """Auth returns False and sends 401 if Authorization is not Bearer and mcp_require_auth=True."""
 
@@ -16985,6 +17056,40 @@ def test_get_scoped_visibility_from_user_context_admin_with_team_scope():
 
     assert user_email == "admin@x.com"
     assert token_teams == ["team1"]
+
+
+@pytest.mark.asyncio
+async def test_try_oauth_access_token_with_canonical_url(monkeypatch):
+    """_try_oauth_access_token uses canonical_url as fallback audience and metadata."""
+    # First-Party
+    from mcpgateway.transports.streamablehttp_transport import (
+        _StreamableHttpAuthHandler,
+    )
+
+    canonical_url = "https://gw.example.com/my-canon/mcp"
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+    mock_server.oauth_config = {"authorization_server": "https://auth.example.com"}
+    mock_server.canonical_url = canonical_url
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+
+    @asynccontextmanager
+    async def _fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _fake_get_db)
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token",
+        AsyncMock(return_value=None),
+    )
+
+    scope = _make_scope("/servers/abc123def/mcp")
+    handler = _StreamableHttpAuthHandler(scope, AsyncMock(), AsyncMock())
+
+    result = await handler._try_oauth_access_token("fake-token", unverified={"iss": "https://auth.example.com"})
+    assert result is tr.OAuthAuthResult.FAILED
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -13951,6 +13951,45 @@ def test_build_resource_metadata_url_exception_returns_empty():
     assert url == ""
 
 
+class TestBuildCanonicalMetadataUrl:
+    """Verify _build_canonical_metadata_url helper function."""
+
+    def test_simple_path(self):
+        """Builds metadata URL from simple canonical URL."""
+        url = tr._build_canonical_metadata_url("https://gw.example.com/mcp")
+        assert url == "https://gw.example.com/.well-known/oauth-protected-resource/mcp"
+
+    def test_multi_segment_path(self):
+        """Builds metadata URL from multi-segment canonical URL."""
+        url = tr._build_canonical_metadata_url("https://gw.example.com/servers/my-srv/mcp")
+        assert url == "https://gw.example.com/.well-known/oauth-protected-resource/servers/my-srv/mcp"
+
+    def test_empty_string(self):
+        """Returns empty string for empty input."""
+        url = tr._build_canonical_metadata_url("")
+        assert url == ""
+
+    def test_no_scheme(self):
+        """Returns empty string for URL without scheme."""
+        url = tr._build_canonical_metadata_url("gw.example.com/mcp")
+        assert url == ""
+
+    def test_no_netloc(self):
+        """Returns empty string for URL without netloc."""
+        url = tr._build_canonical_metadata_url("https:///mcp")
+        assert url == ""
+
+    def test_trailing_slash(self):
+        """Handles canonical URL with trailing slash."""
+        url = tr._build_canonical_metadata_url("https://gw.example.com/mcp/")
+        assert url == "https://gw.example.com/.well-known/oauth-protected-resource/mcp/"
+
+    def test_http_scheme(self):
+        """Works with HTTP scheme."""
+        url = tr._build_canonical_metadata_url("http://internal.example.com/mcp")
+        assert url == "http://internal.example.com/.well-known/oauth-protected-resource/mcp"
+
+
 # ---------------------------------------------------------------------------
 # _check_streamable_permission: exception path
 # ---------------------------------------------------------------------------

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -103,6 +103,8 @@ class MockPermissionService:
         team_id: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        token_teams: Optional[list] = None,
+        **kwargs: object,
     ) -> bool:
         """Mock permission check that returns configured result.
 
@@ -114,6 +116,8 @@ class MockPermissionService:
             team_id: Optional team context
             ip_address: Optional IP address
             user_agent: Optional user agent
+            token_teams: Optional token-scoped teams collection
+            **kwargs: Any additional keyword arguments (forward-compatible)
 
         Returns:
             bool: Permission result
@@ -122,11 +126,13 @@ class MockPermissionService:
             return True
         return self.custom_permissions.get(permission, False)
 
-    async def check_admin_permission(self, user_email: str) -> bool:
+    async def check_admin_permission(self, user_email: str, token_teams: Optional[list] = None, **kwargs: object) -> bool:
         """Mock admin permission check.
 
         Args:
             user_email: User email
+            token_teams: Optional token-scoped teams collection
+            **kwargs: Any additional keyword arguments (forward-compatible)
 
         Returns:
             bool: Admin permission result


### PR DESCRIPTION
## Problem

MCP virtual servers are identified by UUIDs (e.g., `/servers/a1b2c3d4-.../mcp`). When used as OAuth 2.0 Protected Resource identifiers per [RFC 9728 §3.1](https://www.rfc-editor.org/rfc/rfc9728), these UUID URLs cause two problems:

1. **Unstable identifiers** — regenerating a server or migrating between environments changes the UUID, breaking existing OAuth client registrations.
2. **Poor UX** — UUIDs are not human-readable, making debugging and configuration harder for operators.

Additionally, Auth0 and similar OAuth providers require that the `resource` field in the WWW-Authenticate header exactly match the URL the client uses to fetch metadata (`/.well-known/oauth-protected-resource/...`). UUID-based URLs satisfy this technically, but any UUID change forces all connected MCP clients to re-register.

## Solution

Add an optional `canonical_url` field to virtual servers — a stable, operator-chosen URL that replaces UUIDs in RFC 9728 metadata and WWW-Authenticate headers while leaving UUID-based routing fully intact.

## Architecture Decisions & Rationale

### Global uniqueness (not per-team)

The well-known metadata endpoint (`/.well-known/oauth-protected-resource/{path}`) is **unauthenticated** per RFC 9728. Per-team resolution would create ambiguous lookups — multiple servers on different teams could claim the same path, and the endpoint has no authentication context to disambiguate. Global uniqueness ensures deterministic resolution.

### Application-layer uniqueness only

`canonical_url` is `nullable=True` with no DB-level `UNIQUE` constraint. SQLite and PostgreSQL treat `NULL != NULL` differently in unique constraints, creating platform-dependent behavior. Application-layer uniqueness via `get_for_update()` (row-level locking) provides consistent behavior and protection against race conditions.

### Column length (767)

Matches the existing `Gateway.url` column. 767 bytes is the maximum indexable length in MySQL/InnoDB with utf8mb4, keeping the door open for a future index if needed.

### Two-strategy well-known resolution

The `/.well-known/oauth-protected-resource/{path}` endpoint tries **Strategy 1 first** (UUID-based, checking for `servers/{uuid}/mcp` prefix), then falls through to **Strategy 2** (canonical URL path lookup). This ordering ensures:

- UUID resolution is O(1) — direct primary key lookup
- Canonical path resolution is O(n) — linear scan of canonical_url column
- UUID paths are rejected early with a clear error if the format is invalid (defense-in-depth)

### `servers/` path reservation

Paths starting with `servers/` are reserved for UUID routing. The well-known endpoint rejects UUID paths with invalid format (not a UUID) rather than falling through to canonical path resolution. This prevents operators from accidentally creating canonical URLs that shadow UUID routes.

### Defense-in-depth validation chain

Validation happens at every layer:

1. **Schema** (Pydantic) — field_validator + model_validator on ServerCreate/ServerUpdate
2. **Service** — global uniqueness check with row-level locking in register_server and update_server
3. **Transport** — isinstance(string) guard to prevent MagicMock leakage from test mocks
4. **Migration** — idempotent with column-existence checks

### Audience fallback chain

During OAuth token verification, the audience is checked in this order:

1. `canonical_url` (operator-chosen, primary)
2. Auto-derived UUID URL (`/servers/{id}/mcp`)
3. Legacy `client_id` (pre-existing fallback)

This means an operator who sets `canonical_url` gets it used for audience validation immediately without any configuration change on the OAuth provider side.

### `isinstance(server.canonical_url, str)` guard

Test mocks (`MagicMock()`) auto-create attributes on access, so `mock_server.canonical_url` returns a `MagicMock` instead of `None`. The guard prevents MagicMock values from leaking into URL construction or Pydantic validation.

### `getattr(server_update, "canonical_url", None)` for legacy objects

The `update_server` service handles both `ServerUpdate` (Pydantic model) and `LegacyServerUpdate` (SimpleNamespace used in tests). The latter lacks the `canonical_url` attribute entirely. Using `getattr` with a default avoids AttributeError.

## Key Changes

### Database & Migration
- `mcpgateway/db.py` — Add `canonical_url` column to `Server` model
- `mcpgateway/alembic/versions/1d92a8045125_*.py` — Idempotent migration with column/table existence checks

### Schema Validation
- `mcpgateway/schemas.py` — `_validate_canonical_url()`: domain matching, non-root path, UUID rejection, HTTPS in production, length limit. Field + model validators on `ServerCreate`, `ServerUpdate`, `ServerRead`

### Service Layer
- `mcpgateway/services/server_service.py` — Pass canonical_url to DbServer constructor; global uniqueness check with `get_for_update()`; update handling with `model_fields_set` detection for explicit clearing; `_safe_str()` guard in `convert_server_to_read()`

### Well-Known Endpoint
- `mcpgateway/routers/well_known.py` — Two-strategy RFC 9728 resolution: UUID first, canonical fallback

### Transport Layer
- `mcpgateway/transports/streamablehttp_transport.py` — `_build_canonical_metadata_url()` helper; WWW-Authenticate header with canonical resource_metadata; audience fallback: canonical_url → UUID URL → client_id

### Documentation
- `docs/docs/architecture/oauth-design.md` — Bullet on canonical_url configuration

## Testing

- **Schema**: 10 unit tests — valid URL, trailing slash, no scheme, no path, root path, UUID content, domain mismatch, OAuth requirement, clear via None, update
- **Service**: 6 async unit tests — duplicate rejection, without canonical succeeds, set/clear/duplicate/ignore
- **Well-known**: 4 unit tests — UUID→canonical, UUID→UUID, canonical path resolution, 404 for unknown
- **Transport**: 7 unit tests — simple/multi-segment/empty/no-scheme/no-netloc/trailing-slash/HTTP scheme
- **Integration**: 5 E2E tests — create with canonical, UUID→canonical metadata, canonical→metadata, 404 for unknown, UUID fallback without canonical
- **RBAC mocks**: Added `**kwargs` to `check_permission`/`check_admin_permission` for forward-compatibility

Closes #4685
