### PR TITLE
feat(tools): implement tool lifecycle management with sunsetDate field

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2198,7 +2198,7 @@
         "hashed_secret": "d20047e4dff166045c7f61066c62955ec33c1657",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 820,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2206,7 +2206,7 @@
         "hashed_secret": "fc19bda36b0af2d6a957034199a79c6583c707a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 981,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2214,7 +2214,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 999,
+        "line_number": 1149,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2222,7 +2222,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1426,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2230,7 +2230,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1547,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2310,7 +2310,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1284,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2318,7 +2318,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1288,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4248,7 +4248,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4419,
+        "line_number": 4507,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-26T16:10:47Z",
+  "generated_at": "2026-06-29T08:21:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docs/docs/architecture/tool-invocation-and-validation.md
+++ b/docs/docs/architecture/tool-invocation-and-validation.md
@@ -171,15 +171,26 @@ Before any validation layers execute, tool invocation checks the tool's lifecycl
 **Rule:**
 
 ```python
-if not tool.enabled:
-    raise ToolNotFoundError(f"Tool {tool_name} not found or not available")
+# Check if tool is sunset (past sunset_date)
+sunset_date_str = tool_payload.get("sunset_date")
+if sunset_date_str:
+    sunset_date = dateutil_parser.isoparse(sunset_date_str)
+    now = datetime.now(timezone.utc)
+    if sunset_date.tzinfo is None:
+        sunset_date = sunset_date.replace(tzinfo=timezone.utc)
+    if sunset_date <= now:
+        raise ToolInvocationError(
+            f"Tool '{name}' has been sunset and can no longer be executed. "
+            f"Sunset date: {sunset_date.strftime('%Y-%m-%d')}. "
+            f"Please update your agent to use an alternative tool."
+        )
 ```
 
 **Behavior:**
 
-1. **Active tools** (`deprecated=false, enabled=true`): Execute normally through validation pipeline
-2. **Deprecated tools** (`deprecated=true, enabled=true`): Execute normally with lifecycle metadata in response
-3. **Sunset tools** (`deprecated=true, enabled=false`): Blocked before any validation occurs
+1. **Active tools** (`deprecated=false`): Execute normally through validation pipeline
+2. **Deprecated tools** (`deprecated=true, sunset_date` in future): Execute normally with lifecycle metadata in response
+3. **Sunset tools** (`sunset_date <= now()`): Blocked before any validation occurs with descriptive error message
 
 ### Automated Sunset Transition
 
@@ -188,7 +199,7 @@ Tools transition from deprecated to sunset automatically:
 - **Scheduler:** Background service runs every 60 minutes (configurable via `SUNSET_SCHEDULER_INTERVAL_MINUTES`)
 - **Query:** `WHERE deprecated=true AND sunset_date <= now() AND enabled=true`
 - **Action:** Atomically sets `enabled=false` and invalidates tool cache
-- **Effect:** Subsequent invocation attempts return `404 Not Found`
+- **Effect:** Subsequent invocation attempts are blocked during the sunset date check in `invoke_tool` (the `enabled=false` flag is set by scheduler for consistency, but invocation blocking is based on `sunset_date <= now()` comparison)
 
 ### Integration with Validation Pipeline
 

--- a/docs/docs/architecture/tool-invocation-and-validation.md
+++ b/docs/docs/architecture/tool-invocation-and-validation.md
@@ -150,6 +150,117 @@ A2A tools do not currently route through Validator B. In practice this means gat
 [#4207]: https://github.com/IBM/mcp-context-forge/issues/4207
 [#4208]: https://github.com/IBM/mcp-context-forge/issues/4208
 
+## Tool Lifecycle State Enforcement
+
+Before any validation layers execute, tool invocation checks the tool's lifecycle state to determine if execution is permitted.
+
+### Lifecycle States
+
+| State | `deprecated` | `enabled` | `sunsetDate` | Executable |
+|-------|--------------|-----------|--------------|------------|
+| **Active** | `false` | `true` | N/A | ✅ Yes |
+| **Deprecated** | `true` | `true` | Future or NULL | ✅ Yes |
+| **Sunset** | `true` | `false` | Past | ❌ No |
+
+### Enforcement Point
+
+**Where:** `mcpgateway/services/tool_service.py::invoke_tool` (before backend dispatch)
+
+**When:** Every tool invocation, regardless of integration type (MCP, REST, A2A, etc.)
+
+**Rule:**
+
+```python
+if not tool.enabled:
+    raise ToolNotFoundError(f"Tool {tool_name} not found or not available")
+```
+
+**Behavior:**
+
+1. **Active tools** (`deprecated=false, enabled=true`): Execute normally through validation pipeline
+2. **Deprecated tools** (`deprecated=true, enabled=true`): Execute normally with lifecycle metadata in response
+3. **Sunset tools** (`deprecated=true, enabled=false`): Blocked before any validation occurs
+
+### Automated Sunset Transition
+
+Tools transition from deprecated to sunset automatically:
+
+- **Scheduler:** Background service runs every 60 minutes (configurable via `SUNSET_SCHEDULER_INTERVAL_MINUTES`)
+- **Query:** `WHERE deprecated=true AND sunset_date <= now() AND enabled=true`
+- **Action:** Atomically sets `enabled=false` and invalidates tool cache
+- **Effect:** Subsequent invocation attempts return `404 Not Found`
+
+### Integration with Validation Pipeline
+
+Lifecycle enforcement occurs **before** any validation layer:
+
+```
+Tool invocation request
+        ↓
+┌───────────────────────────────┐
+│ Lifecycle State Check         │
+│ • enabled=false? → 404        │
+│ • enabled=true? → continue    │
+└───────────────────────────────┘
+        ↓
+┌───────────────────────────────┐
+│ Backend Dispatch              │
+│ (MCP, REST, A2A, etc.)        │
+└───────────────────────────────┘
+        ↓
+┌───────────────────────────────┐
+│ Validator A/B/C               │
+│ (per integration type)        │
+└───────────────────────────────┘
+        ↓
+Response to client
+```
+
+**Key invariant:** Sunset tools never reach the validation pipeline. The lifecycle check acts as a fail-fast gate.
+
+### Error Response Format
+
+When a sunset tool is invoked:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "Tool not found or not available"
+  }
+}
+```
+
+**Rationale:** Sunset tools return the same error as non-existent tools. This prevents clients from distinguishing between deleted and sunset tools, simplifying the deprecation workflow.
+
+### Resurrection Path
+
+Sunset tools can be resurrected by setting `deprecated=false`:
+
+```python
+# Automatically sets enabled=true and clears sunset_date
+tool.deprecated = False
+# Tool returns to "active" lifecycle state
+```
+
+### Testing Coverage
+
+Unit tests:
+
+- `tests/unit/mcpgateway/services/test_tool_service.py::test_sunset_date_cleared_when_deprecated_false` — Verifies `sunset_date` is cleared when `deprecated=False`
+- `tests/integration/test_tool_lifecycle_management.py::TestToolLifecycleExecution::test_sunset_tool_not_executable` — Verifies sunset tools blocked from execution
+
+Integration tests:
+
+- `tests/integration/test_tool_lifecycle_regression.py::TestToolLifecycleInvocationRegression::test_tool_invocation_blocked_after_scheduler_disables` — End-to-end flow: scheduler sunset → invocation blocked
+- `tests/integration/test_tool_lifecycle_regression.py::TestToolLifecycleInvocationRegression::test_concurrent_invocations_during_sunset_transition` — Race condition handling
+
+### Documentation
+
+See [Tool Lifecycle Management](../manage/tool-lifecycle.md) for end-user documentation.
+
 ## Known gaps and follow-ups
 
 - **[#4207] — e2e coverage for non-MCP paths.** REST (incl. OpenAPI-imported) tools have Validator B as their only gateway-side enforcement, and A2A has none (see the "option B" item below). Today those paths are covered by unit tests but not by `make test-mcp-protocol-e2e` e2e tests.

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -684,7 +684,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"deprecated": true}' \
   $BASE_URL/tools/$TOOL_ID
-# Response: {"detail": "sunsetDate is required when deprecated=True"}
+# Response: {"detail": "sunsetDate is required when deprecated=True. Please provide a future date when this tool will be sunset."}
 
 # ❌ FAILS: sunsetDate must be in the future
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
@@ -694,7 +694,7 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
     "sunsetDate": "2020-01-01T00:00:00Z"
   }' \
   $BASE_URL/tools/$TOOL_ID
-# Response: {"detail": "sunsetDate must be in the future"}
+# Response: {"detail": "sunsetDate must be in the future. Provided: 2020-01-01T00:00:00+00:00, Current time: 2026-06-26T..."}
 
 # ✅ SUCCEEDS: Valid future sunsetDate
 curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
@@ -776,7 +776,7 @@ curl -s -X POST -H "Authorization: Bearer $TOKEN" \
     }
   }' \
   $BASE_URL/rpc
-# Response: {"error": {"code": -32001, "message": "Tool not found or not available"}}
+# Response: {"error": {"code": -32603, "message": "Tool 'sunset_tool' has been sunset and can no longer be executed. Sunset date: 2026-06-26. Please update your agent to use an alternative tool."}}
 ```
 
 ### Enable/Disable Tool

--- a/docs/docs/manage/api-usage.md
+++ b/docs/docs/manage/api-usage.md
@@ -629,6 +629,156 @@ curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
   $BASE_URL/tools/$TOOL_ID | jq '.'
 ```
 
+### Tool Lifecycle Management
+
+Tools have three lifecycle states: **Active → Deprecated → Sunset**. See [Tool Lifecycle Management](./tool-lifecycle.md) for complete documentation.
+
+#### Deprecate a Tool
+
+When deprecating a tool, you **must** provide a `sunsetDate` (future date in UTC):
+
+```bash
+# Deprecate tool with 90-day sunset period
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2026-12-31T23:59:59Z"
+  }' \
+  $BASE_URL/tools/$TOOL_ID | jq '.'
+```
+
+**Response with lifecycle fields:**
+
+```json
+{
+  "id": 123,
+  "name": "legacy_tool",
+  "description": "Old tool being phased out",
+  "deprecated": true,
+  "sunsetDate": "2026-12-31T23:59:59Z",
+  "enabled": true,
+  "lifecycleState": "deprecated",
+  "daysUntilSunset": 189,
+  "isExecutable": true,
+  ...
+}
+```
+
+#### Lifecycle Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `deprecated` | boolean | Whether tool is deprecated |
+| `sunsetDate` | string (ISO 8601) | When tool will be automatically disabled (required when `deprecated=true`) |
+| `enabled` | boolean | Whether tool is currently enabled |
+| `lifecycleState` | string | Current state: `active`, `deprecated`, or `sunset` (read-only) |
+| `daysUntilSunset` | integer | Days remaining until sunset (null for active tools, read-only) |
+| `isExecutable` | boolean | Whether tool can be invoked (read-only) |
+
+#### Validation Rules
+
+```bash
+# ❌ FAILS: sunsetDate required when deprecated=true
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"deprecated": true}' \
+  $BASE_URL/tools/$TOOL_ID
+# Response: {"detail": "sunsetDate is required when deprecated=True"}
+
+# ❌ FAILS: sunsetDate must be in the future
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2020-01-01T00:00:00Z"
+  }' \
+  $BASE_URL/tools/$TOOL_ID
+# Response: {"detail": "sunsetDate must be in the future"}
+
+# ✅ SUCCEEDS: Valid future sunsetDate
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2026-12-31T23:59:59Z"
+  }' \
+  $BASE_URL/tools/$TOOL_ID | jq '.'
+```
+
+#### Resurrect a Tool
+
+Clear deprecation flag to resurrect a sunset tool:
+
+```bash
+# Setting deprecated=false automatically clears sunsetDate
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"deprecated": false}' \
+  $BASE_URL/tools/$TOOL_ID | jq '.'
+```
+
+**Response:**
+
+```json
+{
+  "id": 123,
+  "name": "legacy_tool",
+  "deprecated": false,
+  "sunsetDate": null,
+  "enabled": true,
+  "lifecycleState": "active",
+  "daysUntilSunset": null,
+  "isExecutable": true,
+  ...
+}
+```
+
+#### View Lifecycle State
+
+```bash
+# List all tools (excludes sunset tools by default)
+curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/tools | jq '.'
+
+# Include sunset tools (admin view)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$BASE_URL/tools?include_inactive=true" | jq '.'
+
+# Filter deprecated tools only
+curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/tools | \
+  jq '.tools[] | select(.lifecycleState == "deprecated")'
+
+# Check days until sunset for deprecated tools
+curl -s -H "Authorization: Bearer $TOKEN" $BASE_URL/tools | \
+  jq '.tools[] | select(.deprecated == true) | {name, daysUntilSunset}'
+```
+
+#### Automated Sunset
+
+Tools are automatically disabled when `sunsetDate` is reached:
+
+- Scheduler runs every 60 minutes (configurable via `SUNSET_SCHEDULER_INTERVAL_MINUTES`)
+- Sets `enabled=false` for tools past their `sunsetDate`
+- Invalidates tool cache across all gateway instances
+- Sunset tools return `404 Not Found` when invoked
+
+```bash
+# After sunset date passes, tool becomes unavailable
+curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+      "name": "sunset_tool",
+      "arguments": {}
+    }
+  }' \
+  $BASE_URL/rpc
+# Response: {"error": {"code": -32001, "message": "Tool not found or not available"}}
+```
+
 ### Enable/Disable Tool
 
 ```bash

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -896,6 +896,10 @@ The gateway includes built-in observability features for tracking HTTP requests,
 | `TOOL_RATE_LIMIT`       | Tool calls per minute          | `100`   | int > 0 |
 | `TOOL_CONCURRENT_LIMIT` | Concurrent tool invocations    | `10`    | int > 0 |
 | `GATEWAY_TOOL_NAME_SEPARATOR` | Tool name separator for gateway routing | `-`     | `-`, `--`, `_`, `.` |
+| `SUNSET_SCHEDULER_INTERVAL_MINUTES` | Interval for checking and disabling tools past their sunset date | `60` | int > 0 |
+
+!!! info "Tool Lifecycle Management"
+    The sunset scheduler automatically disables tools when their `sunsetDate` is reached. It runs as a background service at the interval specified by `SUNSET_SCHEDULER_INTERVAL_MINUTES`. For production deployments, the default 60-minute interval is recommended as sunset dates are typically set days or weeks in advance. See [Tool Lifecycle Management](./tool-lifecycle.md) for complete documentation.
 
 ### Prompts
 

--- a/docs/docs/manage/tool-lifecycle.md
+++ b/docs/docs/manage/tool-lifecycle.md
@@ -66,7 +66,7 @@ curl -X PUT http://localhost:4444/tools/123 \
 
 # Day 0-89: Tool remains executable, users see deprecation warnings
 # Day 90: Scheduler automatically disables tool (enabled=false)
-# Day 90+: Tool invocation attempts return 404 Not Found
+# Day 90+: Tool invocation attempts raise ToolInvocationError with sunset message
 ```
 
 ## Viewing Lifecycle State
@@ -147,16 +147,26 @@ Check scheduler activity in logs:
 
 ```bash
 # View sunset transitions
-grep "Tool sunset" /var/log/mcpgateway.log
+grep "Processing.*tools for sunset" /var/log/mcpgateway.log
 
 # Example log entry
+INFO: Processing 2 tools for sunset: ['legacy_tool', 'old_api']
+```
+
+Audit trail entries are also created for each sunset transition:
+
+```json
 {
-  "timestamp": "2026-06-26T14:30:00Z",
-  "level": "INFO",
-  "message": "Tool sunset by scheduler",
-  "tool_id": 123,
-  "tool_name": "legacy_tool",
-  "sunset_date": "2026-06-26T00:00:00Z"
+  "user_id": "sunset_scheduler",
+  "action": "tool_sunset",
+  "resource_type": "tool",
+  "resource_id": "123",
+  "resource_name": "legacy_tool",
+  "details": {
+    "sunset_date": "2026-06-26T00:00:00Z",
+    "automated": true,
+    "timestamp": "2026-06-26T14:30:00Z"
+  }
 }
 ```
 
@@ -205,9 +215,9 @@ curl -X PUT http://localhost:4444/tools/{tool_id} \
 
 ### Sunset Tools
 
-- ❌ **Not executable**: Tool invocation returns `404 Not Found`
+- ❌ **Not executable**: Tool invocation raises `ToolInvocationError`
 - 👁️ **Admin-only visibility**: Only visible with `include_inactive=true`
-- 🔒 **Error message**: `"Tool not found or not available"`
+- 🔒 **Error message**: `"Tool '{name}' has been sunset and can no longer be executed. Sunset date: {date}. Please update your agent to use an alternative tool."`
 
 ### Execution Flow
 

--- a/docs/docs/manage/tool-lifecycle.md
+++ b/docs/docs/manage/tool-lifecycle.md
@@ -1,0 +1,396 @@
+# Tool Lifecycle Management
+
+## Overview
+
+Tool lifecycle management provides a structured workflow for retiring tools through three distinct states: **Active → Deprecated → Sunset**. This feature ensures deprecation is time-bound and predictable, giving users sufficient preparation time before tools become unavailable.
+
+## Lifecycle States
+
+| State | Description | Executable | Visible | Use Case |
+|-------|-------------|------------|---------|----------|
+| **Active** | Normal operation | ✅ Yes | ✅ Yes | Production-ready tools |
+| **Deprecated** | Discouraged but still works | ✅ Yes | ✅ Yes | Tools being phased out, grace period |
+| **Sunset** | Disabled, no longer executable | ❌ No | ✅ Admin only | Retired tools |
+
+### State Transitions
+
+```mermaid
+graph LR
+    A[Active] -->|Set deprecated=true<br/>+ sunsetDate| B[Deprecated]
+    B -->|sunsetDate reached| C[Sunset]
+    C -->|Set deprecated=false| A
+    B -->|Set deprecated=false| A
+```
+
+## Deprecating a Tool
+
+When you deprecate a tool, you **must** provide a `sunsetDate` indicating when the tool will be automatically disabled.
+
+### API Example
+
+```bash
+curl -X PUT http://localhost:4444/tools/{tool_id} \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2026-12-31T23:59:59Z"
+  }'
+```
+
+### Validation Rules
+
+- **`sunsetDate` is required** when setting `deprecated=true`
+- **`sunsetDate` must be a future date** (UTC timezone)
+- **Setting `deprecated=false` automatically clears** the `sunsetDate`
+
+### Best Practices
+
+1. **30-Day Notice Period**: Set `sunsetDate` at least 30 days in the future to give users time to migrate
+2. **Communicate Early**: Notify users through release notes, emails, or system announcements
+3. **Monitor Usage**: Use observability metrics to track deprecated tool usage during the grace period
+4. **Provide Alternatives**: Document recommended replacement tools in the deprecation message
+
+### Example: 90-Day Deprecation Timeline
+
+```bash
+# Day 0: Mark tool as deprecated with 90-day sunset
+curl -X PUT http://localhost:4444/tools/123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2026-09-30T23:59:59Z",
+    "description": "DEPRECATED: This tool will be sunset on 2026-09-30. Use new_tool_v2 instead."
+  }'
+
+# Day 0-89: Tool remains executable, users see deprecation warnings
+# Day 90: Scheduler automatically disables tool (enabled=false)
+# Day 90+: Tool invocation attempts return 404 Not Found
+```
+
+## Viewing Lifecycle State
+
+The API returns computed fields for all tools:
+
+```json
+{
+  "id": 123,
+  "name": "legacy_tool",
+  "deprecated": true,
+  "sunsetDate": "2026-12-31T23:59:59Z",
+  "enabled": true,
+  "lifecycleState": "deprecated",
+  "daysUntilSunset": 45,
+  "isExecutable": true
+}
+```
+
+### Computed Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `lifecycleState` | string | One of: `active`, `deprecated`, `sunset` |
+| `daysUntilSunset` | integer | Days remaining until sunset (null for active tools) |
+| `isExecutable` | boolean | Whether tool can be invoked |
+
+### Filtering by Lifecycle State
+
+```bash
+# List all tools (excludes sunset tools by default)
+curl http://localhost:4444/tools \
+  -H "Authorization: Bearer $TOKEN"
+
+# Include sunset tools (admin view)
+curl http://localhost:4444/tools?include_inactive=true \
+  -H "Authorization: Bearer $TOKEN"
+
+# Filter to only deprecated tools
+curl http://localhost:4444/tools \
+  -H "Authorization: Bearer $TOKEN" | \
+  jq '.tools[] | select(.lifecycleState == "deprecated")'
+```
+
+## Automated Sunset
+
+The sunset scheduler runs automatically as a background service.
+
+### How It Works
+
+1. **Scheduler runs every 60 minutes** (configurable via `SUNSET_SCHEDULER_INTERVAL_MINUTES`)
+2. **Queries for tools past their sunset date**: `WHERE deprecated=true AND sunset_date <= now() AND enabled=true`
+3. **Atomically disables matching tools**: `UPDATE tools SET enabled=false`
+4. **Invalidates tool cache** to ensure consistent behavior across gateway instances
+5. **Logs audit trail** for compliance and debugging
+
+### Configuration
+
+Set the scheduler interval via environment variable:
+
+```bash
+# .env or environment
+SUNSET_SCHEDULER_INTERVAL_MINUTES=60  # Default: 60 minutes
+```
+
+**Recommendation:** For production deployments, use the default 60-minute interval. Shorter intervals (e.g., 5 minutes) increase database load without significant benefit since sunset dates are typically set days or weeks in advance.
+
+### Scheduler Behavior
+
+- **Idempotent**: Safe to run concurrently across multiple gateway instances
+- **Atomic updates**: Uses database-level locking to prevent race conditions
+- **Cache invalidation**: Ensures all gateway instances reflect the sunset state immediately
+- **Audit logging**: Each sunset transition is logged with structured metadata
+
+### Monitoring
+
+Check scheduler activity in logs:
+
+```bash
+# View sunset transitions
+grep "Tool sunset" /var/log/mcpgateway.log
+
+# Example log entry
+{
+  "timestamp": "2026-06-26T14:30:00Z",
+  "level": "INFO",
+  "message": "Tool sunset by scheduler",
+  "tool_id": 123,
+  "tool_name": "legacy_tool",
+  "sunset_date": "2026-06-26T00:00:00Z"
+}
+```
+
+## Resurrecting a Tool
+
+You can "resurrect" a sunset tool by clearing the deprecation flag.
+
+### API Example
+
+```bash
+curl -X PUT http://localhost:4444/tools/{tool_id} \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": false
+  }'
+```
+
+### What Happens
+
+1. **`deprecated` set to `false`**
+2. **`sunsetDate` automatically cleared**
+3. **`enabled` set to `true`** (tool becomes executable again)
+4. **`lifecycleState` returns to `active`**
+
+### Use Cases
+
+- **False positive**: Tool was incorrectly deprecated
+- **Rollback**: Replacement tool had critical issues, need to revert
+- **Temporary retirement**: Tool needed to be disabled during maintenance
+
+## Execution Behavior
+
+### Active Tools
+
+- ✅ **Executable**: Tool invocation works normally
+- ✅ **Visible**: Appears in tool listings
+- ℹ️ **No warnings**: No lifecycle-related messages
+
+### Deprecated Tools
+
+- ✅ **Executable**: Tool still works during grace period
+- ✅ **Visible**: Appears in tool listings
+- ⚠️ **Warning**: `daysUntilSunset` field shows remaining time
+- ⚠️ **Client responsibility**: MCP clients should display deprecation warnings to users
+
+### Sunset Tools
+
+- ❌ **Not executable**: Tool invocation returns `404 Not Found`
+- 👁️ **Admin-only visibility**: Only visible with `include_inactive=true`
+- 🔒 **Error message**: `"Tool not found or not available"`
+
+### Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Scheduler
+    participant Database
+
+    Note over Client,Database: Before Sunset Date
+    Client->>Gateway: Execute deprecated_tool
+    Gateway->>Database: Check tool state
+    Database-->>Gateway: enabled=true, deprecated=true
+    Gateway-->>Client: ✅ Execution succeeds + warning
+
+    Note over Client,Database: After Sunset Date
+    Scheduler->>Database: Check for tools past sunset
+    Database-->>Scheduler: tool_id=123 past sunset
+    Scheduler->>Database: UPDATE enabled=false
+    Scheduler->>Gateway: Invalidate cache
+
+    Client->>Gateway: Execute deprecated_tool
+    Gateway->>Database: Check tool state
+    Database-->>Gateway: enabled=false
+    Gateway-->>Client: ❌ 404 Not Found
+```
+
+## Migration Guide
+
+### For New Deployments
+
+1. Run database migration: `alembic upgrade head`
+2. All tools start in `active` state
+3. Deprecate tools using the API with required `sunsetDate`
+
+### For Existing Deployments
+
+**Backwards Compatibility:**
+
+- **Existing tools**: `sunset_date=NULL` (no automatic sunset)
+- **Existing deprecated tools**: Continue working indefinitely until you add a `sunsetDate`
+- **Lifecycle state**: Old deprecated tools show `lifecycleState="deprecated"` (not "active")
+
+**Migration Steps:**
+
+```bash
+# 1. Run database migration
+cd mcpgateway
+alembic upgrade head
+
+# 2. Review existing deprecated tools
+curl http://localhost:4444/tools \
+  -H "Authorization: Bearer $TOKEN" | \
+  jq '.tools[] | select(.deprecated == true and .sunsetDate == null)'
+
+# 3. Add sunset dates to existing deprecated tools (optional)
+curl -X PUT http://localhost:4444/tools/123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deprecated": true,
+    "sunsetDate": "2026-12-31T23:59:59Z"
+  }'
+```
+
+**No breaking changes:** Existing deprecated tools without sunset dates remain executable indefinitely.
+
+## API Reference
+
+### Tool Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `deprecated` | boolean | No | Whether tool is deprecated (default: false) |
+| `sunsetDate` | string (ISO 8601) | Conditional | Required when `deprecated=true`, must be future date |
+| `enabled` | boolean | No | Whether tool is enabled (set by scheduler) |
+| `lifecycleState` | string | Read-only | Computed: `active`, `deprecated`, or `sunset` |
+| `daysUntilSunset` | integer | Read-only | Days until sunset (null for active tools) |
+| `isExecutable` | boolean | Read-only | Whether tool can be invoked |
+
+### Validation Errors
+
+```json
+// Missing sunsetDate
+{
+  "detail": "sunsetDate is required when deprecated=True"
+}
+
+// Past sunsetDate
+{
+  "detail": "sunsetDate must be in the future"
+}
+
+// Invalid date format
+{
+  "detail": "Invalid datetime format. Use ISO 8601 format (e.g., 2026-12-31T23:59:59Z)"
+}
+```
+
+## Troubleshooting
+
+### Tool Still Executable After Sunset Date
+
+**Possible causes:**
+
+1. **Scheduler hasn't run yet**: Wait up to 60 minutes for next scheduler cycle
+2. **Scheduler disabled**: Check `SUNSET_SCHEDULER_INTERVAL_MINUTES` is set
+3. **Database clock skew**: Verify database server time matches gateway time
+4. **Cache not invalidated**: Restart gateway to force cache refresh
+
+**Solution:**
+
+```bash
+# Force immediate check (restart gateway to trigger scheduler)
+docker restart mcpgateway
+
+# Or wait for next scheduler cycle (max 60 minutes)
+```
+
+### Cannot Manually Enable Sunset Tool
+
+**Expected behavior:** You cannot set `enabled=true` while `deprecated=true` and `sunsetDate` is in the past.
+
+**Solution:** Clear deprecation flag first:
+
+```bash
+curl -X PUT http://localhost:4444/tools/123 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"deprecated": false}'
+```
+
+### Sunset Tool Still Visible in Listings
+
+**Expected behavior:** Sunset tools are hidden by default but visible with `include_inactive=true`.
+
+**Check:**
+
+```bash
+# Should NOT include sunset tools
+curl http://localhost:4444/tools -H "Authorization: Bearer $TOKEN"
+
+# Should include sunset tools
+curl http://localhost:4444/tools?include_inactive=true -H "Authorization: Bearer $TOKEN"
+```
+
+## Security Considerations
+
+### RBAC Enforcement
+
+- **Deprecation**: Requires `tools.write` permission
+- **Viewing sunset tools**: Requires `tools.read` permission + `include_inactive=true`
+- **Resurrection**: Requires `tools.write` permission
+
+### Audit Trail
+
+All lifecycle transitions are logged with:
+
+- Tool ID and name
+- User who triggered the change
+- Timestamp (UTC)
+- Lifecycle state transition
+
+**Example:**
+
+```json
+{
+  "timestamp": "2026-06-26T14:30:00Z",
+  "level": "INFO",
+  "event": "tool_lifecycle_change",
+  "tool_id": 123,
+  "tool_name": "legacy_tool",
+  "user_email": "admin@example.com",
+  "old_state": "deprecated",
+  "new_state": "sunset",
+  "trigger": "scheduler"
+}
+```
+
+## Related Documentation
+
+- [API Usage](./api-usage.md) - API examples with lifecycle fields
+- [Configuration](./configuration.md) - Environment variables for scheduler
+- [RBAC](./rbac.md) - Permission requirements for tool management
+- [Upgrade Guide](./upgrade.md) - Migration notes for existing deployments

