### PR TITLE
fix(chore): collapse identical if/elif auth branches in catalog_service.py

### DIFF
--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -312,12 +312,8 @@ class CatalogService:
 
             if request and request.api_key and auth_type != "Open":
                 # Handle all possible auth types from the catalog
-                if auth_type in ["API Key", "API"]:
-                    # Use bearer token for API key authentication
-                    gateway_data["auth_type"] = "bearer"
-                    gateway_data["auth_token"] = request.api_key
-                elif auth_type in ["OAuth2.1", "OAuth", "OAuth2.1 & API Key"]:
-                    # OAuth servers and mixed auth may need API key as a bearer token
+                if auth_type in ["API Key", "API", "OAuth2.1", "OAuth", "OAuth2.1 & API Key"]:
+                    # Use bearer token for API key and OAuth authentication
                     gateway_data["auth_type"] = "bearer"
                     gateway_data["auth_token"] = request.api_key
                 else:


### PR DESCRIPTION
## 📌 Summary
Removes duplicate code flagged by SonarQube rule `python:S3923`. Two consecutive `if`/`elif` branches in `catalog_service.py` performed identical operations — setting `auth_type` to `"bearer"` and assigning `auth_token` from `request.api_key` — for `["API Key", "API"]` and `["OAuth2.1", "OAuth", "OAuth2.1 & API Key"]` respectively. They have been collapsed into a single condition with no behaviour change.

## 🔗 Related Issue
Closes: #2381

## 🔁 Reproduction Steps
See [#2381](https://github.com/IBM/mcp-context-forge/issues/2381). SonarQube reports `python:S3923` (all branches of an if/elif chain have identical implementations) at `mcpgateway/services/catalog_service.py` lines 310–317.

## 🐞 Root Cause
The `if auth_type in ["API Key", "API"]` and `elif auth_type in ["OAuth2.1", "OAuth", "OAuth2.1 & API Key"]` branches were written separately, likely in anticipation of future differentiation, but both bodies were identical. SonarQube correctly flagged this as dead/duplicate logic.

## 💡 Fix Description
Combined both conditions into a single `if` using `in` membership:

```python
if auth_type in ["API Key", "API", "OAuth2.1", "OAuth", "OAuth2.1 & API Key"]:
    gateway_data["auth_type"] = "bearer"
    gateway_data["auth_token"] = request.api_key
```

No logic change — the `else` branch (custom `authheaders`) and the outer `elif auth_type in ["OAuth2.1", "OAuth"]` (skip-initialization path) are untouched.

## 🧪 Verification

| Check                             | Command             | Status |
|-----------------------------------|---------------------|--------|
| Lint suite                        | `make lint`         |    Pass    |
| Unit tests                        | `make test`         |    Pass    |
| Coverage ≥ 90 %                   | `make coverage`     |   Pass     |
| Manual regression no longer fails | steps / screenshots |   Pass     |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed