### PR TITLE
 fix: admin users can now view and edit their own private resources (tools, prompts, resources, servers, gateways)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-29T13:12:51Z",
+  "generated_at": "2026-06-04T10:56:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 885,
+        "line_number": 918,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1172,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1198,
+        "line_number": 1231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1206,
+        "line_number": 1239,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1285,
+        "line_number": 1318,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1290,
+        "line_number": 1323,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1301,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1313,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1331,
+        "line_number": 1364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1392,
+        "line_number": 1425,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -570,7 +570,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1066,
+        "line_number": 1126,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -578,7 +578,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1373,
+        "line_number": 1433,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -588,7 +588,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 286,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -634,7 +634,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 829,
+        "line_number": 845,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 984,
+        "line_number": 1000,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1087,
+        "line_number": 1103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1090,
+        "line_number": 1106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1256,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1295,
+        "line_number": 1311,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1344,
+        "line_number": 1360,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1439,
+        "line_number": 1455,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +698,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1810,
+        "line_number": 1826,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1324,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1332,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1794,7 +1794,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2412,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1218,
+        "line_number": 1275,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2828,7 +2828,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 316,
+        "line_number": 320,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4348,7 +4348,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15099,
+        "line_number": 14971,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4392,7 +4392,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 667,
+        "line_number": 665,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5128,7 +5128,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 10689,
+        "line_number": 11204,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5138,8 +5138,18 @@
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2716,
+        "line_number": 2745,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_auth_ratelimiter_redis.py": [
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 228,
+        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T14:29:13Z",
+  "generated_at": "2026-05-29T13:12:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 918,
+        "line_number": 885,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1239,
+        "line_number": 1206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1318,
+        "line_number": 1285,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1290,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1301,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1364,
+        "line_number": 1331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1425,
+        "line_number": 1392,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -570,7 +570,7 @@
         "hashed_secret": "bc1a7c4dc707a3b61e2e9a345eec9e23674efa11",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1126,
+        "line_number": 1066,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -578,7 +578,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1433,
+        "line_number": 1373,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -588,7 +588,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 286,
+        "line_number": 301,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -634,7 +634,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 845,
+        "line_number": 829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -642,7 +642,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 984,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1090,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1360,
+        "line_number": 1344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1455,
+        "line_number": 1439,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +698,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1810,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1324,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 711,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1332,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1440,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1794,7 +1794,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2412,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1218,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2828,7 +2828,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 320,
+        "line_number": 316,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4348,7 +4348,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14971,
+        "line_number": 15099,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4392,7 +4392,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 665,
+        "line_number": 667,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5128,7 +5128,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11185,
+        "line_number": 10689,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -5138,18 +5138,8 @@
         "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2745,
+        "line_number": 2716,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_auth_ratelimiter_redis.py": [
-      {
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 228,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -2645,6 +2645,7 @@ async def get_configuration_settings(
 @admin_router.get("/servers", response_model=PaginatedResponse)
 @require_permission("servers.read", allow_admin_bypass=False)
 async def admin_list_servers(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Items per page"),
     include_inactive: bool = False,
@@ -2658,6 +2659,7 @@ async def admin_list_servers(
     including those that are inactive. Uses offset-based (page/per_page) pagination.
 
     Args:
+        request (Request): FastAPI request object (required for token team extraction via request.state.token_teams).
         page (int): Page number (1-indexed) for offset pagination.
         per_page (int): Number of items per page.
         include_inactive (bool): Whether to include inactive servers.
@@ -2678,6 +2680,7 @@ async def admin_list_servers(
     """
     LOGGER.debug(f"User {get_user_email(user)} requested server list (page={page}, per_page={per_page})")
     user_email = get_user_email(user)
+    token_teams = get_token_teams_from_request(request)
 
     # Call server_service.list_servers with page-based pagination
     paginated_result = await server_service.list_servers(
@@ -2686,6 +2689,7 @@ async def admin_list_servers(
         page=page,
         per_page=per_page,
         user_email=user_email,
+        token_teams=token_teams,
     )
 
     # End the read-only transaction early to avoid idle-in-transaction under load.
@@ -3448,6 +3452,7 @@ async def admin_list_prompts(
 @admin_router.get("/gateways", response_model=PaginatedResponse)
 @require_permission("gateways.read", allow_admin_bypass=False)
 async def admin_list_gateways(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Items per page"),
     include_inactive: bool = False,
@@ -3461,6 +3466,7 @@ async def admin_list_gateways(
     including those that are inactive. Uses offset-based (page/per_page) pagination.
 
     Args:
+        request (Request): FastAPI request object (required for token team extraction via request.state.token_teams).
         page (int): Page number (1-indexed) for offset pagination.
         per_page (int): Number of items per page.
         include_inactive (bool): Whether to include inactive gateways in the results.
@@ -3480,6 +3486,7 @@ async def admin_list_gateways(
         'admin_list_gateways'
     """
     user_email = get_user_email(user)
+    token_teams = get_token_teams_from_request(request)
     LOGGER.debug(f"User {user_email} requested gateway list (page={page}, per_page={per_page})")
 
     # Call gateway_service.list_gateways with page-based pagination
@@ -3489,6 +3496,7 @@ async def admin_list_gateways(
         page=page,
         per_page=per_page,
         user_email=user_email,
+        token_teams=token_teams,
     )
 
     # Return standardized paginated response

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -3347,6 +3347,7 @@ async def admin_delete_server(server_id: str, request: Request, db: Session = De
 @admin_router.get("/resources", response_model=PaginatedResponse)
 @require_permission("resources.read", allow_admin_bypass=False)
 async def admin_list_resources(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Items per page"),
     include_inactive: bool = False,
@@ -3360,6 +3361,7 @@ async def admin_list_resources(
     including those that are inactive. Uses offset-based (page/per_page) pagination.
 
     Args:
+        request (Request): FastAPI request object (required for token team extraction via request.state.token_teams).
         page (int): Page number (1-indexed). Default: 1.
         per_page (int): Items per page. Default: 50.
         include_inactive (bool): Whether to include inactive resources in the results.
@@ -3375,8 +3377,9 @@ async def admin_list_resources(
         >>> admin_list_resources.__name__
         'admin_list_resources'
     """
-    LOGGER.debug(f"User {get_user_email(user)} requested resource list (page={page}, per_page={per_page})")
     user_email = get_user_email(user)
+    token_teams = get_token_teams_from_request(request)
+    LOGGER.debug(f"User {user_email} requested resource list (page={page}, per_page={per_page})")
 
     # Call resource_service.list_resources with page-based pagination
     paginated_result = await resource_service.list_resources(
@@ -3385,6 +3388,7 @@ async def admin_list_resources(
         page=page,
         per_page=per_page,
         user_email=user_email,
+        token_teams=token_teams,
     )
 
     # Return standardized paginated response
@@ -3398,6 +3402,7 @@ async def admin_list_resources(
 @admin_router.get("/prompts", response_model=PaginatedResponse)
 @require_permission("prompts.read", allow_admin_bypass=False)
 async def admin_list_prompts(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Items per page"),
     include_inactive: bool = False,
@@ -3411,6 +3416,7 @@ async def admin_list_prompts(
     including those that are inactive. Uses offset-based (page/per_page) pagination.
 
     Args:
+        request (Request): FastAPI request object (required for token team extraction via request.state.token_teams).
         page (int): Page number (1-indexed) for offset pagination.
         per_page (int): Number of items per page.
         include_inactive (bool): Whether to include inactive prompts in the results.
@@ -3429,8 +3435,9 @@ async def admin_list_prompts(
         >>> admin_list_prompts.__name__
         'admin_list_prompts'
     """
-    LOGGER.debug(f"User {get_user_email(user)} requested prompt list (page={page}, per_page={per_page})")
     user_email = get_user_email(user)
+    token_teams = get_token_teams_from_request(request)
+    LOGGER.debug(f"User {user_email} requested prompt list (page={page}, per_page={per_page})")
 
     # Call prompt_service.list_prompts with page-based pagination
     paginated_result = await prompt_service.list_prompts(
@@ -3439,6 +3446,7 @@ async def admin_list_prompts(
         page=page,
         per_page=per_page,
         user_email=user_email,
+        token_teams=token_teams,
     )
 
     # Return standardized paginated response
@@ -8479,6 +8487,7 @@ async def admin_force_password_change(
 @admin_router.get("/tools", response_model=PaginatedResponse)
 @require_permission("tools.read", allow_admin_bypass=False)
 async def admin_list_tools(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number (1-indexed)"),
     per_page: int = Query(settings.pagination_default_page_size, ge=1, le=settings.pagination_max_page_size, description="Items per page"),
     include_inactive: bool = False,
@@ -8492,6 +8501,7 @@ async def admin_list_tools(
     including those that are inactive. Uses offset-based (page/per_page) pagination.
 
     Args:
+        request (Request): FastAPI request object (required for token team extraction via request.state.token_teams).
         page (int): Page number (1-indexed). Default: 1.
         per_page (int): Items per page. Default: 50.
         include_inactive (bool): Whether to include inactive tools in the results.
@@ -8502,8 +8512,9 @@ async def admin_list_tools(
         Dict with 'data', 'pagination', and 'links' keys containing paginated tools.
 
     """
-    LOGGER.debug(f"User {get_user_email(user)} requested tool list (page={page}, per_page={per_page})")
     user_email = get_user_email(user)
+    token_teams = get_token_teams_from_request(request)
+    LOGGER.debug(f"User {user_email} requested tool list (page={page}, per_page={per_page})")
     _is_admin = bool(user.get("is_admin", False) if isinstance(user, dict) else getattr(user, "is_admin", False))
     _team_roles = _get_user_team_roles(db, user_email) if not _is_admin else {}
 
@@ -8514,6 +8525,7 @@ async def admin_list_tools(
         page=page,
         per_page=per_page,
         user_email=user_email,
+        token_teams=token_teams,
         requesting_user_email=user_email,
         requesting_user_is_admin=_is_admin,
         requesting_user_team_roles=_team_roles,
@@ -16852,6 +16864,7 @@ async def admin_get_grpc_methods(
 @admin_router.get("/sections/resources")
 @require_permission("resources.read", allow_admin_bypass=False)
 async def get_resources_section(
+    request: Request,
     team_id: Optional[str] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
@@ -16859,6 +16872,7 @@ async def get_resources_section(
     """Get resources data filtered by team.
 
     Args:
+        request: FastAPI request object
         team_id: Optional team ID to filter by
         db: Database session
         user: Current authenticated user context
@@ -16868,11 +16882,16 @@ async def get_resources_section(
     """
     try:
         local_resource_service = ResourceService()
-        user_email = get_user_email(user)
-        LOGGER.debug(f"User {user_email} requesting resources section with team_id={team_id}")
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
+        LOGGER.debug(f"User {user_email} requesting resources section with team_id={team_id}, token_teams={token_teams}")
 
-        # Get all resources and filter by team
-        resources_result = await local_resource_service.list_resources(db, include_inactive=True)
+        # Get all resources with token_teams for proper scoping
+        resources_result = await local_resource_service.list_resources(
+            db,
+            include_inactive=True,
+            user_email=user_email,
+            token_teams=token_teams
+        )
         if isinstance(resources_result, tuple):
             resources_list = resources_result[0]
         else:
@@ -16911,6 +16930,7 @@ async def get_resources_section(
 @admin_router.get("/sections/prompts")
 @require_permission("prompts.read", allow_admin_bypass=False)
 async def get_prompts_section(
+    request: Request,
     team_id: Optional[str] = None,
     db: Session = Depends(get_db),
     user=Depends(get_current_user_with_permissions),
@@ -16918,6 +16938,7 @@ async def get_prompts_section(
     """Get prompts data filtered by team.
 
     Args:
+        request: FastAPI request object
         team_id: Optional team ID to filter by
         db: Database session
         user: Current authenticated user context
@@ -16927,11 +16948,16 @@ async def get_prompts_section(
     """
     try:
         local_prompt_service = PromptService()
-        user_email = get_user_email(user)
-        LOGGER.debug(f"User {user_email} requesting prompts section with team_id={team_id}")
+        user_email, token_teams = get_scoped_resource_access_context(request, user)
+        LOGGER.debug(f"User {user_email} requesting prompts section with team_id={team_id}, token_teams={token_teams}")
 
-        # Get all prompts and filter by team
-        prompts_result = await local_prompt_service.list_prompts(db, include_inactive=True)
+        # Get all prompts with token_teams for proper scoping
+        prompts_result = await local_prompt_service.list_prompts(
+            db,
+            include_inactive=True,
+            user_email=user_email,
+            token_teams=token_teams
+        )
         if isinstance(prompts_result, tuple):
             prompts_list = prompts_result[0]
         else:

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -490,10 +490,10 @@ def get_scoped_resource_access_context(request: Request, user) -> tuple[Optional
     if not _has_verified_jwt_payload(request):
         _requester_email, fallback_admin = get_request_identity(request, user)
         if fallback_admin:
-            return None, None
+            return _requester_email, None  # Keep email for owner matching (PR #4341 / issue #4694)
 
     if is_admin and token_teams is None:
-        return None, None
+        return user_email, None  # Keep user_email for owner matching (PR #4341 / issue #4694)
     if token_teams is None:
         return user_email, []
     return user_email, token_teams

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3965,7 +3965,6 @@ async def list_servers(
     # - None: admin bypass (is_admin=true with explicit null teams) - sees ALL resources
     # - []: public-only (missing teams or explicit empty) - sees only public
     # - [...]: team-scoped - sees public + teams + user's private
-    is_admin_bypass = token_teams is None
     is_public_only_token = token_teams is not None and len(token_teams) == 0
 
     # Use consolidated server listing with optional team filtering
@@ -6873,7 +6872,6 @@ async def list_gateways(
     # - None: admin bypass (is_admin=true with explicit null teams) - sees ALL resources
     # - []: public-only (missing teams or explicit empty) - sees only public
     # - [...]: team-scoped - sees public + teams + user's private
-    is_admin_bypass = token_teams is None
     is_public_only_token = token_teams is not None and len(token_teams) == 0
 
     # Use consolidated gateway listing with optional team filtering

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10468,8 +10468,9 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             _req_email, _req_is_admin = user_email, is_admin
             _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
             # Admin bypass - only when token has NO team restrictions
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             if is_admin and token_teams is None:
-                user_email = None
+                # user_email stays as-is (not None) for owner matching
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10511,9 +10512,10 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             _req_email, _req_is_admin = user_email, is_admin
             _req_team_roles = get_user_team_roles(db, _req_email) if _req_email and not _req_is_admin else None
             # Admin bypass - only when token has NO team restrictions (token_teams is None)
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             # If token has explicit team scope (even empty [] for public-only), respect it
             if is_admin and token_teams is None:
-                user_email = None
+                # user_email stays as-is (not None) for owner matching
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10570,8 +10572,9 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             await _ensure_rpc_permission(user, db, "resources.read", method, request=request)
             user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
             # Admin bypass - only when token has NO team restrictions
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             if is_admin and token_teams is None:
-                user_email = None
+                # user_email stays as-is (not None) for owner matching
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10596,10 +10599,12 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 raise JSONRPCError(-32602, "Missing resource URI in parameters", params)
 
             # Get authorization context (same as resources/list)
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
             if auth_is_admin and auth_token_teams is None:
-                auth_user_email = None
+                # auth_user_email stays as-is (not None) for owner matching
                 # auth_token_teams stays None (unrestricted)
+                pass
             elif auth_token_teams is None:
                 auth_token_teams = []  # Non-admin without teams = public-only
 
@@ -10672,8 +10677,9 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             await _ensure_rpc_permission(user, db, "prompts.read", method, request=request)
             user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
             # Admin bypass - only when token has NO team restrictions
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             if is_admin and token_teams is None:
-                user_email = None
+                # user_email stays as-is (not None) for owner matching
                 token_teams = None  # Admin unrestricted
             elif token_teams is None:
                 token_teams = []  # Non-admin without teams = public-only (secure default)
@@ -10698,10 +10704,12 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 raise JSONRPCError(-32602, "Missing prompt name in parameters", params)
 
             # Get authorization context (same as prompts/list)
+            # Keep user_email for owner matching (PR #4341 / issue #4694)
             auth_user_email, auth_token_teams, auth_is_admin = get_rpc_filter_context(request, user)
             if auth_is_admin and auth_token_teams is None:
-                auth_user_email = None
+                # auth_user_email stays as-is (not None) for owner matching
                 # auth_token_teams stays None (unrestricted)
+                pass
             elif auth_token_teams is None:
                 auth_token_teams = []  # Non-admin without teams = public-only
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -3969,7 +3969,7 @@ async def list_servers(
     is_public_only_token = token_teams is not None and len(token_teams) == 0
 
     # Use consolidated server listing with optional team filtering
-    # For admin bypass: pass user_email=None and token_teams=None to skip all filtering
+    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
     logger.debug(
         f"User: {SecurityValidator.sanitize_log_message(user_email)} requested server list with include_inactive={include_inactive}, tags={tags_list}, team_id={team_id}, visibility={visibility}"
     )
@@ -3980,7 +3980,7 @@ async def list_servers(
         include_inactive=include_inactive,
         include_metrics=include_metrics,
         tags=tags_list,
-        user_email=None if is_admin_bypass else user_email,  # Admin bypass: no user filtering
+        user_email=user_email,  # Keep for owner matching (PR #4341 / issue #4694)
         team_id=team_id,
         visibility="public" if is_public_only_token and not visibility else visibility,
         token_teams=token_teams,  # None = admin bypass, [] = public-only, [...] = team-scoped
@@ -6877,14 +6877,14 @@ async def list_gateways(
     is_public_only_token = token_teams is not None and len(token_teams) == 0
 
     # Use consolidated gateway listing with optional team filtering
-    # For admin bypass: pass user_email=None and token_teams=None to skip all filtering
+    # Keep user_email set for owner matching on private resources (PR #4341 / issue #4694)
     logger.debug(f"User: {SecurityValidator.sanitize_log_message(user_email)} requested gateway list with include_inactive={include_inactive}, team_id={team_id}, visibility={visibility}")
     data, next_cursor = await gateway_service.list_gateways(
         db=db,
         cursor=cursor,
         limit=limit,
         include_inactive=include_inactive,
-        user_email=None if is_admin_bypass else user_email,  # Admin bypass: no user filtering
+        user_email=user_email,  # Keep for owner matching (PR #4341 / issue #4694)
         team_id=team_id,
         visibility="public" if is_public_only_token and not visibility else visibility,
         token_teams=token_teams,  # None = admin bypass, [] = public-only, [...] = team-scoped

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2806,7 +2806,11 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             return True
 
         if is_admin_bypass_granted(db, user_email, token_teams):
-            return visibility != "private"
+            # Admin bypass grants access to public + team resources + OWN private resources (PR #4341 / issue #4694)
+            if visibility == "private":
+                gateway_owner_email = getattr(gateway, "owner_email", None)
+                return gateway_owner_email and gateway_owner_email == user_email
+            return True  # public or team visibility
 
         if not user_email:
             return False

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -3701,16 +3701,19 @@ class ResourceService(BaseService):
         """Subscribe to Resource events via the EventService.
 
         Args:
-            user_email: Requesting user email. ``None`` with ``token_teams=None`` indicates unrestricted admin context.
+            user_email: Requesting user email. After PR #4341, admin bypass
+                is ``(email, None)`` not ``(None, None)`` — the email is
+                kept for owner matching. The ``is_admin_bypass`` parameter
+                is the authoritative bypass flag.
             token_teams: Token team scope context:
-                - ``None`` = unrestricted admin
+                - ``None`` = unrestricted (checked via ``is_admin_bypass``)
                 - ``[]`` = public-only
                 - ``[...]`` = team-scoped access
             is_admin_bypass: Pre-resolved DB-admin bypass flag.  Callers
                 that can consult a request-scoped session (e.g. the SSE
                 HTTP handler) should compute this once via
-                :func:`mcpgateway.utils.admin_check.is_user_admin` and
-                pass it in; this avoids a throw-away session spawn per
+                :func:`mcpgateway.utils.admin_check.is_admin_bypass_granted`
+                and pass it in; this avoids a throw-away session spawn per
                 subscription and keeps the bypass check near the auth
                 boundary.
 
@@ -3722,12 +3725,13 @@ class ResourceService(BaseService):
             for the stream lifetime.  A user demoted mid-subscription
             keeps visibility until reconnect — this is an intentional
             trade-off between auth freshness and SSE simplicity.  Callers
-            MUST only pass ``is_admin_bypass=True`` when
-            ``token_teams is None`` (auth-layer bypass); see
-            :mod:`mcpgateway.utils.admin_check`.
+            MUST only pass ``is_admin_bypass=True`` when the caller has
+            been validated via ``is_admin_bypass_granted()``.
         """
         async for event in self._event_service.subscribe_events():
-            if (user_email is None and token_teams is None) or is_admin_bypass:
+            # Rely on is_admin_bypass for admin bypass (PR #4341 / issue #4694)
+            # Admin bypass is now (email, None) not (None, None) for owner matching
+            if is_admin_bypass:
                 yield event
                 continue
 

--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1018,7 +1018,11 @@ class ServerService(BaseService):
             return True
 
         if is_admin_bypass_granted(db, user_email, token_teams):
-            return visibility != "private"
+            # Admin bypass grants access to public + team resources + OWN private resources (PR #4341 / issue #4694)
+            if visibility == "private":
+                server_owner_email = getattr(server, "owner_email", None)
+                return server_owner_email and server_owner_email == user_email
+            return True  # public or team visibility
 
         if not user_email:
             return False

--- a/tests/unit/mcpgateway/services/test_gateway_access.py
+++ b/tests/unit/mcpgateway/services/test_gateway_access.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_gateway_access.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Tests for gateway access control (_check_gateway_access) with admin bypass and owner matching.
+"""
+
+# Standard
+from unittest.mock import MagicMock, Mock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Gateway as DbGateway
+from mcpgateway.services.gateway_service import GatewayService
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    db = MagicMock()
+    # Mock is_admin_bypass_granted check (db.execute for user lookup)
+    mock_result = Mock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+    return db
+
+
+@pytest.fixture
+def gateway_service():
+    """Create a GatewayService instance."""
+    return GatewayService()
+
+
+@pytest.fixture
+def public_gateway():
+    """Create a public gateway fixture."""
+    gateway = MagicMock(spec=DbGateway)
+    gateway.visibility = "public"
+    gateway.owner_email = "owner@example.com"
+    gateway.team_id = None
+    return gateway
+
+
+@pytest.fixture
+def team_gateway():
+    """Create a team gateway fixture."""
+    gateway = MagicMock(spec=DbGateway)
+    gateway.visibility = "team"
+    gateway.owner_email = "owner@example.com"
+    gateway.team_id = "team-123"
+    return gateway
+
+
+@pytest.fixture
+def private_gateway():
+    """Create a private gateway fixture."""
+    gateway = MagicMock(spec=DbGateway)
+    gateway.visibility = "private"
+    gateway.owner_email = "owner@example.com"
+    gateway.team_id = None
+    return gateway
+
+
+class TestCanAccessGatewayAdminBypass:
+    """Test _check_gateway_access with admin bypass (token_teams=None)."""
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_own_private_gateway(self, gateway_service, private_gateway):
+        """Admin with token_teams=None can access their own private gateway (PR #4877)."""
+        # Admin user accessing their own private gateway
+        user_email = "owner@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await gateway_service._check_gateway_access(mock_db_admin, private_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_cannot_access_others_private_gateway(self, gateway_service, private_gateway):
+        """Admin with token_teams=None cannot access another user's private gateway (PR #4877)."""
+        # Admin user accessing someone else's private gateway
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+        private_gateway.owner_email = "other@example.com"
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await gateway_service._check_gateway_access(mock_db_admin, private_gateway, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_public_gateway(self, gateway_service, public_gateway):
+        """Admin with token_teams=None can access public gateways (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await gateway_service._check_gateway_access(mock_db_admin, public_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_team_gateway(self, gateway_service, team_gateway):
+        """Admin with token_teams=None can access team gateways (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await gateway_service._check_gateway_access(mock_db_admin, team_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_private_gateway_without_owner_email(self, gateway_service, private_gateway):
+        """Admin cannot access private gateway without owner_email set (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+        private_gateway.owner_email = None
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await gateway_service._check_gateway_access(mock_db_admin, private_gateway, user_email, token_teams)
+
+        # Implementation returns None when owner_email is None (truthy check fails)
+        assert not result
+
+
+class TestCanAccessGatewayNonAdmin:
+    """Test _check_gateway_access without admin bypass (regular users)."""
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_public_gateway(self, gateway_service, mock_db, public_gateway):
+        """Regular user can access public gateways."""
+        user_email = "user@example.com"
+        token_teams = []  # Regular user, not admin bypass
+
+        result = await gateway_service._check_gateway_access(mock_db, public_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_team_gateway_when_in_team(self, gateway_service, mock_db, team_gateway):
+        """Regular user can access team gateway when their token includes the team."""
+        user_email = "user@example.com"
+        token_teams = ["team-123"]  # User is in the team
+
+        result = await gateway_service._check_gateway_access(mock_db, team_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_cannot_access_team_gateway_when_not_in_team(self, gateway_service, mock_db, team_gateway):
+        """Regular user cannot access team gateway when not in the team."""
+        user_email = "user@example.com"
+        token_teams = ["other-team"]  # User is not in the gateway's team
+
+        result = await gateway_service._check_gateway_access(mock_db, team_gateway, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_own_private_gateway(self, gateway_service, mock_db, private_gateway):
+        """Regular user can access their own private gateway when they have team membership."""
+        user_email = "owner@example.com"
+        token_teams = ["team-123"]  # Regular user with team membership (not public-only)
+
+        result = await gateway_service._check_gateway_access(mock_db, private_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_cannot_access_others_private_gateway(self, gateway_service, mock_db, private_gateway):
+        """Regular user cannot access another user's private gateway."""
+        user_email = "user@example.com"
+        token_teams = []  # Regular user
+        private_gateway.owner_email = "other@example.com"
+
+        result = await gateway_service._check_gateway_access(mock_db, private_gateway, user_email, token_teams)
+
+        assert result is False
+
+
+class TestCanAccessGatewayEdgeCases:
+    """Test edge cases for _check_gateway_access."""
+
+    @pytest.mark.asyncio
+    async def test_empty_user_email(self, gateway_service, mock_db, public_gateway):
+        """Empty user_email can access public gateways."""
+        user_email = ""
+        token_teams = []
+
+        result = await gateway_service._check_gateway_access(mock_db, public_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_none_user_email_public(self, gateway_service, mock_db, public_gateway):
+        """None user_email can access public gateways."""
+        user_email = None
+        token_teams = []
+
+        result = await gateway_service._check_gateway_access(mock_db, public_gateway, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_none_user_email_private(self, gateway_service, mock_db, private_gateway):
+        """None user_email cannot access private gateways."""
+        user_email = None
+        token_teams = []
+
+        result = await gateway_service._check_gateway_access(mock_db, private_gateway, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_gateway_without_visibility(self, gateway_service, mock_db):
+        """Gateway without visibility attribute defaults to False."""
+        gateway = MagicMock(spec=DbGateway)
+        gateway.visibility = None
+        gateway.owner_email = "owner@example.com"
+        user_email = "user@example.com"
+        token_teams = []
+
+        result = await gateway_service._check_gateway_access(mock_db, gateway, user_email, token_teams)
+
+        assert result is False

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1393,8 +1393,8 @@ class TestResourceSubscriptions:
         # Mock the EventService's subscribe_events method
         resource_service._event_service.subscribe_events = MagicMock(return_value=mock_generator())
 
-        # Subscribe and get one event
-        event_gen = resource_service.subscribe_events()
+        # Subscribe with admin bypass enabled to receive all events
+        event_gen = resource_service.subscribe_events(is_admin_bypass=True)
         event = await anext(event_gen)
 
         # Verify the event came through
@@ -1415,8 +1415,8 @@ class TestResourceSubscriptions:
         # Mock the EventService method
         resource_service._event_service.subscribe_events = MagicMock(return_value=mock_generator())
 
-        # Subscribe globally (no uri parameter)
-        event_gen = resource_service.subscribe_events()
+        # Subscribe globally with admin bypass to receive all events
+        event_gen = resource_service.subscribe_events(is_admin_bypass=True)
         event = await anext(event_gen)
 
         assert event["type"] == "resource_created"
@@ -5311,7 +5311,8 @@ class TestResourceServiceCoverageEdges:
         svc._event_service.subscribe_events = MagicMock(return_value=_gen())
 
         out = []
-        async for ev in svc.subscribe_events():
+        # Pass is_admin_bypass=True to receive all events
+        async for ev in svc.subscribe_events(is_admin_bypass=True):
             out.append(ev)
         assert out == [{"type": "resource_added"}]
 

--- a/tests/unit/mcpgateway/services/test_server_access.py
+++ b/tests/unit/mcpgateway/services/test_server_access.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_server_access.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Tests for server access control (_check_server_access) with admin bypass and owner matching.
+"""
+
+# Standard
+from unittest.mock import MagicMock, Mock
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Server as DbServer
+from mcpgateway.services.server_service import ServerService
+
+
+@pytest.fixture
+def mock_db():
+    """Create a mock database session."""
+    db = MagicMock()
+    # Mock is_admin_bypass_granted check (db.execute for user lookup)
+    mock_result = Mock()
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute.return_value = mock_result
+    return db
+
+
+@pytest.fixture
+def server_service():
+    """Create a ServerService instance."""
+    return ServerService()
+
+
+@pytest.fixture
+def public_server():
+    """Create a public server fixture."""
+    server = MagicMock(spec=DbServer)
+    server.visibility = "public"
+    server.owner_email = "owner@example.com"
+    server.team_id = None
+    return server
+
+
+@pytest.fixture
+def team_server():
+    """Create a team server fixture."""
+    server = MagicMock(spec=DbServer)
+    server.visibility = "team"
+    server.owner_email = "owner@example.com"
+    server.team_id = "team-123"
+    return server
+
+
+@pytest.fixture
+def private_server():
+    """Create a private server fixture."""
+    server = MagicMock(spec=DbServer)
+    server.visibility = "private"
+    server.owner_email = "owner@example.com"
+    server.team_id = None
+    return server
+
+
+class TestCanAccessServerAdminBypass:
+    """Test _check_server_access with admin bypass (token_teams=None)."""
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_own_private_server(self, server_service, private_server):
+        """Admin with token_teams=None can access their own private server (PR #4877)."""
+        # Admin user accessing their own private server
+        user_email = "owner@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await server_service._check_server_access(mock_db_admin, private_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_cannot_access_others_private_server(self, server_service, private_server):
+        """Admin with token_teams=None cannot access another user's private server (PR #4877)."""
+        # Admin user accessing someone else's private server
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+        private_server.owner_email = "other@example.com"
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await server_service._check_server_access(mock_db_admin, private_server, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_public_server(self, server_service, public_server):
+        """Admin with token_teams=None can access public servers (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await server_service._check_server_access(mock_db_admin, public_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_team_server(self, server_service, team_server):
+        """Admin with token_teams=None can access team servers (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await server_service._check_server_access(mock_db_admin, team_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_admin_private_server_without_owner_email(self, server_service, private_server):
+        """Admin cannot access private server without owner_email set (PR #4877)."""
+        user_email = "admin@example.com"
+        token_teams = None  # Signals admin bypass
+        private_server.owner_email = None
+
+        # Mock is_admin_bypass_granted to return True
+        mock_db_admin = MagicMock()
+        mock_admin_result = Mock()
+        mock_admin_result.scalar_one_or_none.return_value = MagicMock(is_admin=True)
+        mock_db_admin.execute.return_value = mock_admin_result
+
+        result = await server_service._check_server_access(mock_db_admin, private_server, user_email, token_teams)
+
+        # Implementation returns None when owner_email is None (truthy check fails)
+        assert not result
+
+
+class TestCanAccessServerNonAdmin:
+    """Test _check_server_access without admin bypass (regular users)."""
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_public_server(self, server_service, mock_db, public_server):
+        """Regular user can access public servers."""
+        user_email = "user@example.com"
+        token_teams = []  # Regular user, not admin bypass
+
+        result = await server_service._check_server_access(mock_db, public_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_team_server_when_in_team(self, server_service, mock_db, team_server):
+        """Regular user can access team server when their token includes the team."""
+        user_email = "user@example.com"
+        token_teams = ["team-123"]  # User is in the team
+
+        result = await server_service._check_server_access(mock_db, team_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_cannot_access_team_server_when_not_in_team(self, server_service, mock_db, team_server):
+        """Regular user cannot access team server when not in the team."""
+        user_email = "user@example.com"
+        token_teams = ["other-team"]  # User is not in the server's team
+
+        result = await server_service._check_server_access(mock_db, team_server, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_regular_user_can_access_own_private_server(self, server_service, mock_db, private_server):
+        """Regular user can access their own private server when they have team membership."""
+        user_email = "owner@example.com"
+        token_teams = ["team-123"]  # Regular user with team membership (not public-only)
+
+        result = await server_service._check_server_access(mock_db, private_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_regular_user_cannot_access_others_private_server(self, server_service, mock_db, private_server):
+        """Regular user cannot access another user's private server."""
+        user_email = "user@example.com"
+        token_teams = []  # Regular user
+        private_server.owner_email = "other@example.com"
+
+        result = await server_service._check_server_access(mock_db, private_server, user_email, token_teams)
+
+        assert result is False
+
+
+class TestCanAccessServerEdgeCases:
+    """Test edge cases for _check_server_access."""
+
+    @pytest.mark.asyncio
+    async def test_empty_user_email(self, server_service, mock_db, public_server):
+        """Empty user_email can access public servers."""
+        user_email = ""
+        token_teams = []
+
+        result = await server_service._check_server_access(mock_db, public_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_none_user_email_public(self, server_service, mock_db, public_server):
+        """None user_email can access public servers."""
+        user_email = None
+        token_teams = []
+
+        result = await server_service._check_server_access(mock_db, public_server, user_email, token_teams)
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_none_user_email_private(self, server_service, mock_db, private_server):
+        """None user_email cannot access private servers."""
+        user_email = None
+        token_teams = []
+
+        result = await server_service._check_server_access(mock_db, private_server, user_email, token_teams)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_server_without_visibility(self, server_service, mock_db):
+        """Server without visibility attribute defaults to False."""
+        server = MagicMock(spec=DbServer)
+        server.visibility = None
+        server.owner_email = "owner@example.com"
+        user_email = "user@example.com"
+        token_teams = []
+
+        result = await server_service._check_server_access(mock_db, server, user_email, token_teams)
+
+        assert result is False

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -458,7 +458,9 @@ class TestAdminServerRoutes:
         )
 
         # Test with include_inactive=False
-        result = await admin_list_servers(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request = MagicMock()
+        mock_request.state = MagicMock(token_teams=None)
+        result = await admin_list_servers(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
         assert "data" in result
         assert "pagination" in result
@@ -3113,7 +3115,9 @@ class TestAdminGatewayRoutes:
             return_value={"data": [mock_gateway], "pagination": PaginationMeta(page=1, per_page=50, total_items=1, total_pages=1, has_next=False, has_prev=False), "links": None}
         )
 
-        result = await admin_list_gateways(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+        mock_request = MagicMock()
+        mock_request.state = MagicMock(token_teams=None)
+        result = await admin_list_gateways(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
         assert "data" in result
         assert result["data"][0]["authType"] == "bearer"  # Using camelCase as per by_alias=True

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1273,6 +1273,11 @@ class TestAdminToolRoutes:
         # First-Party
         from mcpgateway.schemas import PaginationMeta
 
+        # Create mock request with token_teams
+        mock_request = MagicMock()
+        mock_request.state = MagicMock()
+        mock_request.state.token_teams = []
+
         # Test empty list
         # Mock tool_service.list_tools to return empty paginated response
         mock_tool_service.list_tools = AsyncMock(
@@ -1280,7 +1285,7 @@ class TestAdminToolRoutes:
         )
 
         # Call the function with explicit pagination params
-        result = await admin_list_tools(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+        result = await admin_list_tools(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
         # Expect structure with 'data' key and empty list
         assert isinstance(result, dict)
@@ -1291,7 +1296,7 @@ class TestAdminToolRoutes:
         mock_tool_service.list_tools = AsyncMock(side_effect=RuntimeError("Service unavailable"))
 
         with pytest.raises(RuntimeError):
-            await admin_list_tools(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+            await admin_list_tools(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
     @patch.object(ToolService, "get_tool")
     async def test_admin_get_tool_various_exceptions(self, mock_get_tool, mock_request, mock_db):
@@ -2436,7 +2441,12 @@ class TestAdminResourceRoutes:
             return_value={"data": [resource_read], "pagination": PaginationMeta(page=1, per_page=50, total_items=1, total_pages=1, has_next=False, has_prev=False), "links": None}
         )
 
-        result = await admin_list_resources(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+        # Create mock request with token_teams
+        mock_request = MagicMock()
+        mock_request.state = MagicMock()
+        mock_request.state.token_teams = []
+
+        result = await admin_list_resources(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
         assert "data" in result
         assert len(result["data"]) == 1
@@ -2765,7 +2775,12 @@ class TestAdminPromptRoutes:
             return_value={"data": [mock_prompt], "pagination": PaginationMeta(page=1, per_page=50, total_items=1, total_pages=1, has_next=False, has_prev=False), "links": None}
         )
 
-        result = await admin_list_prompts(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
+        # Create mock request with token_teams
+        mock_request = MagicMock()
+        mock_request.state = MagicMock()
+        mock_request.state.token_teams = []
+
+        result = await admin_list_prompts(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "test-user", "db": mock_db})
 
         assert "data" in result
         assert "pagination" in result
@@ -16776,7 +16791,12 @@ async def test_get_resources_section_team_filter(mock_list, mock_db, allow_permi
             visibility="public",
         )
     ]
-    response = await get_resources_section(team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_resources_section(request=mock_request, team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     payload = json.loads(response.body)
     assert payload["team_id"] == "team-1"
     assert len(payload["resources"]) == 1
@@ -16800,7 +16820,12 @@ async def test_get_resources_section_team_filter_with_tuple_result(mock_list, mo
         ],
         None,
     )
-    response = await get_resources_section(team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_resources_section(request=mock_request, team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     payload = json.loads(response.body)
     assert payload["team_id"] == "team-1"
     assert len(payload["resources"]) == 1
@@ -16811,7 +16836,12 @@ async def test_get_resources_section_team_filter_with_tuple_result(mock_list, mo
 async def test_get_resources_section_exception_returns_500(mock_list, mock_db, allow_permission):
     """Cover get_resources_section exception handler."""
     mock_list.side_effect = RuntimeError("boom")
-    response = await get_resources_section(team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_resources_section(request=mock_request, team_id="team-1", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert response.status_code == 500
     payload = json.loads(response.body)
     assert "boom" in payload["error"]
@@ -16832,7 +16862,12 @@ async def test_get_prompts_section_team_filter(mock_list, mock_db, allow_permiss
             visibility="team",
         )
     ]
-    response = await get_prompts_section(team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_prompts_section(request=mock_request, team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     payload = json.loads(response.body)
     assert payload["team_id"] == "team-2"
     assert len(payload["prompts"]) == 1
@@ -16856,7 +16891,12 @@ async def test_get_prompts_section_team_filter_with_tuple_result(mock_list, mock
         ],
         None,
     )
-    response = await get_prompts_section(team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_prompts_section(request=mock_request, team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     payload = json.loads(response.body)
     assert payload["team_id"] == "team-2"
     assert len(payload["prompts"]) == 1
@@ -16867,7 +16907,12 @@ async def test_get_prompts_section_team_filter_with_tuple_result(mock_list, mock
 async def test_get_prompts_section_exception_returns_500(mock_list, mock_db, allow_permission):
     """Cover get_prompts_section exception handler."""
     mock_list.side_effect = RuntimeError("boom")
-    response = await get_prompts_section(team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
+    # Create mock request with token_teams
+    mock_request = MagicMock()
+    mock_request.state = MagicMock()
+    mock_request.state.token_teams = []
+
+    response = await get_prompts_section(request=mock_request, team_id="team-2", db=mock_db, user={"email": "u@example.com", "db": mock_db})
     assert response.status_code == 500
     payload = json.loads(response.body)
     assert "boom" in payload["error"]
@@ -21206,8 +21251,13 @@ class TestAdminGetToolPassesTeamRoles:
             }
         )
 
+        # Create mock request with token_teams
+        mock_request = MagicMock()
+        mock_request.state = MagicMock()
+        mock_request.state.token_teams = []
+
         with patch("mcpgateway.admin.tool_service", mock_tool_svc), patch("mcpgateway.admin._get_user_team_roles", return_value={"team-2": "member"}) as mock_roles:
-            await admin_list_tools(page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "user@example.com", "is_admin": False, "db": mock_db})
+            await admin_list_tools(request=mock_request, page=1, per_page=50, include_inactive=False, db=mock_db, user={"email": "user@example.com", "is_admin": False, "db": mock_db})
 
             mock_roles.assert_called_once_with(mock_db, "user@example.com")
             mock_tool_svc.list_tools.assert_called_once()

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -1534,6 +1534,8 @@ async def test_get_user_team_ids_returns_cached_ids_without_service_lookup(monke
 @pytest.mark.asyncio
 async def test_admin_list_servers_returns_paginated(monkeypatch):
     mock_db = MagicMock()
+    mock_request = _make_request()
+    mock_request.state = SimpleNamespace(token_teams=None)
 
     mock_server = MagicMock()
     mock_server.model_dump.return_value = {"id": "server-1"}
@@ -1549,7 +1551,7 @@ async def test_admin_list_servers_returns_paginated(monkeypatch):
 
     monkeypatch.setattr(admin.server_service, "list_servers", _fake_list_servers)
 
-    result = await admin.admin_list_servers(page=1, per_page=10, include_inactive=False, db=mock_db, user={"email": "user@example.com"})
+    result = await admin.admin_list_servers(request=mock_request, page=1, per_page=10, include_inactive=False, db=mock_db, user={"email": "user@example.com"})
     assert result["data"] == [{"id": "server-1"}]
     assert result["pagination"] == {"page": 1, "per_page": 10}
     assert result["links"] == {"self": "/admin/servers?page=1&per_page=10"}

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -1458,19 +1458,19 @@ class TestResourceEndpoints:
 
     @patch("mcpgateway.main.resource_service.list_resource_templates", new_callable=AsyncMock)
     def test_list_resource_templates_admin_bypass_nulls_user_email(self, mock_list, test_client, auth_headers):
-        """SECURITY: admin bypass must pass (user_email=None, token_teams=None) to list_resource_templates.
+        """SECURITY: admin bypass must pass (user_email=email, token_teams=None) to list_resource_templates.
 
-        Regression for Oracle review of PR #4341 — earlier wiring passed the admin's email
-        while nulling token_teams, which caused the service to skip the private-exclusion
-        WHERE clause and leak other users' private templates.
+        Updated for PR #4877 / issue #4877 — admin bypass now keeps user_email for owner matching
+        on private resources. This allows admins to view/edit their OWN private resources while
+        maintaining proper access control (token_teams=None grants admin bypass).
         """
         mock_list.return_value = []
         response = test_client.get("/resources/templates/list", headers=auth_headers)
         assert response.status_code == 200
         mock_list.assert_called_once()
         call_kwargs = mock_list.call_args.kwargs
-        assert call_kwargs.get("user_email") is None
-        assert call_kwargs.get("token_teams") is None
+        assert call_kwargs.get("user_email") == "test_user@example.com"  # Preserved for owner matching
+        assert call_kwargs.get("token_teams") is None  # None = admin bypass
 
     @patch("mcpgateway.main.resource_service.set_resource_state")
     def test_set_resource_state(self, mock_toggle, test_client, auth_headers):
@@ -1509,9 +1509,9 @@ class TestResourceEndpoints:
         response = test_client.post("/resources/subscribe", headers=auth_headers)
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
-        # Handler pre-resolves is_admin_bypass; with user_email=None it resolves to True
-        # (no-auth-context bypass).  See mcpgateway.utils.admin_check.
-        mock_subscribe.assert_called_once_with(user_email=None, token_teams=None, is_admin_bypass=True)
+        # Admin bypass now preserves user_email for owner matching (PR #4877 / issue #4877)
+        # is_admin_bypass=False because test user is not a DB admin (no DB setup in test)
+        mock_subscribe.assert_called_once_with(user_email="test_user@example.com", token_teams=None, is_admin_bypass=False)
 
     @patch("mcpgateway.main.resource_service.subscribe_events")
     def test_subscribe_resource_events_sse_format(self, mock_subscribe, test_client, auth_headers):
@@ -1573,7 +1573,10 @@ class TestPromptEndpoints:
 
     @patch("mcpgateway.main.prompt_service.get_prompt")
     def test_get_prompt_no_args_non_jwt_admin_bypass(self, mock_get, test_client, auth_headers):
-        """Non-JWT admin (dev-mode / basic-auth) gets admin bypass via get_scoped_resource_access_context."""
+        """Non-JWT admin (dev-mode / basic-auth) gets admin bypass via get_scoped_resource_access_context.
+
+        Updated for PR #4877 — admin bypass now preserves user_email for owner matching.
+        """
         mock_get.return_value = {"name": "test", "template": "Hello"}
         response = test_client.get("/prompts/test", headers=auth_headers)
         assert response.status_code == 200
@@ -1581,9 +1584,9 @@ class TestPromptEndpoints:
             ANY,
             "test",
             {},
-            user=None,
+            user="test_user@example.com",  # Preserved for owner matching (PR #4877)
             server_id=None,
-            token_teams=None,
+            token_teams=None,  # None = admin bypass
             plugin_context_table=None,
             plugin_global_context=ANY,
         )
@@ -1615,8 +1618,8 @@ class TestPromptEndpoints:
         result = await get_prompt_no_args(request=mock_request, prompt_id="test", db=mock_db, user=admin_user)
 
         assert result == {"name": "test", "template": "Hello"}
-        # Admin bypass: both auth_user_email and auth_token_teams should be None
-        mock_get.assert_called_once_with(mock_db, "test", {}, user=None, server_id=None, token_teams=None, plugin_context_table=None, plugin_global_context=None)
+        # Admin bypass: user_email preserved for owner matching (PR #4877), token_teams=None
+        mock_get.assert_called_once_with(mock_db, "test", {}, user="admin@example.com", server_id=None, token_teams=None, plugin_context_table=None, plugin_global_context=None)
 
     @pytest.mark.asyncio
     @patch("mcpgateway.main.prompt_service.get_prompt")
@@ -1645,8 +1648,8 @@ class TestPromptEndpoints:
         result = await get_prompt(request=mock_request, prompt_id="test", args={"name": "World"}, db=mock_db, user=admin_user)
 
         assert result == {"name": "test", "template": "Hello {{name}}"}
-        # Admin bypass: both auth_user_email and auth_token_teams should be None
-        mock_get.assert_called_once_with(mock_db, "test", {"name": "World"}, user=None, server_id=None, token_teams=None, plugin_context_table=None, plugin_global_context=None)
+        # Admin bypass: user_email preserved for owner matching (PR #4877), token_teams=None
+        mock_get.assert_called_once_with(mock_db, "test", {"name": "World"}, user="admin@example.com", server_id=None, token_teams=None, plugin_context_table=None, plugin_global_context=None)
 
     @pytest.mark.asyncio
     @patch("mcpgateway.main.resource_service.read_resource")
@@ -1679,11 +1682,11 @@ class TestPromptEndpoints:
 
         # The endpoint converts ResourceContent to dict via model_dump()
         assert result == {"type": "resource", "id": "test-resource", "uri": "file://test.txt", "mime_type": None, "text": "content", "blob": None}
-        # Admin bypass: both user and token_teams should be None
+        # Admin bypass: user_email preserved for owner matching (PR #4877), token_teams=None
         mock_read.assert_called_once()
         call_kwargs = mock_read.call_args[1]
-        assert call_kwargs["user"] is None
-        assert call_kwargs["token_teams"] is None
+        assert call_kwargs["user"] == "admin@example.com"  # Preserved for owner matching
+        assert call_kwargs["token_teams"] is None  # None = admin bypass
 
     @patch("mcpgateway.main.prompt_service.update_prompt")
     def test_update_prompt_endpoint_secondary(self, mock_update, test_client, auth_headers):
@@ -2701,11 +2704,11 @@ class TestRPCEndpoints:
 
     @patch("mcpgateway.main.resource_service.list_resource_templates", new_callable=AsyncMock)
     def test_rpc_resource_templates_list_admin_bypass_nulls_user_email(self, mock_list_templates, test_client, auth_headers):
-        """SECURITY: admin bypass via JSON-RPC must pass (user_email=None, token_teams=None).
+        """SECURITY: admin bypass via JSON-RPC must pass (user_email=email, token_teams=None).
 
-        Regression for Oracle review of PR #4341 — the JSON-RPC resources/templates/list
-        handler in main.py previously kept the admin's email while nulling token_teams,
-        causing list_resource_templates to skip the private-exclusion filter.
+        Updated for PR #4877 / issue #4877 — admin bypass now keeps user_email for owner matching
+        on private resources. This allows admins to view/edit their OWN private resources while
+        maintaining proper access control (token_teams=None grants admin bypass).
         """
         mock_list_templates.return_value = []
 
@@ -2719,8 +2722,8 @@ class TestRPCEndpoints:
         assert response.status_code == 200
         mock_list_templates.assert_called_once()
         call_kwargs = mock_list_templates.call_args.kwargs
-        assert call_kwargs.get("user_email") is None
-        assert call_kwargs.get("token_teams") is None
+        assert call_kwargs.get("user_email") == "test_user@example.com"  # Preserved for owner matching
+        assert call_kwargs.get("token_teams") is None  # None = admin bypass
 
     @patch("mcpgateway.main.prompt_service.list_prompts", new_callable=AsyncMock)
     def test_rpc_prompts_list_next_cursor(self, mock_list_prompts, test_client, auth_headers):

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -13107,8 +13107,9 @@ class TestHardeningHelperCoverage:
         request = MagicMock(spec=Request)
         request.state = SimpleNamespace(_jwt_verified_payload=("tok", {"sub": "u"}))
 
+        # Admin bypass now preserves user_email for owner matching (PR #4877 / issue #4877)
         with patch("mcpgateway.auth_context.get_rpc_filter_context", return_value=("user@example.com", None, True)):
-            assert main_mod.get_scoped_resource_access_context(request, {"email": "user@example.com"}) == (None, None)
+            assert main_mod.get_scoped_resource_access_context(request, {"email": "user@example.com"}) == ("user@example.com", None)
 
         with patch("mcpgateway.auth_context.get_rpc_filter_context", return_value=("user@example.com", None, False)):
             assert main_mod.get_scoped_resource_access_context(request, {"email": "user@example.com"}) == ("user@example.com", [])


### PR DESCRIPTION
 Closes: #4877

  This PR fixes issue #4877, allowing admin users to view and edit their own private resources across all resource types (tools, prompts, resources, servers, gateways) through the Admin UI and API.

  Background: Issue #4694 was previously closed by PR #4788, which fixed A2A agents only. Issue #4877 discovered the same problem persisted for all other resource types.

  Before: Admin users with token_teams=None could access public/team resources but were blocked from viewing/editing their own private resources.

  After: Admin users can now access their OWN private resources while maintaining the security invariant that admin bypass NEVER reveals other users' private resources.

  ---
  Problem
  
  Issue #4877 identified that after PR #4788 closed #4694 for A2A agents, the problem remained for other resource types:

  1. Admin bypass (token_teams=None) granted access to public/team resources only
  2. Admin bypass blocked ALL private resources, including the admin's own
  3. Users could CREATE private resources but couldn't VIEW or EDIT them
  4. Affected: tools, prompts, resources, gateways, servers

  Root Cause: mcpgateway/auth_context.py lines 493, 496

  if is_admin and token_teams is None:
      return None, None  # ❌ Sets user_email=None, breaks owner matching

  Setting user_email=None broke the owner-matching logic in service access control methods (_check_*_access). Services check owner_email == user_email, but when user_email=None, this always fails.

  ---
  Solution
  
  1. Root cause fix - Preserve user_email in auth_context.py during admin bypass
  2. Service updates - Add owner matching to server/gateway services (tools/prompts/resources already had it)
  3. Admin endpoints - Pass token context correctly

  Security: Maintains PR #4341 invariant - admin bypass grants access to public + team + own private resources, but NEVER reveals other users' private resources.

  ---
  Changes
  
  mcpgateway/auth_context.py (lines 493, 496)
  # Before: return None, None
  # After:  return user_email, None  # Keep for owner matching
  
  mcpgateway/services/server_service.py (lines 1020-1025)
  mcpgateway/services/gateway_service.py (lines 2808-2813)
  if is_admin_bypass_granted(db, user_email, token_teams):
      if visibility == "private":
          resource_owner_email = getattr(resource, "owner_email", None)
          return resource_owner_email and resource_owner_email == user_email
      return True  # public or team
      
  mcpgateway/main.py (lines 3925, 6829)
  - Removed user_email=None if is_admin_bypass else user_email
  - Now always passes user_email=user_email
  
  mcpgateway/admin.py (lines 2515, 2528, 3322, 3357)
  - Admin list endpoints accept Request parameter
  - Extract and pass token_teams to service layer

  ---
  Tests
  
  New test files (512 lines total):
  - tests/unit/mcpgateway/services/test_server_access.py (256 lines)
  - tests/unit/mcpgateway/services/test_gateway_access.py (256 lines)

  28 new tests covering:
  - ✅ Admin can access own private resources
  - ✅ Admin cannot access others' private resources
  - ✅ Admin can access public/team resources
  - ✅ Regular user access unchanged
  - ✅ Edge cases (None user_email, missing owner_email)

  Verification:
  pytest tests/unit/mcpgateway/services/test_server_access.py -v
  pytest tests/unit/mcpgateway/services/test_gateway_access.py -v
  make test
  
  Results: All 28 new tests + 17,000+ existing tests passing ✅


  ---
  Related Issues
  
  - Closes: #4877
  - Related: #4694 (closed by PR #4788 - A2A agents only), #4341 (admin bypass security invariant)