### PR TITLE
bugfix/4304-gateway-federation-drops-upstream-tools

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -6086,6 +6086,29 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         """
         await self._event_service.publish_event(event)
 
+    @staticmethod
+    async def _fetch_all_tools(session: ClientSession) -> list:
+        """Fetch all tools from an initialized MCP session, handling pagination.
+
+        Iterates over paginated ``tools/list`` responses until the server
+        returns no ``nextCursor``, collecting every tool into a single list.
+
+        Args:
+            session: An initialized MCP ``ClientSession``.
+
+        Returns:
+            List of ``mcp.types.Tool`` objects from every page.
+        """
+        all_tools: list = []
+        cursor: str | None = None
+        while True:
+            response = await session.list_tools(cursor=cursor)
+            all_tools.extend(response.tools)
+            if not response.nextCursor:
+                break
+            cursor = response.nextCursor
+        return all_tools
+
     def _validate_tools(self, tools: list[dict[str, Any]], context: str = "default") -> tuple[list[ToolCreate], list[str]]:
         """Validate tools individually with richer logging and error aggregation.
 
@@ -6172,8 +6195,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     capabilities = response.capabilities.model_dump(by_alias=True, exclude_none=True)
                     logger.debug("Server capabilities: %s", capabilities)
 
-                    response = await session.list_tools()
-                    tools = response.tools
+                    tools = await self._fetch_all_tools(session)
                     tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
                     tools, validation_errors = self._validate_tools(tools, context="oauth")
@@ -6349,8 +6371,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 capabilities = response.capabilities.model_dump(by_alias=True, exclude_none=True)
                 logger.debug("Server capabilities: %s", capabilities)
 
-                response = await session.list_tools()
-                tools = response.tools
+                tools = await self._fetch_all_tools(session)
                 tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
                 tools, validation_errors = self._validate_tools(tools)
@@ -6515,8 +6536,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 capabilities = response.capabilities.model_dump(by_alias=True, exclude_none=True)
                 logger.debug("Server capabilities: %s", capabilities)
 
-                response = await session.list_tools()
-                tools = response.tools
+                tools = await self._fetch_all_tools(session)
                 tools = [tool.model_dump(by_alias=True, exclude_none=True, exclude_unset=True) for tool in tools]
 
                 tools, validation_errors = self._validate_tools(tools)

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -6104,9 +6104,10 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         while True:
             response = await session.list_tools(cursor=cursor)
             all_tools.extend(response.tools)
-            if not response.nextCursor:
+            next_cursor = getattr(response, 'nextCursor', None)
+            if not isinstance(next_cursor, str):
                 break
-            cursor = response.nextCursor
+            cursor = next_cursor
         return all_tools
 
     def _validate_tools(self, tools: list[dict[str, Any]], context: str = "default") -> tuple[list[ToolCreate], list[str]]:

--- a/tests/live_gateway/protocol_compliance/COMPLIANCE_GAPS.md
+++ b/tests/live_gateway/protocol_compliance/COMPLIANCE_GAPS.md
@@ -223,49 +223,32 @@ limitation. Independent of #4205.
 
 ---
 
-### GAP-008 — Gateway federation drops a subset of upstream tools
+### GAP-008 — Gateway federation drops a subset of upstream tools *(closed 2026-05-26)*
 
-| | |
-|---|---|
-| **Targets affected** | `gateway_proxy`, `gateway_virtual` |
-| **Tests** | `test_drift.py::test_drift_tool_names`, `test_tools.py::test_tool_error_is_surfaced_as_is_error`, `test_utilities.py::test_long_running_tool_is_cancellable`, `::test_cancellation_notification_reaches_server`, `test_notifications.py::test_tools_list_changed_notification_delivered`, `::test_resources_list_changed_notification_delivered`, `::test_prompts_list_changed_notification_delivered` (co-blocked with GAP-006), `::test_resources_updated_after_bump` (co-blocked with GAP-009) |
-| **Spec** | [MCP 2025-11-25 — server `tools` capability](https://modelcontextprotocol.io/specification/2025-11-25/server/tools) |
+**Root cause**: `session.list_tools()` was called once per session without
+iterating paginated responses. Servers that return partial results with
+a `nextCursor` (including the compliance reference server, which
+registers 120 `stub_NNN` tools beyond the first page) silently lost any
+tools on subsequent pages. The fix adds a `_fetch_all_tools()` helper
+that loops over `session.list_tools(cursor=...)` until `nextCursor` is
+`None`, then applies it to all three federation paths (SSE, SSE OAuth,
+Streamable HTTP).
 
-**Observed**: the reference server registers 136 tools (16 named tools —
-`echo`, `add`, `boom`, `progress_reporter`, `long_running`,
-`get_cancellation_count`, `mutate_tool_list`, `mutate_resource_list`,
-`mutate_prompt_list`, `bump_subscribable`, `roots_echo`,
-`sample_trigger`, `sample_trigger_with_params`, `elicit_trigger`,
-`elicit_trigger_numeric`, `log_at_level` — plus 120 `stub_NNN`
-pagination stubs). Several of the named tools are missing after gateway
-federation (specifically the no-arg / raising / long-sleep variants —
-`boom`, `bump_subscribable`, `mutate_tool_list`, `long_running` have
-been observed dropped; exact current set varies and should be re-probed
-when this gap is investigated).
+**How we learned it closed**:
+- `test_drift_tool_names` XPASSed after the code change — all 136 tools
+  (16 named + 120 stubs) are now surfaced identically across every target.
+- `test_tool_error_is_surfaced_as_is_error` (exercises `boom`) passes on
+  all targets.
+- `test_long_running_tool_is_cancellable` (exercises `long_running`)
+  passes on all targets.
+- Remaining xfail markers on `test_cancellation_notification_reaches_server`,
+  `test_tools_list_changed_notification_delivered`,
+  `test_resources_list_changed_notification_delivered`,
+  `test_prompts_list_changed_notification_delivered`,
+  `test_resources_updated_after_bump` are now attributed to their
+  surviving gaps (GAP-001/002, GAP-006, GAP-009) respectively.
 
-**Expected**: the gateway should federate every tool the upstream
-advertises, provided it passes the gateway's validator layer. If a tool
-is intentionally rejected (e.g. missing input schema), the rejection
-should be observable (log, diagnostic endpoint) so operators can spot it.
-
-**Why**: unclear. Not obviously a common property — the dropped tools
-don't all lack args (e.g. `long_running` takes `duration_seconds`). The
-dropped `boom` tool has no args AND raises; possibly the gateway
-validates return types or rejects tools without output schemas.
-Investigation needed to confirm whether this is intentional filtering
-or a silent federation bug.
-
-**How to close**: confirm root cause, either (a) fix federation to
-propagate all well-formed tools, or (b) document the filter rule
-explicitly so the reference server can sidestep it in the stubs it
-uses to exercise federation. Once federation covers the missing tools,
-re-probe every test in the "Tests" row and drop or narrow the
-`xfail_on` call individually as each passes. Tests that depend on a
-dropped tool AND a separate gap (e.g. `test_resources_updated_after_bump`
-needs GAP-009's resource federation too, and
-`test_tools_list_changed_notification_delivered` needs the
-POST-correlated notification relay tracked by GAP-001/002) will
-remain xfailed against the surviving gap after GAP-008 closes.
+**Fixing PR**: #4304 (this issue).
 
 ---
 

--- a/tests/live_gateway/protocol_compliance/test_drift.py
+++ b/tests/live_gateway/protocol_compliance/test_drift.py
@@ -85,10 +85,6 @@ async def _collect(drift_helper: Callable, collect_fn: Callable) -> dict[str, Op
 # ---------------------------------------------------------------------------
 # Drift probes
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(
-    strict=False,
-    reason=("GAP-008: gateway federation drops boom/bump_subscribable/mutate_tool_list/" "long_running from upstream — expected drift until federation filter is " "understood or fixed."),
-)
 async def test_drift_tool_names(drift_helper) -> None:
     """Normalized tool-name sets agree across every available target."""
 

--- a/tests/live_gateway/protocol_compliance/test_notifications.py
+++ b/tests/live_gateway/protocol_compliance/test_notifications.py
@@ -37,10 +37,8 @@ async def test_tools_list_changed_notification_delivered(connect, request) -> No
         "gateway_proxy",
         "gateway_virtual",
         reason=(
-            "GAP-008: gateway federation drops `mutate_tool_list`, so the trigger is "
-            "unreachable. Even with federation fixed, the list_changed notification "
-            "would still be blocked by the same POST-correlated-stream "
-            "notification-relay issue tracked in GAP-001/GAP-002."
+            "GAP-001/GAP-002: gateway does not relay list_changed notifications on the "
+            "POST-correlated stream — the notification never reaches the client."
         ),
     )
     observed_methods: list[str] = []
@@ -67,10 +65,8 @@ async def test_resources_list_changed_notification_delivered(connect, request) -
         "gateway_proxy",
         "gateway_virtual",
         reason=(
-            "GAP-008: gateway federation drops `mutate_resource_list`, so the trigger "
-            "is unreachable. Even with federation fixed, the list_changed "
-            "notification would still be blocked by the same POST-correlated-stream "
-            "notification-relay issue tracked in GAP-001/GAP-002."
+            "GAP-001/GAP-002: gateway does not relay list_changed notifications on the "
+            "POST-correlated stream — the notification never reaches the client."
         ),
     )
     observed_methods: list[str] = []
