### PR TITLE
[Chore]: Security Hardening - idna and openssl upgrades

### DIFF
--- a/mcp-servers/rust/filesystem-server/Cargo.lock
+++ b/mcp-servers/rust/filesystem-server/Cargo.lock
@@ -1211,9 +1211,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1242,9 +1242,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",

--- a/mcp-servers/rust/filesystem-server/Cargo.toml
+++ b/mcp-servers/rust/filesystem-server/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.54", features = ["derive"] }
 futures = "0.3.31"
 globset = "0.4.18"
 ignore = "0.4.25"
-openssl = "0.10.78"
+openssl = "0.10.80"
 rmcp = { version = "0.14.0", features = ["transport-streamable-http-server"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
@@ -32,7 +32,7 @@ axum-test = "18.7.0"
 bytes = "1.11.0"
 http = "1.4.0"
 hyper = "1.8.1"
-openssl = "0.10.78"
+openssl = "0.10.80"
 reqwest = { version = "0.13.1", default-features = false, features = [
     "native-tls",
     "json",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-15T09:32:28.113931Z"
+exclude-newer = "2026-05-15T13:46:18.175998Z"
 exclude-newer-span = "P10D"
 
 [options.exclude-newer-package]
@@ -2086,11 +2086,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## 🔗 Related Issue
Closes # 210 and 211 (dependabot)
---

## 📝 Summary
This PR addresses multiple dependencies identified by Dependabot. Security Hardening.

---
#### 1. idna: 3.13 → 3.15
**Details:**
- Fixes incomplete remediation from previous 3.13 patch
- Specially crafted inputs like `"\u0660" * N` could cause DoS
- Version 3.15 rejects long inputs early to prevent resource consumption
- Affects 38+ transitive dependencies (httpx, requests, aiohttp, fastapi, etc.)

**Files changed:**
- `uv.lock`

#### 2. openssl: 0.10.78 → 0.10.80 (Rust)

**Files changed:**
- `mcp-servers/rust/filesystem-server/Cargo.toml`
- `mcp-servers/rust/filesystem-server/Cargo.lock`

---

### 📝 Notes
- Both updates are backward compatible
- No API changes
- Standard security patches
