### PR TITLE
docs: clarify section 14 manual testing expected behaviours

### DIFF
--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -1012,7 +1012,7 @@ export MCPGATEWAY_ADMIN_TOKEN=$(./.venv/bin/python -m mcpgateway.utils.create_jw
   --username admin@example.com \
   --admin \
   --exp 10080 \
-  --secret "${JWT_SECRET_KEY:-my-test-key-but-now-longer-than-32-bytes}" \
+  --secret "$JWT_SECRET_KEY" \
   --algo HS256 \
   2>/dev/null | tail -n 1)
 

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -1205,7 +1205,18 @@ The migration test suite follows an **n-2 support policy** and tests sequential 
 
 ## 14. Manual Testing
 
-These tests verify core user-facing workflows that automated tests do not fully cover. Build and start the compose stack first:
+These tests verify core user-facing workflows that automated tests do not fully cover.
+
+Before starting, ensure `.env` has a real JWT secret (the default `.env` ships with a placeholder that breaks token authentication):
+
+```bash
+# Generate secrets and merge into .env (skip if already done)
+make init-secrets
+# Confirm JWT_SECRET_KEY is no longer the placeholder
+grep JWT_SECRET_KEY .env   # must not contain __REPLACE_ME__
+```
+
+Build and start the compose stack:
 
 ```bash
 make docker-prod && make testing-up
@@ -1216,10 +1227,13 @@ make docker-prod && make testing-up
 Create a token for API and client access:
 
 ```bash
+# JWT_SECRET_KEY must match the value in .env (run make init-secrets if not set)
+export JWT_SECRET_KEY=$(grep '^JWT_SECRET_KEY=' .env | cut -d= -f2-)
+
 export MCPGATEWAY_BEARER_TOKEN=$(python -m mcpgateway.utils.create_jwt_token \
   --username admin@example.com \
   --exp 10080 \
-  --secret my-test-key-but-now-longer-than-32-bytes)
+  --secret "$JWT_SECRET_KEY")
 
 export BASE_URL="http://localhost:8080"
 ```
@@ -1246,6 +1260,8 @@ curl -s -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 curl -s -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" $BASE_URL/tools | jq
 ```
 
+**Expected:** Each tool object contains `gateway_id` (UUID of the registering gateway) but no `gateway_name` field — the `/tools` API does not denormalize the gateway name. To resolve a human-readable name, call `GET /gateways/<gateway_id>`. This is by design.
+
 ### 14.3 Register an MCP server via Streamable HTTP
 
 Streamable HTTP transport requires the `--expose-streamable-http` flag and an explicit `"transport":"STREAMABLEHTTP"` field in the registration payload — the gateway does not auto-detect transport from the URL:
@@ -1268,6 +1284,8 @@ curl -s -X POST -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
 curl -s -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" $BASE_URL/tools | jq
 ```
 
+**Expected:** Tools from both gateways appear in the catalog, each with `gateway_id` populated. As with SSE, `gateway_name` is not included in the response; use `GET /gateways/<gateway_id>` to resolve the name.
+
 ### 14.4 Create a virtual server and export it
 
 The request body must wrap the server fields under a `"server"` key:
@@ -1286,8 +1304,11 @@ curl -s -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" $BASE_URL/servers | 
 Export the configuration for backup verification. Override `HOST`/`PORT` via env — do not use a `--url` flag:
 
 ```bash