@@ -95,7 +91,7 @@ async def test_prompts_list_changed_notification_delivered(connect, request) -> 
         request,
         "gateway_proxy",
         "gateway_virtual",
-        reason=("GAP-006 (prompts not federated) + GAP-008 (mutate_prompt_list dropped by gateway). " "Both paths make the trigger unreachable via the gateway."),
+        reason="GAP-006: prompts not federated through gateway — tools are available but the prompt list remains empty.",
     )
     observed_methods: list[str] = []
 
@@ -119,7 +115,7 @@ async def test_resources_updated_after_bump(connect, request) -> None:
         request,
         "gateway_proxy",
         "gateway_virtual",
-        reason="GAP-008: gateway federation drops `bump_subscribable` (among other tools); " "also GAP-009 for the associated `reference://mutable/counter` resource",
+        reason="GAP-009: gateway does not federate resources through virtual-server paths — `reference://mutable/counter` is unreachable.",
     )
     async with connect() as client:
         name = await resolve_tool(client, "bump_subscribable")

--- a/tests/live_gateway/protocol_compliance/test_tools.py
+++ b/tests/live_gateway/protocol_compliance/test_tools.py
@@ -43,12 +43,6 @@ async def test_add_returns_sum(client: Client) -> None:
 
 
 async def test_tool_error_is_surfaced_as_is_error(client: Client, request) -> None:
-    xfail_on(
-        request,
-        "gateway_proxy",
-        "gateway_virtual",
-        reason="GAP-008: gateway federation drops `boom` (among other tools)",
-    )
     name = await resolve_tool(client, "boom")
     assert name is not None, "boom tool missing on reference target (unexpected)"
     result = await client.call_tool_mcp(name=name, arguments={})

--- a/tests/live_gateway/protocol_compliance/test_utilities.py
+++ b/tests/live_gateway/protocol_compliance/test_utilities.py
@@ -44,12 +44,6 @@ async def test_progress_notifications_delivered(connect, request) -> None:
 
 async def test_long_running_tool_is_cancellable(connect, request) -> None:
     """A long-running tool call can be cancelled via asyncio.wait_for."""
-    xfail_on(
-        request,
-        "gateway_proxy",
-        "gateway_virtual",
-        reason="GAP-008: gateway federation drops `long_running` (among other tools)",
-    )
     async with connect() as client:
         name = await resolve_tool(client, "long_running")
         assert name is not None, "long_running tool missing on reference target (unexpected)"
@@ -90,9 +84,8 @@ async def test_cancellation_notification_reaches_server(connect, request) -> Non
         "gateway_proxy",
         "gateway_virtual",
         reason=(
-            "GAP-008: gateway federation drops `long_running`, so the trigger is "
-            "unreachable. Even with federation fixed, the notification would need "
-            "relay on the POST-correlated stream (same shape as GAP-001/002)."
+            "GAP-001/GAP-002: gateway does not relay notifications on the POST-correlated "
+            "stream — the cancellation notification never reaches the server."
         ),
     )
 

--- a/tests/unit/mcpgateway/services/test_gateway_resources_prompts.py
+++ b/tests/unit/mcpgateway/services/test_gateway_resources_prompts.py
@@ -58,6 +58,7 @@ class TestGatewayResourcesPrompts:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Mock resources response
@@ -129,6 +130,7 @@ class TestGatewayResourcesPrompts:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
@@ -182,6 +184,7 @@ class TestGatewayResourcesPrompts:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Mock resources response - failure

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -2478,6 +2478,7 @@ class TestGatewayService:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {"type": "object"}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Mock resources response with URI handling
@@ -2540,6 +2541,7 @@ class TestGatewayService:
             # Mock tools response
             mock_tools_response = MagicMock()
             mock_tools_response.tools = []
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Mock resources response with complex URI object
@@ -2599,6 +2601,7 @@ class TestGatewayService:
             # Mock tools response
             mock_tools_response = MagicMock()
             mock_tools_response.tools = []
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Mock prompts response
@@ -2653,6 +2656,7 @@ class TestGatewayService:
             # Mock tools response
             mock_tools_response = MagicMock()
             mock_tools_response.tools = []
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Make list_resources fail
@@ -2698,6 +2702,7 @@ class TestGatewayService:
             # Mock tools response
             mock_tools_response = MagicMock()
             mock_tools_response.tools = []
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Make list_prompts fail
@@ -3277,6 +3282,7 @@ class TestGatewayRefresh:
         long_name_tool.model_dump.return_value = {"name": long_name, "inputSchema": {}}
         mock_list_tools = MagicMock()
         mock_list_tools.tools = [valid_tool, long_name_tool]
+        mock_list_tools.nextCursor = None
         mock_session.list_tools.return_value = mock_list_tools
 
         mock_sse_cm = AsyncMock()
@@ -3358,6 +3364,7 @@ class TestGatewayRefresh:
 
         mock_list_tools = MagicMock()
         mock_list_tools.tools = [MagicMock(model_dump=MagicMock(return_value={"name": "tool1", "inputSchema": {}}))]
+        mock_list_tools.nextCursor = None
         mock_session.list_tools.return_value = mock_list_tools
 
         mock_list_resources = MagicMock()
@@ -3401,6 +3408,7 @@ class TestGatewayRefresh:
 
         mock_list_tools = MagicMock()
         mock_list_tools.tools = []
+        mock_list_tools.nextCursor = None
         mock_session.list_tools.return_value = mock_list_tools
 
         # Simulate failures
@@ -4104,8 +4112,8 @@ async def test_connect_to_sse_server_without_validation_fallbacks(monkeypatch):
             capabilities = SimpleNamespace(model_dump=lambda **_kw: {"resources": True, "prompts": True})
             return DummyResponse(capabilities=capabilities)
 
-        async def list_tools(self):
-            return DummyResponse(tools=[DummyTool()])
+        async def list_tools(self, cursor=None):
+            return DummyResponse(tools=[DummyTool()], nextCursor=None)
 
         async def list_resources(self):
             return DummyResponse(resources=[DummyResource()])
@@ -4213,8 +4221,8 @@ async def test_connect_to_streamablehttp_server_resources_and_prompts(monkeypatc
             capabilities = SimpleNamespace(model_dump=lambda **_kw: {"resources": True, "prompts": True})
             return DummyResponse(capabilities=capabilities)
 
-        async def list_tools(self):
-            return DummyResponse(tools=[DummyTool()])
+        async def list_tools(self, cursor=None):
+            return DummyResponse(tools=[DummyTool()], nextCursor=None)
 
         async def list_resources(self):
             return DummyResponse(resources=[DummyResource()])
@@ -4331,8 +4339,8 @@ async def test_connect_to_sse_server_resources_and_prompts(monkeypatch):
             capabilities = SimpleNamespace(model_dump=lambda **_kw: {"resources": True, "prompts": True})
             return DummyResponse(capabilities=capabilities)
 
-        async def list_tools(self):
-            return DummyResponse(tools=[DummyTool()])
+        async def list_tools(self, cursor=None):
+            return DummyResponse(tools=[DummyTool()], nextCursor=None)
 
         async def list_resources(self):
             return DummyResponse(resources=[DummyResource()])

--- a/tests/unit/mcpgateway/services/test_gateway_service_extended.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service_extended.py
@@ -91,6 +91,7 @@ class TestGatewayServiceExtended:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
@@ -139,6 +140,7 @@ class TestGatewayServiceExtended:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {"name": "test_tool", "description": "Test tool", "inputSchema": {}}
             mock_tools_response.tools = [mock_tool]
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             # Execute
@@ -206,6 +208,7 @@ class TestGatewayServiceExtended:
 
             mock_tools_response = MagicMock()
             mock_tools_response.tools = []
+            mock_tools_response.nextCursor = None
             mock_session_instance.list_tools.return_value = mock_tools_response
 
             await service._initialize_gateway(


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #4304 
Root cause
session.list_tools() was called once per federation path, discarding nextCursor. The reference server registers 120 stub_NNN tools beyond the first page; tools on subsequent pages were silently dropped.

Fix
Added _fetch_all_tools(session) static method (gateway_service.py:5507) that loops over paginated responses, then replaced response = await session.list_tools() / tools = response.tools with tools = await self._fetch_all_tools(session) at all three call sites:
connect_to_sse_server_without_validation (line 5616)
connect_to_sse_server (line 5794)
connect_to_streamablehttp_server (line 5959)

Test Results

  ✅ test_drift_tool_names: PASSED - All 136 tools now surface correctly across all targets
  ✅ test_tool_error_is_surfaced_as_is_error: PASSED - The boom tool is now available
  ✅ test_long_running_tool_is_cancellable: PASSED - The long_running tool is now available


 Documentation Updates

  ✅ COMPLIANCE_GAPS.md: Properly updated to mark GAP-008 as closed with detailed explanation
  ✅ Test xfail markers removed: All GAP-008 related xfail decorators have been removed from:
  - test_drift.py
  - test_tools.py
  - test_utilities.py
  - test_notifications.py (updated to attribute remaining failures to other gaps)


