### PR TITLE
fix: schema builder input_schema not persisting and dark mode missing styles

### DIFF
--- a/mcpgateway/admin_ui/formFieldHandlers.js
+++ b/mcpgateway/admin_ui/formFieldHandlers.js
@@ -122,7 +122,7 @@ export const createParameterForm = function (parameterCount) {
   nameInput.name = `param_name_${parameterCount}`;
   nameInput.required = true;
   nameInput.className =
-  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200";
+  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-400";
 
   // Add validation to name input
   nameInput.addEventListener("blur", function () {
@@ -149,7 +149,7 @@ export const createParameterForm = function (parameterCount) {
   const typeSelect = document.createElement("select");
   typeSelect.name = `param_type_${parameterCount}`;
   typeSelect.className =
-  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200";
+  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-800 dark:text-gray-200";
 
   const typeOptions = [
     { value: "string", text: "String" },
@@ -185,7 +185,7 @@ export const createParameterForm = function (parameterCount) {
   const descTextarea = document.createElement("textarea");
   descTextarea.name = `param_description_${parameterCount}`;
   descTextarea.className =
-  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200";
+  "mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-400";
   descTextarea.rows = 2;
 
   descGroup.appendChild(descLabel);
@@ -233,6 +233,8 @@ export const handleAddParameter = function () {
       "mb-4",
       "rounded-md",
       "bg-gray-50",
+      "dark:bg-gray-700",
+      "dark:border-gray-600",
       "shadow-sm",
     );
 

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -611,14 +611,13 @@ export const handleToolFormSubmit = async function (event) {
 
   try {
     const form = event.target;
-    const formData = new FormData(form);
 
-    // Validate form inputs
-    const name = formData.get("name");
-    const url = formData.get("url");
-
-    const nameValidation = validateInputName(name, "tool");
-    const urlValidation = validateUrl(url);
+    // Validate form inputs before touching editors
+    const nameValidation = validateInputName(
+      form.elements["name"]?.value,
+      "tool"
+    );
+    const urlValidation = validateUrl(form.elements["url"]?.value);
 
     if (!nameValidation.valid) {
       throw new Error(nameValidation.error);
@@ -628,7 +627,8 @@ export const handleToolFormSubmit = async function (event) {
       throw new Error(urlValidation.error);
     }
 
-    // If in UI mode, update schemaEditor with generated schema
+    // If in UI mode, generate schema and inject it into the hidden textarea
+    // BEFORE taking the FormData snapshot so the value is included.
     const mode = document.querySelector(
       'input[name="schema_input_mode"]:checked'
     );
@@ -646,7 +646,8 @@ export const handleToolFormSubmit = async function (event) {
       }
     }
 
-    // Save CodeMirror editors' contents
+    // Flush all CodeMirror editors to their underlying <textarea> elements
+    // BEFORE constructing FormData so the snapshot captures current values.
     if (window.headersEditor) {
       window.headersEditor.save();
     }
@@ -656,6 +657,9 @@ export const handleToolFormSubmit = async function (event) {
     if (window.outputSchemaEditor) {
       window.outputSchemaEditor.save();
     }
+
+    // Snapshot form data AFTER editors are flushed.
+    const formData = new FormData(form);
 
     const isInactiveCheckedBool = isInactiveChecked("tools");
     formData.append("is_inactive_checked", isInactiveCheckedBool);

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -700,11 +700,9 @@ export const handleEditToolFormSubmit = async function (event) {
   const form = event.target;
 
   try {
-    const formData = new FormData(form);
-
-    // Basic validation (customize as needed)
-    const name = formData.get("name");
-    const url = formData.get("url");
+    // Basic validation before touching editors
+    const name = form.elements["name"]?.value;
+    const url = form.elements["url"]?.value;
     const nameValidation = validateInputName(name, "tool");
     const urlValidation = validateUrl(url);
 
@@ -715,8 +713,8 @@ export const handleEditToolFormSubmit = async function (event) {
       throw new Error(urlValidation.error);
     }
 
-    // // Save CodeMirror editors' contents if present
-
+    // Flush all CodeMirror editors to their underlying <textarea> elements
+    // BEFORE constructing FormData so the snapshot captures current values.
     if (window.editToolHeadersEditor) {
       window.editToolHeadersEditor.save();
     }
@@ -726,6 +724,9 @@ export const handleEditToolFormSubmit = async function (event) {
     if (window.editToolOutputSchemaEditor) {
       window.editToolOutputSchemaEditor.save();
     }
+
+    // Snapshot form data AFTER editors are flushed.
+    const formData = new FormData(form);
 
     const isInactiveCheckedBool = isInactiveChecked("tools");
     formData.append("is_inactive_checked", isInactiveCheckedBool);

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3826,7 +3826,7 @@
                     JSON Input
                   </label>
                 </div>
-                <div id="ui-builder" class="border p-4 mb-4">
+                <div id="ui-builder" class="border p-4 mb-4 rounded-md dark:border-gray-600 dark:bg-gray-800">
                   <div id="parameters-container"></div>
                   <button
                     type="button"
@@ -3843,7 +3843,7 @@
                     >
                       Advanced: Add Passthrough
                     </button>
-                    <fieldset id="passthrough-container" class="mt-2 border p-4 rounded-lg" style="display:none;">
+                    <fieldset id="passthrough-container" class="mt-2 border p-4 rounded-lg dark:border-gray-600 dark:bg-gray-700" style="display:none;">
                       <!-- Passthrough fields will be dynamically added here -->
                     </fieldset>
                 </div>

--- a/tests/unit/js/formSubmitHandlers.test.js
+++ b/tests/unit/js/formSubmitHandlers.test.js
@@ -475,6 +475,39 @@ describe("handleEditToolFormSubmit", () => {
     delete window.editToolSchemaEditor;
     delete window.editToolOutputSchemaEditor;
   });
+
+  test("FormData snapshot includes schema value written by editor.save()", async () => {
+    // Simulate a CodeMirror editor whose .save() flushes a value into the
+    // underlying <textarea>. If FormData is constructed before .save() is
+    // called the textarea will still be empty and the schema will be lost.
+    const schemaValue = '{"type":"object","properties":{}}';
+
+    window.editToolSchemaEditor = {
+      save: vi.fn(function () {
+        // Simulate CodeMirror writing its internal value into the textarea
+        const textarea = document.querySelector("textarea[name='input_schema']");
+        if (textarea) textarea.value = schemaValue;
+      }),
+    };
+
+    const event = createFormEvent(`
+      <form action="/admin/tools/1/edit">
+        <input name="name" value="EditedTool" />
+        <input name="url" value="http://example.com/api" />
+        <textarea name="input_schema"></textarea>
+      </form>
+    `);
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true });
+    safeParseJsonResponse.mockResolvedValue({ success: true });
+
+    await handleEditToolFormSubmit(event);
+
+    const submittedFormData = globalThis.fetch.mock.calls[0][1].body;
+    expect(submittedFormData.get("input_schema")).toBe(schemaValue);
+
+    delete window.editToolSchemaEditor;
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary
Two bugs in the REST tool creation schema builder in the Admin UI:

1. **Schema not persisting** — tools created via the Schema Builder (UI mode) were saved with an empty `input_schema` every time. JSON Input mode worked correctly.
2. **Dark mode not applied** — the schema builder panel, parameter cards, and all their input fields rendered with white backgrounds and unstyled controls when dark mode was active.

Closes #4887

---

## 🔁 Reproduction Steps

**Bug 1 — schema not persisting:**
1. Admin UI → Tools → "Add New Tool from REST API"
2. Select Schema Builder mode (default)
3. Add a parameter, fill in name/type/description
4. Submit — tool is created with `input_schema: {}`

**Bug 2 — dark mode:**
1. Toggle dark mode in the Admin UI
2. Navigate to Tools → "Add New Tool from REST API"
3. The schema builder section (#ui-builder, parameter cards, inputs) renders white

---

## 🐞 Root Cause

**Bug 1:** In `handleToolFormSubmit` (`mcpgateway/admin_ui/formSubmitHandlers.js`), `new FormData(form)` was called at the top of the handler — before `window.schemaEditor.save()`. CodeMirror only syncs its internal state to the underlying `<textarea name="input_schema">` when `.save()` is explicitly called. The Schema Builder path injects the generated schema via `schemaEditor.setValue()` and then flushes via `schemaEditor.save()`, but `FormData` had already snapshotted the empty textarea. The JSON Input path appeared to work because typing in CodeMirror can trigger auto-sync events, but it had the same latent ordering bug.

**Bug 2:** The schema builder container (`#ui-builder`), passthrough fieldset (`#passthrough-container`), dynamically-created parameter card divs, and all their child inputs/select/textarea elements were missing Tailwind `dark:` variants entirely.

---

## 💡 Fix Description

**Bug 1** (`mcpgateway/admin_ui/formSubmitHandlers.js`):
Moved `new FormData(form)` to **after** all editor `.save()` calls (`headersEditor`, `schemaEditor`, `outputSchemaEditor`) and after the schema builder `setValue()` call. Validation still runs first using `form.elements["name"].value` / `form.elements["url"].value` directly from the DOM, so no functionality is lost.

**Bug 2** (`mcpgateway/admin_ui/formFieldHandlers.js`, `mcpgateway/templates/admin.html`):
- `#ui-builder` div: added `dark:border-gray-600 dark:bg-gray-800`
- `#passthrough-container` fieldset: added `dark:border-gray-600 dark:bg-gray-700`
- `handleAddParameter` parameter card: added `dark:bg-gray-700 dark:border-gray-600`
- `createParameterForm` name input, type select, description textarea: added `dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:placeholder-gray-400`

Bundle rebuilt after both source changes.

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80 % | `make coverage` | |
| Schema builder persists on submit | manual — create tool via UI mode, verify `input_schema` non-empty | |
| Dark mode renders correctly | manual — toggle dark mode, open schema builder, add parameter | |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed