### PR TITLE
fix: resolve plugin metadata from packages

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -588,7 +588,7 @@
         "hashed_secret": "c58a69e6abb14e59f5e5761ac85a933c671bda09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 301,
+        "line_number": 286,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1324,7 +1324,7 @@
         "hashed_secret": "38297d822c960daea26f148a2fede848dcc2083b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 711,
+        "line_number": 708,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1332,7 +1332,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1440,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-28T13:31:00Z",
+  "generated_at": "2026-05-28T14:33:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/charts/mcp-stack/profiles/ocp/values-pgo.yaml
+++ b/charts/mcp-stack/profiles/ocp/values-pgo.yaml
@@ -59,9 +59,6 @@ mcpContextForge:
       plugins:
         - name: "PIIFilterPlugin"
           kind: "cpex_pii_filter.PIIFilterPlugin"
-          description: "Detects and masks Personally Identifiable Information"
-          version: "0.1.0"
-          author: "Mihai Criveti"
           hooks: ["prompt_pre_fetch", "prompt_post_fetch", "tool_pre_invoke", "tool_post_invoke"]
           tags: ["security", "pii", "compliance", "filter", "gdpr", "hipaa"]
           mode: "permissive"
@@ -86,9 +83,6 @@ mcpContextForge:
               - "555-555-5555"
         - name: "RateLimiterPlugin"
           kind: "cpex_rate_limiter.RateLimiterPlugin"
-          description: "Per-user/tenant/tool rate limits"
-          version: "0.1.0"
-          author: "Mihai Criveti"
           hooks: ["prompt_pre_fetch", "tool_pre_invoke"]
           tags: ["limits", "throttle"]
           mode: "permissive"
@@ -104,9 +98,6 @@ mcpContextForge:
             by_tool: {}
         - name: "RetryWithBackoffPlugin"
           kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
-          description: "Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay"
-          version: "0.1.0"
-          author: "Mihai Criveti"
           hooks: ["tool_post_invoke"]
           tags: ["retry", "backoff", "resilience"]
           mode: "permissive"
@@ -137,9 +128,6 @@ mcpContextForge:
             ellipsis: "…"
         - name: "SecretsDetection"
           kind: "cpex_secrets_detection.SecretsDetectionPlugin"
-          description: "Detects keys/tokens/secrets in inputs/outputs; optional redaction/blocking"
-          version: "0.1.0"
-          author: "ContextForge"
           hooks: ["prompt_pre_fetch", "tool_post_invoke", "resource_post_fetch"]
           tags: ["security", "secrets", "dlp"]
           mode: "permissive"
@@ -161,9 +149,6 @@ mcpContextForge:
             min_findings_to_block: 1
         - name: "EncodedExfilDetector"
           kind: "cpex_encoded_exfil_detection.EncodedExfilDetectorPlugin"
-          description: "Detects suspicious encoded exfiltration patterns in prompt args and tool outputs"
-          version: "0.1.0"
-          author: "Mihai Criveti"
           hooks: ["prompt_pre_fetch", "tool_post_invoke"]
           tags: ["security", "exfiltration", "dlp", "encoding"]
           mode: "permissive"

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -154,9 +154,6 @@ plugins:
 
   - name: "PIIFilterPlugin"                    # Unique plugin identifier
     kind: "cpex_pii_filter.PIIFilterPlugin"  # Plugin class path
-    description: "Detects and masks PII"       # Human-readable description
-    version: "1.0.0"                          # Plugin version
-    author: "Security Team"                   # Plugin author
     hooks:                                    # Hook registration
 
       - "prompt_pre_fetch"

--- a/docs/docs/howto/code-engine-plugin-configmap.md
+++ b/docs/docs/howto/code-engine-plugin-configmap.md
@@ -35,8 +35,6 @@ plugins:
   # PII Filter — detect and mask sensitive data
   - name: "PIIFilterPlugin"
     kind: "cpex_pii_filter.PIIFilterPlugin"
-    description: "Detects and masks Personally Identifiable Information"
-    version: "0.1.0"
     hooks:
       - "prompt_pre_fetch"
       - "prompt_post_fetch"

--- a/mcpgateway/admin_ui/plugins.js
+++ b/mcpgateway/admin_ui/plugins.js
@@ -24,6 +24,56 @@ const MODE_CSS = {
   disabled: "bg-gray-100 text-gray-800",
 };
 