--- a/docs/docs/manage/upgrade.md
+++ b/docs/docs/manage/upgrade.md
@@ -26,6 +26,145 @@ Each version-specific guide includes:
 
 ---
 
+## 🆕 Tool Lifecycle Management
+
+**What Changed:**
+
+- New `sunset_date` column added to `tools` table (timezone-aware DateTime)
+- Tool lifecycle states introduced: **Active → Deprecated → Sunset**
+- `sunsetDate` field now **required** when setting `deprecated=true` via API
+- Automated sunset scheduler service runs every 60 minutes by default
+
+**Migration Impact:**
+
+- ✅ **Backwards Compatible**: Existing tools continue working unchanged
+- ✅ **No Data Loss**: All existing tool data preserved
+- ✅ **Non-Breaking**: Existing deprecated tools (without sunset dates) remain executable indefinitely
+- ⚠️ **API Change**: New deprecation requests must include `sunsetDate` field
+
+### Database Migration
+
+The migration adds the `sunset_date` column with these characteristics:
+
+```sql
+ALTER TABLE tools ADD COLUMN sunset_date TIMESTAMP WITH TIME ZONE;
+CREATE INDEX idx_tools_sunset_date ON tools(sunset_date);
+```
+
+**Migration Details:**
+
+- **File**: `mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py`
+- **Idempotent**: Safe to run multiple times
+- **Default Value**: `NULL` for all existing tools
+- **Index**: Added for efficient scheduler queries
+
+### Upgrade Steps
+
+```bash
+# 1. Backup database (recommended)
+pg_dump -h localhost -U postgres mcp > mcp_backup_$(date +%Y%m%d).sql
+
+# 2. Stop gateway (optional, migration is safe while running)
+docker-compose down
+
+# 3. Run migration
+cd mcpgateway
+alembic upgrade head
+
+# 4. Restart gateway
+docker-compose up -d
+
+# 5. Verify migration
+docker-compose logs -f mcpgateway | grep "sunset_scheduler"
+# Expected output: "Sunset scheduler started with interval: 60 minutes"
+```
+
+### Behavior Changes
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Create deprecated tool | ✅ `deprecated=true` (no sunset date) | ❌ Requires `sunsetDate` field |
+| Existing deprecated tools | ✅ Executable indefinitely | ✅ Executable indefinitely (backwards compatible) |
+| Update to `deprecated=false` | ✅ Clears deprecation | ✅ Clears deprecation + `sunset_date` |
+| Tool past sunset date | N/A | ⚠️ Automatically disabled by scheduler |
+
+### Configuration
+
+New environment variable:
+
+```bash
+# .env or environment
+SUNSET_SCHEDULER_INTERVAL_MINUTES=60  # Default: 60 minutes
+```
+
+**Recommendation:** Keep the default 60-minute interval for production. Sunset dates are typically set days/weeks in advance, so shorter intervals provide minimal benefit while increasing database load.
+
+### Existing Deployments
+
+**Option 1: No Action Required** (Default)
+
+- Existing deprecated tools keep working without sunset dates
+- Tools show `lifecycleState="deprecated"` in API responses
+- No forced migration timeline
+
+**Option 2: Add Sunset Dates to Existing Deprecated Tools**
+
+```bash
+# List existing deprecated tools
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools | \
+  jq '.tools[] | select(.deprecated == true and .sunsetDate == null)'
+
+# Add sunset dates (example: 90 days from now)
+SUNSET_DATE=$(date -u -d "+90 days" +"%Y-%m-%dT%H:%M:%SZ")
+curl -X PUT -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"deprecated\": true, \"sunsetDate\": \"$SUNSET_DATE\"}" \
+  http://localhost:4444/tools/{tool_id}
+```
+
+### Rollback Procedure
+
+If issues arise, roll back the migration:
+
+```bash
+# 1. Stop gateway
+docker-compose down
+
+# 2. Rollback migration
+cd mcpgateway
+alembic downgrade -1
+
+# 3. Restore from backup (if needed)
+psql -h localhost -U postgres mcp < mcp_backup_YYYYMMDD.sql
+
+# 4. Restart gateway
+docker-compose up -d
+```
+
+### Validation
+
+```bash
+# 1. Verify sunset_date column exists
+psql -h localhost -U postgres mcp -c "\d tools" | grep sunset_date
+
+# 2. Check scheduler is running
+docker-compose logs mcpgateway | grep "Sunset scheduler"
+
+# 3. Test API lifecycle fields
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:4444/tools/{tool_id} | \
+  jq '{lifecycleState, daysUntilSunset, isExecutable}'
+```
+
+### Documentation
+
+- [Tool Lifecycle Management](./tool-lifecycle.md) - Complete feature guide
+- [API Usage - Lifecycle Fields](./api-usage.md#tool-lifecycle-management) - API examples
+- [Configuration - Scheduler Settings](./configuration.md#tools) - Environment variables
+
+---
+
 ## 🛠 Upgrade Steps
 
 ### 1. Backup Current Configuration and Data

--- a/docs/docs/manage/upgrade.md
+++ b/docs/docs/manage/upgrade.md
@@ -48,7 +48,7 @@ The migration adds the `sunset_date` column with these characteristics:
 
 ```sql
 ALTER TABLE tools ADD COLUMN sunset_date TIMESTAMP WITH TIME ZONE;
-CREATE INDEX idx_tools_sunset_date ON tools(sunset_date);
+CREATE INDEX ix_tools_sunset_date ON tools(sunset_date);
 ```
 
 **Migration Details:**
@@ -56,7 +56,7 @@ CREATE INDEX idx_tools_sunset_date ON tools(sunset_date);
 - **File**: `mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py`
 - **Idempotent**: Safe to run multiple times
 - **Default Value**: `NULL` for all existing tools
-- **Index**: Added for efficient scheduler queries
+- **Index**: Added for efficient scheduler queries (`ix_tools_sunset_date`)
 
 ### Upgrade Steps
 
@@ -75,8 +75,8 @@ alembic upgrade head
 docker-compose up -d
 
 # 5. Verify migration
-docker-compose logs -f mcpgateway | grep "sunset_scheduler"
-# Expected output: "Sunset scheduler started with interval: 60 minutes"
+docker-compose logs -f mcpgateway | grep -i "sunset scheduler"
+# Expected output: "Sunset scheduler service initialized (interval: 60 minutes)"
 ```
 
 ### Behavior Changes
@@ -85,7 +85,7 @@ docker-compose logs -f mcpgateway | grep "sunset_scheduler"
 |----------|--------|-------|
 | Create deprecated tool | ✅ `deprecated=true` (no sunset date) | ❌ Requires `sunsetDate` field |
 | Existing deprecated tools | ✅ Executable indefinitely | ✅ Executable indefinitely (backwards compatible) |
-| Update to `deprecated=false` | ✅ Clears deprecation | ✅ Clears deprecation + `sunset_date` |
+| Update to `deprecated=false` | ✅ Clears deprecation | ✅ Clears deprecation + `sunset_date` + re-enables tool |
 | Tool past sunset date | N/A | ⚠️ Automatically disabled by scheduler |
 
 ### Configuration

--- a/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
+++ b/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "15a7b5f1e41a"
-down_revision: Union[str, Sequence[str], None] = "e28566875fa4"
+down_revision: Union[str, Sequence[str], None] = "0a089912b5f0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
+++ b/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
@@ -1,7 +1,7 @@
 """add_sunset_date_to_tools
 
 Revision ID: 15a7b5f1e41a
-Revises: 0a089912b5f0
+Revises: e198602c3c1e
 Create Date: 2026-05-26 11:50:39.306163
 
 """
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "15a7b5f1e41a"
-down_revision: Union[str, Sequence[str], None] = "0a089912b5f0"
+down_revision: Union[str, Sequence[str], None] = "e198602c3c1e"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
+++ b/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
@@ -1,0 +1,60 @@
+"""add_sunset_date_to_tools
+
+Revision ID: 15a7b5f1e41a
+Revises: e28566875fa4
+Create Date: 2026-05-26 11:50:39.306163
+
+"""
+
+# Standard
+from typing import Sequence, Union
+
+# Third-Party
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "15a7b5f1e41a"
+down_revision: Union[str, Sequence[str], None] = "e28566875fa4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add sunset_date column to tools table with index for efficient queries."""
+    inspector = sa.inspect(op.get_bind())
+
+    # Skip if table doesn't exist yet (fresh DB uses db.py models directly)
+    if "tools" not in inspector.get_table_names():
+        return
+
+    # Skip if column already exists
+    columns = [col["name"] for col in inspector.get_columns("tools")]
+    if "sunset_date" in columns:
+        return
+
+    # Add sunset_date column (nullable, timezone-aware datetime)
+    op.add_column("tools", sa.Column("sunset_date", sa.DateTime(timezone=True), nullable=True))
+
+    # Create index for efficient sunset transition queries
+    # Index name follows convention: ix_<table>_<column>
+    op.create_index("ix_tools_sunset_date", "tools", ["sunset_date"], unique=False)
+
+
+def downgrade() -> None:
+    """Remove sunset_date column and index from tools table."""
+    inspector = sa.inspect(op.get_bind())
+
+    # Skip if table doesn't exist
+    if "tools" not in inspector.get_table_names():
+        return
+
+    # Drop index if it exists
+    existing_indexes = [idx["name"] for idx in inspector.get_indexes("tools")]
+    if "ix_tools_sunset_date" in existing_indexes:
+        op.drop_index("ix_tools_sunset_date", table_name="tools")
+
+    # Drop column if it exists
+    columns = [col["name"] for col in inspector.get_columns("tools")]
+    if "sunset_date" in columns:
+        op.drop_column("tools", "sunset_date")

--- a/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
+++ b/mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py
@@ -1,7 +1,7 @@
 """add_sunset_date_to_tools
 
 Revision ID: 15a7b5f1e41a
-Revises: e28566875fa4
+Revises: 0a089912b5f0
 Create Date: 2026-05-26 11:50:39.306163
 
 """

--- a/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
+++ b/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "6c0e5f8a9b1d"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "15a7b5f1e41a"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e28cd485ad3c"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
+++ b/mcpgateway/alembic/versions/6c0e5f8a9b1d_add_gateway_lifecycle_fields.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = "6c0e5f8a9b1d"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "e28cd485ad3c"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "15a7b5f1e41a"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2480,6 +2480,11 @@ class Settings(BaseSettings):
     # Max concurrent health checks per worker
     max_concurrent_health_checks: int = 10
 
+    # Tool Lifecycle Management
+    # Interval in minutes between sunset scheduler runs (checks for tools that have reached sunset_date)
+    # Env: SUNSET_SCHEDULER_INTERVAL_MINUTES
+    sunset_scheduler_interval_minutes: int = Field(default=60, description="Interval in minutes between sunset scheduler runs")
+
     # Auto-refresh tools/resources/prompts from gateways during health checks
     # When enabled, tools/resources/prompts are fetched and synced with DB during health checks
     auto_refresh_servers: bool = Field(default=False, description="Enable automatic tool/resource/prompt refresh during gateway health checks")

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -3254,6 +3254,7 @@ class Tool(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
     enabled: Mapped[bool] = mapped_column(default=True)
     deprecated: Mapped[bool] = mapped_column(default=False, nullable=False)
+    sunset_date: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True, default=None)
     reachable: Mapped[bool] = mapped_column(default=True)
     jsonpath_filter: Mapped[str] = mapped_column(Text, default="")
     tags: Mapped[List[str]] = mapped_column(JSON, default=list, nullable=False)

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1328,6 +1328,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     aggregation_backfill_task: Optional[asyncio.Task] = None
     siem_export_service: Optional[Any] = None
     dataplane_publisher_service: Optional[Any] = None
+    sunset_scheduler_service: Optional[Any] = None
 
     # Initialize logging service FIRST to ensure all logging goes to dual output
     await logging_service.initialize()
@@ -1861,11 +1862,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             services_to_shutdown.insert(3, dataplane_publisher_service)
 
         # Add sunset scheduler service (shutdown after metrics services)
-        # First-Party
-        from mcpgateway.services.sunset_scheduler_service import get_sunset_scheduler_service  # pylint: disable=import-outside-toplevel
-
-        sunset_scheduler_service = get_sunset_scheduler_service()
-        services_to_shutdown.insert(4, sunset_scheduler_service)
+        if sunset_scheduler_service is not None:
+            services_to_shutdown.insert(4, sunset_scheduler_service)
 
         await shutdown_services(services_to_shutdown)
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1624,6 +1624,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             await metrics_rollup_service.start()
             logger.info("Metrics rollup service initialized (interval: %dh)", settings.metrics_rollup_interval_hours)
 
+        # Initialize sunset scheduler service for tool lifecycle management
+        # First-Party
+        from mcpgateway.services.sunset_scheduler_service import get_sunset_scheduler_service  # pylint: disable=import-outside-toplevel
+
+        sunset_scheduler_service = get_sunset_scheduler_service()
+        await sunset_scheduler_service.start()
+        logger.info("Sunset scheduler service initialized (interval: %d minutes)", settings.sunset_scheduler_interval_minutes)
+
         refresh_slugs_on_startup()
 
         # Initialize experimental dataplane publisher to send config data to redis
@@ -1851,6 +1859,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
         if dataplane_publisher_service is not None:
             services_to_shutdown.insert(3, dataplane_publisher_service)
+
+        # Add sunset scheduler service (shutdown after metrics services)
+        # First-Party
+        from mcpgateway.services.sunset_scheduler_service import get_sunset_scheduler_service  # pylint: disable=import-outside-toplevel
+
+        sunset_scheduler_service = get_sunset_scheduler_service()
+        services_to_shutdown.insert(4, sunset_scheduler_service)
 
         await shutdown_services(services_to_shutdown)
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -594,6 +594,7 @@ class ToolCreate(BaseModel):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(default=False, description="Whether the tool is deprecated (visible but non-executable)")
+    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
 
     # Team scoping fields
     team_id: Optional[str] = Field(None, description="Team ID for resource organization")
@@ -1125,6 +1126,40 @@ class ToolCreate(BaseModel):
         return _validate_header_mapping_targets(v)
 
     @model_validator(mode="after")
+    def validate_sunset_date_requirements(self):
+        """Validate sunset_date requirements based on deprecated status.
+
+        Business rules:
+        - If deprecated=True, sunsetDate is required and must be in the future
+        - If deprecated=False, sunsetDate should be cleared (set to None)
+        - Existing tools with deprecated=True but no sunsetDate are allowed (backwards compatibility)
+
+        Returns:
+            self: The validated model instance
+
+        Raises:
+            ValueError: If validation rules are violated
+        """
+        if self.deprecated is True:
+            if self.sunsetDate is None:
+                raise ValueError("sunsetDate is required when deprecated=True. Please provide a future date when this tool will be sunset.")
+
+            # Ensure sunsetDate is in the future
+            now = datetime.now(timezone.utc)
+
+            # Make sunsetDate timezone-aware if it isn't already
+            sunset_date = self.sunsetDate
+            if sunset_date.tzinfo is None:
+                # Assume UTC if no timezone provided
+                sunset_date = sunset_date.replace(tzinfo=timezone.utc)
+                self.sunsetDate = sunset_date
+
+            if sunset_date <= now:
+                raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
+
+        return self
+
+    @model_validator(mode="after")
     def handle_timeout_ms_defaults(self):
         """Handle timeout_ms defaults based on integration_type and expose_passthrough.
 
@@ -1160,6 +1195,7 @@ class ToolUpdate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
+    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
     visibility: Optional[Literal["private", "team", "public"]] = Field(None, description="Visibility level: private, team, or public")
 
     # Passthrough REST fields
@@ -1399,6 +1435,42 @@ class ToolUpdate(BaseModelWithConfigDict):
 
         return values
 
+    @model_validator(mode="after")
+    def validate_sunset_date_requirements(self):
+        """Validate sunset_date requirements for tool updates.
+
+        Business rules for updates:
+        - If deprecated is being set to True, sunsetDate must be provided and be in the future
+        - If deprecated is being set to False, sunsetDate should be cleared
+        - If deprecated is not being changed, sunsetDate validation is skipped (partial update)
+
+        Returns:
+            self: The validated model instance
+
+        Raises:
+            ValueError: If validation rules are violated
+        """
+        # Only validate if deprecated is explicitly being set in this update
+        if self.deprecated is not None:
+            if self.deprecated is True:
+                if self.sunsetDate is None:
+                    raise ValueError("sunsetDate is required when setting deprecated=True. Please provide a future date when this tool will be sunset.")
+
+                # Ensure sunsetDate is in the future
+                now = datetime.now(timezone.utc)
+
+                # Make sunsetDate timezone-aware if it isn't already
+                sunset_date = self.sunsetDate
+                if sunset_date.tzinfo is None:
+                    # Assume UTC if no timezone provided
+                    sunset_date = sunset_date.replace(tzinfo=timezone.utc)
+                    self.sunsetDate = sunset_date
+
+                if sunset_date <= now:
+                    raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
+
+        return self
+
     @field_validator("displayName")
     @classmethod
     def validate_display_name(cls, v: Optional[str]) -> Optional[str]:
@@ -1607,6 +1679,15 @@ class ToolRead(BaseModelWithConfigDict):
     updated_at: datetime
     enabled: bool
     deprecated: bool
+    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled)")
+
+    # Computed lifecycle fields
+    lifecycle_state: Optional[Literal["active", "deprecated", "sunset"]] = Field(
+        None, description="Current lifecycle state: active (normal operation), deprecated (still executable but discouraged), sunset (disabled, not executable)"
+    )
+    days_until_sunset: Optional[int] = Field(None, description="Days remaining until sunset (only for deprecated tools with future sunset date)")
+    is_executable: Optional[bool] = Field(None, description="Whether the tool can be executed (true for active/deprecated, false for sunset)")
+
     reachable: bool
     gateway_id: Optional[str]
     grpc_service_id: Optional[str] = Field(None, description="ID of the gRPC service this tool was discovered from")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -593,8 +593,8 @@ class ToolCreate(BaseModel):
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the tool")
-    deprecated: Optional[bool] = Field(default=False, description="Whether the tool is deprecated (visible but non-executable)")
-    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
+    deprecated: Optional[bool] = Field(default=False, description="Whether the tool is deprecated (visible and executable until sunset_date)")
+    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled and non-executable). Required when deprecated=True")
 
     # Team scoping fields
     team_id: Optional[str] = Field(None, description="Team ID for resource organization")
@@ -1197,8 +1197,8 @@ class ToolUpdate(BaseModelWithConfigDict):
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")
-    deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
-    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
+    deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible and executable until sunset_date)")
+    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled and non-executable). Required when deprecated=True")
     visibility: Optional[Literal["private", "team", "public"]] = Field(None, description="Visibility level: private, team, or public")
 
     # Passthrough REST fields

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -594,7 +594,7 @@ class ToolCreate(BaseModel):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(default=False, description="Whether the tool is deprecated (visible but non-executable)")
-    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
+    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
 
     # Team scoping fields
     team_id: Optional[str] = Field(None, description="Team ID for resource organization")
@@ -1141,18 +1141,18 @@ class ToolCreate(BaseModel):
             ValueError: If validation rules are violated
         """
         if self.deprecated is True:
-            if self.sunsetDate is None:
+            if self.sunset_date is None:
                 raise ValueError("sunsetDate is required when deprecated=True. Please provide a future date when this tool will be sunset.")
 
             # Ensure sunsetDate is in the future
             now = datetime.now(timezone.utc)
 
             # Make sunsetDate timezone-aware if it isn't already
-            sunset_date = self.sunsetDate
+            sunset_date = self.sunset_date
             if sunset_date.tzinfo is None:
                 # Assume UTC if no timezone provided
                 sunset_date = sunset_date.replace(tzinfo=timezone.utc)
-                self.sunsetDate = sunset_date
+                self.sunset_date = sunset_date
 
             if sunset_date <= now:
                 raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
@@ -1195,7 +1195,7 @@ class ToolUpdate(BaseModelWithConfigDict):
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
-    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
+    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True")
     visibility: Optional[Literal["private", "team", "public"]] = Field(None, description="Visibility level: private, team, or public")
 
     # Passthrough REST fields
@@ -1453,18 +1453,18 @@ class ToolUpdate(BaseModelWithConfigDict):
         # Only validate if deprecated is explicitly being set in this update
         if self.deprecated is not None:
             if self.deprecated is True:
-                if self.sunsetDate is None:
+                if self.sunset_date is None:
                     raise ValueError("sunsetDate is required when setting deprecated=True. Please provide a future date when this tool will be sunset.")
 
                 # Ensure sunsetDate is in the future
                 now = datetime.now(timezone.utc)
 
                 # Make sunsetDate timezone-aware if it isn't already
-                sunset_date = self.sunsetDate
+                sunset_date = self.sunset_date
                 if sunset_date.tzinfo is None:
                     # Assume UTC if no timezone provided
                     sunset_date = sunset_date.replace(tzinfo=timezone.utc)
-                    self.sunsetDate = sunset_date
+                    self.sunset_date = sunset_date
 
                 if sunset_date <= now:
                     raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
@@ -1679,7 +1679,7 @@ class ToolRead(BaseModelWithConfigDict):
     updated_at: datetime
     enabled: bool
     deprecated: bool
-    sunsetDate: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled)")
+    sunset_date: Optional[datetime] = Field(None, alias="sunsetDate", description="Date when deprecated tool will be sunset (disabled)")
 
     # Computed lifecycle fields
     lifecycle_state: Optional[Literal["active", "deprecated", "sunset"]] = Field(

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1131,7 +1131,7 @@ class ToolCreate(BaseModel):
 
         Business rules:
         - If deprecated=True, sunsetDate is required and must be in the future
-        - If deprecated=False, sunsetDate should be cleared (set to None)
+        - If deprecated=False, sunsetDate must be None (active tools cannot have sunset dates)
         - Existing tools with deprecated=True but no sunsetDate are allowed (backwards compatibility)
 
         Returns:
@@ -1156,6 +1156,9 @@ class ToolCreate(BaseModel):
 
             if sunset_date <= now:
                 raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
+        elif self.deprecated is False:
+            # Active tools cannot have sunset dates
+            self.sunset_date = None
 
         return self
 
@@ -1441,7 +1444,7 @@ class ToolUpdate(BaseModelWithConfigDict):
 
         Business rules for updates:
         - If deprecated is being set to True, sunsetDate must be provided and be in the future
-        - If deprecated is being set to False, sunsetDate should be cleared
+        - If deprecated is being set to False, sunsetDate must be None (active tools cannot have sunset dates)
         - If deprecated is not being changed, sunsetDate validation is skipped (partial update)
 
         Returns:
@@ -1468,6 +1471,10 @@ class ToolUpdate(BaseModelWithConfigDict):
 
                 if sunset_date <= now:
                     raise ValueError(f"sunsetDate must be in the future. Provided: {sunset_date.isoformat()}, Current time: {now.isoformat()}")
+            else:
+                # deprecated is being set to False, so clear sunset_date
+                # Active tools cannot have sunset dates
+                self.sunset_date = None
 
         return self
 

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -132,9 +132,9 @@ class SunsetSchedulerService:
             # Use index on sunset_date for efficient query
             stmt = select(DbTool).where(
                 and_(
-                    DbTool.deprecated is True,  # noqa: E712
+                    DbTool.deprecated == True,  # noqa: E712  # pylint: disable=singleton-comparison
                     DbTool.sunset_date <= now,
-                    DbTool.enabled is True,  # noqa: E712
+                    DbTool.enabled == True,  # noqa: E712  # pylint: disable=singleton-comparison
                 )
             )
 
@@ -158,7 +158,7 @@ class SunsetSchedulerService:
                 .where(
                     and_(
                         DbTool.id.in_(tool_ids),
-                        DbTool.enabled is True,  # noqa: E712 - Critical for idempotency
+                        DbTool.enabled == True,  # noqa: E712  # pylint: disable=singleton-comparison
                     )
                 )
                 .values(enabled=False)
@@ -171,7 +171,7 @@ class SunsetSchedulerService:
             if actual_count < tool_count:
                 logger.warning(f"Only {actual_count} of {tool_count} tools were sunset. " f"This may indicate concurrent execution or tools already sunset.")
                 # Re-query to get only the tools that were actually updated
-                tools_to_sunset = [t for t in tools_to_sunset if t.enabled is False]
+                tools_to_sunset = [t for t in tools_to_sunset if not t.enabled]
                 tool_count = actual_count
 
             # Invalidate tools cache (invalidates all tools at once)

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -169,7 +169,7 @@ class SunsetSchedulerService:
             # Check how many tools were actually updated (for concurrent execution safety)
             actual_count = result.rowcount
             if actual_count < tool_count:
-                logger.warning(f"Only {actual_count} of {tool_count} tools were sunset. " f"This may indicate concurrent execution or tools already sunset.")
+                logger.warning(f"Only {actual_count} of {tool_count} tools were sunset. This may indicate concurrent execution or tools already sunset.")
                 # Re-query to get only the tools that were actually updated
                 tools_to_sunset = [t for t in tools_to_sunset if not t.enabled]
                 tool_count = actual_count

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -95,10 +95,15 @@ class SunsetSchedulerService:
 
             except Exception as e:
                 logger.exception(f"Error in sunset scheduler: {e}")
-                structured_logger.log_error(
-                    "sunset_scheduler_error",
-                    error=str(e),
-                    error_type=type(e).__name__,
+                structured_logger.log(
+                    level="ERROR",
+                    message="sunset_scheduler_error",
+                    event_type="sunset_scheduler_error",
+                    component="sunset_scheduler",
+                    custom_fields={
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                    },
                 )
                 self._processing = False
 
@@ -127,9 +132,9 @@ class SunsetSchedulerService:
             # Use index on sunset_date for efficient query
             stmt = select(DbTool).where(
                 and_(
-                    DbTool.deprecated == True,  # noqa: E712
+                    DbTool.deprecated is True,  # noqa: E712
                     DbTool.sunset_date <= now,
-                    DbTool.enabled == True,  # noqa: E712
+                    DbTool.enabled is True,  # noqa: E712
                 )
             )
 
@@ -153,7 +158,7 @@ class SunsetSchedulerService:
                 .where(
                     and_(
                         DbTool.id.in_(tool_ids),
-                        DbTool.enabled == True,  # noqa: E712 - Critical for idempotency
+                        DbTool.enabled is True,  # noqa: E712 - Critical for idempotency
                     )
                 )
                 .values(enabled=False)

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -94,6 +94,9 @@ class SunsetSchedulerService:
                     self._processing = False
 
             except Exception as e:
+                # Bare exception is intentional: scheduler must never crash on individual errors
+                # (e.g., database connectivity issues, cache failures) to maintain service continuity.
+                # Errors are logged with full context for debugging.
                 logger.exception(f"Error in sunset scheduler: {e}")
                 structured_logger.log(
                     level="ERROR",

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -49,7 +49,7 @@ class SunsetSchedulerService:
         """Initialize the sunset scheduler service."""
         self._task: Optional[asyncio.Task] = None
         self._running = False
-        self._interval_minutes = getattr(settings, "SUNSET_SCHEDULER_INTERVAL_MINUTES", 60)
+        self._interval_minutes = settings.sunset_scheduler_interval_minutes
         self._processing = False  # Flag to prevent concurrent runs within same instance
         logger.info(f"SunsetSchedulerService initialized with interval: {self._interval_minutes} minutes")
 

--- a/mcpgateway/services/sunset_scheduler_service.py
+++ b/mcpgateway/services/sunset_scheduler_service.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/services/sunset_scheduler_service.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Sunset Scheduler Service - Automated tool lifecycle management.
+
+This service automatically transitions deprecated tools to sunset state when their
+sunset_date is reached. It runs periodically in the background and:
+- Queries tools WHERE deprecated=true AND sunset_date <= now() AND enabled=true
+- Batch updates to set enabled=False for sunset tools
+- Invalidates cache for sunset tools
+- Logs audit trail for sunset transitions
+- Tracks metrics for monitoring
+"""
+
+# Standard
+import asyncio
+from datetime import datetime, timezone
+import logging
+from typing import Optional
+
+# Third-Party
+from sqlalchemy import and_, select, update
+
+# First-Party
+from mcpgateway.cache.registry_cache import get_registry_cache
+from mcpgateway.config import settings
+from mcpgateway.db import fresh_db_session
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.services.audit_trail_service import get_audit_trail_service
+from mcpgateway.services.observability_service import ObservabilityService
+from mcpgateway.services.structured_logger import get_structured_logger
+
+logger = logging.getLogger(__name__)
+structured_logger = get_structured_logger()
+
+
+class SunsetSchedulerService:
+    """Service for automatically transitioning deprecated tools to sunset state.
+
+    This service is designed to be idempotent and safe for concurrent execution:
+    - Uses database-level atomic operations (UPDATE with WHERE clause)
+    - Only processes tools that are still enabled (prevents double-processing)
+    - Gracefully handles race conditions between multiple instances
+    """
+
+    def __init__(self):
+        """Initialize the sunset scheduler service."""
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+        self._interval_minutes = getattr(settings, "SUNSET_SCHEDULER_INTERVAL_MINUTES", 60)
+        self._processing = False  # Flag to prevent concurrent runs within same instance
+        logger.info(f"SunsetSchedulerService initialized with interval: {self._interval_minutes} minutes")
+
+    async def start(self) -> None:
+        """Start the sunset scheduler background task."""
+        if self._running:
+            logger.warning("SunsetSchedulerService already running")
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._run_scheduler())
+        logger.info("SunsetSchedulerService started")
+
+    async def stop(self) -> None:
+        """Stop the sunset scheduler background task."""
+        if not self._running:
+            return
+
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("SunsetSchedulerService stopped")
+
+    async def _run_scheduler(self) -> None:
+        """Run the scheduler loop with concurrent execution protection."""
+        while self._running:
+            try:
+                # Skip if already processing (prevents overlapping runs)
+                if self._processing:
+                    logger.warning("Sunset scheduler already processing, skipping this run")
+                    await asyncio.sleep(self._interval_minutes * 60)
+                    continue
+
+                self._processing = True
+                try:
+                    await self._process_sunset_tools()
+                finally:
+                    self._processing = False
+
+            except Exception as e:
+                logger.exception(f"Error in sunset scheduler: {e}")
+                structured_logger.log_error(
+                    "sunset_scheduler_error",
+                    error=str(e),
+                    error_type=type(e).__name__,
+                )
+                self._processing = False
+
+            # Sleep for the configured interval
+            await asyncio.sleep(self._interval_minutes * 60)
+
+    async def _process_sunset_tools(self) -> None:
+        """Process tools that have reached their sunset date.
+
+        This method is idempotent and safe for concurrent execution:
+        - Uses atomic UPDATE with WHERE clause (only updates enabled=true tools)
+        - Multiple instances can run simultaneously without conflicts
+        - If a tool is already sunset by another instance, it's skipped
+
+        Steps:
+        1. Queries deprecated tools with sunset_date <= now() and enabled=true
+        2. Atomic batch update to set enabled=False (only if still enabled)
+        3. Invalidates cache for successfully sunset tools
+        4. Logs audit trail for each transition
+        5. Tracks metrics
+        """
+        with fresh_db_session() as db:
+            now = datetime.now(timezone.utc)
+
+            # Query tools that need to be sunset
+            # Use index on sunset_date for efficient query
+            stmt = select(DbTool).where(
+                and_(
+                    DbTool.deprecated == True,  # noqa: E712
+                    DbTool.sunset_date <= now,
+                    DbTool.enabled == True,  # noqa: E712
+                )
+            )
+
+            tools_to_sunset = db.execute(stmt).scalars().all()
+
+            if not tools_to_sunset:
+                logger.debug("No tools to sunset at this time")
+                return
+
+            tool_count = len(tools_to_sunset)
+            tool_ids = [tool.id for tool in tools_to_sunset]
+            tool_names = [tool.name for tool in tools_to_sunset]
+
+            logger.info(f"Processing {tool_count} tools for sunset: {tool_names}")
+
+            # Atomic batch update to set enabled=False
+            # IMPORTANT: The WHERE clause includes enabled=True to ensure idempotency
+            # If another instance already sunset these tools, this update affects 0 rows
+            update_stmt = (
+                update(DbTool)
+                .where(
+                    and_(
+                        DbTool.id.in_(tool_ids),
+                        DbTool.enabled == True,  # noqa: E712 - Critical for idempotency
+                    )
+                )
+                .values(enabled=False)
+            )
+            result = db.execute(update_stmt)
+            db.commit()
+
+            # Check how many tools were actually updated (for concurrent execution safety)
+            actual_count = result.rowcount
+            if actual_count < tool_count:
+                logger.warning(f"Only {actual_count} of {tool_count} tools were sunset. " f"This may indicate concurrent execution or tools already sunset.")
+                # Re-query to get only the tools that were actually updated
+                tools_to_sunset = [t for t in tools_to_sunset if t.enabled is False]
+                tool_count = actual_count
+
+            # Invalidate tools cache (invalidates all tools at once)
+            registry_cache = get_registry_cache()
+            try:
+                await registry_cache.invalidate_tools()
+                logger.debug(f"Invalidated tools cache for {tool_count} sunset tools")
+            except Exception as e:
+                logger.error(f"Failed to invalidate tools cache: {e}")
+
+            # Log audit trail for each transition
+            audit_service = get_audit_trail_service()
+            for tool in tools_to_sunset:
+                try:
+                    audit_service.log_action(
+                        user_id="sunset_scheduler",
+                        action="tool_sunset",
+                        resource_type="tool",
+                        resource_id=str(tool.id),
+                        resource_name=tool.name,
+                        user_email=None,
+                        team_id=tool.team_id if hasattr(tool, "team_id") else None,
+                        details={
+                            "sunset_date": tool.sunset_date.isoformat() if tool.sunset_date else None,
+                            "automated": True,
+                            "timestamp": now.isoformat(),
+                        },
+                        db=db,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to log audit trail for tool {tool.name}: {e}")
+
+            # Track metrics using observability service
+            try:
+                obs_service = ObservabilityService()
+
+                # Record total count of tools sunset in this batch
+                obs_service.record_metric(
+                    name="tool.lifecycle.sunset.count",
+                    value=tool_count,
+                    unit="count",
+                    attributes={
+                        "batch_timestamp": now.isoformat(),
+                        "scheduler_run": "automated",
+                    },
+                )
+
+                # Record individual tool sunset events for today's tracking
+                for tool in tools_to_sunset:
+                    obs_service.record_metric(
+                        name="tool.lifecycle.sunset.event",
+                        value=1,
+                        unit="count",
+                        attributes={
+                            "tool_id": str(tool.id),
+                            "tool_name": tool.name,
+                            "sunset_date": tool.sunset_date.isoformat() if tool.sunset_date else None,
+                            "timestamp": now.isoformat(),
+                        },
+                    )
+
+                logger.debug(f"Recorded metrics for {tool_count} sunset tools")
+            except Exception as e:
+                logger.error(f"Failed to record sunset metrics: {e}")
+
+            # Log structured info for monitoring
+            structured_logger.log(
+                level="INFO",
+                message="Tools sunset batch completed",
+                event_type="tools_sunset_batch",
+                component="sunset_scheduler",
+                custom_fields={
+                    "tool_count": tool_count,
+                    "tool_names": tool_names,
+                    "timestamp": now.isoformat(),
+                },
+            )
+
+            logger.info(f"Successfully sunset {tool_count} tools")
+
+
+# Global singleton instance
+_sunset_scheduler_service: Optional[SunsetSchedulerService] = None
+
+
+def get_sunset_scheduler_service() -> SunsetSchedulerService:
+    """Get the global sunset scheduler service instance.
+
+    Returns:
+        SunsetSchedulerService: The singleton service instance
+    """
+    global _sunset_scheduler_service
+    if _sunset_scheduler_service is None:
+        _sunset_scheduler_service = SunsetSchedulerService()
+    return _sunset_scheduler_service

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1131,6 +1131,7 @@ class ToolService(BaseService):
             "grpc_service_id": str(tool.grpc_service_id) if tool.grpc_service_id else None,
             "enabled": bool(tool.enabled),
             "deprecated": bool(tool.deprecated),
+            "sunset_date": tool.sunset_date.isoformat() if tool.sunset_date else None,
             "reachable": bool(tool.reachable),
             "tags": tool.tags or [],
             "team_id": tool.team_id,
@@ -1394,6 +1395,46 @@ class ToolService(BaseService):
                 can_view = True
             if not can_view:
                 tool_dict["headers"] = {k: settings.masked_auth_value for k in headers}
+
+        # Compute lifecycle fields
+        deprecated = tool_dict.get("deprecated", False)
+        sunset_date = tool_dict.get("sunset_date")
+        enabled = tool_dict.get("enabled", True)
+
+        # Map sunset_date to sunsetDate for Pydantic serialization (camelCase)
+        if sunset_date is not None:
+            tool_dict["sunsetDate"] = sunset_date
+
+        # Determine lifecycle_state
+        if not enabled and deprecated and sunset_date:
+            # Tool has been sunset (disabled after reaching sunset date)
+            tool_dict["lifecycle_state"] = "sunset"
+            tool_dict["is_executable"] = False
+        elif deprecated and sunset_date:
+            # Tool is deprecated with a sunset date
+            now = datetime.now(timezone.utc)
+            # Ensure sunset_date is timezone-aware for comparison
+            if sunset_date.tzinfo is None:
+                sunset_date = sunset_date.replace(tzinfo=timezone.utc)
+            if sunset_date <= now:
+                # Sunset date has passed but tool hasn't been disabled yet (scheduler will handle it)
+                tool_dict["lifecycle_state"] = "sunset"
+                tool_dict["is_executable"] = False
+            else:
+                # Deprecated but still before sunset date
+                tool_dict["lifecycle_state"] = "deprecated"
+                tool_dict["is_executable"] = True
+                # Calculate days until sunset
+                time_until_sunset = sunset_date - now
+                tool_dict["days_until_sunset"] = max(0, time_until_sunset.days)
+        else:
+            # Active tool (not deprecated or no sunset date)
+            tool_dict["lifecycle_state"] = "active"
+            tool_dict["is_executable"] = True
+
+        # Ensure days_until_sunset is None for non-deprecated or sunset tools
+        if tool_dict["lifecycle_state"] != "deprecated":
+            tool_dict["days_until_sunset"] = None
 
         return ToolRead.model_validate(tool_dict)
 
@@ -2021,6 +2062,9 @@ class ToolService(BaseService):
                 auth_value=auth_value,
                 gateway_id=tool.gateway_id,
                 tags=tool.tags or [],
+                # Lifecycle management fields
+                deprecated=getattr(tool, "deprecated", False),
+                sunset_date=getattr(tool, "sunsetDate", None),
                 # Metadata fields
                 created_by=created_by,
                 created_from_ip=created_from_ip,
@@ -4590,11 +4634,25 @@ class ToolService(BaseService):
                 # Don't reveal tool existence - return generic "not found"
                 raise ToolNotFoundError(f"Tool not found: {name}")
 
-            # Check deprecated status after RBAC to avoid leaking tool existence
-            if tool_payload.get("deprecated") is True:
-                # Cache the deprecated status to avoid repeated DB queries
-                await tool_lookup_cache.set_negative(name, "deprecated")
-                raise ToolInvocationError(f"Tool '{name}' is deprecated and cannot be executed. Please update your agent to use an alternative tool.")
+            # Check sunset status after RBAC to avoid leaking tool existence
+            # Deprecated tools CAN still be executed until their sunset date
+            # Only sunset tools (deprecated + past sunset_date) are blocked
+            sunset_date_str = tool_payload.get("sunset_date")
+            if sunset_date_str:
+                # Third-Party
+                from dateutil import parser as dateutil_parser
+
+                sunset_date = dateutil_parser.isoparse(sunset_date_str)
+                now = datetime.now(timezone.utc)
+                # Ensure sunset_date is timezone-aware for comparison
+                if sunset_date.tzinfo is None:
+                    sunset_date = sunset_date.replace(tzinfo=timezone.utc)
+                if sunset_date <= now:
+                    # Tool has reached sunset - prevent execution
+                    await tool_lookup_cache.set_negative(name, "sunset")
+                    raise ToolInvocationError(
+                        f"Tool '{name}' has been sunset and can no longer be executed. " f"Sunset date: {sunset_date.strftime('%Y-%m-%d')}. " f"Please update your agent to use an alternative tool."
+                    )
 
             # ═══════════════════════════════════════════════════════════════════════════
             # SECURITY: Enforce server scoping if server_id is provided
@@ -6406,6 +6464,14 @@ class ToolService(BaseService):
             # Update tags if provided
             if tool_update.tags is not None:
                 tool.tags = tool_update.tags
+
+            # Update deprecated status if provided
+            if tool_update.deprecated is not None:
+                tool.deprecated = tool_update.deprecated
+
+            # Update sunset_date if provided
+            if tool_update.sunsetDate is not None:
+                tool.sunset_date = tool_update.sunsetDate
 
             # Update modification metadata
             if modified_by is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1427,8 +1427,12 @@ class ToolService(BaseService):
                 # Calculate days until sunset
                 time_until_sunset = sunset_date - now
                 tool_dict["days_until_sunset"] = max(0, time_until_sunset.days)
+        elif deprecated:
+            # Deprecated without sunset date (backwards compatibility)
+            tool_dict["lifecycle_state"] = "deprecated"
+            tool_dict["is_executable"] = True
         else:
-            # Active tool (not deprecated or no sunset date)
+            # Active tool (not deprecated)
             tool_dict["lifecycle_state"] = "active"
             tool_dict["is_executable"] = True
 
@@ -2064,7 +2068,7 @@ class ToolService(BaseService):
                 tags=tool.tags or [],
                 # Lifecycle management fields
                 deprecated=getattr(tool, "deprecated", False),
-                sunset_date=getattr(tool, "sunsetDate", None),
+                sunset_date=tool.sunset_date,
                 # Metadata fields
                 created_by=created_by,
                 created_from_ip=created_from_ip,
@@ -6468,10 +6472,16 @@ class ToolService(BaseService):
             # Update deprecated status if provided
             if tool_update.deprecated is not None:
                 tool.deprecated = tool_update.deprecated
+                # If deprecated is being set to False, explicitly clear sunset_date
+                if tool_update.deprecated is False:
+                    tool.sunset_date = None
 
-            # Update sunset_date if provided
+            # Update sunset_date if provided (and deprecated is not being set to False)
             if tool_update.sunset_date is not None:
                 tool.sunset_date = tool_update.sunset_date
+            # Explicitly clear sunset_date if the validator set it to None (when deprecated=False)
+            elif tool_update.deprecated is False:
+                tool.sunset_date = None
 
             # Update modification metadata
             if modified_by is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -1415,8 +1415,10 @@ class ToolService(BaseService):
             now = datetime.now(timezone.utc)
             # Ensure sunset_date is timezone-aware for comparison
             if sunset_date.tzinfo is None:
-                sunset_date = sunset_date.replace(tzinfo=timezone.utc)
-            if sunset_date <= now:
+                sunset_date_aware = sunset_date.replace(tzinfo=timezone.utc)
+            else:
+                sunset_date_aware = sunset_date
+            if sunset_date_aware <= now:
                 # Sunset date has passed but tool hasn't been disabled yet (scheduler will handle it)
                 tool_dict["lifecycle_state"] = "sunset"
                 tool_dict["is_executable"] = False
@@ -1425,7 +1427,7 @@ class ToolService(BaseService):
                 tool_dict["lifecycle_state"] = "deprecated"
                 tool_dict["is_executable"] = True
                 # Calculate days until sunset
-                time_until_sunset = sunset_date - now
+                time_until_sunset = sunset_date_aware - now
                 tool_dict["days_until_sunset"] = max(0, time_until_sunset.days)
         elif deprecated:
             # Deprecated without sunset date (backwards compatibility)
@@ -6472,16 +6474,14 @@ class ToolService(BaseService):
             # Update deprecated status if provided
             if tool_update.deprecated is not None:
                 tool.deprecated = tool_update.deprecated
-                # If deprecated is being set to False, explicitly clear sunset_date
+                # If deprecated is being set to False, clear sunset_date and re-enable the tool
                 if tool_update.deprecated is False:
                     tool.sunset_date = None
+                    tool.enabled = True
 
             # Update sunset_date if provided (and deprecated is not being set to False)
             if tool_update.sunset_date is not None:
                 tool.sunset_date = tool_update.sunset_date
-            # Explicitly clear sunset_date if the validator set it to None (when deprecated=False)
-            elif tool_update.deprecated is False:
-                tool.sunset_date = None
 
             # Update modification metadata
             if modified_by is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6470,8 +6470,8 @@ class ToolService(BaseService):
                 tool.deprecated = tool_update.deprecated
 
             # Update sunset_date if provided
-            if tool_update.sunsetDate is not None:
-                tool.sunset_date = tool_update.sunsetDate
+            if tool_update.sunset_date is not None:
+                tool.sunset_date = tool_update.sunset_date
 
             # Update modification metadata
             if modified_by is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4655,7 +4655,7 @@ class ToolService(BaseService):
                     # Tool has reached sunset - prevent execution
                     await tool_lookup_cache.set_negative(name, "sunset")
                     raise ToolInvocationError(
-                        f"Tool '{name}' has been sunset and can no longer be executed. " f"Sunset date: {sunset_date.strftime('%Y-%m-%d')}. " f"Please update your agent to use an alternative tool."
+                        f"Tool '{name}' has been sunset and can no longer be executed. Sunset date: {sunset_date.strftime('%Y-%m-%d')}. Please update your agent to use an alternative tool."
                     )
 
             # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/integration/test_tool_lifecycle_management.py
+++ b/tests/integration/test_tool_lifecycle_management.py
@@ -215,7 +215,13 @@ class TestToolLifecycleExecution:
     """Test tool execution based on lifecycle state."""
 
     def test_execute_deprecated_tool_before_sunset_succeeds(self, test_client):
-        """Test that deprecated tools can be executed before sunset date."""
+        """Test that deprecated tools can be executed before sunset date.
+
+        CRITICAL BEHAVIOR: Deprecated tools must remain executable until sunset_date.
+        This test verifies the lifecycle state indicates executability, which is the
+        prerequisite for actual execution. Full MCP endpoint execution testing would
+        require session setup (see test_rate_limiter_multi_tenant.py for pattern).
+        """
         # Create deprecated tool with future sunset date
         future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
 
@@ -236,17 +242,26 @@ class TestToolLifecycleExecution:
         assert create_response.status_code == 200
         tool_id = create_response.json()["id"]
 
-        # Mock the actual tool execution to avoid network calls
-        with patch("mcpgateway.services.tool_service.ToolService.invoke_tool") as mock_invoke:
-            mock_invoke.return_value = AsyncMock(return_value={"result": "success"})
+        # Verify tool is in deprecated state and marked as executable
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        data = get_response.json()
 
-            # Attempt to execute the tool - should succeed
-            # Note: Actual execution endpoint depends on your API structure
-            # This is a placeholder for the execution test
-            pass  # TODO: Add actual execution test when endpoint is available
+        # CRITICAL: These assertions prove the tool is executable
+        assert data["deprecated"] is True
+        assert data["enabled"] is True
+        assert data["lifecycleState"] == "deprecated"
+        assert data["isExecutable"] is True, "Deprecated tools MUST be executable before sunset"
+        assert data["daysUntilSunset"] > 0
 
     def test_execute_sunset_tool_fails(self, test_client):
-        """Test that sunset tools cannot be executed."""
+        """Test that sunset tools cannot be executed.
+
+        CRITICAL BEHAVIOR: Sunset tools (enabled=False) must be blocked from execution.
+        This test verifies the lifecycle state indicates non-executability. The actual
+        execution block happens in tool_service.py:invoke_tool where enabled=False
+        raises ToolNotFoundError.
+        """
         # Create tool with past sunset date (already sunset)
         past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
 
@@ -272,15 +287,16 @@ class TestToolLifecycleExecution:
         finally:
             db.close()
 
-        # Verify tool is in sunset state
+        # Verify tool is in sunset state and NOT executable
         get_response = test_client.get(f"/tools/{tool_id}")
         assert get_response.status_code == 200
         data = get_response.json()
-        assert data["lifecycleState"] == "sunset"
-        assert data["isExecutable"] is False
 
-        # Attempt to execute should fail
-        # TODO: Add actual execution test when endpoint is available
+        # CRITICAL: These assertions prove the tool is blocked from execution
+        assert data["deprecated"] is True
+        assert data["enabled"] is False
+        assert data["lifecycleState"] == "sunset"
+        assert data["isExecutable"] is False, "Sunset tools MUST NOT be executable"
 
 
 class TestSunsetScheduler:

--- a/tests/integration/test_tool_lifecycle_management.py
+++ b/tests/integration/test_tool_lifecycle_management.py
@@ -1,0 +1,782 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_tool_lifecycle_management.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for Tool Lifecycle Management feature.
+
+Tests the complete lifecycle of tools through deprecated and sunset states:
+1. Create tools with deprecated=true and future sunsetDate
+2. Execute deprecated tools (should succeed before sunset)
+3. Execute sunset tools (should fail after sunset date)
+4. Automated scheduler transitions tools to sunset
+5. Lifecycle state computation and API responses
+6. Cache invalidation on sunset transitions
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+import tempfile
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, Tool as DbTool
+from mcpgateway.main import app
+from mcpgateway.services.sunset_scheduler_service import SunsetSchedulerService
+from mcpgateway.utils.verify_credentials import require_auth
+
+# Local
+from tests.utils.rbac_mocks import MockPermissionService
+
+
+@pytest.fixture
+def test_client():
+    """FastAPI TestClient with proper database setup and auth dependency overridden."""
+    # Standard
+    from _pytest.monkeypatch import MonkeyPatch
+
+    # First-Party
+    from mcpgateway.auth import get_current_user
+    from mcpgateway.config import settings
+    from mcpgateway.middleware.rbac import get_current_user_with_permissions
+    from mcpgateway.middleware.rbac import get_db as rbac_get_db
+    from mcpgateway.middleware.rbac import get_permission_service
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+
+    mp = MonkeyPatch()
+
+    # Create temp SQLite file
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    # Patch settings
+    mp.setattr(settings, "database_url", url, raising=False)
+    mp.setattr(settings, "csrf_enabled", False, raising=False)
+
+    # Create engine and session
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    # Create schema
+    Base.metadata.create_all(bind=engine)
+
+    # Set up authentication overrides
+    mock_email_user = MagicMock()
+    mock_email_user.email = "test-user@example.com"
+    mock_email_user.full_name = "Test User"
+    mock_email_user.is_admin = True
+    mock_email_user.is_active = True
+
+    async def mock_user_with_permissions():
+        """Mock user context for RBAC."""
+        db_session = TestSessionLocal()
+        try:
+            yield {
+                "email": "test-user@example.com",
+                "full_name": "Test User",
+                "is_admin": True,
+                "ip_address": "127.0.0.1",
+                "user_agent": "test-client",
+                "db": db_session,
+            }
+        finally:
+            db_session.close()
+
+    def mock_get_permission_service(*args, **kwargs):
+        """Return a mock permission service that always grants access."""
+        return MockPermissionService(always_grant=True)
+
+    def override_get_db():
+        """Override database dependency to return our test database."""
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Patch the PermissionService class to always return our mock
+    with patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService):
+        app.dependency_overrides[require_auth] = lambda: "test-user"
+        app.dependency_overrides[get_current_user] = lambda: mock_email_user
+        app.dependency_overrides[get_current_user_with_permissions] = mock_user_with_permissions
+        app.dependency_overrides[get_permission_service] = mock_get_permission_service
+        app.dependency_overrides[rbac_get_db] = override_get_db
+
+        client = TestClient(app)
+
+        # Store session factory for direct DB access in tests
+        client.test_session_factory = TestSessionLocal
+
+        yield client
+
+        # Cleanup
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_current_user_with_permissions, None)
+        app.dependency_overrides.pop(get_permission_service, None)
+        app.dependency_overrides.pop(rbac_get_db, None)
+
+    mp.undo()
+    engine.dispose()
+
+
+class TestToolLifecycleCreation:
+    """Test creating tools with lifecycle fields."""
+
+    def test_create_deprecated_tool_with_future_sunset_date(self, test_client):
+        """Test creating a tool with deprecated=true and future sunsetDate."""
+        future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "deprecated_tool",
+                    "description": "A deprecated tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deprecated"] is True
+        assert data["sunsetDate"] is not None
+        assert data["lifecycleState"] == "deprecated"
+        assert data["isExecutable"] is True
+        assert data["daysUntilSunset"] >= 29  # At least 29 days remaining
+
+    def test_create_deprecated_tool_without_sunset_date_fails(self, test_client):
+        """Test that creating deprecated tool without sunsetDate fails validation."""
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "invalid_deprecated_tool",
+                    "description": "Invalid deprecated tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    # Missing sunsetDate
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 422  # Validation error
+        error_detail = response.json()["detail"]
+        assert any("sunsetdate" in str(err).lower() for err in error_detail)
+
+    def test_create_active_tool_has_correct_lifecycle_state(self, test_client):
+        """Test that active tools have correct lifecycle_state."""
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "active_tool",
+                    "description": "An active tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": False,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deprecated"] is False
+        assert data["sunsetDate"] is None
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+        assert data["daysUntilSunset"] is None
+
+
+class TestToolLifecycleExecution:
+    """Test tool execution based on lifecycle state."""
+
+    def test_execute_deprecated_tool_before_sunset_succeeds(self, test_client):
+        """Test that deprecated tools can be executed before sunset date."""
+        # Create deprecated tool with future sunset date
+        future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+        create_response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "exec_deprecated_tool",
+                    "description": "Executable deprecated tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert create_response.status_code == 200
+        tool_id = create_response.json()["id"]
+
+        # Mock the actual tool execution to avoid network calls
+        with patch("mcpgateway.services.tool_service.ToolService.invoke_tool") as mock_invoke:
+            mock_invoke.return_value = AsyncMock(return_value={"result": "success"})
+
+            # Attempt to execute the tool - should succeed
+            # Note: Actual execution endpoint depends on your API structure
+            # This is a placeholder for the execution test
+            pass  # TODO: Add actual execution test when endpoint is available
+
+    def test_execute_sunset_tool_fails(self, test_client):
+        """Test that sunset tools cannot be executed."""
+        # Create tool with past sunset date (already sunset)
+        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+
+        # Directly insert sunset tool into database
+        db = test_client.test_session_factory()
+        try:
+            sunset_tool = DbTool(
+                original_name="sunset_tool",
+                custom_name="sunset_tool",
+                custom_name_slug="sunset-tool",
+                display_name="Sunset Tool",
+                url="http://example.com/tool",
+                description="A sunset tool",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,  # Sunset tools are disabled
+            )
+            db.add(sunset_tool)
+            db.commit()
+            db.refresh(sunset_tool)
+            tool_id = sunset_tool.id
+        finally:
+            db.close()
+
+        # Verify tool is in sunset state
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        data = get_response.json()
+        assert data["lifecycleState"] == "sunset"
+        assert data["isExecutable"] is False
+
+        # Attempt to execute should fail
+        # TODO: Add actual execution test when endpoint is available
+
+
+class TestSunsetScheduler:
+    """Test automated sunset scheduler service."""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_transitions_tools_to_sunset(self, test_client):
+        """Test that scheduler automatically transitions deprecated tools to sunset."""
+        # Create deprecated tool with past sunset date
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        db = test_client.test_session_factory()
+        try:
+            # Insert tool that should be sunset
+            tool_to_sunset = DbTool(
+                original_name="should_be_sunset",
+                custom_name="should_be_sunset",
+                custom_name_slug="should-be-sunset",
+                display_name="Should Be Sunset",
+                url="http://example.com/tool",
+                description="Tool that should be sunset",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,  # Still enabled, scheduler should disable it
+            )
+            db.add(tool_to_sunset)
+            db.commit()
+            db.refresh(tool_to_sunset)
+            tool_id = tool_to_sunset.id
+        finally:
+            db.close()
+
+        # Run scheduler
+        scheduler = SunsetSchedulerService()
+        await scheduler._process_sunset_tools()
+
+        # Verify tool was sunset (enabled=False)
+        db = test_client.test_session_factory()
+        try:
+            stmt = select(DbTool).where(DbTool.id == tool_id)
+            updated_tool = db.execute(stmt).scalar_one()
+            assert updated_tool.enabled is False
+            assert updated_tool.deprecated is True
+        finally:
+            db.close()
+
+    @pytest.mark.asyncio
+    async def test_scheduler_idempotency(self, test_client):
+        """Test that scheduler can run multiple times without issues."""
+        # Create deprecated tool with past sunset date
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        db = test_client.test_session_factory()
+        try:
+            tool_to_sunset = DbTool(
+                original_name="idempotent_test",
+                custom_name="idempotent_test",
+                custom_name_slug="idempotent-test",
+                display_name="Idempotent Test",
+                url="http://example.com/tool",
+                description="Tool for idempotency test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,
+            )
+            db.add(tool_to_sunset)
+            db.commit()
+            db.refresh(tool_to_sunset)
+            tool_id = tool_to_sunset.id
+        finally:
+            db.close()
+
+        # Run scheduler twice
+        scheduler = SunsetSchedulerService()
+        await scheduler._process_sunset_tools()
+        await scheduler._process_sunset_tools()  # Second run should be idempotent
+
+        # Verify tool is still sunset (only disabled once)
+        db = test_client.test_session_factory()
+        try:
+            stmt = select(DbTool).where(DbTool.id == tool_id)
+            updated_tool = db.execute(stmt).scalar_one()
+            assert updated_tool.enabled is False
+        finally:
+            db.close()
+
+
+class TestLifecycleStateComputation:
+    """Test lifecycle_state computation in API responses."""
+
+    def test_active_tool_lifecycle_state(self, test_client):
+        """Test lifecycle_state for active tools."""
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "active_state_tool",
+                    "description": "Active tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": False,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+        assert data["daysUntilSunset"] is None
+
+    def test_deprecated_tool_lifecycle_state(self, test_client):
+        """Test lifecycle_state for deprecated tools."""
+        future_date = (datetime.now(timezone.utc) + timedelta(days=15)).isoformat()
+
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "deprecated_state_tool",
+                    "description": "Deprecated tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lifecycleState"] == "deprecated"
+        assert data["isExecutable"] is True
+        assert data["daysUntilSunset"] >= 14  # At least 14 days remaining
+
+    def test_sunset_tool_lifecycle_state(self, test_client):
+        """Test lifecycle_state for sunset tools."""
+        # Create tool with past sunset date
+        db = test_client.test_session_factory()
+        try:
+            sunset_tool = DbTool(
+                original_name="sunset_state_tool",
+                custom_name="sunset_state_tool",
+                custom_name_slug="sunset-state-tool",
+                display_name="Sunset State Tool",
+                url="http://example.com/tool",
+                description="Sunset tool",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,
+            )
+            db.add(sunset_tool)
+            db.commit()
+            db.refresh(sunset_tool)
+            tool_id = sunset_tool.id
+        finally:
+            db.close()
+
+        # Get tool and verify lifecycle state
+        response = test_client.get(f"/tools/{tool_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["lifecycleState"] == "sunset"
+        assert data["isExecutable"] is False
+        assert data["daysUntilSunset"] is None  # No days remaining for sunset tools
+
+
+class TestBackwardsCompatibility:
+    """Test backwards compatibility of lifecycle fields."""
+
+    def test_existing_tools_without_lifecycle_fields(self, test_client):
+        """Test that existing tools without lifecycle fields work correctly."""
+        # Create tool without lifecycle fields (simulating existing tool)
+        db = test_client.test_session_factory()
+        try:
+            legacy_tool = DbTool(
+                original_name="legacy_tool",
+                custom_name="legacy_tool",
+                custom_name_slug="legacy-tool",
+                display_name="Legacy Tool",
+                url="http://example.com/tool",
+                description="Legacy tool without lifecycle fields",
+                input_schema={"type": "object", "properties": {}},
+                # No deprecated or sunset_date fields
+            )
+            db.add(legacy_tool)
+            db.commit()
+            db.refresh(legacy_tool)
+            tool_id = legacy_tool.id
+        finally:
+            db.close()
+
+        # Get tool and verify it's treated as active
+        response = test_client.get(f"/tools/{tool_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deprecated"] is False
+        assert data["sunsetDate"] is None
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+
+class TestLifecycleRegression:
+    """Regression tests to prevent feature regressions and ensure critical behaviors.
+
+    These tests specifically verify:
+    1. Deprecated tools ARE executable (critical behavior change from old implementation)
+    2. Only sunset tools (enabled=False) are blocked from execution
+    3. Validation rules are enforced consistently
+    4. Scheduler behavior remains idempotent
+    5. Cache invalidation works correctly
+    6. API response fields are always present
+    """
+
+    def test_regression_deprecated_tools_are_executable(self, test_client):
+        """REGRESSION: Verify deprecated tools ARE executable until sunset.
+
+        This is a CRITICAL behavior change from the old implementation where
+        deprecated tools were immediately blocked. This test ensures we don't
+        regress back to the old behavior.
+        """
+        future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+        # Create deprecated tool
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_deprecated_executable",
+                    "description": "Deprecated but executable tool",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # CRITICAL: Deprecated tools MUST be executable
+        assert data["deprecated"] is True
+        assert data["isExecutable"] is True
+        assert data["lifecycleState"] == "deprecated"
+        assert data["enabled"] is True  # Still enabled
+
+    def test_regression_only_sunset_tools_blocked(self, test_client):
+        """REGRESSION: Verify only sunset tools (enabled=False) are blocked."""
+        # Create sunset tool directly in DB
+        db = test_client.test_session_factory()
+        try:
+            sunset_tool = DbTool(
+                original_name="regression_sunset_blocked",
+                custom_name="regression_sunset_blocked",
+                custom_name_slug="regression-sunset-blocked",
+                display_name="Sunset Blocked Tool",
+                url="http://example.com/tool",
+                description="Sunset tool that should be blocked",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,  # CRITICAL: Only disabled tools are blocked
+            )
+            db.add(sunset_tool)
+            db.commit()
+            db.refresh(sunset_tool)
+            tool_id = sunset_tool.id
+        finally:
+            db.close()
+
+        # Verify tool is NOT executable
+        response = test_client.get(f"/tools/{tool_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["isExecutable"] is False
+        assert data["enabled"] is False
+        assert data["lifecycleState"] == "sunset"
+
+    def test_regression_validation_rules_enforced(self, test_client):
+        """REGRESSION: Verify validation rules are consistently enforced."""
+        # Test 1: deprecated=True requires sunsetDate
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_validation_1",
+                    "description": "Test validation",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    # Missing sunsetDate - should fail
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert response.status_code == 422
+
+        # Test 2: sunsetDate must be future date
+        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_validation_2",
+                    "description": "Test validation",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": past_date,  # Past date - should fail
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert response.status_code == 422
+
+    def test_regression_api_response_fields_always_present(self, test_client):
+        """REGRESSION: Verify all lifecycle fields are always in API responses."""
+        # Create active tool
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_api_fields",
+                    "description": "Test API fields",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": False,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # CRITICAL: All lifecycle fields must be present
+        assert "deprecated" in data
+        assert "sunsetDate" in data
+        assert "lifecycleState" in data
+        assert "isExecutable" in data
+        assert "daysUntilSunset" in data
+
+        # Verify correct values for active tool
+        assert data["deprecated"] is False
+        assert data["sunsetDate"] is None
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+        assert data["daysUntilSunset"] is None
+
+    @pytest.mark.asyncio
+    async def test_regression_scheduler_idempotency_preserved(self, test_client):
+        """REGRESSION: Verify scheduler remains idempotent across runs."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        # Create multiple tools that should be sunset
+        db = test_client.test_session_factory()
+        try:
+            for i in range(3):
+                tool = DbTool(
+                    original_name=f"regression_scheduler_{i}",
+                    custom_name=f"regression_scheduler_{i}",
+                    custom_name_slug=f"regression-scheduler-{i}",
+                    display_name=f"Regression Scheduler {i}",
+                    url="http://example.com/tool",
+                    description=f"Tool {i} for scheduler test",
+                    input_schema={"type": "object", "properties": {}},
+                    deprecated=True,
+                    sunset_date=past_date,
+                    enabled=True,
+                )
+                db.add(tool)
+            db.commit()
+        finally:
+            db.close()
+
+        # Run scheduler multiple times
+        scheduler = SunsetSchedulerService()
+        await scheduler._process_sunset_tools()
+        await scheduler._process_sunset_tools()
+        await scheduler._process_sunset_tools()
+
+        # Verify all tools are sunset exactly once
+        db = test_client.test_session_factory()
+        try:
+            stmt = select(DbTool).where(DbTool.original_name.like("regression_scheduler_%"))
+            tools = db.execute(stmt).scalars().all()
+            assert len(tools) == 3
+            for tool in tools:
+                assert tool.enabled is False
+                assert tool.deprecated is True
+        finally:
+            db.close()
+
+    def test_regression_backwards_compatibility_maintained(self, test_client):
+        """REGRESSION: Verify tools without lifecycle fields still work."""
+        # Create tool without any lifecycle fields (simulating pre-feature tool)
+        db = test_client.test_session_factory()
+        try:
+            legacy_tool = DbTool(
+                original_name="regression_legacy",
+                custom_name="regression_legacy",
+                custom_name_slug="regression-legacy",
+                display_name="Regression Legacy Tool",
+                url="http://example.com/tool",
+                description="Legacy tool from before lifecycle feature",
+                input_schema={"type": "object", "properties": {}},
+                # No deprecated or sunset_date - defaults should apply
+            )
+            db.add(legacy_tool)
+            db.commit()
+            db.refresh(legacy_tool)
+            tool_id = legacy_tool.id
+        finally:
+            db.close()
+
+        # Verify tool works as active tool
+        response = test_client.get(f"/tools/{tool_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        # CRITICAL: Legacy tools must be treated as active
+        assert data["deprecated"] is False
+        assert data["sunsetDate"] is None
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+        assert data["enabled"] is True
+
+    def test_regression_deprecated_field_persists_correctly(self, test_client):
+        """REGRESSION: Verify deprecated field persists correctly through lifecycle."""
+        future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+        # Create deprecated tool
+        create_response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_persist_test",
+                    "description": "Tool for testing field persistence",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert create_response.status_code == 200
+        created_data = create_response.json()
+        tool_id = created_data["id"]
+
+        # CRITICAL: Verify deprecated tool is created correctly
+        assert created_data["deprecated"] is True
+        assert created_data["sunsetDate"] is not None
+        assert created_data["lifecycleState"] == "deprecated"
+        assert created_data["isExecutable"] is True
+
+        # Fetch tool again to verify persistence
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        fetched_data = get_response.json()
+
+        # CRITICAL: Deprecated state must persist across fetches
+        assert fetched_data["deprecated"] is True
+        assert fetched_data["sunsetDate"] is not None
+        assert fetched_data["lifecycleState"] == "deprecated"
+        assert fetched_data["isExecutable"] is True
+
+    def test_regression_days_until_sunset_calculation(self, test_client):
+        """REGRESSION: Verify daysUntilSunset is calculated correctly."""
+        # Create tool with sunset in exactly 10 days
+        future_date = (datetime.now(timezone.utc) + timedelta(days=10, hours=12)).isoformat()
+
+        response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "regression_days_calc",
+                    "description": "Test days calculation",
+                    "url": "http://example.com/tool",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # CRITICAL: daysUntilSunset should be approximately 10
+        assert data["daysUntilSunset"] is not None
+        assert 9 <= data["daysUntilSunset"] <= 11  # Allow 1 day margin for timing

--- a/tests/integration/test_tool_lifecycle_regression.py
+++ b/tests/integration/test_tool_lifecycle_regression.py
@@ -1,0 +1,689 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_tool_lifecycle_regression.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Regression tests for tool lifecycle management.
+
+These tests ensure that the tool lifecycle feature (deprecated → sunset) doesn't
+introduce regressions in critical paths:
+- Tool listing and filtering
+- Tool invocation
+- Cache consistency
+- Update operations
+- Multi-worker scenarios
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+import os
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, Tool as DbTool
+from mcpgateway.main import app
+from mcpgateway.services.sunset_scheduler_service import SunsetSchedulerService
+from mcpgateway.utils.verify_credentials import require_auth
+
+# Local
+from tests.utils.rbac_mocks import MockPermissionService
+
+
+@pytest.fixture
+def test_client():
+    """FastAPI TestClient with proper database setup and auth dependency overridden."""
+    # Standard
+    from _pytest.monkeypatch import MonkeyPatch
+
+    # First-Party
+    from mcpgateway.auth import get_current_user
+    from mcpgateway.config import settings
+    from mcpgateway.middleware.rbac import get_current_user_with_permissions
+    from mcpgateway.middleware.rbac import get_db as rbac_get_db
+    from mcpgateway.middleware.rbac import get_permission_service
+    import mcpgateway.db as db_mod
+    import mcpgateway.main as main_mod
+
+    mp = MonkeyPatch()
+
+    # Create temp SQLite file
+    fd, path = tempfile.mkstemp(suffix=".db")
+    url = f"sqlite:///{path}"
+
+    # Patch settings
+    mp.setattr(settings, "database_url", url, raising=False)
+    mp.setattr(settings, "csrf_enabled", False, raising=False)
+
+    # Create engine and session
+    engine = create_engine(url, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    mp.setattr(db_mod, "engine", engine, raising=False)
+    mp.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "SessionLocal", TestSessionLocal, raising=False)
+    mp.setattr(main_mod, "engine", engine, raising=False)
+
+    # Create schema
+    Base.metadata.create_all(bind=engine)
+
+    # Set up authentication overrides
+    from unittest.mock import MagicMock  # pylint: disable=import-outside-toplevel
+
+    mock_email_user = MagicMock()
+    mock_email_user.email = "test-user@example.com"
+    mock_email_user.full_name = "Test User"
+    mock_email_user.is_admin = True
+    mock_email_user.is_active = True
+
+    async def mock_user_with_permissions():
+        """Mock user context for RBAC."""
+        db_session = TestSessionLocal()
+        try:
+            yield {
+                "email": "test-user@example.com",
+                "full_name": "Test User",
+                "is_admin": True,
+                "ip_address": "127.0.0.1",
+                "user_agent": "test-client",
+                "db": db_session,
+            }
+        finally:
+            db_session.close()
+
+    def mock_get_permission_service(*args, **kwargs):
+        """Return a mock permission service that always grants access."""
+        return MockPermissionService(always_grant=True)
+
+    def override_get_db():
+        """Override database dependency to return our test database."""
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    # Patch the PermissionService class to always return our mock
+    with patch("mcpgateway.middleware.rbac.PermissionService", MockPermissionService):
+        app.dependency_overrides[require_auth] = lambda: "test-user"
+        app.dependency_overrides[get_current_user] = lambda: mock_email_user
+        app.dependency_overrides[get_current_user_with_permissions] = mock_user_with_permissions
+        app.dependency_overrides[get_permission_service] = mock_get_permission_service
+        app.dependency_overrides[rbac_get_db] = override_get_db
+
+        client = TestClient(app)
+
+        # Store session factory for direct DB access in tests
+        client.test_session_factory = TestSessionLocal
+
+        yield client
+
+        # Cleanup
+        app.dependency_overrides.pop(require_auth, None)
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_current_user_with_permissions, None)
+        app.dependency_overrides.pop(get_permission_service, None)
+        app.dependency_overrides.pop(rbac_get_db, None)
+
+    mp.undo()
+    engine.dispose()
+
+
+@pytest.mark.integration
+class TestToolLifecycleListingRegression:
+    """Regression tests for tool listing with lifecycle states."""
+
+    def test_sunset_tools_excluded_from_default_list(self, test_client):
+        """REGRESSION: Sunset tools should not appear in default tool listings.
+
+        Critical: MCP clients should not see disabled (sunset) tools in their
+        tool lists, as this would cause invocation failures.
+        """
+        # Create an active tool
+        active_response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "active_tool",
+                    "description": "Active tool",
+                    "url": "http://example.com/active",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert active_response.status_code == 200
+
+        # Create a deprecated tool with past sunset date (will be sunset)
+        past_date = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+
+        # Directly insert sunset tool into database
+        db = test_client.test_session_factory()
+        try:
+            sunset_tool = DbTool(
+                original_name="sunset_tool",
+                custom_name="sunset_tool",
+                custom_name_slug="sunset-tool",
+                display_name="Sunset Tool",
+                url="http://example.com/sunset",
+                description="A sunset tool",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,  # Sunset by scheduler
+            )
+            db.add(sunset_tool)
+            db.commit()
+            db.refresh(sunset_tool)
+            sunset_tool_id = sunset_tool.id
+        finally:
+            db.close()
+
+        # List tools (default behavior - should exclude sunset tools)
+        list_response = test_client.get("/tools")
+        assert list_response.status_code == 200
+        tools_data = list_response.json()
+
+        # Verify active tool is in list
+        tool_names = [t["name"] for t in tools_data]
+        assert "active-tool" in tool_names
+
+        # CRITICAL: Sunset tool should NOT be in default list
+        assert "sunset-tool" not in tool_names, "Sunset tools should be excluded from default tool listings"
+
+        # Verify we can still get the sunset tool by ID (for admin purposes)
+        get_response = test_client.get(f"/tools/{sunset_tool_id}")
+        assert get_response.status_code == 200
+        tool_data = get_response.json()
+        assert tool_data["lifecycleState"] == "sunset"
+        assert tool_data["enabled"] is False
+
+    def test_sunset_tools_visible_with_include_inactive(self, test_client):
+        """REGRESSION: Admins should see sunset tools with include_inactive=True.
+
+        Critical: Admin interfaces need to see all tools including sunset ones
+        for auditing and management purposes.
+        """
+        # Create a sunset tool
+        db = test_client.test_session_factory()
+        try:
+            sunset_tool = DbTool(
+                original_name="admin_sunset_tool",
+                custom_name="admin_sunset_tool",
+                custom_name_slug="admin-sunset-tool",
+                display_name="Admin Sunset Tool",
+                url="http://example.com/admin-sunset",
+                description="Sunset tool for admin view test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,
+            )
+            db.add(sunset_tool)
+            db.commit()
+        finally:
+            db.close()
+
+        # List tools with include_inactive (admin view)
+        list_response = test_client.get("/tools?include_inactive=true")
+        assert list_response.status_code == 200
+        tools_data = list_response.json()
+
+        # CRITICAL: Sunset tool should be visible with include_inactive
+        tool_names = [t["name"] for t in tools_data]
+        assert "admin-sunset-tool" in tool_names, "Sunset tools should be visible with include_inactive=true"
+
+        # Find the sunset tool and verify its lifecycle state
+        sunset_tool_data = next((t for t in tools_data if t["name"] == "admin-sunset-tool"), None)
+        assert sunset_tool_data is not None
+        assert sunset_tool_data["lifecycleState"] == "sunset"
+        assert sunset_tool_data["enabled"] is False
+        assert sunset_tool_data["deprecated"] is True
+
+
+@pytest.mark.integration
+class TestToolLifecycleInvocationRegression:
+    """Regression tests for tool invocation with lifecycle management."""
+
+    @pytest.mark.asyncio
+    async def test_tool_invocation_blocked_after_scheduler_run(self, test_client):
+        """REGRESSION: Tool invocation must be blocked after scheduler sunsets tool.
+
+        Critical: Tools past their sunset_date must not be executable, even if
+        the scheduler hasn't run yet. The invocation check should verify sunset_date.
+        """
+        # Create a deprecated tool with past sunset date but still enabled
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)  # noqa: F841
+
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="invocation_test_tool",
+                custom_name="invocation_test_tool",
+                custom_name_slug="invocation-test-tool",
+                display_name="Invocation Test Tool",
+                url="http://example.com/invocation-test",
+                description="Tool for invocation blocking test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,  # Still enabled (scheduler hasn't run)
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Run the sunset scheduler to disable the tool
+        scheduler = SunsetSchedulerService()
+
+        # Mock dependencies to avoid Redis/audit trail issues in tests
+        with patch("mcpgateway.services.sunset_scheduler_service.get_registry_cache") as mock_cache:
+            mock_registry = AsyncMock()
+            mock_cache.return_value = mock_registry
+
+            with patch("mcpgateway.services.sunset_scheduler_service.get_audit_trail_service"):
+                with patch("mcpgateway.services.sunset_scheduler_service.ObservabilityService"):
+                    await scheduler._process_sunset_tools()
+
+        # Verify tool was disabled
+        db = test_client.test_session_factory()
+        try:
+            db_tool = db.get(DbTool, tool_id)
+            assert db_tool is not None
+            assert db_tool.enabled is False, "Scheduler should have disabled the tool"
+        finally:
+            db.close()
+
+        # Verify tool shows sunset state via API
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        tool_data = get_response.json()
+        assert tool_data["lifecycleState"] == "sunset"
+        assert tool_data["isExecutable"] is False
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invocation_during_sunset_transition(self, test_client):
+        """REGRESSION: Concurrent invocations during sunset should fail gracefully.
+
+        Critical: If a tool is being invoked while the scheduler is disabling it,
+        the system should handle the race condition cleanly without errors.
+        """
+        # Create a deprecated tool about to be sunset
+        past_date = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="concurrent_test_tool",
+                custom_name="concurrent_test_tool",
+                custom_name_slug="concurrent-test-tool",
+                display_name="Concurrent Test Tool",
+                url="http://example.com/concurrent-test",
+                description="Tool for concurrent execution test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,  # Still enabled
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # The tool should be blocked even before scheduler runs
+        # because invoke_tool checks sunset_date
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        tool_data = get_response.json()
+
+        # Tool is technically still enabled but past sunset
+        assert tool_data["enabled"] is True
+        assert tool_data["deprecated"] is True
+        # The lifecycle_state should show "sunset" because sunset_date is in the past
+        assert tool_data["lifecycleState"] == "sunset"
+        assert tool_data["isExecutable"] is False
+
+
+@pytest.mark.integration
+class TestToolLifecycleCacheRegression:
+    """Regression tests for cache consistency with lifecycle management."""
+
+    @pytest.mark.asyncio
+    async def test_sunset_scheduler_invalidates_tool_cache(self, test_client):
+        """REGRESSION: Sunset scheduler must invalidate cached tool entries.
+
+        Critical: Stale cache entries could allow execution of sunset tools.
+        The scheduler must invalidate the cache when disabling tools.
+        """
+        # Create a deprecated tool ready to sunset
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="cache_invalidation_tool",
+                custom_name="cache_invalidation_tool",
+                custom_name_slug="cache-invalidation-tool",
+                display_name="Cache Invalidation Tool",
+                url="http://example.com/cache-test",
+                description="Tool for cache invalidation test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Mock the cache to verify invalidation is called
+        mock_invalidate_called = False
+
+        with patch("mcpgateway.services.sunset_scheduler_service.get_registry_cache") as mock_cache_getter:
+            mock_cache = AsyncMock()
+
+            # Track if invalidate_tools is called (no arguments)
+            async def track_invalidate():
+                nonlocal mock_invalidate_called
+                mock_invalidate_called = True
+
+            mock_cache.invalidate_tools = track_invalidate
+            mock_cache_getter.return_value = mock_cache
+
+            # Run scheduler
+            scheduler = SunsetSchedulerService()
+            with patch("mcpgateway.services.sunset_scheduler_service.get_audit_trail_service"):
+                with patch("mcpgateway.services.sunset_scheduler_service.ObservabilityService"):
+                    await scheduler._process_sunset_tools()
+
+        # CRITICAL: Cache invalidation should have been called
+        assert mock_invalidate_called, "Scheduler must invalidate cache for sunset tools"
+
+        # Verify tool was actually disabled
+        db = test_client.test_session_factory()
+        try:
+            db_tool = db.get(DbTool, tool_id)
+            assert db_tool.enabled is False
+        finally:
+            db.close()
+
+
+@pytest.mark.integration
+class TestToolLifecycleUpdateRegression:
+    """Regression tests for update operations on lifecycle-managed tools."""
+
+    def test_cannot_manually_enable_sunset_tool_without_clearing_deprecated(self, test_client):
+        """REGRESSION: Cannot enable sunset tool without clearing deprecated flag.
+
+        Critical: Attempting to set enabled=True on a sunset tool without first
+        clearing deprecated=False should fail to prevent inconsistent state.
+        """
+        # Create a sunset tool
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="manual_enable_test",
+                custom_name="manual_enable_test",
+                custom_name_slug="manual-enable-test",
+                display_name="Manual Enable Test",
+                url="http://example.com/manual-enable",
+                description="Tool for manual enable test",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,
+                owner_email="test-user@example.com",  # Set owner to match test user
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Verify tool starts as sunset
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        assert get_response.json()["lifecycleState"] == "sunset"
+
+        # Try to enable the tool without clearing deprecated
+        # This should either fail or be allowed but maintain consistency
+        _update_response = test_client.put(
+            f"/tools/{tool_id}",
+            json={
+                "deprecated": True,  # Still deprecated
+                # enabled is managed by the system, not directly settable via this endpoint
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+
+        # The tool should remain in sunset state
+        get_after = test_client.get(f"/tools/{tool_id}")
+        assert get_after.status_code == 200
+        data = get_after.json()
+
+        # CRITICAL: Tool must remain disabled if deprecated=True
+        if data["deprecated"] is True:
+            assert data["enabled"] is False, "Deprecated tools cannot be enabled while deprecated=True"
+
+    def test_update_other_fields_on_sunset_tool(self, test_client):
+        """REGRESSION: Should be able to update non-lifecycle fields on sunset tools.
+
+        Critical: Admins need to update metadata (description, tags) on sunset
+        tools for documentation purposes.
+        """
+        # Create a sunset tool
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="update_fields_test",
+                custom_name="update_fields_test",
+                custom_name_slug="update-fields-test",
+                display_name="Update Fields Test",
+                url="http://example.com/update-fields",
+                description="Original description",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,
+                tags=["original"],
+                owner_email="test-user@example.com",  # Set owner to match test user
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Update description and tags on sunset tool
+        update_response = test_client.put(
+            f"/tools/{tool_id}",
+            json={
+                "description": "Updated description for archived tool",
+                "tags": ["archived", "deprecated"],
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert update_response.status_code == 200, f"Update failed: {update_response.status_code} - {update_response.text}"
+
+        # Verify updates were applied
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        data = get_response.json()
+
+        # CRITICAL: Non-lifecycle fields should be updated
+        assert data["description"] == "Updated description for archived tool"
+        # Tags are returned as objects with id and label
+        tag_ids = [tag["id"] for tag in data["tags"]]
+        assert "archived" in tag_ids
+        assert "deprecated" in tag_ids
+
+        # Lifecycle state should remain unchanged
+        assert data["lifecycleState"] == "sunset"
+        assert data["enabled"] is False
+        assert data["deprecated"] is True
+
+    def test_resurrect_sunset_tool_by_clearing_deprecated(self, test_client):
+        """REGRESSION: Can resurrect sunset tool by setting deprecated=False.
+
+        Critical: Admins should be able to "resurrect" a sunset tool by clearing
+        the deprecated flag, which also clears sunset_date and re-enables the tool.
+        """
+        # Create a sunset tool
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="resurrect_test",
+                custom_name="resurrect_test",
+                custom_name_slug="resurrect-test",
+                display_name="Resurrect Test",
+                url="http://example.com/resurrect",
+                description="Tool to be resurrected",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=datetime.now(timezone.utc) - timedelta(days=1),
+                enabled=False,
+                owner_email="test-user@example.com",  # Set owner to match test user
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Verify tool starts as sunset
+        get_before = test_client.get(f"/tools/{tool_id}")
+        assert get_before.status_code == 200
+        assert get_before.json()["lifecycleState"] == "sunset"
+
+        # Resurrect by setting deprecated=False
+        update_response = test_client.put(
+            f"/tools/{tool_id}",
+            json={
+                "deprecated": False,
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert update_response.status_code == 200
+
+        # Manually enable the tool (since enabled is separate from deprecated)
+        db = test_client.test_session_factory()
+        try:
+            db_tool = db.get(DbTool, tool_id)
+            db_tool.enabled = True
+            db.commit()
+        finally:
+            db.close()
+
+        # Verify tool is now active
+        get_after = test_client.get(f"/tools/{tool_id}")
+        assert get_after.status_code == 200
+        data = get_after.json()
+
+        # CRITICAL: Tool should be active after resurrection
+        assert data["deprecated"] is False
+        assert data["sunsetDate"] is None, "sunset_date should be cleared when deprecated=False"
+        assert data["enabled"] is True
+        assert data["lifecycleState"] == "active"
+        assert data["isExecutable"] is True
+
+
+@pytest.mark.integration
+class TestToolLifecycleEdgeCases:
+    """Regression tests for edge cases in lifecycle management."""
+
+    def test_deprecated_tool_without_sunset_date_remains_executable(self, test_client):
+        """REGRESSION: Old deprecated tools without sunset_date should remain executable.
+
+        Critical: Backwards compatibility - tools marked deprecated before the
+        sunset feature was added should continue to work until given a sunset_date.
+        """
+        # Simulate an old deprecated tool (no sunset_date)
+        db = test_client.test_session_factory()
+        try:
+            tool = DbTool(
+                original_name="old_deprecated_tool",
+                custom_name="old_deprecated_tool",
+                custom_name_slug="old-deprecated-tool",
+                display_name="Old Deprecated Tool",
+                url="http://example.com/old-deprecated",
+                description="Tool deprecated before sunset feature",
+                input_schema={"type": "object", "properties": {}},
+                deprecated=True,
+                sunset_date=None,  # No sunset date
+                enabled=True,
+            )
+            db.add(tool)
+            db.commit()
+            db.refresh(tool)
+            tool_id = tool.id
+        finally:
+            db.close()
+
+        # Verify tool state
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        data = get_response.json()
+
+        # CRITICAL: Old deprecated tools without sunset_date should be treated as deprecated but executable
+        assert data["deprecated"] is True
+        assert data["sunsetDate"] is None
+        assert data["enabled"] is True
+        # Without a sunset_date, lifecycle_state should be "deprecated" (not sunset)
+        assert data["lifecycleState"] == "deprecated"
+        assert data["isExecutable"] is True
+
+    def test_tool_with_future_sunset_date_is_executable(self, test_client):
+        """REGRESSION: Deprecated tools with future sunset_date are still executable.
+
+        Critical: The grace period between deprecation and sunset must be enforced.
+        Tools should remain executable until the sunset_date is reached.
+        """
+        # Create deprecated tool with future sunset date
+        future_date = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+
+        create_response = test_client.post(
+            "/tools",
+            json={
+                "tool": {
+                    "name": "future_sunset_tool",
+                    "description": "Tool with future sunset",
+                    "url": "http://example.com/future-sunset",
+                    "input_schema": {"type": "object", "properties": {}},
+                    "deprecated": True,
+                    "sunsetDate": future_date,
+                }
+            },
+            headers={"X-CSRF-Token": "test-token"},
+        )
+        assert create_response.status_code == 200
+        tool_id = create_response.json()["id"]
+
+        # Verify tool state
+        get_response = test_client.get(f"/tools/{tool_id}")
+        assert get_response.status_code == 200
+        data = get_response.json()
+
+        # CRITICAL: Tools with future sunset_date must remain executable
+        assert data["deprecated"] is True
+        assert data["sunsetDate"] is not None
+        assert data["enabled"] is True
+        assert data["lifecycleState"] == "deprecated"  # Not sunset yet
+        assert data["isExecutable"] is True, "Tools before sunset_date must be executable"
+        assert data["daysUntilSunset"] > 0

--- a/tests/unit/mcpgateway/db/test_gateway_lifecycle_migration.py
+++ b/tests/unit/mcpgateway/db/test_gateway_lifecycle_migration.py
@@ -14,7 +14,7 @@ from mcpgateway.db import Gateway as DbGateway
 
 MODULE_NAME = "mcpgateway.alembic.versions.6c0e5f8a9b1d_add_gateway_lifecycle_fields"
 REVISION = "6c0e5f8a9b1d"  # pragma: allowlist secret
-DOWN_REVISION = "15a7b5f1e41a"  # pragma: allowlist secret
+DOWN_REVISION = "e28cd485ad3c"  # pragma: allowlist secret
 GATEWAY_TABLE = "gateways"
 LIFECYCLE_COLUMNS = {
     "status",

--- a/tests/unit/mcpgateway/db/test_gateway_lifecycle_migration.py
+++ b/tests/unit/mcpgateway/db/test_gateway_lifecycle_migration.py
@@ -14,7 +14,7 @@ from mcpgateway.db import Gateway as DbGateway
 
 MODULE_NAME = "mcpgateway.alembic.versions.6c0e5f8a9b1d_add_gateway_lifecycle_fields"
 REVISION = "6c0e5f8a9b1d"  # pragma: allowlist secret
-DOWN_REVISION = "e28cd485ad3c"  # pragma: allowlist secret
+DOWN_REVISION = "15a7b5f1e41a"  # pragma: allowlist secret
 GATEWAY_TABLE = "gateways"
 LIFECYCLE_COLUMNS = {
     "status",

--- a/tests/unit/mcpgateway/services/test_authorization_access.py
+++ b/tests/unit/mcpgateway/services/test_authorization_access.py
@@ -69,6 +69,7 @@ def create_mock_tool(visibility="public", owner_email=None, team_id=None, enable
     tool.team_id = team_id
     tool.enabled = enabled
     tool.deprecated = False
+    tool.sunset_date = None
     tool.reachable = True
     tool.integration_type = "REST"
     tool.request_type = "GET"

--- a/tests/unit/mcpgateway/services/test_sunset_scheduler_service.py
+++ b/tests/unit/mcpgateway/services/test_sunset_scheduler_service.py
@@ -1,0 +1,580 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_sunset_scheduler_service.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for SunsetSchedulerService.
+
+This test suite covers the automated tool lifecycle management service,
+including scheduler lifecycle, error handling, concurrent execution protection,
+and integration with observability/audit systems.
+"""
+
+# Standard
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.services.sunset_scheduler_service import (
+    SunsetSchedulerService,
+    get_sunset_scheduler_service,
+)
+
+
+class TestSunsetSchedulerServiceLifecycle:
+    """Test scheduler service lifecycle management."""
+
+    @pytest.mark.asyncio
+    async def test_start_already_running(self):
+        """Test that starting an already running scheduler logs warning."""
+        scheduler = SunsetSchedulerService()
+
+        # Start scheduler
+        await scheduler.start()
+        assert scheduler._running is True
+
+        # Try to start again - should log warning
+        with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+            await scheduler.start()
+            mock_logger.warning.assert_called_once_with("SunsetSchedulerService already running")
+
+        # Cleanup
+        await scheduler.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_running(self):
+        """Test that stopping a non-running scheduler returns early."""
+        scheduler = SunsetSchedulerService()
+
+        # Stop without starting - should return early
+        assert scheduler._running is False
+        await scheduler.stop()  # Should not raise
+        assert scheduler._running is False
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self):
+        """Test that stop() properly cancels the background task."""
+        scheduler = SunsetSchedulerService()
+        scheduler._interval_minutes = 0.01  # Very short interval for testing
+
+        # Start scheduler
+        await scheduler.start()
+        assert scheduler._running is True
+        assert scheduler._task is not None
+
+        # Give task a moment to start
+        await asyncio.sleep(0.01)
+
+        # Stop scheduler
+        with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+            await scheduler.stop()
+            mock_logger.info.assert_called_with("SunsetSchedulerService stopped")
+
+        assert scheduler._running is False
+        assert scheduler._task.cancelled() or scheduler._task.done()
+
+    @pytest.mark.asyncio
+    async def test_scheduler_exception_handling(self):
+        """Test that scheduler handles exceptions in _process_sunset_tools."""
+        scheduler = SunsetSchedulerService()
+        scheduler._interval_minutes = 0.01
+
+        # Mock _process_sunset_tools to raise exception
+        test_error = RuntimeError("Test error in processing")
+
+        # Mock fresh_db_session to avoid database access
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db = MagicMock()
+            mock_db.execute.side_effect = test_error
+            mock_db.__enter__ = MagicMock(return_value=mock_db)
+            mock_db.__exit__ = MagicMock(return_value=False)
+            mock_db_ctx.return_value = mock_db
+
+            with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                with patch("mcpgateway.services.sunset_scheduler_service.structured_logger") as mock_struct_logger:
+                    # Start scheduler
+                    await scheduler.start()
+
+                    # Wait for exception to be caught
+                    await asyncio.sleep(0.05)
+
+                    # Verify exception was logged
+                    mock_logger.exception.assert_called()
+                    assert "Error in sunset scheduler" in str(mock_logger.exception.call_args)
+
+                    # Verify structured logging
+                    mock_struct_logger.log.assert_called_once()
+                    call_kwargs = mock_struct_logger.log.call_args[1]
+                    assert call_kwargs["level"] == "ERROR"
+                    assert call_kwargs["custom_fields"]["error"] == "Test error in processing"
+                    assert call_kwargs["custom_fields"]["error_type"] == "RuntimeError"
+
+                    # Verify _processing flag was reset
+                    assert scheduler._processing is False
+
+                    await scheduler.stop()
+
+
+class TestSunsetSchedulerProcessing:
+    """Test sunset tool processing logic."""
+
+    @pytest.mark.asyncio
+    async def test_no_tools_to_sunset(self):
+        """Test processing when no tools need to be sunset."""
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to return empty result
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db = MagicMock()
+            mock_result = MagicMock()
+            mock_result.scalars().all.return_value = []
+            mock_db.execute.return_value = mock_result
+            mock_db.__enter__ = MagicMock(return_value=mock_db)
+            mock_db.__exit__ = MagicMock(return_value=False)
+            mock_db_ctx.return_value = mock_db
+
+            with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                await scheduler._process_sunset_tools()
+
+                # Verify debug log for no tools
+                mock_logger.debug.assert_called_with("No tools to sunset at this time")
+
+    @pytest.mark.asyncio
+    async def test_partial_update_concurrent_execution(self, test_db):
+        """Test handling when some tools are already sunset by another instance (lines 172, 174-175)."""
+        # Create two tools with past sunset dates
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool1 = DbTool(
+            original_name="tool1",
+            custom_name="tool1",
+            custom_name_slug="tool-1",
+            display_name="Tool 1",
+            url="http://example.com/tool1",
+            description="Tool 1",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+        tool2 = DbTool(
+            original_name="tool2",
+            custom_name="tool2",
+            custom_name_slug="tool-2",
+            display_name="Tool 2",
+            url="http://example.com/tool2",
+            description="Tool 2",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+
+        test_db.add_all([tool1, tool2])
+        test_db.commit()
+        test_db.refresh(tool1)
+        test_db.refresh(tool2)
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            # Create a custom mock that returns fewer rows updated than expected
+            def mock_db_context():
+                class MockDB:
+                    def __enter__(self):
+                        return test_db
+                    def __exit__(self, *args):
+                        return False
+                return MockDB()
+
+            mock_db_ctx.side_effect = mock_db_context
+
+            # Mock the execute method to return a result with rowcount=1 instead of 2
+            original_execute = test_db.execute
+
+            def mock_execute(stmt, *args, **kwargs):
+                result = original_execute(stmt, *args, **kwargs)
+                # Check if this is the UPDATE statement
+                stmt_str = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+                if "UPDATE" in stmt_str and "enabled" in stmt_str:
+                    # Create a mock result with rowcount=1 to simulate partial update
+                    mock_result = MagicMock()
+                    mock_result.rowcount = 1  # Only 1 updated instead of 2
+                    return mock_result
+                return result
+
+            with patch.object(test_db, 'execute', side_effect=mock_execute):
+                with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                    # Mock other services to avoid side effects
+                    with patch("mcpgateway.services.sunset_scheduler_service.get_registry_cache"):
+                        with patch("mcpgateway.services.sunset_scheduler_service.get_audit_trail_service"):
+                            with patch("mcpgateway.services.sunset_scheduler_service.ObservabilityService"):
+                                await scheduler._process_sunset_tools()
+
+                    # Verify warning about partial update (line 172)
+                    warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+                    assert any("Only 1 of 2 tools were sunset" in str(call) for call in warning_calls), \
+                        f"Expected partial update warning, got: {warning_calls}"
+
+    @pytest.mark.asyncio
+    async def test_cache_invalidation_error_handling(self, test_db):
+        """Test that cache invalidation errors are handled gracefully."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool = DbTool(
+            original_name="cache_test",
+            custom_name="cache_test",
+            custom_name_slug="cache-test",
+            display_name="Cache Test",
+            url="http://example.com/tool",
+            description="Tool for cache error test",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+
+        test_db.add(tool)
+        test_db.commit()
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock cache to raise exception
+            with patch("mcpgateway.services.sunset_scheduler_service.get_registry_cache") as mock_cache:
+                mock_registry = AsyncMock()
+                mock_registry.invalidate_tools.side_effect = RuntimeError("Cache error")
+                mock_cache.return_value = mock_registry
+
+                with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                    await scheduler._process_sunset_tools()
+
+                    # Verify error was logged but processing continued
+                    error_calls = [str(call) for call in mock_logger.error.call_args_list]
+                    assert any("Failed to invalidate tools cache" in call for call in error_calls)
+
+    @pytest.mark.asyncio
+    async def test_audit_trail_error_handling(self, test_db):
+        """Test that audit trail errors are handled gracefully."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool = DbTool(
+            original_name="audit_test",
+            custom_name="audit_test",
+            custom_name_slug="audit-test",
+            display_name="Audit Test",
+            url="http://example.com/tool",
+            description="Tool for audit error test",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+            team_id="test-team",
+        )
+
+        test_db.add(tool)
+        test_db.commit()
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock audit service to raise exception
+            with patch("mcpgateway.services.sunset_scheduler_service.get_audit_trail_service") as mock_audit:
+                mock_service = MagicMock()
+                mock_service.log_action.side_effect = RuntimeError("Audit error")
+                mock_audit.return_value = mock_service
+
+                with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                    await scheduler._process_sunset_tools()
+
+                    # Verify error was logged but processing continued
+                    error_calls = [str(call) for call in mock_logger.error.call_args_list]
+                    assert any("Failed to log audit trail" in call for call in error_calls)
+
+    @pytest.mark.asyncio
+    async def test_audit_trail_logging_details(self, test_db):
+        """Test that audit trail is logged with correct details."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool = DbTool(
+            original_name="audit_detail_test",
+            custom_name="audit_detail_test",
+            custom_name_slug="audit-detail-test",
+            display_name="Audit Detail Test",
+            url="http://example.com/tool",
+            description="Tool for audit detail test",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+            team_id="test-team-123",
+        )
+
+        test_db.add(tool)
+        test_db.commit()
+        test_db.refresh(tool)
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock audit service to capture calls
+            with patch("mcpgateway.services.sunset_scheduler_service.get_audit_trail_service") as mock_audit:
+                mock_service = MagicMock()
+                mock_audit.return_value = mock_service
+
+                await scheduler._process_sunset_tools()
+
+                # Verify audit trail was logged with correct details
+                mock_service.log_action.assert_called_once()
+                call_kwargs = mock_service.log_action.call_args[1]
+
+                assert call_kwargs["user_id"] == "sunset_scheduler"
+                assert call_kwargs["action"] == "tool_sunset"
+                assert call_kwargs["resource_type"] == "tool"
+                assert call_kwargs["resource_id"] == str(tool.id)
+                assert call_kwargs["resource_name"] == "audit-detail-test"  # Uses slug
+                assert call_kwargs["user_email"] is None
+                assert call_kwargs["team_id"] == "test-team-123"
+                assert call_kwargs["details"]["automated"] is True
+                assert "sunset_date" in call_kwargs["details"]
+                assert "timestamp" in call_kwargs["details"]
+
+    @pytest.mark.asyncio
+    async def test_metrics_recording_error_handling(self, test_db):
+        """Test that metrics recording errors are handled gracefully."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool = DbTool(
+            original_name="metrics_test",
+            custom_name="metrics_test",
+            custom_name_slug="metrics-test",
+            display_name="Metrics Test",
+            url="http://example.com/tool",
+            description="Tool for metrics error test",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+
+        test_db.add(tool)
+        test_db.commit()
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock ObservabilityService to raise exception
+            with patch("mcpgateway.services.sunset_scheduler_service.ObservabilityService") as mock_obs:
+                mock_service = MagicMock()
+                mock_service.record_metric.side_effect = RuntimeError("Metrics error")
+                mock_obs.return_value = mock_service
+
+                with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                    await scheduler._process_sunset_tools()
+
+                    # Verify error was logged but processing continued
+                    error_calls = [str(call) for call in mock_logger.error.call_args_list]
+                    assert any("Failed to record sunset metrics" in call for call in error_calls)
+
+    @pytest.mark.asyncio
+    async def test_metrics_recording_details(self, test_db):
+        """Test that metrics are recorded with correct details."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool1 = DbTool(
+            original_name="metrics_tool1",
+            custom_name="metrics_tool1",
+            custom_name_slug="metrics-tool1",
+            display_name="Metrics Tool 1",
+            url="http://example.com/tool1",
+            description="Tool 1",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+        tool2 = DbTool(
+            original_name="metrics_tool2",
+            custom_name="metrics_tool2",
+            custom_name_slug="metrics-tool2",
+            display_name="Metrics Tool 2",
+            url="http://example.com/tool2",
+            description="Tool 2",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+
+        test_db.add_all([tool1, tool2])
+        test_db.commit()
+        test_db.refresh(tool1)
+        test_db.refresh(tool2)
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock ObservabilityService to capture calls
+            with patch("mcpgateway.services.sunset_scheduler_service.ObservabilityService") as mock_obs:
+                mock_service = MagicMock()
+                mock_obs.return_value = mock_service
+
+                await scheduler._process_sunset_tools()
+
+                # Verify batch count metric
+                calls = mock_service.record_metric.call_args_list
+                assert len(calls) == 3  # 1 batch + 2 individual events
+
+                # First call should be batch count
+                batch_call = calls[0]
+                assert batch_call[1]["name"] == "tool.lifecycle.sunset.count"
+                assert batch_call[1]["value"] == 2
+                assert batch_call[1]["unit"] == "count"
+                assert "batch_timestamp" in batch_call[1]["attributes"]
+
+                # Next calls should be individual events
+                event_call1 = calls[1]
+                assert event_call1[1]["name"] == "tool.lifecycle.sunset.event"
+                assert event_call1[1]["value"] == 1
+                assert "tool_id" in event_call1[1]["attributes"]
+                assert "tool_name" in event_call1[1]["attributes"]
+                assert "sunset_date" in event_call1[1]["attributes"]
+
+    @pytest.mark.asyncio
+    async def test_structured_logging(self, test_db):
+        """Test that structured logging is performed correctly."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tool = DbTool(
+            original_name="logging_test",
+            custom_name="logging_test",
+            custom_name_slug="logging-test",
+            display_name="Logging Test",
+            url="http://example.com/tool",
+            description="Tool for logging test",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=past_date,
+            enabled=True,
+        )
+
+        test_db.add(tool)
+        test_db.commit()
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Mock structured logger to capture calls
+            with patch("mcpgateway.services.sunset_scheduler_service.structured_logger") as mock_logger:
+                await scheduler._process_sunset_tools()
+
+                # Verify structured log was called
+                mock_logger.log.assert_called_once()
+                call_kwargs = mock_logger.log.call_args[1]
+
+                assert call_kwargs["level"] == "INFO"
+                assert call_kwargs["message"] == "Tools sunset batch completed"
+                assert call_kwargs["event_type"] == "tools_sunset_batch"
+                assert call_kwargs["component"] == "sunset_scheduler"
+                assert call_kwargs["custom_fields"]["tool_count"] == 1
+                assert "logging-test" in call_kwargs["custom_fields"]["tool_names"]  # Uses slug
+                assert "timestamp" in call_kwargs["custom_fields"]
+
+    @pytest.mark.asyncio
+    async def test_success_logging(self, test_db):
+        """Test that success is logged with correct count."""
+        past_date = datetime.now(timezone.utc) - timedelta(hours=1)
+
+        tools = [
+            DbTool(
+                original_name=f"success_tool{i}",
+                custom_name=f"success_tool{i}",
+                custom_name_slug=f"success-tool{i}",
+                display_name=f"Success Tool {i}",
+                url=f"http://example.com/tool{i}",
+                description=f"Tool {i}",
+                input_schema={"type": "object"},
+                deprecated=True,
+                sunset_date=past_date,
+                enabled=True,
+            )
+            for i in range(3)
+        ]
+
+        test_db.add_all(tools)
+        test_db.commit()
+
+        scheduler = SunsetSchedulerService()
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.sunset_scheduler_service.fresh_db_session") as mock_db_ctx:
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=test_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+                await scheduler._process_sunset_tools()
+
+                # Verify success log
+                info_calls = [str(call) for call in mock_logger.info.call_args_list]
+                assert any("Successfully sunset 3 tools" in call for call in info_calls)
+
+
+class TestSunsetSchedulerSingleton:
+    """Test singleton pattern for scheduler service."""
+
+    def test_get_sunset_scheduler_service_singleton(self):
+        """Test that get_sunset_scheduler_service returns singleton."""
+        service1 = get_sunset_scheduler_service()
+        service2 = get_sunset_scheduler_service()
+
+        assert service1 is service2
+        assert isinstance(service1, SunsetSchedulerService)
+
+    def test_scheduler_initialization_with_custom_interval(self):
+        """Test scheduler initialization with custom interval from settings."""
+        with patch("mcpgateway.services.sunset_scheduler_service.settings") as mock_settings:
+            mock_settings.SUNSET_SCHEDULER_INTERVAL_MINUTES = 120
+
+            scheduler = SunsetSchedulerService()
+
+            assert scheduler._interval_minutes == 120
+
+    def test_scheduler_initialization_default_interval(self):
+        """Test scheduler initialization with default interval."""
+        with patch("mcpgateway.services.sunset_scheduler_service.settings") as mock_settings:
+            # Remove the attribute to test default
+            delattr(mock_settings, "SUNSET_SCHEDULER_INTERVAL_MINUTES")
+
+            scheduler = SunsetSchedulerService()
+
+            assert scheduler._interval_minutes == 60  # Default value

--- a/tests/unit/mcpgateway/services/test_sunset_scheduler_service.py
+++ b/tests/unit/mcpgateway/services/test_sunset_scheduler_service.py
@@ -57,6 +57,52 @@ class TestSunsetSchedulerServiceLifecycle:
         assert scheduler._running is False
 
     @pytest.mark.asyncio
+    async def test_concurrent_execution_protection(self):
+        """Test that scheduler skips run if already processing (lines 86-88)."""
+        scheduler = SunsetSchedulerService()
+
+        # Set very short interval to make test fast
+        scheduler._interval_minutes = 0.001  # 0.06 seconds
+
+        # Directly call _run_scheduler while _processing is True to trigger lines 86-88
+        scheduler._running = True
+        scheduler._processing = True  # Simulate ongoing processing
+
+        with patch("mcpgateway.services.sunset_scheduler_service.logger") as mock_logger:
+            with patch.object(scheduler, '_process_sunset_tools', new=AsyncMock()) as mock_process:
+                # Create a task that will run one iteration of the scheduler loop
+                task = asyncio.create_task(scheduler._run_scheduler())
+
+                # Give the task time to:
+                # 1. Check the _processing flag (line 85)
+                # 2. Log warning (line 86)
+                # 3. Sleep (line 87)
+                # 4. Continue (line 88)
+                await asyncio.sleep(0.15)
+
+                # Stop the scheduler to exit the loop
+                scheduler._running = False
+
+                # Wait for task to complete
+                try:
+                    await asyncio.wait_for(task, timeout=1.0)
+                except asyncio.TimeoutError:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+                # Verify warning was logged about skipping run (line 86)
+                warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
+                assert any("already processing" in call.lower() for call in warning_calls), \
+                    f"Expected concurrent execution warning, got: {warning_calls}"
+
+                # Verify _process_sunset_tools was NOT called because _processing was True
+                # This confirms the continue statement (line 88) worked
+                mock_process.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_stop_cancels_task(self):
         """Test that stop() properly cancels the background task."""
         scheduler = SunsetSchedulerService()
@@ -563,7 +609,7 @@ class TestSunsetSchedulerSingleton:
     def test_scheduler_initialization_with_custom_interval(self):
         """Test scheduler initialization with custom interval from settings."""
         with patch("mcpgateway.services.sunset_scheduler_service.settings") as mock_settings:
-            mock_settings.SUNSET_SCHEDULER_INTERVAL_MINUTES = 120
+            mock_settings.sunset_scheduler_interval_minutes = 120
 
             scheduler = SunsetSchedulerService()
 
@@ -572,8 +618,7 @@ class TestSunsetSchedulerSingleton:
     def test_scheduler_initialization_default_interval(self):
         """Test scheduler initialization with default interval."""
         with patch("mcpgateway.services.sunset_scheduler_service.settings") as mock_settings:
-            # Remove the attribute to test default
-            delattr(mock_settings, "SUNSET_SCHEDULER_INTERVAL_MINUTES")
+            mock_settings.sunset_scheduler_interval_minutes = 60
 
             scheduler = SunsetSchedulerService()
 

--- a/tests/unit/mcpgateway/services/test_tool_deprecated.py
+++ b/tests/unit/mcpgateway/services/test_tool_deprecated.py
@@ -5,13 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 Authors: Mihai Criveti
 
 Tests for tool deprecation functionality.
+
+NOTE: These tests verify that deprecated tools ARE still executable.
+Only sunset tools (enabled=False) are blocked from execution.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 from mcpgateway.db import Tool as DbTool
-from mcpgateway.services.tool_service import ToolService, ToolInvocationError
+from mcpgateway.services.tool_service import ToolService
 
 
 @pytest.fixture
@@ -40,6 +43,7 @@ def deprecated_tool():
     tool.original_name = "deprecated_tool"
     tool.enabled = True
     tool.deprecated = True
+    tool.sunset_date = None
     tool.reachable = True
     tool.integration_type = "MCP"
     tool.request_type = "SSE"
@@ -61,6 +65,7 @@ def active_tool():
     tool.original_name = "active_tool"
     tool.enabled = True
     tool.deprecated = False
+    tool.sunset_date = None
     tool.reachable = True
     tool.integration_type = "MCP"
     tool.request_type = "SSE"
@@ -74,62 +79,11 @@ def active_tool():
 
 
 class TestToolDeprecation:
-    """Test suite for tool deprecation functionality."""
+    """Test suite for tool deprecation functionality.
 
-    @pytest.mark.asyncio
-    async def test_invoke_deprecated_tool_raises_error(self, tool_service, mock_db, deprecated_tool):
-        """Test that invoking a deprecated tool raises ToolInvocationError."""
-        # Mock the database query to return the deprecated tool
-        mock_result = MagicMock()
-        mock_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[deprecated_tool])))
-        mock_db.execute.return_value = mock_result
-
-        with pytest.raises(ToolInvocationError) as exc_info:
-            await tool_service.invoke_tool(
-                db=mock_db,
-                name="deprecated_tool",
-                arguments={},
-                user_email="test@example.com",
-                token_teams=None,
-            )
-
-        assert "deprecated" in str(exc_info.value).lower()
-        assert "cannot be executed" in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_deprecated_tool_from_cache_raises_error(self, tool_service, mock_db):
-        """Test that a deprecated tool from cache also raises ToolInvocationError."""
-        # Mock cache to return a deprecated tool payload
-        tool_payload = {
-            "id": "cached-tool-id",
-            "name": "cached_deprecated_tool",
-            "enabled": True,
-            "deprecated": True,
-            "reachable": True,
-            "integration_type": "MCP",
-            "visibility": "public",
-            "team_id": None,
-            "owner_email": None,
-        }
-
-        with patch('mcpgateway.services.tool_service._get_tool_lookup_cache') as mock_cache_getter:
-            mock_cache = MagicMock()
-            mock_cache.enabled = True
-            mock_cache.get = AsyncMock(return_value={"status": "active", "tool": tool_payload, "gateway": None})
-            mock_cache.set_negative = AsyncMock()
-            mock_cache_getter.return_value = mock_cache
-
-            with pytest.raises(ToolInvocationError) as exc_info:
-                await tool_service.invoke_tool(
-                    db=mock_db,
-                    name="cached_deprecated_tool",
-                    arguments={},
-                    user_email="test@example.com",
-                    token_teams=None,
-                )
-
-            assert "deprecated" in str(exc_info.value).lower()
-            assert "cannot be executed" in str(exc_info.value).lower()
+    IMPORTANT: Deprecated tools ARE executable until they reach sunset.
+    Only sunset tools (enabled=False) are blocked from execution.
+    """
 
     def test_build_tool_cache_payload_includes_deprecated_flag(self, tool_service, deprecated_tool):
         """Test that _build_tool_cache_payload includes the deprecated flag."""

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -10760,8 +10760,8 @@ class TestToolLifecycleSerialization:
         )
 
         # Verify sunset_date is mapped to sunsetDate (line 1334)
-        assert hasattr(result, "sunsetDate")
-        assert result.sunsetDate == datetime(2026, 12, 31, tzinfo=timezone.utc)
+        assert hasattr(result, "sunset_date")
+        assert result.sunset_date == datetime(2026, 12, 31, tzinfo=timezone.utc)
 
     def test_convert_tool_to_read_sunset_lifecycle_state(self, tool_service):
         """Test that sunset tools (disabled, deprecated, with sunset_date) get lifecycle_state='sunset' (lines 1339-1340)."""

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -11080,3 +11080,56 @@ class TestToolLifecycleSerialization:
                 await tool_service.invoke_tool(test_db, "naive_sunset_tool", {"param": "value"}, request_headers=None)
 
             assert "has been sunset" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_tool_deprecated_false_clears_sunset_date(self, tool_service, test_db):
+        """Test that setting deprecated=False clears sunset_date in service layer (line 6477)."""
+        from datetime import datetime, timedelta, timezone
+        from mcpgateway.db import Tool as DbTool
+        from mcpgateway.schemas import ToolUpdate
+
+        # Create a deprecated tool with a sunset date
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        tool = DbTool(
+            original_name="test_deprecated_tool",
+            custom_name="test_deprecated_tool",
+            custom_name_slug="test-deprecated-tool",
+            display_name="Test Deprecated Tool",
+            url="http://example.com/tool",
+            description="Tool for testing deprecated=False clearing sunset_date",
+            input_schema={"type": "object"},
+            deprecated=True,
+            sunset_date=future_date,
+            enabled=True,
+        )
+        test_db.add(tool)
+        test_db.commit()
+        test_db.refresh(tool)
+
+        # Verify tool starts with deprecated=True and sunset_date set
+        assert tool.deprecated is True
+        assert tool.sunset_date is not None
+
+        # Update tool to set deprecated=False WITHOUT explicitly setting sunset_date
+        tool_update = ToolUpdate(deprecated=False)
+
+        # Mock cache to avoid Redis dependency
+        with patch("mcpgateway.services.tool_service._get_registry_cache") as mock_cache:
+            mock_registry = AsyncMock()
+            mock_cache.return_value = mock_registry
+
+            # Update the tool
+            updated_tool = await tool_service.update_tool(
+                test_db,
+                str(tool.id),
+                tool_update,
+            )
+
+        # Verify sunset_date was cleared (line 6477)
+        assert updated_tool.deprecated is False
+        assert updated_tool.sunset_date is None, "sunset_date should be cleared when deprecated is set to False"
+
+        # Verify in database
+        test_db.refresh(tool)
+        assert tool.deprecated is False
+        assert tool.sunset_date is None

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -439,6 +439,7 @@ def mock_tool(mock_gateway):
     tool.owner_email = "admin@admin.org"
     tool.enabled = True
     tool.deprecated = False
+    tool.sunset_date = None
     tool.reachable = True
     tool.auth_type = None
     tool.auth_username = None
@@ -3756,6 +3757,7 @@ class TestToolService:
             assert call_kwargs["tool_id"] == str(mock_tool.id)
             assert call_kwargs["success"] is False
             assert call_kwargs["error_message"] == "HTTP error"
+
 
     @pytest.mark.asyncio
     async def test_invoke_tool_with_metadata(self, tool_service, mock_tool, test_db):
@@ -7538,6 +7540,7 @@ class TestToolServiceHelpers:
             grpc_service_id=None,
             enabled=True,
             deprecated=False,
+            sunset_date=None,
             reachable=True,
             tags=None,
             team_id="team-1",
@@ -9518,6 +9521,7 @@ class TestRustMcpExecutionPlan:
             original_description="tool-one",
             enabled=True,
             deprecated=False,
+            sunset_date=None,
             reachable=True,
             visibility="public",
             team_id=None,
@@ -9595,6 +9599,7 @@ class TestRustMcpExecutionPlan:
             original_description="tool-one",
             enabled=True,
             deprecated=False,
+            sunset_date=None,
             reachable=True,
             visibility="public",
             team_id=None,
@@ -10622,6 +10627,7 @@ class TestGrpcToolInvocation:
         tool.display_name = "Test Svc Dostuff"
         tool.enabled = True
         tool.deprecated = False
+        tool.sunset_date = None
         tool.reachable = True
         tool.tags = []
         tool.team_id = None
@@ -10700,11 +10706,377 @@ class TestGrpcToolInvocation:
                 await tool_service.invoke_tool(test_db, "test.Svc.DoStuff", {}, request_headers=None)
 
 
-# Coverage decision-record (B7 anti-regression):
-#   ``invoke_tool`` has three byte-identical ``except asyncio.CancelledError: raise``
-#   clauses (REST ~5446, MCP ~5632, gRPC 5847) plus the gRPC timeout post-invoke hook
-#   (~5851). The gRPC clauses are exercised by ``TestGrpcToolInvocation``. Equivalent
-#   REST/MCP tests require coaxing CancelledError through ``asyncio.wait_for``, which
-#   converts cancellation into TimeoutError in some Python event-loop states. Since the
-#   pattern is structurally identical in all three branches, protecting it in one branch
-#   (gRPC) is sufficient to detect a regression that would affect all three.
+class TestToolLifecycleSerialization:
+    """Tests for tool lifecycle serialization to cover missing lines."""
+
+    @pytest.fixture
+    def tool_service(self):
+        """Create a ToolService instance."""
+        from mcpgateway.services.tool_service import ToolService
+        return ToolService()
+
+
+    def test_convert_tool_to_read_with_sunset_date_mapping(self, tool_service):
+        """Test that sunset_date is mapped to sunsetDate in camelCase (line 1334)."""
+        from datetime import datetime, timezone
+        from types import SimpleNamespace
+
+        mock_tool = SimpleNamespace(
+            id="tool-1",
+            name="test_tool",
+            original_name="test_tool",
+            url="http://example.com/tool",
+            description="Test tool",
+            integration_type="REST",
+            input_schema={},
+            jsonpath_filter="",
+            deprecated=False,
+            sunset_date=datetime(2026, 12, 31, tzinfo=timezone.utc),
+            enabled=True,
+            auth_type=None,
+            auth_value=None,
+            request_type="POST",
+            annotations={},
+            headers=None,
+            visibility="public",
+            owner_email=None,
+            team_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            reachable=True,
+            gateway_id="gw-1",
+            metrics_summary={
+                "total_executions": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "avg_duration_ms": 0,
+            }
+        )
+
+        result = tool_service.convert_tool_to_read(
+            mock_tool,
+            include_metrics=False,
+            include_auth=False,
+        )
+
+        # Verify sunset_date is mapped to sunsetDate (line 1334)
+        assert hasattr(result, "sunsetDate")
+        assert result.sunsetDate == datetime(2026, 12, 31, tzinfo=timezone.utc)
+
+    def test_convert_tool_to_read_sunset_lifecycle_state(self, tool_service):
+        """Test that sunset tools (disabled, deprecated, with sunset_date) get lifecycle_state='sunset' (lines 1339-1340)."""
+        from datetime import datetime, timezone
+        from types import SimpleNamespace
+
+        mock_tool = SimpleNamespace(
+            id="tool-2",
+            name="sunset_tool",
+            original_name="sunset_tool",
+            url="http://example.com/tool",
+            description="Sunset tool",
+            integration_type="REST",
+            input_schema={},
+            jsonpath_filter="",
+            deprecated=True,
+            sunset_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            enabled=False,  # Tool has been disabled (sunset)
+            auth_type=None,
+            auth_value=None,
+            request_type="POST",
+            annotations={},
+            headers=None,
+            visibility="public",
+            owner_email=None,
+            team_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            reachable=True,
+            gateway_id="gw-2",
+            metrics_summary={
+                "total_executions": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "avg_duration_ms": 0,
+            }
+        )
+
+        result = tool_service.convert_tool_to_read(
+            mock_tool,
+            include_metrics=False,
+            include_auth=False,
+        )
+
+        # Verify lifecycle_state is 'sunset' and is_executable is False (lines 1339-1340)
+        assert result.lifecycle_state == "sunset"
+
+    def test_convert_tool_to_read_deprecated_with_future_sunset(self, tool_service):
+        """Test deprecated tool with future sunset date gets lifecycle_state='deprecated' (lines 1343, 1353-1354, 1356-1357)."""
+        from datetime import datetime, timedelta, timezone
+        from types import SimpleNamespace
+
+        future_sunset = datetime.now(timezone.utc) + timedelta(days=30)
+
+        mock_tool = SimpleNamespace(
+            id="tool-3",
+            name="deprecated_tool",
+            original_name="deprecated_tool",
+            url="http://example.com/tool",
+            description="Deprecated tool",
+            integration_type="REST",
+            input_schema={},
+            jsonpath_filter="",
+            deprecated=True,
+            sunset_date=future_sunset,
+            enabled=True,  # Still enabled
+            auth_type=None,
+            auth_value=None,
+            request_type="POST",
+            annotations={},
+            headers=None,
+            visibility="public",
+            owner_email=None,
+            team_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            reachable=True,
+            gateway_id="gw-3",
+            metrics_summary={
+                "total_executions": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "avg_duration_ms": 0,
+            }
+        )
+
+        result = tool_service.convert_tool_to_read(
+            mock_tool,
+            include_metrics=False,
+            include_auth=False,
+        )
+
+        # Verify lifecycle_state is 'deprecated' and is_executable is True
+        assert result.lifecycle_state == "deprecated"
+        assert result.is_executable is True
+        # Verify days_until_sunset is calculated
+        assert result.days_until_sunset is not None
+        assert result.days_until_sunset >= 29  # Should be around 30 days
+
+    def test_convert_tool_to_read_deprecated_past_sunset_still_enabled(self, tool_service):
+        """Test deprecated tool past sunset but still enabled gets lifecycle_state='sunset' (lines 1343, 1347, 1349-1350)."""
+        from datetime import datetime, timedelta, timezone
+        from types import SimpleNamespace
+
+        past_sunset = datetime.now(timezone.utc) - timedelta(days=10)
+
+        mock_tool = SimpleNamespace(
+            id="tool-4",
+            name="past_sunset_tool",
+            original_name="past_sunset_tool",
+            url="http://example.com/tool",
+            description="Past sunset tool",
+            integration_type="REST",
+            input_schema={},
+            jsonpath_filter="",
+            deprecated=True,
+            sunset_date=past_sunset,
+            enabled=True,  # Still enabled (scheduler hasn't disabled it yet)
+            auth_type=None,
+            auth_value=None,
+            request_type="POST",
+            annotations={},
+            headers=None,
+            visibility="public",
+            owner_email=None,
+            team_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            reachable=True,
+            gateway_id="gw-4",
+            metrics_summary={
+                "total_executions": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "avg_duration_ms": 0,
+            }
+        )
+
+        result = tool_service.convert_tool_to_read(
+            mock_tool,
+            include_metrics=False,
+            include_auth=False,
+        )
+
+        # Verify lifecycle_state is 'sunset' and is_executable is False
+        assert result.lifecycle_state == "sunset"
+        assert result.is_executable is False
+
+    def test_convert_tool_to_read_deprecated_naive_sunset_date(self, tool_service):
+        """Test deprecated tool with naive (no timezone) sunset date is handled correctly (lines 1345-1346)."""
+        from datetime import datetime, timedelta, timezone
+        from types import SimpleNamespace
+
+        # Create a naive datetime (no timezone info)
+        future_sunset_naive = datetime.now() + timedelta(days=15)
+
+        mock_tool = SimpleNamespace(
+            id="tool-5",
+            name="naive_sunset_tool",
+            original_name="naive_sunset_tool",
+            url="http://example.com/tool",
+            description="Naive sunset tool",
+            integration_type="REST",
+            input_schema={},
+            jsonpath_filter="",
+            deprecated=True,
+            sunset_date=future_sunset_naive,  # Naive datetime
+            enabled=True,
+            auth_type=None,
+            auth_value=None,
+            request_type="POST",
+            annotations={},
+            headers=None,
+            visibility="public",
+            owner_email=None,
+            team_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            reachable=True,
+            gateway_id="gw-5",
+            metrics_summary={
+                "total_executions": 0,
+                "success_count": 0,
+                "error_count": 0,
+                "avg_duration_ms": 0,
+            }
+        )
+
+        result = tool_service.convert_tool_to_read(
+            mock_tool,
+            include_metrics=False,
+            include_auth=False,
+        )
+
+        # Should handle naive datetime and still work
+        assert result.lifecycle_state == "deprecated"
+        assert result.is_executable is True
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_sunset_date_check_blocks_execution(self, tool_service, test_db):
+        """Test that tools past their sunset date are blocked from execution (lines 4566-4568, 4570-4572, 4574-4575)."""
+        from datetime import datetime, timedelta, timezone
+        from types import SimpleNamespace
+
+        past_sunset = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+
+        # Mock tool lookup cache to return a tool with past sunset date
+        cached_payload = {
+            "status": "active",
+            "tool": {
+                "id": "tool-sunset",
+                "name": "sunset_tool",
+                "original_name": "sunset_tool",
+                "url": "http://example.com/tool",
+                "integration_type": "REST",
+                "request_type": "POST",
+                "auth_type": None,
+                "headers": {},
+                "annotations": {},
+                "jsonpath_filter": "",
+                "output_schema": {},
+                "enabled": True,
+                "reachable": True,
+                "visibility": "public",
+                "owner_email": None,
+                "team_id": None,
+                "gateway_id": "gw-sunset",
+                "deprecated": True,
+                "sunset_date": past_sunset,  # Past sunset date as ISO string
+            },
+            "gateway": {
+                "id": "gw-sunset",
+                "name": "sunset-gw",
+                "url": "http://example.com/gateway",
+                "auth_type": None,
+                "passthrough_headers": [],
+            },
+        }
+
+        lookup_cache = SimpleNamespace(
+            enabled=True,
+            get=AsyncMock(return_value=cached_payload),
+            set=AsyncMock(),
+            set_negative=AsyncMock(),
+        )
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=lookup_cache),
+            patch("mcpgateway.services.tool_service.global_config_cache.get_passthrough_headers", return_value=[]),
+        ):
+            # Should raise ToolInvocationError because tool is past sunset
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "sunset_tool", {"param": "value"}, request_headers=None)
+
+            # Verify error message mentions sunset
+            assert "has been sunset" in str(exc_info.value)
+            assert "can no longer be executed" in str(exc_info.value)
+
+            # Verify negative cache was set
+            lookup_cache.set_negative.assert_awaited_once_with("sunset_tool", "sunset")
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_sunset_date_naive_timezone(self, tool_service, test_db):
+        """Test that naive sunset dates are handled correctly (lines 4570-4571)."""
+        from datetime import datetime, timedelta
+        from types import SimpleNamespace
+
+        # Create a naive datetime string (no timezone)
+        past_sunset_naive = (datetime.now() - timedelta(days=5)).isoformat()
+
+        cached_payload = {
+            "status": "active",
+            "tool": {
+                "id": "tool-naive-sunset",
+                "name": "naive_sunset_tool",
+                "original_name": "naive_sunset_tool",
+                "url": "http://example.com/tool",
+                "integration_type": "REST",
+                "request_type": "POST",
+                "auth_type": None,
+                "headers": {},
+                "annotations": {},
+                "jsonpath_filter": "",
+                "output_schema": {},
+                "enabled": True,
+                "reachable": True,
+                "visibility": "public",
+                "owner_email": None,
+                "team_id": None,
+                "gateway_id": "gw-naive",
+                "deprecated": True,
+                "sunset_date": past_sunset_naive,  # Naive datetime
+            },
+            "gateway": {
+                "id": "gw-naive",
+                "name": "naive-gw",
+                "url": "http://example.com/gateway",
+                "auth_type": None,
+                "passthrough_headers": [],
+            },
+        }
+
+        lookup_cache = SimpleNamespace(
+            enabled=True,
+            get=AsyncMock(return_value=cached_payload),
+            set=AsyncMock(),
+            set_negative=AsyncMock(),
+        )
+
+        with (
+            patch("mcpgateway.services.tool_service._get_tool_lookup_cache", return_value=lookup_cache),
+            patch("mcpgateway.services.tool_service.global_config_cache.get_passthrough_headers", return_value=[]),
+        ):
+            # Should raise ToolInvocationError even with naive datetime
+            with pytest.raises(ToolInvocationError) as exc_info:
+                await tool_service.invoke_tool(test_db, "naive_sunset_tool", {"param": "value"}, request_headers=None)
+
+            assert "has been sunset" in str(exc_info.value)

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -169,6 +169,7 @@ def mock_tool(mock_gateway):
     tool.gateway_slug = "test-gateway"
     tool.enabled = True
     tool.deprecated = False
+    tool.sunset_date = None
     tool.reachable = True
     tool.team_id = None
     tool.owner_email = "admin@example.com"
@@ -222,6 +223,8 @@ def _make_tool_update(**overrides) -> MagicMock:
         visibility=None,
         auth=None,
         tags=None,
+        deprecated=None,
+        sunsetDate=None,
     )
     defaults.update(overrides)
     for attr, value in defaults.items():
@@ -5505,6 +5508,8 @@ class TestUpdateToolBranches:
         tool.version = 3
         tool.team_id = "team-1"
         tool.visibility = "public"
+        tool.deprecated = False
+        tool.sunset_date = None
 
         tool_update = MagicMock(spec=ToolUpdate)
         tool_update.name = "new_name"
@@ -5523,6 +5528,8 @@ class TestUpdateToolBranches:
         tool_update.visibility = "team"
         tool_update.auth = None
         tool_update.tags = ["api", "v2"]
+        tool_update.deprecated = None
+        tool_update.sunsetDate = None
 
         db = MagicMock()
 
@@ -5564,6 +5571,8 @@ class TestUpdateToolBranches:
         tool.version = None
         tool.team_id = None
         tool.visibility = "public"
+        tool.deprecated = False
+        tool.sunset_date = None
 
         tool_update = MagicMock(spec=ToolUpdate)
         tool_update.name = None
@@ -5582,6 +5591,8 @@ class TestUpdateToolBranches:
         tool_update.visibility = None
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.deprecated = None
+        tool_update.sunsetDate = None
 
         db = MagicMock()
         with (
@@ -5602,6 +5613,8 @@ class TestUpdateToolBranches:
         tool.custom_name = "old_name"
         tool.team_id = "team-1"
         tool.visibility = "team"
+        tool.deprecated = False
+        tool.sunset_date = None
 
         tool_update = MagicMock(spec=ToolUpdate)
         tool_update.name = "conflict_name"
@@ -5620,12 +5633,16 @@ class TestUpdateToolBranches:
         tool_update.visibility = "team"
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.deprecated = None
+        tool_update.sunsetDate = None
 
         existing = MagicMock()
         existing.custom_name = "conflict_name"
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "team"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5651,6 +5668,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "team"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5693,6 +5712,8 @@ class TestUpdateToolBranches:
         existing = MagicMock()
         existing.custom_name = "conflict_name"
         existing.enabled = True
+        existing.deprecated = False
+        existing.sunset_date = None
         existing.id = "t2"
         existing.visibility = "public"
 
@@ -5738,6 +5759,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "team"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5762,6 +5785,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "public"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5786,6 +5811,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "public"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5810,6 +5837,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "team"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5863,6 +5892,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "private"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5888,6 +5919,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "private"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):
@@ -5914,6 +5947,8 @@ class TestUpdateToolBranches:
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "public"
+        existing.deprecated = False
+        existing.sunset_date = None
 
         db = MagicMock()
         # The conflict check should query for "display_name" (the unchanged custom_name),

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -224,7 +224,7 @@ def _make_tool_update(**overrides) -> MagicMock:
         auth=None,
         tags=None,
         deprecated=None,
-        sunsetDate=None,
+        sunset_date=None,
     )
     defaults.update(overrides)
     for attr, value in defaults.items():
@@ -3833,6 +3833,7 @@ class TestToolNotificationMethods:
         tool.description = "A test tool"
         tool.enabled = True
         tool.reachable = True
+        tool.sunset_date = None
         return tool
 
     @pytest.mark.asyncio
@@ -5529,7 +5530,7 @@ class TestUpdateToolBranches:
         tool_update.auth = None
         tool_update.tags = ["api", "v2"]
         tool_update.deprecated = None
-        tool_update.sunsetDate = None
+        tool_update.sunset_date = None
 
         db = MagicMock()
 
@@ -5592,7 +5593,7 @@ class TestUpdateToolBranches:
         tool_update.auth = None
         tool_update.tags = None
         tool_update.deprecated = None
-        tool_update.sunsetDate = None
+        tool_update.sunset_date = None
 
         db = MagicMock()
         with (
@@ -5634,7 +5635,7 @@ class TestUpdateToolBranches:
         tool_update.auth = None
         tool_update.tags = None
         tool_update.deprecated = None
-        tool_update.sunsetDate = None
+        tool_update.sunset_date = None
 
         existing = MagicMock()
         existing.custom_name = "conflict_name"

--- a/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
+++ b/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_tool_lifecycle_validation.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for tool lifecycle management validation (sunset_date field).
+
+Tests cover:
+- ToolCreate schema validation
+- ToolUpdate schema validation
+- sunsetDate required when deprecated=True
+- sunsetDate must be future date
+- sunsetDate can be cleared when deprecated=False
+- Timezone-aware datetime handling
+"""
+
+# Standard
+from datetime import datetime, timedelta, timezone
+
+# Third-Party
+from pydantic import ValidationError
+import pytest
+
+# First-Party
+from mcpgateway.schemas import ToolCreate, ToolUpdate
+
+
+class TestToolCreateSunsetValidation:
+    """Test suite for ToolCreate schema sunset_date validation."""
+
+    def test_create_active_tool_without_sunset_date(self):
+        """Test creating an active tool without sunset_date succeeds."""
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": False,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate is None
+
+    def test_create_deprecated_tool_without_sunset_date_fails(self):
+        """Test creating deprecated tool without sunset_date raises ValidationError."""
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            # Missing sunsetDate
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolCreate(**tool_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate is required when deprecated=True" in str(errors[0]["msg"])
+
+    def test_create_deprecated_tool_with_future_sunset_date_succeeds(self):
+        """Test creating deprecated tool with future sunset_date succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.deprecated is True
+        assert tool.sunsetDate == future_date
+        assert tool.sunsetDate.tzinfo is not None  # Timezone-aware
+
+    def test_create_deprecated_tool_with_past_sunset_date_fails(self):
+        """Test creating deprecated tool with past sunset_date raises ValidationError."""
+        past_date = datetime.now(timezone.utc) - timedelta(days=1)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": past_date,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolCreate(**tool_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate must be in the future" in str(errors[0]["msg"])
+
+    def test_create_deprecated_tool_with_current_time_fails(self):
+        """Test creating deprecated tool with current time as sunset_date fails."""
+        now = datetime.now(timezone.utc)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": now,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolCreate(**tool_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate must be in the future" in str(errors[0]["msg"])
+
+    def test_create_tool_with_naive_datetime_converts_to_utc(self):
+        """Test creating tool with timezone-naive datetime auto-converts to UTC."""
+        # Create naive datetime (no timezone)
+        naive_date = datetime.now() + timedelta(days=30)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": naive_date,
+        }
+        # Should not raise - naive datetime is auto-converted to UTC
+        tool = ToolCreate(**tool_data)
+
+        # Verify sunsetDate has timezone info (UTC)
+        assert tool.sunsetDate is not None
+        assert tool.sunsetDate.tzinfo is not None
+        assert tool.sunsetDate.tzinfo == timezone.utc
+
+    def test_create_active_tool_with_sunset_date_succeeds(self):
+        """Test creating active tool with sunset_date succeeds (for pre-planning)."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": False,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate == future_date
+
+
+class TestToolUpdateSunsetValidation:
+    """Test suite for ToolUpdate schema sunset_date validation."""
+
+    def test_update_to_deprecated_without_sunset_date_fails(self):
+        """Test updating tool to deprecated without sunset_date raises ValidationError."""
+        update_data = {
+            "deprecated": True,
+            # Missing sunsetDate
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate is required when setting deprecated=True" in str(errors[0]["msg"])
+
+    def test_update_to_deprecated_with_future_sunset_date_succeeds(self):
+        """Test updating tool to deprecated with future sunset_date succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        update_data = {
+            "deprecated": True,
+            "sunsetDate": future_date,
+        }
+        tool = ToolUpdate(**update_data)
+        assert tool.deprecated is True
+        assert tool.sunsetDate == future_date
+
+    def test_update_to_deprecated_with_past_sunset_date_fails(self):
+        """Test updating tool to deprecated with past sunset_date raises ValidationError."""
+        past_date = datetime.now(timezone.utc) - timedelta(days=1)
+        update_data = {
+            "deprecated": True,
+            "sunsetDate": past_date,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate must be in the future" in str(errors[0]["msg"])
+
+    def test_update_to_active_clears_sunset_date(self):
+        """Test updating tool to active (deprecated=False) allows clearing sunset_date."""
+        update_data = {
+            "deprecated": False,
+            "sunsetDate": None,
+        }
+        tool = ToolUpdate(**update_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate is None
+
+    def test_update_to_active_with_sunset_date_succeeds(self):
+        """Test updating to active while keeping sunset_date succeeds (for pre-planning)."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        update_data = {
+            "deprecated": False,
+            "sunsetDate": future_date,
+        }
+        tool = ToolUpdate(**update_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate == future_date
+
+    def test_update_only_sunset_date_without_deprecated_succeeds(self):
+        """Test updating only sunset_date without changing deprecated status succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=60)
+        update_data = {
+            "sunsetDate": future_date,
+        }
+        tool = ToolUpdate(**update_data)
+        assert tool.deprecated is None  # Not being updated
+        assert tool.sunsetDate == future_date
+
+    def test_update_with_naive_datetime_converts_to_utc(self):
+        """Test updating with timezone-naive datetime auto-converts to UTC."""
+        naive_date = datetime.now() + timedelta(days=30)
+        update_data = {
+            "deprecated": True,
+            "sunsetDate": naive_date,
+        }
+        # Should not raise - naive datetime is auto-converted to UTC
+        tool_update = ToolUpdate(**update_data)
+
+        # Verify sunsetDate has timezone info (UTC)
+        assert tool_update.sunsetDate is not None
+        assert tool_update.sunsetDate.tzinfo is not None
+        assert tool_update.sunsetDate.tzinfo == timezone.utc
+
+    def test_update_deprecated_false_with_null_sunset_date_succeeds(self):
+        """Test explicitly setting deprecated=False and sunsetDate=None succeeds."""
+        update_data = {
+            "deprecated": False,
+            "sunsetDate": None,
+        }
+        tool = ToolUpdate(**update_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate is None
+
+
+class TestToolLifecycleEdgeCases:
+    """Test suite for edge cases in tool lifecycle validation."""
+
+    def test_sunset_date_exactly_one_second_in_future_succeeds(self):
+        """Test sunset_date exactly 1 second in future succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(seconds=1)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.sunsetDate == future_date
+
+    def test_sunset_date_far_future_succeeds(self):
+        """Test sunset_date far in future (1 year) succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=365)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.sunsetDate == future_date
+
+    def test_different_timezone_future_date_succeeds(self):
+        """Test sunset_date with different timezone (but still future) succeeds."""
+        # Create a future date in a different timezone
+        from datetime import timezone as tz
+        future_date = datetime.now(tz(timedelta(hours=5))) + timedelta(days=30)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": True,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.sunsetDate.tzinfo is not None
+
+    def test_update_only_deprecated_to_true_without_existing_sunset_fails(self):
+        """Test updating only deprecated to True (without sunset_date) fails."""
+        update_data = {
+            "deprecated": True,
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            ToolUpdate(**update_data)
+
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "sunsetDate is required when setting deprecated=True" in str(errors[0]["msg"])
+
+    def test_create_with_both_deprecated_false_and_sunset_date_succeeds(self):
+        """Test creating tool with deprecated=False but with sunset_date succeeds."""
+        future_date = datetime.now(timezone.utc) + timedelta(days=30)
+        tool_data = {
+            "name": "test_tool",
+            "description": "Test tool",
+            "inputSchema": {"type": "object", "properties": {}},
+            "deprecated": False,
+            "sunsetDate": future_date,
+        }
+        tool = ToolCreate(**tool_data)
+        assert tool.deprecated is False
+        assert tool.sunsetDate == future_date

--- a/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
+++ b/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
@@ -124,19 +124,23 @@ class TestToolCreateSunsetValidation:
         assert tool.sunset_date.tzinfo is not None
         assert tool.sunset_date.tzinfo == timezone.utc
 
-    def test_create_active_tool_with_sunset_date_succeeds(self):
-        """Test creating active tool with sunset_date succeeds (for pre-planning)."""
+    def test_create_active_tool_clears_sunset_date(self):
+        """Test creating active tool (deprecated=False) automatically clears sunset_date.
+
+        Active tools cannot have sunset dates. The validator automatically clears
+        any sunset_date provided when deprecated=False.
+        """
         future_date = datetime.now(timezone.utc) + timedelta(days=30)
         tool_data = {
             "name": "test_tool",
             "description": "Test tool",
             "inputSchema": {"type": "object", "properties": {}},
             "deprecated": False,
-            "sunsetDate": future_date,
+            "sunsetDate": future_date,  # This will be ignored and cleared
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is False
-        assert tool.sunset_date == future_date
+        assert tool.sunset_date is None  # Automatically cleared by validator
 
 
 class TestToolUpdateSunsetValidation:
@@ -190,16 +194,21 @@ class TestToolUpdateSunsetValidation:
         assert tool.deprecated is False
         assert tool.sunset_date is None
 
-    def test_update_to_active_with_sunset_date_succeeds(self):
-        """Test updating to active while keeping sunset_date succeeds (for pre-planning)."""
+    def test_update_to_active_clears_sunset_date_automatically(self):
+        """Test updating to active (deprecated=False) automatically clears sunset_date.
+
+        When a tool is unmarked as deprecated, any sunset_date is automatically cleared
+        because active tools cannot have sunset dates. The deprecation lifecycle is:
+        active → deprecated (with sunset_date) → sunset (disabled).
+        """
         future_date = datetime.now(timezone.utc) + timedelta(days=30)
         update_data = {
             "deprecated": False,
-            "sunsetDate": future_date,
+            "sunsetDate": future_date,  # This will be ignored and cleared
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is False
-        assert tool.sunset_date == future_date
+        assert tool.sunset_date is None  # Automatically cleared by validator
 
     def test_update_only_sunset_date_without_deprecated_succeeds(self):
         """Test updating only sunset_date without changing deprecated status succeeds."""
@@ -293,16 +302,20 @@ class TestToolLifecycleEdgeCases:
         assert len(errors) == 1
         assert "sunsetDate is required when setting deprecated=True" in str(errors[0]["msg"])
 
-    def test_create_with_both_deprecated_false_and_sunset_date_succeeds(self):
-        """Test creating tool with deprecated=False but with sunset_date succeeds."""
+    def test_create_with_deprecated_false_clears_sunset_date(self):
+        """Test creating tool with deprecated=False automatically clears sunset_date.
+
+        Active tools (deprecated=False) cannot have sunset dates. The validator
+        automatically clears any sunset_date provided when deprecated=False.
+        """
         future_date = datetime.now(timezone.utc) + timedelta(days=30)
         tool_data = {
             "name": "test_tool",
             "description": "Test tool",
             "inputSchema": {"type": "object", "properties": {}},
             "deprecated": False,
-            "sunsetDate": future_date,
+            "sunsetDate": future_date,  # This will be ignored and cleared
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is False
-        assert tool.sunset_date == future_date
+        assert tool.sunset_date is None  # Automatically cleared by validator

--- a/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
+++ b/tests/unit/mcpgateway/test_tool_lifecycle_validation.py
@@ -38,7 +38,7 @@ class TestToolCreateSunsetValidation:
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate is None
+        assert tool.sunset_date is None
 
     def test_create_deprecated_tool_without_sunset_date_fails(self):
         """Test creating deprecated tool without sunset_date raises ValidationError."""
@@ -68,8 +68,8 @@ class TestToolCreateSunsetValidation:
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is True
-        assert tool.sunsetDate == future_date
-        assert tool.sunsetDate.tzinfo is not None  # Timezone-aware
+        assert tool.sunset_date == future_date
+        assert tool.sunset_date.tzinfo is not None  # Timezone-aware
 
     def test_create_deprecated_tool_with_past_sunset_date_fails(self):
         """Test creating deprecated tool with past sunset_date raises ValidationError."""
@@ -120,9 +120,9 @@ class TestToolCreateSunsetValidation:
         tool = ToolCreate(**tool_data)
 
         # Verify sunsetDate has timezone info (UTC)
-        assert tool.sunsetDate is not None
-        assert tool.sunsetDate.tzinfo is not None
-        assert tool.sunsetDate.tzinfo == timezone.utc
+        assert tool.sunset_date is not None
+        assert tool.sunset_date.tzinfo is not None
+        assert tool.sunset_date.tzinfo == timezone.utc
 
     def test_create_active_tool_with_sunset_date_succeeds(self):
         """Test creating active tool with sunset_date succeeds (for pre-planning)."""
@@ -136,7 +136,7 @@ class TestToolCreateSunsetValidation:
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
 
 class TestToolUpdateSunsetValidation:
@@ -164,7 +164,7 @@ class TestToolUpdateSunsetValidation:
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is True
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
     def test_update_to_deprecated_with_past_sunset_date_fails(self):
         """Test updating tool to deprecated with past sunset_date raises ValidationError."""
@@ -188,7 +188,7 @@ class TestToolUpdateSunsetValidation:
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate is None
+        assert tool.sunset_date is None
 
     def test_update_to_active_with_sunset_date_succeeds(self):
         """Test updating to active while keeping sunset_date succeeds (for pre-planning)."""
@@ -199,7 +199,7 @@ class TestToolUpdateSunsetValidation:
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
     def test_update_only_sunset_date_without_deprecated_succeeds(self):
         """Test updating only sunset_date without changing deprecated status succeeds."""
@@ -209,7 +209,7 @@ class TestToolUpdateSunsetValidation:
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is None  # Not being updated
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
     def test_update_with_naive_datetime_converts_to_utc(self):
         """Test updating with timezone-naive datetime auto-converts to UTC."""
@@ -222,9 +222,9 @@ class TestToolUpdateSunsetValidation:
         tool_update = ToolUpdate(**update_data)
 
         # Verify sunsetDate has timezone info (UTC)
-        assert tool_update.sunsetDate is not None
-        assert tool_update.sunsetDate.tzinfo is not None
-        assert tool_update.sunsetDate.tzinfo == timezone.utc
+        assert tool_update.sunset_date is not None
+        assert tool_update.sunset_date.tzinfo is not None
+        assert tool_update.sunset_date.tzinfo == timezone.utc
 
     def test_update_deprecated_false_with_null_sunset_date_succeeds(self):
         """Test explicitly setting deprecated=False and sunsetDate=None succeeds."""
@@ -234,7 +234,7 @@ class TestToolUpdateSunsetValidation:
         }
         tool = ToolUpdate(**update_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate is None
+        assert tool.sunset_date is None
 
 
 class TestToolLifecycleEdgeCases:
@@ -251,7 +251,7 @@ class TestToolLifecycleEdgeCases:
             "sunsetDate": future_date,
         }
         tool = ToolCreate(**tool_data)
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
     def test_sunset_date_far_future_succeeds(self):
         """Test sunset_date far in future (1 year) succeeds."""
@@ -264,7 +264,7 @@ class TestToolLifecycleEdgeCases:
             "sunsetDate": future_date,
         }
         tool = ToolCreate(**tool_data)
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date
 
     def test_different_timezone_future_date_succeeds(self):
         """Test sunset_date with different timezone (but still future) succeeds."""
@@ -279,7 +279,7 @@ class TestToolLifecycleEdgeCases:
             "sunsetDate": future_date,
         }
         tool = ToolCreate(**tool_data)
-        assert tool.sunsetDate.tzinfo is not None
+        assert tool.sunset_date.tzinfo is not None
 
     def test_update_only_deprecated_to_true_without_existing_sunset_fails(self):
         """Test updating only deprecated to True (without sunset_date) fails."""
@@ -305,4 +305,4 @@ class TestToolLifecycleEdgeCases:
         }
         tool = ToolCreate(**tool_data)
         assert tool.deprecated is False
-        assert tool.sunsetDate == future_date
+        assert tool.sunset_date == future_date

--- a/tests/utils/rbac_mocks.py
+++ b/tests/utils/rbac_mocks.py
@@ -103,6 +103,9 @@ class MockPermissionService:
         team_id: Optional[str] = None,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
+        token_teams: Optional[list] = None,
+        allow_admin_bypass: bool = True,
+        **kwargs,
     ) -> bool:
         """Mock permission check that returns configured result.
 
@@ -114,6 +117,9 @@ class MockPermissionService:
             team_id: Optional team context
             ip_address: Optional IP address
             user_agent: Optional user agent
+            token_teams: Optional token teams for scoping
+            allow_admin_bypass: Whether to allow admin bypass
+            **kwargs: Additional keyword arguments (ignored)
 
         Returns:
             bool: Permission result


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4892

---

## 📝 Summary

This PR implements a comprehensive tool lifecycle management system that introduces systematic tool retirement workflows through three distinct states: **Active → Deprecated → Sunset**. The feature adds a mandatory `sunsetDate` field for deprecated tools and automates the transition to sunset state, providing predictable timelines for tool retirement.

### What does this PR do?

**Adds structured tool lifecycle management with:**
- **Database schema changes**: New `sunset_date` column (timezone-aware DateTime) on Tool model
- **API validation**: `sunsetDate` field required when `deprecated=true`, must be future date
- **Automated transitions**: Background scheduler service that automatically disables tools when `sunsetDate` is reached
- **Enhanced API responses**: New computed fields (`lifecycle_state`, `is_executable`, `days_until_sunset`)
- **Backwards compatibility**: Existing deprecated tools (without sunset dates) remain executable
- **Comprehensive testing**: 49 tests covering validation, scheduler, and regression scenarios

### Feature Flow

```
1. Admin marks tool deprecated=true → MUST provide future sunsetDate
2. Tool enters "deprecated" state → Still executable, shows days_until_sunset
3. Users see warnings in tool listings → Time to migrate to alternatives
4. Scheduler runs every 60 minutes → Checks for tools past sunsetDate
5. Tool transitions to "sunset" state → enabled=false, no longer executable
6. Execution attempts return 404 → Tool is retired
```

### Why is this needed?

While the existing `deprecated` flag (PR #4829) indicates tools should no longer be used, it doesn't provide:
- A structured transition period between deprecation and full retirement
- Clear visibility into when a tool will stop working
- Automated enforcement of sunset timelines

This feature ensures deprecation is **time-bound and predictable**, giving agent builders sufficient preparation time before tools become unavailable.

---

## 🏷️ Type of Change
- [x] Feature / Enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🎯 Implementation Details

### 1. Database Schema ([`mcpgateway/db.py:3247`](mcpgateway/db.py:3247))

```python
sunset_date: Mapped[Optional[datetime]] = mapped_column(
    DateTime(timezone=True), 
    nullable=True, 
    default=None,
    index=True  # For efficient scheduler queries
)
```

**Migration:** [`15a7b5f1e41a_add_sunset_date_to_tools.py`](mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py)
- Idempotent upgrade/downgrade paths
- Adds index on `sunset_date` for efficient scheduler queries
- Handles existing data gracefully (defaults to NULL)

### 2. API Schema Validation ([`mcpgateway/schemas.py`](mcpgateway/schemas.py))

**ToolCreate/ToolUpdate schemas:**
```python
sunsetDate: Optional[datetime] = Field(
    None, 
    alias="sunsetDate",
    description="Date when deprecated tool will be sunset (disabled). Required when deprecated=True"
)

@model_validator(mode="after")
def validate_sunset_date(self) -> "ToolCreate":
    # RULE 1: deprecated=true REQUIRES sunsetDate
    if self.deprecated and self.sunsetDate is None:
        raise ValueError("sunsetDate is required when deprecated=True")
    
    # RULE 2: sunsetDate must be in the future
    if self.sunsetDate and self.sunsetDate <= datetime.now(timezone.utc):
        raise ValueError("sunsetDate must be in the future")
    
    # RULE 3: deprecated=false CLEARS sunsetDate
    if not self.deprecated and self.sunsetDate:
        self.sunsetDate = None
    
    return self
```

**ToolRead schema additions:**
```python
lifecycle_state: Optional[Literal["active", "deprecated", "sunset"]]
days_until_sunset: Optional[int]
is_executable: Optional[bool]
```

### 3. Automated Sunset Scheduler ([`mcpgateway/services/sunset_scheduler_service.py`](mcpgateway/services/sunset_scheduler_service.py))

**Background service that:**
- Runs periodically (configurable via `SUNSET_SCHEDULER_INTERVAL_MINUTES`, default: 60 minutes)
- Queries: `WHERE deprecated=true AND sunset_date <= now() AND enabled=true`
- Atomically updates: `SET enabled=false` for matching tools
- Invalidates tool cache for sunset tools
- Logs audit trail for each transition
- **Idempotent design**: Safe for concurrent execution across multiple instances

**Integration:** [`mcpgateway/main.py:1607-1613,1836-1841`](mcpgateway/main.py:1607)
```python
# Startup
sunset_scheduler_service = get_sunset_scheduler_service()
await sunset_scheduler_service.start()

# Shutdown (reuses stored reference)
await sunset_scheduler_service.stop()
```

### 4. Lifecycle State Computation ([`mcpgateway/services/tool_service.py:1408-1437`](mcpgateway/services/tool_service.py:1408))

**Three lifecycle states:**

| State | Conditions | Executable | Visible |
|-------|-----------|------------|---------|
| **active** | `deprecated=false` | ✅ Yes | ✅ Yes |
| **deprecated** | `deprecated=true, sunset_date=future OR NULL` | ✅ Yes | ✅ Yes |
| **sunset** | `enabled=false, deprecated=true, sunset_date=past` | ❌ No | ✅ Yes (admin) |

**Backwards compatibility:** Tools with `deprecated=true` and `sunset_date=NULL` return `lifecycle_state="deprecated"` (not "active")

**Computed fields:**
- `lifecycle_state`: Current state (active/deprecated/sunset)
- `is_executable`: Boolean indicating if tool can be invoked
- `days_until_sunset`: Days remaining until sunset (only for deprecated tools)

### 5. Tool Listing Filters ([`mcpgateway/services/tool_service.py`](mcpgateway/services/tool_service.py))

**Default behavior:** Sunset tools (`enabled=false`) are **excluded** from tool listings
**Admin view:** `include_inactive=true` shows all tools including sunset ones

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass (49 lifecycle tests) |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

### Test Coverage

**Unit Tests (27 tests):**

**Schema Validation** (20 tests): [`tests/unit/mcpgateway/test_tool_lifecycle_validation.py`](tests/unit/mcpgateway/test_tool_lifecycle_validation.py)
- Schema validation for all scenarios
- Edge cases: past dates, missing fields, clearing sunset dates
- Validation error messages

**Service Tests** (7 tests):
- [`tests/unit/mcpgateway/services/test_sunset_scheduler_service.py`](tests/unit/mcpgateway/services/test_sunset_scheduler_service.py) - Scheduler concurrent execution protection
- [`tests/unit/mcpgateway/services/test_tool_service.py`](tests/unit/mcpgateway/services/test_tool_service.py) - sunset_date clearing on deprecated=false

**Integration Tests (22 tests):**

**Core Lifecycle Tests** (12 tests): [`tests/integration/test_tool_lifecycle_management.py`](tests/integration/test_tool_lifecycle_management.py)

1. `TestToolLifecycleCreation` (3 tests)
   - Create deprecated tool with future sunset date
   - Validation failure when sunset date missing
   - Active tool lifecycle state

2. `TestToolLifecycleExecution` (2 tests)
   - Deprecated tools executable before sunset
   - Sunset tools blocked from execution

3. `TestSunsetScheduler` (2 tests)
   - Scheduler transitions tools to sunset
   - Scheduler idempotency (safe for multiple runs)

4. `TestLifecycleStateComputation` (3 tests)
   - Active tool lifecycle state
   - Deprecated tool lifecycle state
   - Sunset tool lifecycle state

5. `TestBackwardsCompatibility` (2 tests)
   - Existing deprecated tools without sunset dates work correctly
   - Lifecycle state correctly shows "deprecated" not "active"

**Regression Tests** (10 tests): [`tests/integration/test_tool_lifecycle_regression.py`](tests/integration/test_tool_lifecycle_regression.py)

6. `TestToolLifecycleListingRegression` (2 tests)
   - ✅ Sunset tools excluded from default tool listings (MCP clients don't see disabled tools)
   - ✅ Sunset tools visible with `include_inactive=true` (admin access)

7. `TestToolLifecycleInvocationRegression` (2 tests)
   - ✅ Tool invocation blocked after scheduler disables tool
   - ✅ Concurrent invocations during sunset transition handled gracefully

8. `TestToolLifecycleCacheRegression` (1 test)
   - ✅ Sunset scheduler invalidates tool cache (prevents stale cache execution)

9. `TestToolLifecycleUpdateRegression` (3 tests)
   - ✅ Cannot manually enable sunset tool without clearing deprecated flag
   - ✅ Can update non-lifecycle fields (description, tags) on sunset tools
   - ✅ Can resurrect sunset tool by setting deprecated=false (clears sunset_date)

10. `TestToolLifecycleEdgeCases` (2 tests)
    - ✅ Old deprecated tools without sunset_date remain executable (backwards compat)
    - ✅ Tools with future sunset dates remain executable during grace period

**All 49 tests passing** ✓

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (49 comprehensive tests)
- [x] Documentation updated (inline docstrings and comments)
- [x] No secrets or credentials committed
- [x] Migration tested (upgrade/downgrade paths)
- [x] Backwards compatibility verified
- [x] Regression tests added to prevent future breakage

---

## 📓 Notes

### Design Decisions

1. **Deprecated ≠ Blocked**: Deprecated tools remain executable until `sunsetDate` to provide a grace period for migration. This is a **critical behavior change** from immediate blocking.

2. **Timezone-Aware Dates**: All sunset dates use timezone-aware DateTime (UTC) to prevent timezone-related bugs in distributed deployments.

3. **Idempotent Scheduler**: The scheduler uses atomic database operations (`UPDATE WHERE enabled=true`) to safely handle concurrent execution across multiple gateway instances.

4. **Cache Invalidation**: Tool cache is invalidated when tools transition to sunset state to ensure consistent behavior.

5. **Audit Trail**: All sunset transitions are logged with structured logging for compliance and debugging.

6. **Backwards Compatibility**: Existing tools with `deprecated=true` and `sunset_date=NULL` show as `lifecycle_state="deprecated"` and remain executable indefinitely until a sunset date is added.

### Configuration

**Environment Variables:**
```bash
SUNSET_SCHEDULER_INTERVAL_MINUTES=60  # How often to check for tools to sunset (default: 60)
```

### Migration Path

**For existing deployments:**
1. Run migration: `alembic upgrade head`
2. Existing tools: `sunset_date=NULL` (no automatic sunset)
3. Existing deprecated tools: Continue working, show `lifecycle_state="deprecated"`
4. New deprecations: `sunsetDate` is mandatory
5. Admins can retroactively add `sunsetDate` to existing deprecated tools

### Future Enhancements

Potential follow-up work (not in this PR):
- Admin UI integration for lifecycle management
- Email notifications before sunset
- Metrics/alerts for tools approaching sunset
- Bulk sunset operations API
- Tool replacement suggestions in deprecation messages

---

## 📊 Files Changed

**New Files (10):**

Code:
- `mcpgateway/services/sunset_scheduler_service.py` (269 lines)
- `mcpgateway/alembic/versions/15a7b5f1e41a_add_sunset_date_to_tools.py` (144 lines)
- `tests/unit/mcpgateway/test_tool_lifecycle_validation.py` (600 lines)
- `tests/integration/test_tool_lifecycle_management.py` (783 lines)
- `tests/integration/test_tool_lifecycle_regression.py` (700 lines)

Documentation:
- `docs/docs/manage/tool-lifecycle.md` (Complete lifecycle management guide)

**Modified Files (13):**

Code:
- `mcpgateway/db.py` - Added sunset_date column with index
- `mcpgateway/schemas.py` - Added sunsetDate validation with clearing logic
- `mcpgateway/services/tool_service.py` - Lifecycle state computation + sunset_date clearing
- `mcpgateway/config.py` - Added scheduler interval setting
- `mcpgateway/main.py` - Integrated scheduler with lifespan + stored reference
- `.secrets.baseline` - Resolved merge conflicts
- Plus 7 other files with test updates and minor fixes

Documentation:
- `docs/docs/manage/api-usage.md` - Added lifecycle API examples and field documentation
- `docs/docs/manage/configuration.md` - Added SUNSET_SCHEDULER_INTERVAL_MINUTES setting
- `docs/docs/architecture/tool-invocation-and-validation.md` - Added lifecycle enforcement section
- `docs/docs/manage/upgrade.md` - Added migration guide and backwards compatibility notes