-HOST=localhost PORT=8080 python -m mcpgateway.cli export --out release-test-export.json
+MCPGATEWAY_BEARER_TOKEN=$MCPGATEWAY_BEARER_TOKEN HOST=localhost PORT=8080 \
+  python -m mcpgateway.cli export --out release-test-export.json
 ```
+
+**Expected:** The export file contains the virtual server, both registered gateways, and any standalone (local REST) tools. MCP gateway-discovered tools — those imported from an upstream MCP server — are intentionally excluded from the `tools` list in the export. They are considered ephemeral: when the gateway is re-imported, the tools are re-discovered automatically. Only standalone tools created directly via `POST /tools` appear as independent exported entities. Verify that `entities.gateways` contains both `release_test_sse` and `release_test_streamable`, and `entities.servers` contains `release_test_server`.
 
 ### 14.5 Test with MCP Inspector
 
@@ -1311,6 +1332,8 @@ Repeat with **Streamable HTTP**:
 2. Set **URL** to `$BASE_URL/servers/<VIRTUAL_SERVER_UUID>/mcp`
 3. Set the same Authorization header
 4. Verify: tools list loads and tool calls execute correctly
+
+> **Note:** Streamable HTTP is a stateful protocol. Before `tools/list` can be called, the client must complete an `initialize` handshake, which the server responds to with a `Mcp-Session-Id` header. All subsequent requests must include that header. MCP Inspector handles this automatically. Raw `curl` calls that skip `initialize` will receive a `-32600 Missing session ID` error — this is expected protocol behaviour, not a gateway bug.
 
 ### 14.6 Test with VS Code (GitHub Copilot)
 

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -1008,6 +1008,8 @@ curl -sS -X POST "$BASE_URL/servers/$SERVER_ID/mcp/" \
 Check the plugin framework is healthy via the Admin UI or API. The bearer token must have the `admin.plugins` permission, so generate a platform admin token before calling the endpoint:
 
 ```bash
+export JWT_SECRET_KEY=$(grep '^JWT_SECRET_KEY=' .env | cut -d= -f2-)
+
 export MCPGATEWAY_ADMIN_TOKEN=$(./.venv/bin/python -m mcpgateway.utils.create_jwt_token \
   --username admin@example.com \
   --admin \


### PR DESCRIPTION
## Summary

Documents five behaviours in section 14 that were undocumented or incorrect and caused failures during v1.0.2 manual testing. No code changes — doc only.

**14 (preamble) — `make init-secrets` prerequisite**
The default `.env` ships with `JWT_SECRET_KEY=__REPLACE_ME__...`. Fresh environments that skip `make init-secrets` generate tokens signed with the wrong key; every API call returns 401 with no obvious cause. Added a prerequisite block at the top of section 14 with the `make init-secrets` command and a `grep` check.

**14.1 — Token generation used a hardcoded `--secret` value**
Original command passed `--secret my-test-key-but-now-longer-than-32-bytes`, which will not match `JWT_SECRET_KEY` on any real deployment. Fixed to extract `JWT_SECRET_KEY` from `.env` via `grep` and pass `"$JWT_SECRET_KEY"` to `--secret`.

**14.2 / 14.3 — `gateway_name` absent from `/tools` API response**
The `ToolRead` schema returns `gateway_id` (UUID) but not a human-readable gateway name. Added an "Expected" note explaining this is by design and directing callers to `GET /gateways/<gateway_id>`.

**14.4 — Export command missing `MCPGATEWAY_BEARER_TOKEN`**
`python -m mcpgateway.cli export` requires auth; the original command omitted the env var and failed with `No authentication configured`. Fixed by prepending `MCPGATEWAY_BEARER_TOKEN=$MCPGATEWAY_BEARER_TOKEN` to the export command.

**14.4 — Export excludes MCP gateway-discovered tools**
`export_service.py` filters out tools with `integration_type == "MCP" and gateway_id set` — they are ephemeral and re-discovered on import. Added an "Expected" note explaining the filter, what is included, and what to verify in the export file.

**14.5 — Streamable HTTP requires `initialize` before `tools/list`**
Streamable HTTP is stateful. Clients must complete the `initialize` handshake and receive a `Mcp-Session-Id` before calling `tools/list`. MCP Inspector handles this silently; raw `curl` without `initialize` returns `-32600 Missing session ID`. Added a note explaining the protocol requirement.

Closes #4896