+const appendHeading = function (parent, text) {
+  const heading = document.createElement("h4");
+  heading.className = "font-medium text-gray-700 dark:text-gray-300";
+  heading.textContent = text;
+  parent.appendChild(heading);
+};
+
+const appendTextSection = function (parent, headingText, value) {
+  const section = document.createElement("div");
+  appendHeading(section, headingText);
+
+  const text = document.createElement("p");
+  text.className = "mt-1";
+  text.textContent = value;
+  section.appendChild(text);
+
+  parent.appendChild(section);
+};
+
+const appendBadgeListSection = function (
+  parent,
+  headingText,
+  values,
+  className
+) {
+  const section = document.createElement("div");
+  appendHeading(section, headingText);
+
+  const badgeList = document.createElement("div");
+  badgeList.className = "mt-1 flex flex-wrap gap-1";
+  (values || []).forEach((value) => {
+    const badge = document.createElement("span");
+    badge.className = className;
+    badge.textContent = value;
+    badgeList.appendChild(badge);
+  });
+
+  section.appendChild(badgeList);
+  parent.appendChild(section);
+};
+
+const getModeLabel = function (mode) {
+  return (
+    MODE_LABEL[mode] ||
+    (mode || "unknown")
+      .replace(/_/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+};
+
 // Populate hook, tag, and author filters on page load
 export const populatePluginFilters = function () {
   const cards = document.querySelectorAll(".plugin-card");
@@ -306,7 +356,11 @@ export const showPluginDetails = async function (pluginName) {
 
   // Show loading state
   modalName.textContent = pluginName;
-  modalContent.innerHTML = '<div class="text-center py-4">Loading...</div>';
+  modalContent.textContent = "";
+  const loading = document.createElement("div");
+  loading.className = "text-center py-4";
+  loading.textContent = "Loading...";
+  modalContent.appendChild(loading);
   modal.classList.remove("hidden");
 
   try {
@@ -329,85 +383,83 @@ export const showPluginDetails = async function (pluginName) {
     const plugin = await response.json();
 
     // Render plugin details
-    modalContent.innerHTML = `
-                  <div class="space-y-4">
-                      <div>
-                          <h4 class="font-medium text-gray-700 dark:text-gray-300">Description</h4>
-                          <p class="mt-1">${plugin.description || "No description available"}</p>
-                      </div>
+    modalContent.textContent = "";
 
-                      <div class="grid grid-cols-2 gap-4">
-                          <div>
-                              <h4 class="font-medium text-gray-700 dark:text-gray-300">Author</h4>
-                              <p class="mt-1">${plugin.author || "Unknown"}</p>
-                          </div>
-                          <div>
-                              <h4 class="font-medium text-gray-700 dark:text-gray-300">Version</h4>
-                              <p class="mt-1">${plugin.version || "0.0.0"}</p>
-                          </div>
-                      </div>
+    const content = document.createElement("div");
+    content.className = "space-y-4";
 
-                      <div class="grid grid-cols-2 gap-4">
-                          <div>
-                              <h4 class="font-medium text-gray-700 dark:text-gray-300">Mode</h4>
-                              <p class="mt-1">
-                                  <span class="px-2 py-1 text-xs rounded-full ${
-  MODE_CSS[plugin.mode] || "bg-gray-100 text-gray-800"
-}">
-                                      ${MODE_LABEL[plugin.mode] || (plugin.mode || "unknown").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-                                  </span>
-                              </p>
-                          </div>
-                          <div>
-                              <h4 class="font-medium text-gray-700 dark:text-gray-300">Priority</h4>
-                              <p class="mt-1">${plugin.priority}</p>
-                          </div>
-                      </div>
+    appendTextSection(
+      content,
+      "Description",
+      plugin.description || "No description available"
+    );
 
-                      <div>
-                          <h4 class="font-medium text-gray-700 dark:text-gray-300">Hooks</h4>
-                          <div class="mt-1 flex flex-wrap gap-1">
-                              ${(plugin.hooks || [])
-    .map(
-      (hook) =>
-        `<span class="px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">${hook}</span>`
-    )
-    .join("")}
-                          </div>
-                      </div>
+    const authorVersionGrid = document.createElement("div");
+    authorVersionGrid.className = "grid grid-cols-2 gap-4";
+    appendTextSection(authorVersionGrid, "Author", plugin.author || "Unknown");
+    appendTextSection(authorVersionGrid, "Version", plugin.version || "0.0.0");
+    content.appendChild(authorVersionGrid);
 
-                      <div>
-                          <h4 class="font-medium text-gray-700 dark:text-gray-300">Tags</h4>
-                          <div class="mt-1 flex flex-wrap gap-1">
-                              ${(plugin.tags || [])
-    .map(
-      (tag) =>
-        `<span class="px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded">${tag}</span>`
-    )
-    .join("")}
-                          </div>
-                      </div>
+    const modePriorityGrid = document.createElement("div");
+    modePriorityGrid.className = "grid grid-cols-2 gap-4";
 
-                      ${
-  plugin.config && Object.keys(plugin.config).length > 0
-    ? `
-                          <div>
-                              <h4 class="font-medium text-gray-700 dark:text-gray-300">Configuration</h4>
-                              <pre class="mt-1 p-2 bg-gray-50 dark:bg-gray-800 rounded text-xs overflow-x-auto">${JSON.stringify(plugin.config, null, 2)}</pre>
-                          </div>
-                      `
-    : ""
-}
-                  </div>
-              `;
+    const modeSection = document.createElement("div");
+    appendHeading(modeSection, "Mode");
+    const modeText = document.createElement("p");
+    modeText.className = "mt-1";
+    const modeBadge = document.createElement("span");
+    modeBadge.className = `px-2 py-1 text-xs rounded-full ${
+      MODE_CSS[plugin.mode] || "bg-gray-100 text-gray-800"
+    }`;
+    modeBadge.textContent = getModeLabel(plugin.mode);
+    modeText.appendChild(modeBadge);
+    modeSection.appendChild(modeText);
+    modePriorityGrid.appendChild(modeSection);
+
+    appendTextSection(modePriorityGrid, "Priority", plugin.priority);
+    content.appendChild(modePriorityGrid);
+
+    appendBadgeListSection(
+      content,
+      "Hooks",
+      plugin.hooks,
+      "px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded"
+    );
+    appendBadgeListSection(
+      content,
+      "Tags",
+      plugin.tags,
+      "px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded"
+    );
+
+    if (plugin.config && Object.keys(plugin.config).length > 0) {
+      const configSection = document.createElement("div");
+      appendHeading(configSection, "Configuration");
+      const config = document.createElement("pre");
+      config.className =
+        "mt-1 p-2 bg-gray-50 dark:bg-gray-800 rounded text-xs overflow-x-auto";
+      config.textContent = JSON.stringify(plugin.config, null, 2);
+      configSection.appendChild(config);
+      content.appendChild(configSection);
+    }
+
+    modalContent.appendChild(content);
   } catch (error) {
     console.error("Error loading plugin details:", error);
-    modalContent.innerHTML = `
-                  <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
-                      <strong class="font-bold">Error:</strong>
-                      <span class="block sm:inline">${error.message}</span>
-                  </div>
-              `;
+    modalContent.textContent = "";
+    const errorBox = document.createElement("div");
+    errorBox.className =
+      "bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded";
+    const label = document.createElement("strong");
+    label.className = "font-bold";
+    label.textContent = "Error:";
+    const message = document.createElement("span");
+    message.className = "block sm:inline";
+    message.textContent = error.message;
+    errorBox.appendChild(label);
+    errorBox.appendChild(document.createTextNode(" "));
+    errorBox.appendChild(message);
+    modalContent.appendChild(errorBox);
   }
 };
 
@@ -435,4 +487,4 @@ export const dispatchPluginAction = function (target) {
   else if (closeEl) closePluginDetails();
   else return false;
   return true;
-}
+};

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm import Session
 # First-Party
 from mcpgateway.plugins._redis import get_shared_redis_client as _redis
 from mcpgateway.plugins._state import active_local_mode_overrides, prune_expired_local_overrides
+from mcpgateway.plugins.metadata import enrich_config_plugin_metadata
 from mcpgateway.services.tool_plugin_binding_service import get_bindings_for_tool
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,7 @@ class TenantPluginManagerFactory:
         db_factory: Optional[Callable[[], Session]] = None,
     ):
         """Initialise the factory, loading base config from *yaml_path*."""
-        self._base_config: Config = ConfigLoader.load_config(yaml_path)
+        self._base_config: Config = enrich_config_plugin_metadata(ConfigLoader.load_config(yaml_path))
         self._timeout = timeout
         self._observability = observability
         self._hook_policies = hook_policies

--- a/mcpgateway/plugins/metadata.py
+++ b/mcpgateway/plugins/metadata.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Resolve plugin display metadata from installed packages."""
+
+# Standard
+from importlib import metadata as importlib_metadata
+import sys
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+# Third-Party
+from cpex.framework.models import Config
+from cpex.framework.utils import parse_class_name
+
+
+def _safe_str(value: Any) -> Optional[str]:
+    """Return non-empty strings only."""
+    return value if isinstance(value, str) and value else None
+
+
+def _module_name_from_kind(kind: Optional[str]) -> Optional[str]:
+    """Extract the importable module name from a plugin kind."""
+    if not kind:
+        return None
+
+    if ":" in kind:
+        module_name = kind.split(":", 1)[0]
+    else:
+        module_name, _class_name = parse_class_name(kind)
+
+    return module_name or None
+
+
+def _distribution_metadata(
+    module_name: Optional[str],
+    package_map: Mapping[str, list[str]],
+    distribution_cache: Dict[str, Tuple[Optional[str], Optional[str], Optional[str]]],
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve version, author, and description from installed distribution metadata."""
+    if not module_name:
+        return None, None, None
+
+    top_level_package = module_name.split(".", 1)[0]
+    candidate_distributions = list(package_map.get(top_level_package, []))
+    candidate_distributions.extend([module_name, top_level_package, top_level_package.replace("_", "-")])
+
+    seen = set()
+    for distribution_name in candidate_distributions:
+        if distribution_name in seen:
+            continue
+        seen.add(distribution_name)
+
+        if distribution_name not in distribution_cache:
+            try:
+                distribution = importlib_metadata.distribution(distribution_name)
+            except importlib_metadata.PackageNotFoundError:
+                distribution_cache[distribution_name] = (None, None, None)
+            else:
+                package_metadata = distribution.metadata
+                author = package_metadata.get("Author") or package_metadata.get("Maintainer") or package_metadata.get("Author-email")
+                distribution_cache[distribution_name] = (_safe_str(distribution.version), _safe_str(author), _safe_str(package_metadata.get("Summary")))
+
+        metadata = distribution_cache[distribution_name]
+        if any(metadata):
+            return metadata
+
+    return None, None, None
+
+
+def _loaded_module_metadata(module_name: Optional[str]) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve metadata from an already-loaded module without importing disabled plugins."""
+    if not module_name:
+        return None, None, None
+
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None, None, None
+
+    return _safe_str(getattr(module, "__version__", None)), _safe_str(getattr(module, "__author__", None)), _safe_str(getattr(module, "__description__", None))
+
+
+def resolve_plugin_metadata(
+    plugin_config: Any,
+    package_map: Optional[Mapping[str, list[str]]] = None,
+    distribution_cache: Optional[Dict[str, Tuple[Optional[str], Optional[str], Optional[str]]]] = None,
+) -> Dict[str, str]:
+    """Resolve display metadata for a plugin config."""
+    kind = _safe_str(getattr(plugin_config, "kind", None)) if plugin_config else None
+    module_name = _module_name_from_kind(kind)
+    resolved_package_map = package_map if package_map is not None else importlib_metadata.packages_distributions()
+    resolved_distribution_cache = distribution_cache if distribution_cache is not None else {}
+    dist_version, dist_author, dist_description = _distribution_metadata(module_name, resolved_package_map, resolved_distribution_cache)
+    module_version, module_author, module_description = _loaded_module_metadata(module_name)
+
+    return {
+        "description": dist_description or module_description or (_safe_str(getattr(plugin_config, "description", None)) if plugin_config else None) or "",
+        "author": dist_author or module_author or (_safe_str(getattr(plugin_config, "author", None)) if plugin_config else None) or "Unknown",
+        "version": dist_version or module_version or (_safe_str(getattr(plugin_config, "version", None)) if plugin_config else None) or "0.0.0",
+    }
+
+
+def enrich_config_plugin_metadata(config: Config) -> Config:
+    """Return config with plugin display metadata resolved once at load time."""
+    if not config.plugins:
+        return config
+
+    package_map = importlib_metadata.packages_distributions()
+    distribution_cache: Dict[str, Tuple[Optional[str], Optional[str], Optional[str]]] = {}
+    plugins = []
+    changed = False
+
+    for plugin in config.plugins:
+        metadata = resolve_plugin_metadata(plugin, package_map=package_map, distribution_cache=distribution_cache)
+        update = {}
+        if metadata["description"] or plugin.description is not None:
+            update["description"] = metadata["description"]
+        if metadata["author"] != "Unknown" or plugin.author is not None:
+            update["author"] = metadata["author"]
+        if metadata["version"] != "0.0.0" or plugin.version is not None:
+            update["version"] = metadata["version"]
+
+        plugins.append(plugin.model_copy(update=update) if update else plugin)
+        changed = changed or any(getattr(plugin, key) != value for key, value in update.items())
+
+    if not changed:
+        return config
+    return config.model_copy(update={"plugins": plugins}, deep=True)

--- a/mcpgateway/services/plugin_service.py
+++ b/mcpgateway/services/plugin_service.py
@@ -104,11 +104,6 @@ class PluginService:
                 "status": "enabled" if plugin_ref.mode != PluginMode.DISABLED else "disabled",
             }
 
-            # Add implementation type if available (e.g., Rust vs Python for PII filter)
-            plugin_instance = plugin_ref.plugin if hasattr(plugin_ref, "plugin") else plugin_ref._plugin if hasattr(plugin_ref, "_plugin") else None  # pylint: disable=protected-access
-            if plugin_instance and hasattr(plugin_instance, "implementation"):
-                plugin_dict["implementation"] = plugin_instance.implementation
-
             # Add config summary (first few keys only for list view)
             if plugin_config and hasattr(plugin_config, "config") and plugin_config.config:
                 config_keys = list(plugin_config.config.keys())[:5]

--- a/mcpgateway/templates/plugins_partial.html
+++ b/mcpgateway/templates/plugins_partial.html
@@ -347,22 +347,6 @@
           {{ mode_label_map.get(m, m | replace('_', ' ') | title) }}
         </span>
 
-        <!-- Implementation Badge -->
-        {% if plugin.implementation == 'Rust' %}
-        <span
-          class="px-2 py-1 bg-orange-100 text-orange-800 text-xs font-medium rounded dark:bg-orange-900 dark:text-orange-200"
-          title="Rust-accelerated implementation (5-100x faster)"
-        >
-          🦀 Rust
-        </span>
-        {% elif plugin.implementation == 'Python' %}
-        <span
-          class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded dark:bg-blue-900 dark:text-blue-200"
-          title="Pure Python implementation"
-        >
-          🐍 Python
-        </span>
-        {% endif %}
       </div>
 
       <!-- Tags -->

--- a/plugins/config.yaml
+++ b/plugins/config.yaml
@@ -88,9 +88,6 @@ plugins:
   # PII Filter Plugin - Run first with highest priority for security
   - name: "PIIFilterPlugin"
     kind: "cpex_pii_filter.PIIFilterPlugin"
-    description: "Detects and masks Personally Identifiable Information"
-    version: "0.2.0"
-    author: "Mihai Criveti"
     hooks:
       [
         "prompt_pre_fetch",
@@ -283,9 +280,6 @@ plugins:
   # Rate limiter (cpex-rate-limiter package)
   - name: "RateLimiterPlugin"
     kind: "cpex_rate_limiter.RateLimiterPlugin"
-    description: "Per-user/tenant/tool rate limits"
-    version: "0.0.6"
-    author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch", "tool_pre_invoke"]
     tags: ["limits", "throttle"]
     mode: "disabled"
@@ -369,9 +363,6 @@ plugins:
   # URL reputation static checks
   - name: "URLReputationPlugin"
     kind: "cpex_url_reputation.URLReputationPlugin"
-    description: "Blocks known-bad domains or patterns before fetch"
-    version: "0.1.1"
-    author: "Mihai Criveti"
     hooks: ["resource_pre_fetch"]
     tags: ["security", "url", "reputation"]
     mode: "disabled"
@@ -401,9 +392,6 @@ plugins:
   # Retry with exponential backoff — triggers real gateway re-invocation
   - name: "RetryWithBackoffPlugin"
     kind: "cpex_retry_with_backoff.RetryWithBackoffPlugin"
-    description: "Detects transient failures and asks the gateway to re-invoke the tool after a jittered exponential backoff delay"
-    version: "0.1.0"
-    author: "Mihai Criveti"
     hooks: ["tool_post_invoke"]
     tags: ["retry", "backoff", "resilience"]
     mode: "disabled"
@@ -776,9 +764,6 @@ plugins:
   # Secrets Detection - regex-based detector for common secrets/keys
   - name: "SecretsDetection"
     kind: "cpex_secrets_detection.SecretsDetectionPlugin"
-    description: "Detects keys/tokens/secrets in inputs/outputs; optional redaction/blocking"
-    version: "0.1.0"
-    author: "ContextForge"
     hooks: ["prompt_pre_fetch", "tool_post_invoke", "resource_post_fetch"]
     tags: ["security", "secrets", "dlp"]
     mode: "disabled"
@@ -802,9 +787,6 @@ plugins:
   # Encoded Exfil Detector - detect suspicious encoded payloads in prompts, tool outputs, and resources
   - name: "EncodedExfilDetector"
     kind: "cpex_encoded_exfil_detection.EncodedExfilDetectorPlugin"
-    description: "Detects suspicious encoded exfiltration patterns in prompts, tool outputs, and resources"
-    version: "0.2.0"
-    author: "Mihai Criveti"
     hooks: ["prompt_pre_fetch", "tool_post_invoke", "resource_post_fetch"]
     tags: ["security", "exfiltration", "dlp", "encoding"]
     # mode: "sequential"

--- a/tests/unit/js/plugins.test.js
+++ b/tests/unit/js/plugins.test.js
@@ -809,6 +809,56 @@ describe("showPluginDetails", () => {
     expect(modalContent.innerHTML).toContain("setting1");
   });
 
+  test("renders plugin metadata as text instead of HTML", async () => {
+    const modal = document.createElement("div");
+    modal.id = "plugin-details-modal";
+    document.body.appendChild(modal);
+
+    const modalName = document.createElement("div");
+    modalName.id = "modal-plugin-name";
+    document.body.appendChild(modalName);
+
+    const modalContent = document.createElement("div");
+    modalContent.id = "modal-plugin-content";
+    document.body.appendChild(modalContent);
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          description: '<img src=x onerror="alert(1)">',
+          author: '<svg onload="alert(2)">',
+          version: "<script>alert(3)</script>",
+          hooks: ['<button onclick="alert(4)">hook</button>'],
+          tags: ['<iframe src="javascript:alert(5)"></iframe>'],
+          config: { nested: '<a onclick="alert(6)">config</a>' },
+        }),
+    });
+
+    await showPluginDetails("test-plugin");
+
+    expect(modalContent.textContent).toContain(
+      '<img src=x onerror="alert(1)">'
+    );
+    expect(modalContent.textContent).toContain('<svg onload="alert(2)">');
+    expect(modalContent.textContent).toContain("<script>alert(3)</script>");
+    expect(modalContent.textContent).toContain(
+      '<button onclick="alert(4)">hook</button>'
+    );
+    expect(modalContent.textContent).toContain(
+      '<iframe src="javascript:alert(5)"></iframe>'
+    );
+    expect(modalContent.textContent).toContain(
+      '<a onclick=\\"alert(6)\\">config</a>'
+    );
+    expect(modalContent.querySelector("img")).toBeNull();
+    expect(modalContent.querySelector("svg")).toBeNull();
+    expect(modalContent.querySelector("script")).toBeNull();
+    expect(modalContent.querySelector("button")).toBeNull();
+    expect(modalContent.querySelector("iframe")).toBeNull();
+    expect(modalContent.querySelector("a")).toBeNull();
+  });
+
   test("handles missing optional fields", async () => {
     const modal = document.createElement("div");
     modal.id = "plugin-details-modal";
@@ -904,7 +954,9 @@ describe("showPluginDetails", () => {
     await showPluginDetails("test-plugin");
 
     expect(modalContent.innerHTML).toContain("Error:");
-    expect(modalContent.innerHTML).toContain("Failed to load plugin details: Not Found");
+    expect(modalContent.innerHTML).toContain(
+      "Failed to load plugin details: Not Found"
+    );
     expect(consoleErrorSpy).toHaveBeenCalled();
   });
 
@@ -927,6 +979,30 @@ describe("showPluginDetails", () => {
 
     expect(modalContent.innerHTML).toContain("Error:");
     expect(modalContent.innerHTML).toContain("Network error");
+    expect(consoleErrorSpy).toHaveBeenCalled();
+  });
+
+  test("renders fetch error as text instead of HTML", async () => {
+    const modal = document.createElement("div");
+    modal.id = "plugin-details-modal";
+    document.body.appendChild(modal);
+
+    const modalName = document.createElement("div");
+    modalName.id = "modal-plugin-name";
+    document.body.appendChild(modalName);
+
+    const modalContent = document.createElement("div");
+    modalContent.id = "modal-plugin-content";
+    document.body.appendChild(modalContent);
+
+    fetchSpy.mockRejectedValue(new Error('<img src=x onerror="alert(1)">'));
+
+    await showPluginDetails("test-plugin");
+
+    expect(modalContent.textContent).toContain(
+      '<img src=x onerror="alert(1)">'
+    );
+    expect(modalContent.querySelector("img")).toBeNull();
     expect(consoleErrorSpy).toHaveBeenCalled();
   });
 

--- a/tests/unit/mcpgateway/plugins/test_plugin_metadata.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_metadata.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Tests for plugin display metadata resolution."""
+
+# Standard
+from email.message import Message
+from types import ModuleType, SimpleNamespace
+
+# Third-Party
+from cpex.framework.models import Config, PluginConfig
+
+# First-Party
+from mcpgateway.plugins import metadata as plugin_metadata
+
+
+class _Distribution:
+    def __init__(self, version: str, author: str | None = None, summary: str | None = None):
+        self.version = version
+        self.metadata = Message()
+        if author is not None:
+            self.metadata["Author"] = author
+        if summary is not None:
+            self.metadata["Summary"] = summary
+
+
+def test_enrich_config_uses_distribution_metadata_before_config(monkeypatch):
+    def _distribution(distribution_name):
+        assert distribution_name == "sample-plugin"
+        return _Distribution("2.0.0", author="Package Author", summary="Package summary")
+
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "packages_distributions", lambda: {"sample_plugin": ["sample-plugin"]})
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "distribution", _distribution)
+
+    config = Config(
+        plugins=[
+            PluginConfig(
+                name="sample",
+                kind="sample_plugin.SamplePlugin",
+                description="config description",
+                author="config author",
+                version="1.0.0",
+            )
+        ]
+    )
+
+    enriched = plugin_metadata.enrich_config_plugin_metadata(config)
+    plugin = enriched.plugins[0]
+
+    assert plugin.version == "2.0.0"
+    assert plugin.author == "Package Author"
+    assert plugin.description == "Package summary"
+
+
+def test_resolve_plugin_metadata_uses_loaded_module_without_import(monkeypatch):
+    module = ModuleType("module_plugin")
+    module.__version__ = "3.0.0"
+    module.__author__ = "Module Author"
+    module.__description__ = "Module description"
+
+    monkeypatch.setitem(plugin_metadata.sys.modules, "module_plugin", module)
+    monkeypatch.setattr(
+        plugin_metadata,
+        "importlib_metadata",
+        SimpleNamespace(packages_distributions=lambda: {}, distribution=lambda _distribution_name: (_ for _ in ()).throw(Exception()), PackageNotFoundError=Exception),
+    )
+
+    metadata = plugin_metadata.resolve_plugin_metadata(PluginConfig(name="sample", kind="module_plugin.ModulePlugin"))
+
+    assert metadata["version"] == "3.0.0"
+    assert metadata["author"] == "Module Author"
+    assert metadata["description"] == "Module description"
+
+
+def test_resolve_plugin_metadata_falls_back_per_field_when_distribution_metadata_incomplete(monkeypatch):
+    def _distribution(distribution_name):
+        assert distribution_name == "sample-plugin"
+        return _Distribution("2.0.0")
+
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "packages_distributions", lambda: {"sample_plugin": ["sample-plugin"]})
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "distribution", _distribution)
+
+    metadata = plugin_metadata.resolve_plugin_metadata(
+        PluginConfig(
+            name="sample",
+            kind="sample_plugin.SamplePlugin",
+            description="config description",
+            author="config author",
+            version="1.0.0",
+        )
+    )
+
+    assert metadata["version"] == "2.0.0"
+    assert metadata["author"] == "config author"
+    assert metadata["description"] == "config description"
+
+
+def test_resolve_plugin_metadata_handles_colon_style_kind(monkeypatch):
+    def _distribution(distribution_name):
+        assert distribution_name == "sample-plugin"
+        return _Distribution("2.0.0", author="Package Author", summary="Package summary")
+
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "packages_distributions", lambda: {"sample_plugin": ["sample-plugin"]})
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "distribution", _distribution)
+
+    metadata = plugin_metadata.resolve_plugin_metadata(PluginConfig(name="sample", kind="sample_plugin.module:SamplePlugin"))
+
+    assert metadata["version"] == "2.0.0"
+    assert metadata["author"] == "Package Author"
+    assert metadata["description"] == "Package summary"
+
+
+def test_enrich_config_does_not_write_display_defaults_for_missing_metadata(monkeypatch):
+    monkeypatch.setattr(plugin_metadata.importlib_metadata, "packages_distributions", lambda: {})
+
+    config = Config(plugins=[PluginConfig(name="local", kind="plugins.local.LocalPlugin")])
+    enriched = plugin_metadata.enrich_config_plugin_metadata(config)
+    plugin = enriched.plugins[0]
+
+    assert plugin.description is None
+    assert plugin.author is None
+    assert plugin.version is None

