### PR TITLE
fix(init-secrets): merge into .env when present, warn on real values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,20 @@ check-env-dev:
 init-secrets: ## Generate secure secrets for the gateway (US-3)
 	python3 -m mcpgateway.scripts.init_secrets
 
+.PHONY: check-secrets
+check-secrets: ## Warn if .env secrets are still placeholders (run 'make init-secrets' first)
+	@if [ ! -f .env ]; then \
+		echo ""; \
+		echo "⚠️  WARNING: .env not found."; \
+		echo "   Run 'make init-secrets' to generate secrets before starting services."; \
+		echo ""; \
+	elif grep -qE '^(JWT_SECRET_KEY|AUTH_ENCRYPTION_SECRET|BASIC_AUTH_PASSWORD|PLATFORM_ADMIN_PASSWORD)=(__REPLACE_ME__|changeme)' .env 2>/dev/null; then \
+		echo ""; \
+		echo "⚠️  WARNING: .env contains placeholder secrets (__REPLACE_ME__ / changeme)."; \
+		echo "   Run 'make init-secrets' before starting production or testing services."; \
+		echo ""; \
+	fi
+
 # =============================================================================
 # ▶️ SERVE
 # =============================================================================
@@ -1672,7 +1686,7 @@ HOST_UID ?= $(shell id -u 2>/dev/null || echo 1000)
 HOST_GID ?= $(shell id -g 2>/dev/null || echo 1000)
 
 .PHONY: testing-up
-testing-up:                                ## Start testing stack (Locust + A2A echo + fast_test_server)
+testing-up: check-secrets                  ## Start testing stack (Locust + A2A echo + fast_test_server)
 	@echo "🧪 Starting testing stack (fast_test_server)..."
 	@echo "   🦗 Locust workers: $(TESTING_LOCUST_WORKERS) (override: TESTING_LOCUST_WORKERS=4 make testing-up)"
 	@# Fail early if port 8080 is already bound (nginx needs it)
@@ -5797,7 +5811,7 @@ docker-dev:
 docker:
 	@$(MAKE) container-build CONTAINER_RUNTIME=docker
 
-docker-prod:
+docker-prod: check-secrets
 	@DOCKER_CONTENT_TRUST=1 $(MAKE) container-build CONTAINER_RUNTIME=docker
 
 docker-prod-rust:

--- a/mcpgateway/scripts/init_secrets.py
+++ b/mcpgateway/scripts/init_secrets.py
@@ -10,6 +10,7 @@ encryption, and administrative passwords. It supports writing to a file,
 overwriting existing configurations, or piping to stdout.
 
 Usage:
+    python -m mcpgateway.scripts.init_secrets            # merges into .env if exists, else writes .env.secrets
     python -m mcpgateway.scripts.init_secrets --output .env.secrets
     python -m mcpgateway.scripts.init_secrets --stdout --force
 """
@@ -224,9 +225,12 @@ def main() -> None:
 
     Parses arguments, generates required secrets for the Gateway,
     and handles file I/O operations or stdout printing.
+
+    When no ``--output`` is given: merges secrets into ``.env`` if it exists,
+    otherwise writes a new ``.env.secrets`` file.
     """
     parser = argparse.ArgumentParser(description="Generate secure secrets for MCP Gateway deployment.")
-    parser.add_argument("--output", type=str, default=".env.secrets", help="Output file path")
+    parser.add_argument("--output", type=str, default=None, help="Output file path (default: .env if it exists, else .env.secrets)")
     parser.add_argument("--force", action="store_true", help="Overwrite existing file if it exists")
     parser.add_argument("--stdout", action="store_true", help="Print secrets to stdout instead of a file")
 
@@ -248,6 +252,41 @@ def main() -> None:
     if args.stdout:
         print(output_content, end="")
         return
+
+    # Auto-detect target: merge into .env if it exists, otherwise write .env.secrets
+    env_file_exists = os.path.isfile(".env")
+    if args.output is None:
+        if env_file_exists:
+            existing = _read_env_file(".env")
+            keys_with_real_values = [
+                key for key in secrets_map
+                if key in existing
+                and existing[key].lower() not in _WEAK_VALUES
+                and not existing[key].lower().startswith("__replace_me__")
+            ]
+            if keys_with_real_values:
+                print("Warning: the following keys in .env already have non-placeholder values:")
+                for key in keys_with_real_values:
+                    print(f"  {key}")
+                print("Replacing these will overwrite existing secrets.")
+                try:
+                    answer = input("Continue? [y/N] ").strip().lower()
+                except EOFError:
+                    answer = ""
+                if answer not in ("y", "yes"):
+                    print("Aborted. No changes made.")
+                    return
+            try:
+                _merge_env_file(".env", secrets_map)
+                print("Secrets merged into .env")
+                print("\nNext steps:")
+                print("1. Review the updated secrets in .env")
+                print("2. IMPORTANT: Keep .env secure and never commit it to Git.")
+            except OSError as e:
+                print(f"Error: Could not write to .env: {e}")
+                sys.exit(1)
+            return
+        args.output = ".env.secrets"
 
     try:
         _write_secrets_file(args.output, output_content, args.force)

--- a/tests/scripts/test_init_secrets.py
+++ b/tests/scripts/test_init_secrets.py
@@ -365,3 +365,117 @@ class TestEnsureEnvFileSecrets:
         env = tmp_path / ".env"
         env.write_text("JWT_SECRET_KEY=changeme # generated\n", encoding="utf-8")
         assert _read_env_file(str(env))["JWT_SECRET_KEY"] == "changeme"
