### PR TITLE
fix(security): drop mcpgateway_ui_enabled from BASIC_AUTH_PASSWORD security gate

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1587,7 +1587,16 @@ class Settings(BaseSettings):
         }
 
         for name, value in critical_secrets.items():
-            if name == "BASIC_AUTH_PASSWORD" and not (self.mcpgateway_ui_enabled or self.api_allow_basic_auth or self.docs_allow_basic_auth):
+            if name == "BASIC_AUTH_PASSWORD" and not (self.api_allow_basic_auth or self.docs_allow_basic_auth):
+                # Only require BASIC_AUTH_PASSWORD when basic auth is an
+                # active login path. mcpgateway_ui_enabled was previously
+                # in this disjunction but the admin UI authenticates via
+                # JWT (cookie or bearer) — it never calls
+                # verify_basic_credentials. The real consumers in v1.0.1
+                # are require_docs_basic_auth (gated by
+                # docs_allow_basic_auth) and the CLI export tool (gated
+                # by api_allow_basic_auth); both already short-circuit
+                # here.
                 continue
             is_sentinel = value in self.SENTINEL_VALUES or value.lower().startswith("__replace_me__")
             is_weak = value.lower() in self.WEAK_VALUES or calculate_entropy(value) < 3.5


### PR DESCRIPTION
## Summary

The strong-secrets gate in `Settings.get_security_status()` (`mcpgateway/config.py`) currently refuses to start the gateway when `BASIC_AUTH_PASSWORD` is weak/empty **and** any of three flags is set:

```python
if name == "BASIC_AUTH_PASSWORD" and not (
    self.mcpgateway_ui_enabled
    or self.api_allow_basic_auth
    or self.docs_allow_basic_auth
):
    continue
```

The `mcpgateway_ui_enabled` clause is incorrect — the admin UI does not consume `basic_auth_password`. `admin.py` imports `verify_jwt_token_cached` (JWT-only). The legacy `require_basic_auth` / `verify_basic_credentials` helpers in `utils/verify_credentials.py` have **no callers** anywhere in the current tree (I grepped). `require_api_key` in `main.py` likewise has no callers.

The real consumers of `basic_auth_password` are:

- `require_docs_basic_auth` in `utils/verify_credentials.py:1004` — already gated by `docs_allow_basic_auth`
- The CLI export tool in `cli_export_import.py:63` — already gated by `api_allow_basic_auth`

Both are covered by the remaining two clauses. Dropping the UI clause lets operators run with `MCPGATEWAY_UI_ENABLED=true` + `API_ALLOW_BASIC_AUTH=false` + `DOCS_ALLOW_BASIC_AUTH=false` (a perfectly reasonable SSO-only setup) without having to set a placeholder `BASIC_AUTH_PASSWORD` just to satisfy a check that wouldn't actually protect any active login path.

## Impact

Today, an operator who:

- enables the admin UI (`MCPGATEWAY_UI_ENABLED=true`),
- relies on JWT/SSO for the API (`API_ALLOW_BASIC_AUTH=false`),
- doesn't expose docs to the public (`DOCS_ALLOW_BASIC_AUTH=false`),

still has to either set a strong `BASIC_AUTH_PASSWORD` they'll never use, or set `REQUIRE_STRONG_SECRETS=false` which defeats the rest of the hardening from #3197. Neither is the right behaviour.

This change makes the gate fire only when basic auth is genuinely a login path.

## Test plan

- [x] Manual: gateway with `MCPGATEWAY_UI_ENABLED=true`, `API_ALLOW_BASIC_AUTH=false`, `DOCS_ALLOW_BASIC_AUTH=false`, no `BASIC_AUTH_PASSWORD`, `ENVIRONMENT=development` boots cleanly after the change (it failed startup before).
- [x] Same config with `API_ALLOW_BASIC_AUTH=true` and weak password still fails the gate as expected.
- [x] Same config with `DOCS_ALLOW_BASIC_AUTH=true` and weak password still fails the gate as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)