--- a/tests/unit/mcpgateway/plugins/test_plugin_service_metadata_installed.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_service_metadata_installed.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Tests for installed plugin metadata through the real manager path."""
+
+# Standard
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
+import sys
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.plugins.gateway_plugin_manager import TenantPluginManagerFactory
+from mcpgateway.services.plugin_service import PluginService
+
+
+def _rate_limiter_package_metadata():
+    try:
+        package_metadata = metadata.metadata("cpex-rate-limiter")
+    except PackageNotFoundError:
+        pytest.skip("cpex-rate-limiter plugin not installed")
+
+    return (
+        metadata.version("cpex-rate-limiter"),
+        package_metadata.get("Author") or package_metadata.get("Maintainer") or package_metadata.get("Author-email"),
+        package_metadata.get("Summary"),
+    )
+
+
+def _write_config(tmp_path, mode: str):
+    config_file = tmp_path / "plugins.yaml"
+    config_file.write_text(
+        f"""
+plugins:
+  - name: "RateLimiterPlugin"
+    kind: "cpex_rate_limiter.RateLimiterPlugin"
+    hooks: ["prompt_pre_fetch"]
+    tags: ["limits"]
+    mode: "{mode}"
+    priority: 50
+    config:
+      by_user: "2/s"
+      by_tenant:
+      by_tool: {{}}
+""",
+        encoding="utf-8",
+    )
+    return config_file
+
+
+@pytest.mark.asyncio
+async def test_installed_plugin_metadata_overrides_stale_config_for_disabled_plugin(tmp_path, monkeypatch):
+    """Verify disabled installed plugins get package metadata without importing plugin modules."""
+    monkeypatch.delitem(sys.modules, "cpex_rate_limiter", raising=False)
+    expected_version, expected_author, expected_summary = _rate_limiter_package_metadata()
+    factory = TenantPluginManagerFactory(str(_write_config(tmp_path, "disabled")))
+
+    manager = await factory.get_manager()
+    try:
+        plugin = PluginService(manager).get_all_plugins()[0]
+    finally:
+        await factory.shutdown()
+
+    assert plugin["version"] == expected_version
+    assert plugin["author"] == expected_author
+    assert plugin["description"] == expected_summary
+    assert plugin["hooks"] == ["prompt_pre_fetch"]
+    assert plugin["tags"] == ["limits"]
+    assert plugin["priority"] == 50
+    assert plugin["config_summary"]["by_user"] == "2/s"
+    assert "cpex_rate_limiter" not in sys.modules
+
+
+@pytest.mark.asyncio
+async def test_installed_plugin_metadata_available_for_registered_plugin(tmp_path):
+    """Verify registered plugin display metadata survives real manager initialization."""
+    expected_version, expected_author, expected_summary = _rate_limiter_package_metadata()
+    factory = TenantPluginManagerFactory(str(_write_config(tmp_path, "sequential")))
+
+    manager = await factory.get_manager()
+    try:
+        plugin = PluginService(manager).get_plugin_by_name("RateLimiterPlugin")
+    finally:
+        await factory.shutdown()
+
+    assert plugin["version"] == expected_version
+    assert plugin["author"] == expected_author
+    assert plugin["description"] == expected_summary
+    assert plugin["hooks"] == ["prompt_pre_fetch"]
+    assert plugin["tags"] == ["limits"]
+    assert plugin["priority"] == 50

--- a/tests/unit/mcpgateway/services/test_plugin_service.py
+++ b/tests/unit/mcpgateway/services/test_plugin_service.py
@@ -8,11 +8,13 @@ Authors: Mihai Criveti
 Module documentation...
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
-from mcpgateway.services.plugin_service import PluginService, get_plugin_service
-import mcpgateway.services.plugin_service as plugin_service_module
+
+import pytest
 from cpex.framework.models import PluginMode
+
+import mcpgateway.services.plugin_service as plugin_service_module
+from mcpgateway.services.plugin_service import PluginService, get_plugin_service
 
 
 @pytest.fixture(autouse=True)
@@ -175,6 +177,9 @@ def test_get_all_plugins_enabled_without_config_has_empty_summary():
     plugins = service.get_all_plugins()
 
     assert plugins[0]["name"] == "sample-no-config"
+    assert plugins[0]["description"] == ""
+    assert plugins[0]["author"] == "Unknown"
+    assert plugins[0]["version"] == "0.0.0"
     assert plugins[0]["config_summary"] == {}
 
 


### PR DESCRIPTION
Closes #4912

## 📌 Summary
Resolves packaged plugin display metadata from the installed plugin package at plugin manager startup instead of relying on duplicated values in `plugins/config.yaml`.

Also removes the Admin UI Rust/Python implementation badge from plugin cards. The old badge was misleading because the external PyPI plugins are Rust-backed, but only one card showed a Rust badge.

<img width="2808" height="1544" alt="image" src="https://github.com/user-attachments/assets/a1216d4e-e925-4701-9357-95347c950e51" />


## 🔁 Reproduction Steps
1. Install the plugin extras.
2. Enable packaged plugins such as rate limiting, PII filtering, secret detection, encoded exfil detection, URL reputation, and retry/backoff.
3. Open the Admin UI plugin list.
4. Compare the displayed version, author, and summary with the installed package metadata.
5. Check that plugin cards no longer show an implementation-language badge.

## 🐞 Root Cause
`PluginService` read display metadata directly from `PluginConfig` fields loaded from YAML. For packaged plugins, those YAML fields duplicated installed package metadata and could drift from the actual installed distribution.

The plugin card also read an optional runtime `implementation` field and rendered Rust/Python badges. That signal was incomplete for packaged plugins and implied a difference between plugins where the UI should not expose implementation language.

## 💡 Fix Description
- Enrich plugin configuration once when `TenantPluginManagerFactory` loads the plugin config.
- Resolve packaged plugin metadata from installed distribution metadata, with a loaded-module dunder fallback that does not import disabled plugins.
- Keep `PluginService` as a cheap reader of the already-enriched config.
- Remove stale packaged plugin display metadata from config, chart, and docs examples.
- Remove the plugin-card Rust/Python implementation badge and stop emitting implementation language in plugin list data.
- Add coverage for distribution metadata, fallback behavior, colon-style plugin kinds, disabled no-import behavior, and the registered plugin manager path.

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Unit tests | `uv run pytest tests/unit/mcpgateway/plugins/test_plugin_metadata.py tests/unit/mcpgateway/services/test_plugin_service.py tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py` | Passed |
| Installed plugin metadata test | `uv run --extra plugins pytest tests/unit/mcpgateway/plugins/test_plugin_service_metadata_installed.py` | Passed |
| Plugin service focused test | `uv run pytest tests/unit/mcpgateway/services/test_plugin_service.py` | Passed |
| Ruff | `uv run ruff check mcpgateway/plugins/metadata.py mcpgateway/plugins/gateway_plugin_manager.py mcpgateway/services/plugin_service.py tests/unit/mcpgateway/plugins/test_plugin_metadata.py tests/unit/mcpgateway/plugins/test_plugin_service_metadata_installed.py tests/unit/mcpgateway/services/test_plugin_service.py` | Passed |
| Black | `uv run black --check mcpgateway/plugins/metadata.py mcpgateway/plugins/gateway_plugin_manager.py mcpgateway/services/plugin_service.py tests/unit/mcpgateway/plugins/test_plugin_metadata.py tests/unit/mcpgateway/plugins/test_plugin_service_metadata_installed.py tests/unit/mcpgateway/services/test_plugin_service.py` | Passed |
| Detect secrets scan | `make detect-secrets-scan` | Passed |
| Pre-commit hooks | `make pre-commit` | Passed |
| Whitespace diff check | `git diff --check origin/main...HEAD` | Passed |
| Manual UI regression | Gateway started with plugin extras, packaged plugins enabled, Admin UI inspected; versions came from package metadata and Rust/Python badges were absent | Passed |

Screenshot captured for PR description: `/tmp/plugin-metadata-before-after-annotated.png`

## 📐 MCP Compliance (if relevant)
No MCP protocol behavior changed.

## ✅ Checklist
- [x] Code formatted
- [x] No secrets/credentials committed