+
+
+# --- Auto-detect target: .env vs .env.secrets ---
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_merges_into_env_when_env_exists(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """No --output + .env present → all 4 secrets merged into .env, other keys preserved."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("JWT_SECRET_KEY=changeme\nOTHER=keep\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    main()
+
+    content = env_file.read_text(encoding="utf-8")
+    assert "OTHER=keep" in content
+    assert "JWT_SECRET_KEY=changeme" not in content
+    assert "JWT_SECRET_KEY=" in content
+    assert "AUTH_ENCRYPTION_SECRET=" in content
+    assert "BASIC_AUTH_PASSWORD=" in content
+    assert "PLATFORM_ADMIN_PASSWORD=" in content
+    assert not (tmp_path / ".env.secrets").exists()
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_writes_env_secrets_when_no_env(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """No --output + no .env → writes .env.secrets with all 4 secrets."""
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    main()
+
+    secrets_file = tmp_path / ".env.secrets"
+    assert secrets_file.exists()
+    content = secrets_file.read_text(encoding="utf-8")
+    assert "JWT_SECRET_KEY=" in content
+    assert "AUTH_ENCRYPTION_SECRET=" in content
+    assert "BASIC_AUTH_PASSWORD=" in content
+    assert "PLATFORM_ADMIN_PASSWORD=" in content
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_no_warning_for_placeholder_values(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """Placeholder (__REPLACE_ME__) and weak values in .env → no confirmation prompt."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "JWT_SECRET_KEY=__REPLACE_ME__run_init-secrets\n"
+        "AUTH_ENCRYPTION_SECRET=changeme\n"
+        "BASIC_AUTH_PASSWORD=changeme\n"
+        "PLATFORM_ADMIN_PASSWORD=changeme\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    with patch("builtins.input") as mock_input:
+        main()
+        mock_input.assert_not_called()
+
+    content = env_file.read_text(encoding="utf-8")
+    assert "JWT_SECRET_KEY=__REPLACE_ME__" not in content
+    assert "JWT_SECRET_KEY=" in content
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_warns_and_proceeds_on_yes(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """Real values in .env → warning shown, user confirms 'y' → secrets replaced."""
+    strong = "x3Kp_mQ8rZvN2wLsA5dYfB7cEjGhTuIo_X3K"  # pragma: allowlist secret
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"JWT_SECRET_KEY={strong}\nOTHER=keep\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    with patch("builtins.input", return_value="y") as mock_input:
+        main()
+        mock_input.assert_called_once()
+
+    content = env_file.read_text(encoding="utf-8")
+    assert f"JWT_SECRET_KEY={strong}" not in content
+    assert "JWT_SECRET_KEY=" in content
+    assert "OTHER=keep" in content
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_warns_and_aborts_on_no(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """Real values in .env → warning shown, user declines → .env unchanged."""
+    strong = "x3Kp_mQ8rZvN2wLsA5dYfB7cEjGhTuIo_X3K"  # pragma: allowlist secret
+    original = f"JWT_SECRET_KEY={strong}\nOTHER=keep\n"
+    env_file = tmp_path / ".env"
+    env_file.write_text(original, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    with patch("builtins.input", return_value="n"):
+        main()
+
+    assert env_file.read_text(encoding="utf-8") == original
+
+
+@patch("argparse.ArgumentParser.parse_args")
+def test_main_warns_and_aborts_on_eof(mock_args: MagicMock, tmp_path: Path, monkeypatch) -> None:
+    """Real values in .env → EOFError on input (non-interactive) → aborts safely."""
+    strong = "x3Kp_mQ8rZvN2wLsA5dYfB7cEjGhTuIo_X3K"  # pragma: allowlist secret
+    original = f"JWT_SECRET_KEY={strong}\n"
+    env_file = tmp_path / ".env"
+    env_file.write_text(original, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    mock_args.return_value = argparse.Namespace(output=None, force=False, stdout=False)
+
+    with patch("builtins.input", side_effect=EOFError):
+        main()
+
+    assert env_file.read_text(encoding="utf-8") == original


### PR DESCRIPTION
## Summary

- `make init-secrets` now auto-detects `.env`: merges all 4 secrets
  (`JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, `BASIC_AUTH_PASSWORD`,
  `PLATFORM_ADMIN_PASSWORD`) in-place when `.env` exists, preserving all
  other variables; falls back to writing `.env.secrets` when `.env` is absent
- `--output` default changed from `.env.secrets` to `None` so auto-detection
  can take effect; explicit `--output`, `--force`, and `--stdout` unchanged
- Before overwriting a key that already holds a real (non-placeholder) value,
  prompts `Continue? [y/N]`; `EOFError` (non-interactive / piped) treats as
  `N` and aborts safely without modifying `.env`
- New `make check-secrets` target warns when `.env` contains `__REPLACE_ME__`
  or `changeme` values; wired as a prerequisite to `docker-prod` and
  `testing-up` so operators are notified before launching services with weak
  secrets
- 6 new unit tests added (44 total, all passing):
  - auto-merge into `.env` when present
  - fallback to `.env.secrets` when `.env` absent
  - no confirmation prompt for placeholder/weak values
  - confirmation prompt + proceed on `y`
  - confirmation prompt + abort on `n`
  - safe abort on `EOFError` (non-interactive)

Closes #4899