### PR TITLE
Add Redis-based configuration publisher for experimental dataplane pu…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -327,6 +327,15 @@ LOG_FOLDER=logs
 # Local OTEL collector endpoint
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
+# -----------------------------------------------------------------------------
+# Experimental DATAPLANE
+# -----------------------------------------------------------------------------
+
+# Send db config to redis to be consumed by experimental Dataplane
+DATAPLANE_PUBLISHER = false
+
+
+
 # =============================================================================
 # Hot toggles (commented quick switches)
 # =============================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-28T13:31:00Z",
+  "generated_at": "2026-05-27T18:30:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 690,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 876,
+        "line_number": 885,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1163,
+        "line_number": 1172,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1189,
+        "line_number": 1198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1197,
+        "line_number": 1206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1285,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1281,
+        "line_number": 1290,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1286,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1292,
+        "line_number": 1301,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1304,
+        "line_number": 1313,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1322,
+        "line_number": 1331,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1383,
+        "line_number": 1392,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2671,8 +2671,6 @@ class Settings(BaseSettings):
     otel_bsp_schedule_delay: int = Field(default=5000, description="Schedule delay in milliseconds")
 
     # ===================================
-
-    # ===================================
     # OpenTelemetry Baggage Configuration
     # ===================================
 
@@ -2711,6 +2709,14 @@ class Settings(BaseSettings):
     otel_baggage_log_sanitization: bool = Field(
         default=True,
         description="Log sanitization events for compliance tracking",
+    )
+
+    # ===================================
+    # Experimental dataplane config
+    # ===================================
+
+    dataplane_publisher: bool = Field(default=False,
+        description="Send data from CF to Rust experimental dataplane"
     )
 
     # Well-Known URI Configuration

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -178,6 +178,7 @@ from mcpgateway.services.prompt_service import PromptError, PromptLockConflictEr
 from mcpgateway.services.resource_service import ResourceError, ResourceLockConflictError, ResourceNotFoundError, ResourceURIConflictError
 from mcpgateway.services.server_service import ServerError, ServerLockConflictError, ServerNameConflictError, ServerNotFoundError
 from mcpgateway.services.tag_service import TagService
+from mcpgateway.services.dataplane_publisher import DataplanePublisherService
 from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError
 from mcpgateway.transports.sse_transport import SSETransport
 from mcpgateway.transports.streamablehttp_transport import (
@@ -1315,6 +1316,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     aggregation_loop_task: Optional[asyncio.Task] = None
     aggregation_backfill_task: Optional[asyncio.Task] = None
     siem_export_service: Optional[Any] = None
+    dataplane_publisher_service: Optional[Any] = None
 
     # Initialize logging service FIRST to ensure all logging goes to dual output
     await logging_service.initialize()
@@ -1606,6 +1608,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
         refresh_slugs_on_startup()
 
+        # Initialize experimental dataplane publisher to send config data to redis
+        if settings.dataplane_publisher:
+            dataplane_publisher_service = DataplanePublisherService()
+            await dataplane_publisher_service.start()
         # Bootstrap SSO providers from environment configuration
         if settings.sso_enabled:
             await attempt_to_bootstrap_sso_providers()
@@ -1807,6 +1813,9 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
             metrics_cleanup_service = get_metrics_cleanup_service()
             services_to_shutdown.insert(2, metrics_cleanup_service)
+
+        if dataplane_publisher_service is not None:
+            services_to_shutdown.insert(3, dataplane_publisher_service)
 
         await shutdown_services(services_to_shutdown)
 

--- a/mcpgateway/services/__init__.py
+++ b/mcpgateway/services/__init__.py
@@ -16,6 +16,7 @@ from mcpgateway.services.gateway_service import GatewayError, GatewayService
 from mcpgateway.services.prompt_service import PromptError, PromptService
 from mcpgateway.services.resource_service import ResourceError, ResourceService
 from mcpgateway.services.tool_service import ToolError, ToolService
+from mcpgateway.services.server_service import ServerService
 
 __all__ = [
     "ToolService",
@@ -26,4 +27,5 @@ __all__ = [
     "PromptError",
     "GatewayService",
     "GatewayError",
+    "ServerService",
 ]

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -1,7 +1,8 @@
 """Experimental Dataplane publisher service for periodically exporting user configuration to Redis.
-    NOTE: This publisher backs dataplane wip feature and it is disabled by default.
-    Be careful not to overfit production-grade assumptions onto the design.
+NOTE: This publisher backs dataplane wip feature and it is disabled by default.
+Be careful not to overfit production-grade assumptions onto the design.
 """
+
 import asyncio
 from collections import defaultdict
 import logging
@@ -24,6 +25,7 @@ from mcpgateway.db import (
     server_tool_association,
 )
 from mcpgateway.utils.redis_client import get_redis_client
+
 logger = logging.getLogger(__name__)
 
 USER_CONFIG_KEY = "UserConfig"
@@ -90,8 +92,7 @@ class DataplanePublisherService:
         try:
             await asyncio.wait_for(self.task, timeout=5)
         except asyncio.TimeoutError:
-            logger.warning(
-                "Dataplane publisher shutdown timed out; cancelling task.")
+            logger.warning("Dataplane publisher shutdown timed out; cancelling task.")
             self.task.cancel()
             try:
                 await self.task
@@ -113,8 +114,7 @@ class DataplanePublisherService:
         while not self._shutdown_event.is_set():
             redis = await get_redis_client()
             if redis is None:
-                logger.error(
-                    f"Redis client is unavailable; retrying in {REDIS_PUBLISHER_TIME} seconds.")
+                logger.error(f"Redis client is unavailable; retrying in {REDIS_PUBLISHER_TIME} seconds.")
                 await asyncio.sleep(REDIS_PUBLISHER_TIME)
                 continue
 
@@ -131,24 +131,20 @@ class DataplanePublisherService:
 
                 if not acquired:
                     # Another worker holds the lock - skip this cycle
-                    logger.debug(
-                        "Another worker holds publisher lock, skipping cycle")
+                    logger.debug("Another worker holds publisher lock, skipping cycle")
                     await asyncio.sleep(REDIS_PUBLISHER_TIME)
                     continue
 
                 # We hold the lock - publish data
-                logger.info(
-                    f"Worker {WORKER_ID} publishing dataplane payload...")
+                logger.info(f"Worker {WORKER_ID} publishing dataplane payload...")
                 payload = await self.fetch_payload()
 
                 if payload is None:
-                    logger.warning(
-                        "Skipping publish cycle due to data fetch failure - keeping existing Redis data")
+                    logger.warning("Skipping publish cycle due to data fetch failure - keeping existing Redis data")
                 else:
                     pipe = redis.pipeline()
                     for key, config in payload.items():
-                        key = msgpack.dumps(
-                            (USER_CONFIG_KEY, key), use_bin_type=True)
+                        key = msgpack.dumps((USER_CONFIG_KEY, key), use_bin_type=True)
                         pipe.set(
                             key,
                             msgpack.dumps(config, use_bin_type=True),
@@ -158,8 +154,7 @@ class DataplanePublisherService:
                         await pipe.execute()
                         logger.info(f"Published {len(payload)} user configs")
                     except Exception as e:
-                        logger.error(
-                            f"Could not write dataplane payload to Redis: {e}")
+                        logger.error(f"Could not write dataplane payload to Redis: {e}")
             except Exception as e:
                 logger.error(f"Error during publish: {e}")
             finally:
@@ -200,15 +195,9 @@ class DataplanePublisherService:
             gateways = user_data["gateways"]
             prompts = user_data["prompts"]
             resources = user_data["resources"]
-            resource_map = {
-                resource["id"]: resource["name"]
-                for resource in resources
-            }
+            resource_map = {resource["id"]: resource["name"] for resource in resources}
 
-            prompt_map = {
-                prompt["id"]: prompt["name"]
-                for prompt in prompts
-            }
+            prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
 
             gateway_base = {
                 gateway["id"]: {
@@ -231,16 +220,8 @@ class DataplanePublisherService:
                     if gateway_config is None:
                         continue
 
-                    allowed_resource_names = [
-                        resource_map[resource_id]
-                        for resource_id in backend_items["resources"]
-                        if resource_id in resource_map
-                    ]
-                    allowed_prompt_names = [
-                        prompt_map[prompt_id]
-                        for prompt_id in backend_items["prompts"]
-                        if prompt_id in prompt_map
-                    ]
+                    allowed_resource_names = [resource_map[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_map]
+                    allowed_prompt_names = [prompt_map[prompt_id] for prompt_id in backend_items["prompts"] if prompt_id in prompt_map]
                     if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
                         continue
 
@@ -251,13 +232,9 @@ class DataplanePublisherService:
                         "allowed_prompt_names": allowed_prompt_names,
                     }
 
-                virtual_hosts[server["id"]] = {
-                    "backends": backends
-                }
+                virtual_hosts[server["id"]] = {"backends": backends}
 
-            result[user_email] = {
-                "virtual_hosts": virtual_hosts
-            }
+            result[user_email] = {"virtual_hosts": virtual_hosts}
 
         return result
 
@@ -265,19 +242,13 @@ class DataplanePublisherService:
         """Fetch active users and dataplane data with bulk minimal-column queries."""
         with fresh_db_session() as db:
             try:
-                user_rows = db.execute(
-                    select(EmailUser.email, EmailUser.is_admin).where(
-                        EmailUser.is_active.is_(True))
-                ).all()
-                userteam_rows = db.execute(
-                    select(EmailTeamMember.user_email, EmailTeamMember.team_id).where(
-                        EmailTeamMember.is_active.is_(True))
-                ).all()
+                user_rows = db.execute(select(EmailUser.email, EmailUser.is_admin).where(EmailUser.is_active.is_(True))).all()
+                userteam_rows = db.execute(select(EmailTeamMember.user_email, EmailTeamMember.team_id).where(EmailTeamMember.is_active.is_(True))).all()
 
                 user_teams_map: dict[str, set[str]] = defaultdict(set)
                 user_admin_map: dict[str, bool] = {}
                 for user_email, is_admin in user_rows:
-                    user_teams_map[user_email]
+                    user_teams_map.setdefault(user_email, set())
                     user_admin_map[user_email] = is_admin
 
                 for user_email, team_id in userteam_rows:
@@ -287,10 +258,7 @@ class DataplanePublisherService:
                 if not user_teams_map:
                     return {}
 
-                server_rows = db.execute(
-                    select(DbServer.id, DbServer.owner_email, DbServer.team_id,
-                           DbServer.visibility).where(DbServer.enabled.is_(True))
-                ).all()
+                server_rows = db.execute(select(DbServer.id, DbServer.owner_email, DbServer.team_id, DbServer.visibility).where(DbServer.enabled.is_(True))).all()
                 gateway_rows = db.execute(
                     select(
                         DbGateway.id,
@@ -303,20 +271,14 @@ class DataplanePublisherService:
                         DbGateway.visibility,
                     ).where(DbGateway.enabled.is_(True))
                 ).all()
-                prompt_rows = db.execute(
-                    select(DbPrompt.id, DbPrompt.name, DbPrompt.owner_email, DbPrompt.team_id,
-                           DbPrompt.visibility).where(DbPrompt.enabled.is_(True))
-                ).all()
+                prompt_rows = db.execute(select(DbPrompt.id, DbPrompt.name, DbPrompt.owner_email, DbPrompt.team_id, DbPrompt.visibility).where(DbPrompt.enabled.is_(True))).all()
                 resource_rows = db.execute(
                     select(DbResource.id, DbResource.name, DbResource.owner_email, DbResource.team_id, DbResource.visibility).where(
                         DbResource.enabled.is_(True),
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(
-                    select(DbTool.id, DbTool.name, DbTool.owner_email, DbTool.team_id,
-                           DbTool.visibility).where(DbTool.enabled.is_(True))
-                ).all()
+                tool_rows = db.execute(select(DbTool.id, DbTool.name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {
@@ -335,8 +297,7 @@ class DataplanePublisherService:
                 }
 
             except Exception as err:
-                logger.error(
-                    f"Could not build dataplane payload data from the database: {err}")
+                logger.error(f"Could not build dataplane payload data from the database: {err}")
                 return None
 
     def _build_user_data(
@@ -352,11 +313,7 @@ class DataplanePublisherService:
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
-        tool_name_by_id = {
-            tool.id: tool.name
-            for tool in tool_rows
-            if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
-        }
+        tool_name_by_id = {tool.id: tool.name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
 
         return {
             "servers": [
@@ -378,16 +335,8 @@ class DataplanePublisherService:
                 for gateway in gateway_rows
                 if self._filter_for_user(gateway, user_email, team_ids, is_admin=is_admin)
             ],
-            "prompts": [
-                {"id": prompt.id, "name": prompt.name}
-                for prompt in prompt_rows
-                if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)
-            ],
-            "resources": [
-                {"id": resource.id, "name": resource.name}
-                for resource in resource_rows
-                if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)
-            ],
+            "prompts": [{"id": prompt.id, "name": prompt.name} for prompt in prompt_rows if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)],
+            "resources": [{"id": resource.id, "name": resource.name} for resource in resource_rows if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)],
         }
 
     @staticmethod
@@ -407,11 +356,7 @@ class DataplanePublisherService:
         """Filter backend tool IDs for one user and convert visible tools to names."""
         return {
             gateway_id: {
-                "tools": [
-                    tool_name_by_id[tool_id]
-                    for tool_id in backend_items["tools"]
-                    if tool_id in tool_name_by_id
-                ],
+                "tools": [tool_name_by_id[tool_id] for tool_id in backend_items["tools"] if tool_id in tool_name_by_id],
                 "resources": list(backend_items["resources"]),
                 "prompts": list(backend_items["prompts"]),
             }
@@ -428,45 +373,33 @@ class DataplanePublisherService:
 
     def _add_tools_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
         """Add active server tools to their backend gateway buckets."""
-        rows = db.execute(
-            select(server_tool_association.c.server_id,
-                   DbTool.id, DbTool.gateway_id)
-            .join(DbTool, DbTool.id == server_tool_association.c.tool_id)
-            .where(DbTool.enabled.is_(True))
-        ).all()
+        rows = db.execute(select(server_tool_association.c.server_id, DbTool.id, DbTool.gateway_id).join(DbTool, DbTool.id == server_tool_association.c.tool_id).where(DbTool.enabled.is_(True))).all()
         for server_id, tool_id, gateway_id in rows:
             if gateway_id is None:
                 continue
-            backend_items = backend_items_by_server[server_id].setdefault(
-                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items = backend_items_by_server[server_id].setdefault(gateway_id, {"tools": [], "resources": [], "prompts": []})
             backend_items["tools"].append(tool_id)
 
     def _add_resources_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
         """Add active server resources to their backend gateway buckets."""
         rows = db.execute(
-            select(server_resource_association.c.server_id,
-                   DbResource.id, DbResource.gateway_id)
+            select(server_resource_association.c.server_id, DbResource.id, DbResource.gateway_id)
             .join(DbResource, DbResource.id == server_resource_association.c.resource_id)
             .where(DbResource.enabled.is_(True))
         ).all()
         for server_id, resource_id, gateway_id in rows:
             if gateway_id is None:
                 continue
-            backend_items = backend_items_by_server[server_id].setdefault(
-                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items = backend_items_by_server[server_id].setdefault(gateway_id, {"tools": [], "resources": [], "prompts": []})
             backend_items["resources"].append(resource_id)
 
     def _add_prompts_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
         """Add active server prompts to their backend gateway buckets."""
         rows = db.execute(
-            select(server_prompt_association.c.server_id,
-                   DbPrompt.id, DbPrompt.gateway_id)
-            .join(DbPrompt, DbPrompt.id == server_prompt_association.c.prompt_id)
-            .where(DbPrompt.enabled.is_(True))
+            select(server_prompt_association.c.server_id, DbPrompt.id, DbPrompt.gateway_id).join(DbPrompt, DbPrompt.id == server_prompt_association.c.prompt_id).where(DbPrompt.enabled.is_(True))
         ).all()
         for server_id, prompt_id, gateway_id in rows:
             if gateway_id is None:
                 continue
-            backend_items = backend_items_by_server[server_id].setdefault(
-                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items = backend_items_by_server[server_id].setdefault(gateway_id, {"tools": [], "resources": [], "prompts": []})
             backend_items["prompts"].append(prompt_id)

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -1,0 +1,472 @@
+"""Experimental Dataplane publisher service for periodically exporting user configuration to Redis.
+    NOTE: This publisher backs dataplane wip feature and it is disabled by default.
+    Be careful not to overfit production-grade assumptions onto the design.
+"""
+import asyncio
+from collections import defaultdict
+import logging
+import os
+import socket
+from typing import Any, TypedDict
+from sqlalchemy import select
+import msgpack
+from mcpgateway.db import (
+    EmailUser,
+    EmailTeamMember,
+    Gateway as DbGateway,
+    Prompt as DbPrompt,
+    Resource as DbResource,
+    Server as DbServer,
+    Tool as DbTool,
+    fresh_db_session,
+    server_prompt_association,
+    server_resource_association,
+    server_tool_association,
+)
+from mcpgateway.utils.redis_client import get_redis_client
+logger = logging.getLogger(__name__)
+
+USER_CONFIG_KEY = "UserConfig"
+REDIS_PUBLISHER_TIME = 60  # Publish interval in seconds
+# Keys are not deleted explicitly; stale configs expire via Redis TTL.
+PUBLISHER_TTL = 70
+
+# Worker ID for multi-worker coordination (same pattern as session_affinity.py)
+WORKER_ID = f"{socket.gethostname()}:{os.getpid()}"
+PUBLISHER_LOCK_KEY = "mcpgw:dataplane_publisher:lock"
+
+
+class BackendConfig(TypedDict):
+    """Backend gateway configuration for dataplane routing."""
+
+    name: str
+    url: str
+    transport: str
+    passthrough_headers: list[str] | None
+    allowed_tool_names: list[str]
+    allowed_resource_names: list[str]
+    allowed_prompt_names: list[str]
+
+
+class VirtualHostConfig(TypedDict):
+    """Virtual host configuration mapping backend IDs to their configs."""
+
+    backends: dict[str, BackendConfig]
+
+
+class UserConfig(TypedDict):
+    """User-specific configuration mapping virtual host IDs to their configs."""
+
+    virtual_hosts: dict[str, VirtualHostConfig]
+
+
+BackendItems = dict[str, list[str]]
+BackendItemsByServer = dict[str, dict[str, BackendItems]]
+
+
+class DataplanePublisherService:
+    """Publishes user server configurations to Redis for dataplane consumption."""
+
+    def __init__(self) -> None:
+        """Initialize the publisher state and dependent services."""
+        self.task: asyncio.Task[None] | None = None
+        self._shutdown_event = asyncio.Event()
+
+    async def start(self) -> None:
+        """Start the background publisher task."""
+        if self.task is not None:
+            logger.warning("Dataplane publisher is already running.")
+            return
+        self._shutdown_event.clear()
+        self.task = asyncio.create_task(self.publish_to_redis())
+        logger.info("Dataplane publisher started.")
+
+    async def shutdown(self) -> None:
+        """Gracefully shutdown the publisher."""
+        if self.task is None:
+            return
+        logger.info("Shutting down dataplane publisher.")
+        self._shutdown_event.set()
+        try:
+            await asyncio.wait_for(self.task, timeout=5)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Dataplane publisher shutdown timed out; cancelling task.")
+            self.task.cancel()
+            try:
+                await self.task
+            except asyncio.CancelledError:
+                pass
+
+        self.task = None
+        logger.info("Dataplane publisher stopped.")
+
+    async def fetch_payload(self) -> dict[str, dict[str, dict[str, Any]]] | None:
+        """Fetch the payload to publish to Redis. Returns None on error."""
+        user_data = await self.get_data_from_db()
+        if user_data is None:
+            return None
+        return self.create_payload(user_data)
+
+    async def publish_to_redis(self) -> None:
+        """Continuously publish user configuration payloads to Redis."""
+        while not self._shutdown_event.is_set():
+            redis = await get_redis_client()
+            if redis is None:
+                logger.error(
+                    f"Redis client is unavailable; retrying in {REDIS_PUBLISHER_TIME} seconds.")
+                await asyncio.sleep(REDIS_PUBLISHER_TIME)
+                continue
+
+            acquired = False
+            try:
+                # Try to acquire lock (atomic SET NX EX)
+                lock_ttl = REDIS_PUBLISHER_TIME + 30  # Lock expires 30s after publish interval
+                acquired = await redis.set(
+                    PUBLISHER_LOCK_KEY,
+                    WORKER_ID,
+                    nx=True,  # Only set if not exists
+                    ex=lock_ttl,  # Auto-expire if worker crashes
+                )
+
+                if not acquired:
+                    # Another worker holds the lock - skip this cycle
+                    logger.debug(
+                        "Another worker holds publisher lock, skipping cycle")
+                    await asyncio.sleep(REDIS_PUBLISHER_TIME)
+                    continue
+
+                # We hold the lock - publish data
+                logger.info(
+                    f"Worker {WORKER_ID} publishing dataplane payload...")
+                payload = await self.fetch_payload()
+
+                if payload is None:
+                    logger.warning(
+                        "Skipping publish cycle due to data fetch failure - keeping existing Redis data")
+                else:
+                    pipe = redis.pipeline()
+                    for key, config in payload.items():
+                        key = msgpack.dumps(
+                            (USER_CONFIG_KEY, key), use_bin_type=True)
+                        pipe.set(
+                            key,
+                            msgpack.dumps(config, use_bin_type=True),
+                            ex=PUBLISHER_TTL,
+                        )
+                    try:
+                        await pipe.execute()
+                        logger.info(f"Published {len(payload)} user configs")
+                    except Exception as e:
+                        logger.error(
+                            f"Could not write dataplane payload to Redis: {e}")
+            except Exception as e:
+                logger.error(f"Error during publish: {e}")
+            finally:
+                if acquired:
+                    # Release lock if we still own it (CAS to prevent stealing)
+                    release_script = """
+                    if redis.call('GET', KEYS[1]) == ARGV[1] then
+                      redis.call('DEL', KEYS[1])
+                      return 1
+                    end
+                    return 0
+                    """
+                    try:
+                        await redis.eval(release_script, 1, PUBLISHER_LOCK_KEY, WORKER_ID)
+                    except Exception as e:
+                        logger.warning(f"Failed to release lock: {e}")
+
+            # Wait for next cycle
+            try:
+                await asyncio.wait_for(self._shutdown_event.wait(), timeout=REDIS_PUBLISHER_TIME)
+                break  # Shutdown signaled
+            except asyncio.TimeoutError:
+                continue
+
+    def create_payload(
+        self,
+        data: dict[str, dict[str, Any]],
+    ) -> dict[str, UserConfig]:
+        """
+        Build dataplane payload from already-filtered per-user data.
+        """
+
+        result: dict[str, UserConfig] = {}
+
+        for user_email, user_data in data.items():
+
+            servers = user_data["servers"]
+            gateways = user_data["gateways"]
+            prompts = user_data["prompts"]
+            resources = user_data["resources"]
+            resource_map = {
+                resource["id"]: resource["name"]
+                for resource in resources
+            }
+
+            prompt_map = {
+                prompt["id"]: prompt["name"]
+                for prompt in prompts
+            }
+
+            gateway_base = {
+                gateway["id"]: {
+                    "name": gateway["name"],
+                    "url": gateway["url"],
+                    "transport": gateway["transport"],
+                    "passthrough_headers": gateway["passthrough_headers"],
+                }
+                for gateway in gateways
+            }
+
+            virtual_hosts: dict[str, VirtualHostConfig] = {}
+
+            for server in servers:
+
+                backends: dict[str, BackendConfig] = {}
+
+                for gateway_id, backend_items in server["backend_items"].items():
+                    gateway_config = gateway_base.get(gateway_id)
+                    if gateway_config is None:
+                        continue
+
+                    allowed_resource_names = [
+                        resource_map[resource_id]
+                        for resource_id in backend_items["resources"]
+                        if resource_id in resource_map
+                    ]
+                    allowed_prompt_names = [
+                        prompt_map[prompt_id]
+                        for prompt_id in backend_items["prompts"]
+                        if prompt_id in prompt_map
+                    ]
+                    if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
+                        continue
+
+                    backends[gateway_id] = {
+                        **gateway_config,
+                        "allowed_tool_names": backend_items["tools"],
+                        "allowed_resource_names": allowed_resource_names,
+                        "allowed_prompt_names": allowed_prompt_names,
+                    }
+
+                virtual_hosts[server["id"]] = {
+                    "backends": backends
+                }
+
+            result[user_email] = {
+                "virtual_hosts": virtual_hosts
+            }
+
+        return result
+
+    async def get_data_from_db(self) -> dict[str, Any] | None:
+        """Fetch active users and dataplane data with bulk minimal-column queries."""
+        with fresh_db_session() as db:
+            try:
+                user_rows = db.execute(
+                    select(EmailUser.email, EmailUser.is_admin).where(
+                        EmailUser.is_active.is_(True))
+                ).all()
+                userteam_rows = db.execute(
+                    select(EmailTeamMember.user_email, EmailTeamMember.team_id).where(
+                        EmailTeamMember.is_active.is_(True))
+                ).all()
+
+                user_teams_map: dict[str, set[str]] = defaultdict(set)
+                user_admin_map: dict[str, bool] = {}
+                for user_email, is_admin in user_rows:
+                    user_teams_map[user_email]
+                    user_admin_map[user_email] = is_admin
+
+                for user_email, team_id in userteam_rows:
+                    if user_email in user_admin_map:
+                        user_teams_map[user_email].add(team_id)
+
+                if not user_teams_map:
+                    return {}
+
+                server_rows = db.execute(
+                    select(DbServer.id, DbServer.owner_email, DbServer.team_id,
+                           DbServer.visibility).where(DbServer.enabled.is_(True))
+                ).all()
+                gateway_rows = db.execute(
+                    select(
+                        DbGateway.id,
+                        DbGateway.name,
+                        DbGateway.url,
+                        DbGateway.transport,
+                        DbGateway.passthrough_headers,
+                        DbGateway.owner_email,
+                        DbGateway.team_id,
+                        DbGateway.visibility,
+                    ).where(DbGateway.enabled.is_(True))
+                ).all()
+                prompt_rows = db.execute(
+                    select(DbPrompt.id, DbPrompt.name, DbPrompt.owner_email, DbPrompt.team_id,
+                           DbPrompt.visibility).where(DbPrompt.enabled.is_(True))
+                ).all()
+                resource_rows = db.execute(
+                    select(DbResource.id, DbResource.name, DbResource.owner_email, DbResource.team_id, DbResource.visibility).where(
+                        DbResource.enabled.is_(True),
+                        DbResource.uri_template.is_(None),
+                    )
+                ).all()
+                tool_rows = db.execute(
+                    select(DbTool.id, DbTool.name, DbTool.owner_email, DbTool.team_id,
+                           DbTool.visibility).where(DbTool.enabled.is_(True))
+                ).all()
+                backend_items_by_server = self._get_backend_items_by_server(db)
+
+                return {
+                    user_email: self._build_user_data(
+                        user_email,
+                        teams,
+                        user_admin_map.get(user_email, False),
+                        server_rows,
+                        gateway_rows,
+                        prompt_rows,
+                        resource_rows,
+                        tool_rows,
+                        backend_items_by_server,
+                    )
+                    for user_email, teams in user_teams_map.items()
+                }
+
+            except Exception as err:
+                logger.error(
+                    f"Could not build dataplane payload data from the database: {err}")
+                return None
+
+    def _build_user_data(
+        self,
+        user_email: str,
+        team_ids: set[str],
+        is_admin: bool,
+        server_rows: list[Any],
+        gateway_rows: list[Any],
+        prompt_rows: list[Any],
+        resource_rows: list[Any],
+        tool_rows: list[Any],
+        backend_items_by_server: BackendItemsByServer,
+    ) -> dict[str, Any]:
+        """Build already-filtered dataplane data for one user."""
+        tool_name_by_id = {
+            tool.id: tool.name
+            for tool in tool_rows
+            if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)
+        }
+
+        return {
+            "servers": [
+                {
+                    "id": server.id,
+                    "backend_items": self._filter_backend_items_for_user(backend_items_by_server.get(server.id, {}), tool_name_by_id),
+                }
+                for server in server_rows
+                if self._filter_for_user(server, user_email, team_ids, is_admin=is_admin)
+            ],
+            "gateways": [
+                {
+                    "id": gateway.id,
+                    "name": gateway.name,
+                    "url": gateway.url,
+                    "transport": gateway.transport,
+                    "passthrough_headers": gateway.passthrough_headers,
+                }
+                for gateway in gateway_rows
+                if self._filter_for_user(gateway, user_email, team_ids, is_admin=is_admin)
+            ],
+            "prompts": [
+                {"id": prompt.id, "name": prompt.name}
+                for prompt in prompt_rows
+                if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)
+            ],
+            "resources": [
+                {"id": resource.id, "name": resource.name}
+                for resource in resource_rows
+                if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)
+            ],
+        }
+
+    @staticmethod
+    def _filter_for_user(row: Any, user_email: str, team_ids: set[str], is_admin: bool = False) -> bool:
+        """Return whether a visibility-scoped row is visible to a dataplane user."""
+        if is_admin:
+            return True
+        visibility = row.visibility
+        if visibility == "public":
+            return True
+        if visibility == "private":
+            return row.owner_email == user_email
+        return row.team_id in team_ids and visibility == "team"
+
+    @staticmethod
+    def _filter_backend_items_for_user(backend_items_by_gateway: dict[str, BackendItems], tool_name_by_id: dict[str, str]) -> dict[str, BackendItems]:
+        """Filter backend tool IDs for one user and convert visible tools to names."""
+        return {
+            gateway_id: {
+                "tools": [
+                    tool_name_by_id[tool_id]
+                    for tool_id in backend_items["tools"]
+                    if tool_id in tool_name_by_id
+                ],
+                "resources": list(backend_items["resources"]),
+                "prompts": list(backend_items["prompts"]),
+            }
+            for gateway_id, backend_items in backend_items_by_gateway.items()
+        }
+
+    def _get_backend_items_by_server(self, db: Any) -> BackendItemsByServer:
+        """Fetch tools, resources, and prompts grouped by server and backend gateway."""
+        backend_items_by_server: BackendItemsByServer = defaultdict(dict)
+        self._add_tools_to_backends(db, backend_items_by_server)
+        self._add_resources_to_backends(db, backend_items_by_server)
+        self._add_prompts_to_backends(db, backend_items_by_server)
+        return backend_items_by_server
+
+    def _add_tools_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
+        """Add active server tools to their backend gateway buckets."""
+        rows = db.execute(
+            select(server_tool_association.c.server_id,
+                   DbTool.id, DbTool.gateway_id)
+            .join(DbTool, DbTool.id == server_tool_association.c.tool_id)
+            .where(DbTool.enabled.is_(True))
+        ).all()
+        for server_id, tool_id, gateway_id in rows:
+            if gateway_id is None:
+                continue
+            backend_items = backend_items_by_server[server_id].setdefault(
+                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items["tools"].append(tool_id)
+
+    def _add_resources_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
+        """Add active server resources to their backend gateway buckets."""
+        rows = db.execute(
+            select(server_resource_association.c.server_id,
+                   DbResource.id, DbResource.gateway_id)
+            .join(DbResource, DbResource.id == server_resource_association.c.resource_id)
+            .where(DbResource.enabled.is_(True))
+        ).all()
+        for server_id, resource_id, gateway_id in rows:
+            if gateway_id is None:
+                continue
+            backend_items = backend_items_by_server[server_id].setdefault(
+                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items["resources"].append(resource_id)
+
+    def _add_prompts_to_backends(self, db: Any, backend_items_by_server: BackendItemsByServer) -> None:
+        """Add active server prompts to their backend gateway buckets."""
+        rows = db.execute(
+            select(server_prompt_association.c.server_id,
+                   DbPrompt.id, DbPrompt.gateway_id)
+            .join(DbPrompt, DbPrompt.id == server_prompt_association.c.prompt_id)
+            .where(DbPrompt.enabled.is_(True))
+        ).all()
+        for server_id, prompt_id, gateway_id in rows:
+            if gateway_id is None:
+                continue
+            backend_items = backend_items_by_server[server_id].setdefault(
+                gateway_id, {"tools": [], "resources": [], "prompts": []})
+            backend_items["prompts"].append(prompt_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ dependencies = [
     "typer>=0.25.1",
     "urllib3>=2.7.0", # Transitive pin (requests); dependabot/76
     "uvicorn[standard]<=0.47.0",
+    "msgpack>=1.1.2",
 ]
 
 # ----------------------------------------------------------------

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -1,0 +1,510 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_dataplane_publisher.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for DataplanePublisherService.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+async def _wait_forever():
+    """Block until cancelled by the test cleanup."""
+    await asyncio.Event().wait()
+
+
+# ============================================================================
+# Lifecycle Management Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_start_creates_background_task():
+    """start() creates and schedules the background publisher task."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    assert service.task is None
+
+    with patch.object(service, "publish_to_redis", new_callable=AsyncMock) as mock_publish:
+        mock_publish.side_effect = _wait_forever
+
+        await service.start()
+
+        assert service.task is not None
+        assert not service.task.done()
+
+        # Cleanup
+        service.task.cancel()
+        try:
+            await service.task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent():
+    """Calling start() twice doesn't create duplicate tasks."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    with patch.object(service, "publish_to_redis", new_callable=AsyncMock) as mock_publish:
+        mock_publish.side_effect = _wait_forever
+
+        await service.start()
+        first_task = service.task
+
+        await service.start()
+        second_task = service.task
+
+        assert first_task is second_task
+
+        # Cleanup
+        service.task.cancel()
+        try:
+            await service.task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_running_task():
+    """shutdown() gracefully stops the background task."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    with patch.object(service, "publish_to_redis", new_callable=AsyncMock) as mock_publish:
+
+        async def _wait_for_shutdown():
+            await service._shutdown_event.wait()
+
+        mock_publish.side_effect = _wait_for_shutdown
+
+        await service.start()
+        assert service.task is not None
+
+        await service.shutdown()
+
+        assert service.task is None
+        assert service._shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_handles_timeout():
+    """shutdown() cancels task if it doesn't stop within timeout."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    with (
+        patch.object(service, "publish_to_redis", new_callable=AsyncMock) as mock_publish,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock) as mock_wait_for,
+    ):
+        mock_publish.side_effect = _wait_forever
+        mock_wait_for.side_effect = asyncio.TimeoutError
+
+        await service.start()
+        assert service.task is not None
+
+        await service.shutdown()
+
+        assert service.task is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_idempotent():
+    """Calling shutdown() when not started is a no-op."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    assert service.task is None
+
+    await service.shutdown()
+
+    assert service.task is None
+
+
+# ============================================================================
+# Integration Test with Mock Database
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_payload_generation_with_mock_db():
+    """Integration test: fetch_payload() with mock database covering main code paths."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+    from unittest.mock import Mock
+
+    service = DataplanePublisherService()
+
+    # Mock database session and queries
+    mock_db = MagicMock()
+
+    # Create properly configured mocks
+    server1 = Mock()
+    server1.id = "s1"
+    server1.owner_email = "user1@example.com"
+    server1.team_id = "team1"
+    server1.visibility = "public"
+    server1.enabled = True
+
+    server2 = Mock()
+    server2.id = "s2"
+    server2.owner_email = "user2@example.com"
+    server2.team_id = "team2"
+    server2.visibility = "private"
+    server2.enabled = True
+
+    gateway1 = Mock()
+    gateway1.id = "g1"
+    gateway1.name = "Gateway 1"
+    gateway1.url = "http://localhost:9000"
+    gateway1.transport = "sse"
+    gateway1.passthrough_headers = ["Authorization"]
+    gateway1.owner_email = "user1@example.com"
+    gateway1.team_id = "team1"
+    gateway1.visibility = "public"
+    gateway1.enabled = True
+
+    prompt1 = Mock()
+    prompt1.id = "p1"
+    prompt1.name = "Prompt 1"
+    prompt1.owner_email = "user1@example.com"
+    prompt1.team_id = "team1"
+    prompt1.visibility = "public"
+    prompt1.enabled = True
+
+    resource1 = Mock()
+    resource1.id = "r1"
+    resource1.name = "Resource 1"
+    resource1.owner_email = "user1@example.com"
+    resource1.team_id = "team1"
+    resource1.visibility = "public"
+    resource1.enabled = True
+
+    tool1 = Mock()
+    tool1.id = "t1"
+    tool1.name = "public_tool"
+    tool1.owner_email = "user1@example.com"
+    tool1.team_id = "team1"
+    tool1.visibility = "public"
+    tool1.enabled = True
+
+    tool2 = Mock()
+    tool2.id = "t2"
+    tool2.name = "private_tool"
+    tool2.owner_email = "user1@example.com"
+    tool2.team_id = "team1"
+    tool2.visibility = "private"
+    tool2.enabled = True
+
+    tool3 = Mock()
+    tool3.id = "t3"
+    tool3.name = "team2_tool"
+    tool3.owner_email = "user2@example.com"
+    tool3.team_id = "team2"
+    tool3.visibility = "team"
+    tool3.enabled = True
+
+    # Mock active users and user-team memberships
+    mock_db.execute.return_value.all.side_effect = [
+        # Active users query
+        [("user1@example.com", False), ("user2@example.com", False), ("user3@example.com", False)],
+        # User-team query
+        [("user1@example.com", "team1"), ("user2@example.com", "team2")],
+        # Server query
+        [server1, server2],
+        # Gateway query
+        [gateway1],
+        # Prompt query
+        [prompt1],
+        # Resource query
+        [resource1],
+        # Tool query
+        [tool1, tool2, tool3],
+        # Tool associations
+        [("s1", "t1", "g1"), ("s1", "t2", "g1"), ("s1", "t3", "g1")],
+        # Resource associations
+        [("s1", "r1", "g1")],
+        # Prompt associations
+        [("s1", "p1", "g1")],
+    ]
+
+    with patch("mcpgateway.services.dataplane_publisher.fresh_db_session") as mock_session:
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        payload = await service.fetch_payload()
+
+        # Verify payload structure
+        assert payload is not None
+        assert "user1@example.com" in payload
+        assert "user2@example.com" in payload
+        assert "user3@example.com" in payload
+
+        # Verify user1 payload (has access to public server)
+        user1_config = payload["user1@example.com"]
+        assert "virtual_hosts" in user1_config
+        assert "s1" in user1_config["virtual_hosts"]
+
+        # Verify backend configuration
+        server1 = user1_config["virtual_hosts"]["s1"]
+        assert "backends" in server1
+        assert "g1" in server1["backends"]
+
+        backend = server1["backends"]["g1"]
+        assert backend["name"] == "Gateway 1"
+        assert backend["url"] == "http://localhost:9000"
+        assert backend["transport"] == "sse"
+        assert backend["passthrough_headers"] == ["Authorization"]
+        assert backend["allowed_tool_names"] == ["public_tool", "private_tool"]
+        assert backend["allowed_resource_names"] == ["Resource 1"]
+        assert backend["allowed_prompt_names"] == ["Prompt 1"]
+
+        # Verify user2 sees public server but not private server from user1
+        user2_config = payload["user2@example.com"]
+        assert "s1" in user2_config["virtual_hosts"]  # public
+        assert "s2" in user2_config["virtual_hosts"]  # own private
+        user2_backend = user2_config["virtual_hosts"]["s1"]["backends"]["g1"]
+        assert user2_backend["allowed_tool_names"] == ["public_tool", "team2_tool"]
+
+        # Verify active users with no team membership still get public-only config.
+        user3_config = payload["user3@example.com"]
+        assert "s1" in user3_config["virtual_hosts"]
+        assert "s2" not in user3_config["virtual_hosts"]
+        user3_backend = user3_config["virtual_hosts"]["s1"]["backends"]["g1"]
+        assert user3_backend["allowed_tool_names"] == ["public_tool"]
+
+
+# ============================================================================
+# Edge Cases
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_handles_db_error():
+    """fetch_payload() returns None when database query fails."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_db = MagicMock()
+    mock_db.execute.side_effect = Exception("Database error")
+
+    with patch("mcpgateway.services.dataplane_publisher.fresh_db_session") as mock_session:
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        result = await service.fetch_payload()
+
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_payload_empty_database():
+    """fetch_payload() handles empty database (no active users)."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value.all.return_value = []  # No users
+
+    with patch("mcpgateway.services.dataplane_publisher.fresh_db_session") as mock_session:
+        mock_session.return_value.__enter__.return_value = mock_db
+
+        result = await service.fetch_payload()
+
+        assert result == {}
+
+
+def test_filter_for_user_visibility_rules():
+    """_filter_for_user() correctly applies visibility rules."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+    from unittest.mock import Mock
+
+    # Public: visible to all
+    public_row = Mock(visibility="public", owner_email="owner@example.com", team_id="team1")
+    assert DataplanePublisherService._filter_for_user(public_row, "anyone@example.com", set())
+
+    # Private: only owner
+    private_row = Mock(visibility="private", owner_email="owner@example.com", team_id="team1")
+    assert DataplanePublisherService._filter_for_user(private_row, "owner@example.com", set())
+    assert not DataplanePublisherService._filter_for_user(private_row, "other@example.com", {"team1"})
+
+    # Team: team members only
+    team_row = Mock(visibility="team", owner_email="owner@example.com", team_id="team1")
+    assert DataplanePublisherService._filter_for_user(team_row, "member@example.com", {"team1"})
+    assert not DataplanePublisherService._filter_for_user(team_row, "outsider@example.com", {"team2"})
+
+
+def test_create_payload_filters_empty_backends():
+    """create_payload() excludes backends with no items."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    data = {
+        "user@example.com": {
+            "servers": [
+                {
+                    "id": "server1",
+                    "backend_items": {
+                        "gateway1": {"tools": [], "resources": [], "prompts": []},
+                    },
+                }
+            ],
+            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "sse", "passthrough_headers": None}],
+            "prompts": [],
+            "resources": [],
+        }
+    }
+
+    result = service.create_payload(data)
+
+    # Server exists but has no backends (all empty)
+    assert "server1" in result["user@example.com"]["virtual_hosts"]
+    assert result["user@example.com"]["virtual_hosts"]["server1"]["backends"] == {}
+
+
+def test_create_payload_handles_missing_references():
+    """create_payload() handles missing gateway/resource/prompt references."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    data = {
+        "user@example.com": {
+            "servers": [
+                {
+                    "id": "server1",
+                    "backend_items": {
+                        "missing_gateway": {"tools": ["tool1"], "resources": ["missing_res"], "prompts": ["missing_prompt"]},
+                    },
+                }
+            ],
+            "gateways": [],  # Gateway not in list
+            "prompts": [],  # Prompt not in list
+            "resources": [],  # Resource not in list
+        }
+    }
+
+    result = service.create_payload(data)
+
+    # Server exists but has no backends (gateway missing)
+    assert "server1" in result["user@example.com"]["virtual_hosts"]
+    assert result["user@example.com"]["virtual_hosts"]["server1"]["backends"] == {}
+
+
+@pytest.mark.asyncio
+async def test_publish_skips_when_redis_unavailable():
+    """publish_to_redis() continues gracefully when Redis is unavailable."""
+    from mcpgateway.services.dataplane_publisher import REDIS_PUBLISHER_TIME, DataplanePublisherService
+
+    service = DataplanePublisherService()
+    real_sleep = asyncio.sleep
+
+    async def _sleep_until_shutdown(_timeout):
+        await service._shutdown_event.wait()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+    ):
+        mock_redis.return_value = None
+        mock_sleep.side_effect = _sleep_until_shutdown
+
+        await service.start()
+        await real_sleep(0)
+        await service.shutdown()
+
+        # Should not raise, just log and continue
+        mock_sleep.assert_awaited_once_with(REDIS_PUBLISHER_TIME)
+
+
+@pytest.mark.asyncio
+async def test_publish_skips_when_fetch_fails():
+    """publish_to_redis() skips publish when fetch_payload returns None."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.pipeline.return_value.execute = AsyncMock()
+    mock_redis.eval = AsyncMock()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch.object(service, "fetch_payload", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_get_redis.return_value = mock_redis
+        mock_fetch.return_value = None
+
+        await service.start()
+        await asyncio.sleep(0.01)
+        await service.shutdown()
+
+        # Pipeline should not be called when fetch returns None
+        mock_redis.pipeline.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_continues_when_lock_acquisition_raises():
+    """publish_to_redis() keeps running when Redis lock acquisition fails."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(side_effect=Exception("redis unavailable"))
+    mock_redis.pipeline.return_value.execute = AsyncMock()
+    mock_redis.eval = AsyncMock()
+
+    with patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis:
+        mock_get_redis.return_value = mock_redis
+
+        await service.start()
+        await asyncio.sleep(0)
+        await service.shutdown()
+
+        mock_redis.set.assert_awaited_once()
+        mock_redis.pipeline.assert_not_called()
+        mock_redis.eval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_skips_when_lock_not_acquired():
+    """publish_to_redis() skips publishing when another worker holds the lock."""
+    from mcpgateway.services.dataplane_publisher import REDIS_PUBLISHER_TIME, DataplanePublisherService
+
+    service = DataplanePublisherService()
+    real_sleep = asyncio.sleep
+
+    async def _sleep_until_shutdown(_timeout):
+        await service._shutdown_event.wait()
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=False)
+    mock_redis.pipeline.return_value.execute = AsyncMock()
+    mock_redis.eval = AsyncMock()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        patch.object(service, "fetch_payload", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_get_redis.return_value = mock_redis
+        mock_sleep.side_effect = _sleep_until_shutdown
+
+        await service.start()
+        await real_sleep(0)
+        await service.shutdown()
+
+        mock_redis.set.assert_awaited_once()
+        mock_sleep.assert_awaited_once_with(REDIS_PUBLISHER_TIME)
+        mock_fetch.assert_not_awaited()
+        mock_redis.pipeline.assert_not_called()
+        mock_redis.eval.assert_not_awaited()

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -327,6 +327,9 @@ def test_filter_for_user_visibility_rules():
     from mcpgateway.services.dataplane_publisher import DataplanePublisherService
     from unittest.mock import Mock
 
+    admin_only_row = Mock(visibility="private", owner_email="owner@example.com", team_id="team1")
+    assert DataplanePublisherService._filter_for_user(admin_only_row, "admin@example.com", set(), is_admin=True)
+
     # Public: visible to all
     public_row = Mock(visibility="public", owner_email="owner@example.com", team_id="team1")
     assert DataplanePublisherService._filter_for_user(public_row, "anyone@example.com", set())
@@ -508,3 +511,165 @@ async def test_publish_skips_when_lock_not_acquired():
         mock_fetch.assert_not_awaited()
         mock_redis.pipeline.assert_not_called()
         mock_redis.eval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait_returns():
+    """publish_to_redis() writes msgpack payloads and releases the worker lock."""
+    import msgpack
+
+    from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, PUBLISHER_TTL, USER_CONFIG_KEY, WORKER_ID, DataplanePublisherService
+
+    service = DataplanePublisherService()
+    payload = {"user@example.com": {"virtual_hosts": {"server1": {"backends": {}}}}}
+
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.pipeline.return_value = pipe
+    mock_redis.eval = AsyncMock()
+
+    async def _finish_cycle(awaitable, timeout):
+        del timeout
+        awaitable.close()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_finish_cycle) as mock_wait_for,
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value=payload),
+    ):
+        mock_get_redis.return_value = mock_redis
+
+        await service.publish_to_redis()
+
+    pipe.set.assert_called_once()
+    key_arg, value_arg = pipe.set.call_args.args
+    assert msgpack.unpackb(key_arg, raw=False) == [USER_CONFIG_KEY, "user@example.com"]
+    assert msgpack.unpackb(value_arg, raw=False) == payload["user@example.com"]
+    assert pipe.set.call_args.kwargs == {"ex": PUBLISHER_TTL}
+    pipe.execute.assert_awaited_once()
+    mock_redis.eval.assert_awaited_once()
+    assert mock_redis.eval.await_args.args[1:] == (1, PUBLISHER_LOCK_KEY, WORKER_ID)
+    mock_wait_for.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_publish_releases_lock_when_pipeline_execute_fails():
+    """publish_to_redis() logs pipeline failures but still releases the lock."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    pipe = MagicMock()
+    pipe.execute = AsyncMock(side_effect=Exception("pipeline boom"))
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.pipeline.return_value = pipe
+    mock_redis.eval = AsyncMock()
+
+    async def _finish_cycle(awaitable, timeout):
+        del timeout
+        awaitable.close()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_finish_cycle),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+    ):
+        mock_get_redis.return_value = mock_redis
+
+        await service.publish_to_redis()
+
+    pipe.set.assert_called_once()
+    pipe.execute.assert_awaited_once()
+    mock_redis.eval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_publish_logs_lock_release_failure():
+    """publish_to_redis() handles Redis errors while releasing the lock."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.pipeline.return_value.execute = AsyncMock()
+    mock_redis.eval = AsyncMock(side_effect=Exception("eval boom"))
+
+    async def _finish_cycle(awaitable, timeout):
+        del timeout
+        awaitable.close()
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_finish_cycle),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+    ):
+        mock_get_redis.return_value = mock_redis
+
+        await service.publish_to_redis()
+
+    mock_redis.eval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_publish_continues_after_cycle_timeout():
+    """publish_to_redis() continues after the inter-cycle wait times out."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+
+    mock_redis = MagicMock()
+    mock_redis.set = AsyncMock(return_value=True)
+    mock_redis.pipeline.return_value.execute = AsyncMock()
+    mock_redis.eval = AsyncMock()
+
+    async def _timeout_and_stop(awaitable, timeout):
+        del timeout
+        awaitable.close()
+        service._shutdown_event.set()
+        raise asyncio.TimeoutError
+
+    with (
+        patch("mcpgateway.services.dataplane_publisher.get_redis_client", new_callable=AsyncMock) as mock_get_redis,
+        patch("mcpgateway.services.dataplane_publisher.asyncio.wait_for", new_callable=AsyncMock, side_effect=_timeout_and_stop),
+        patch.object(service, "fetch_payload", new_callable=AsyncMock, return_value={"user@example.com": {"virtual_hosts": {}}}),
+    ):
+        mock_get_redis.return_value = mock_redis
+
+        await service.publish_to_redis()
+
+    mock_redis.set.assert_awaited_once()
+    mock_redis.eval.assert_awaited_once()
+
+
+def test_backend_item_helpers_add_items_and_skip_missing_gateway():
+    """Backend item helper methods group rows by gateway and skip gateway-less rows."""
+    from collections import defaultdict
+
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    backend_items_by_server = defaultdict(dict)
+
+    db = MagicMock()
+    db.execute.return_value.all.return_value = [("server1", "tool1", None), ("server1", "tool2", "gateway1")]
+    service._add_tools_to_backends(db, backend_items_by_server)  # pylint: disable=protected-access
+
+    db.execute.return_value.all.return_value = [("server1", "resource1", None), ("server1", "resource2", "gateway1")]
+    service._add_resources_to_backends(db, backend_items_by_server)  # pylint: disable=protected-access
+
+    db.execute.return_value.all.return_value = [("server1", "prompt1", None), ("server1", "prompt2", "gateway1")]
+    service._add_prompts_to_backends(db, backend_items_by_server)  # pylint: disable=protected-access
+
+    assert dict(backend_items_by_server) == {
+        "server1": {
+            "gateway1": {
+                "tools": ["tool2"],
+                "resources": ["resource2"],
+                "prompts": ["prompt2"],
+            }
+        }
+    }

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -5365,6 +5365,34 @@ class TestLifespanAdvanced:
             pass
 
     @pytest.mark.asyncio
+    async def test_lifespan_starts_and_stops_dataplane_publisher(self, monkeypatch):
+        """Cover experimental dataplane publisher startup and shutdown wiring."""
+        monkeypatch.setattr("mcpgateway.config.settings.database_url", "sqlite:///:memory:")
+
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        monkeypatch.setattr("mcpgateway.utils.db_isready.wait_for_db_ready", MagicMock())
+        monkeypatch.setattr("mcpgateway.bootstrap_db.main", AsyncMock())
+
+        await self._prepare_lifespan_stubs(monkeypatch, plugins_enabled=False)
+        monkeypatch.setattr(main_mod, "init_plugin_manager_factory", MagicMock())
+        monkeypatch.setattr(main_mod.settings, "dataplane_publisher", True)
+
+        dataplane_publisher = MagicMock()
+        dataplane_publisher.start = AsyncMock()
+        dataplane_publisher.shutdown = AsyncMock()
+        dataplane_publisher_factory = MagicMock(return_value=dataplane_publisher)
+        monkeypatch.setattr(main_mod, "DataplanePublisherService", dataplane_publisher_factory)
+
+        async with main_mod.lifespan(main_mod.app):
+            pass
+
+        dataplane_publisher_factory.assert_called_once_with()
+        dataplane_publisher.start.assert_awaited_once()
+        dataplane_publisher.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_shutdown_services_continues_on_exception(self):
         """Cover shutdown_services exception logging branch."""
         # First-Party

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-15T14:49:11.458664Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P10D"
 
 [options.exclude-newer-package]
@@ -2985,6 +2985,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "mako" },
     { name = "mcp" },
+    { name = "msgpack" },
     { name = "orjson" },
     { name = "parse" },
     { name = "prometheus-client" },
@@ -3196,6 +3197,7 @@ requires-dist = [
     { name = "mcp-contextforge-gateway", extras = ["redis"], marker = "extra == 'all'", specifier = ">=1.0.1" },
     { name = "mcp-contextforge-gateway", extras = ["redis", "dev", "plugins"], marker = "extra == 'dev-all'", specifier = ">=1.0.1" },
     { name = "memray", marker = "extra == 'profiling'", specifier = ">=1.19.3" },
+    { name = "msgpack", specifier = ">=1.1.2" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.42.1" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'observability'", specifier = ">=1.42.1" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'observability'", specifier = ">=1.42.1" },


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #4541

---

## 📝 Summary

This PR introduces an experimental **Dataplane Publisher Service** that periodically exports user configuration (servers, gateways, tools, resources, prompts) to Redis for dataplane consumption. The service implements multi-worker coordination using Redis locks to ensure only one worker publishes at a time.

**Key Features:**
- Background task that publishes configuration every 60 seconds
- Redis-based distributed locking for multi-worker deployments
- MessagePack serialization for efficient data transfer
- Automatic TTL-based expiration (70s) for stale configurations
- Graceful shutdown with task cancellation
- Comprehensive error handling and logging

**Note:** This is an experimental feature backing the dataplane WIP and is **disabled by default**. Configuration is controlled via `DATAPLANE_PUBLISHER_ENABLED` environment variable.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅     |
| Unit tests                | `make test`     | ✅     |
| Coverage ≥ 80%            | `make coverage` | ✅     |

---

## ✅ Checklist
- [x] Code formatted 
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Architecture Decisions

1. **Redis Lock Strategy**: Uses `SET NX EX` for atomic lock acquisition with auto-expiration to prevent deadlocks if a worker crashes
2. **TTL-based Cleanup**: Stale configurations expire automatically via Redis TTL (70s) rather than explicit deletion
3. **Fail-Safe Publishing**: On data fetch errors, skips the publish cycle but keeps existing Redis data intact
4. **Worker Coordination**: Each worker has a unique ID (`hostname:pid`) for distributed lock ownership

### Known Limitations

- Stale dataplane entries remain until TTL expiry 
- All gateways currently attached to all server backends

### Configuration

```bash
# Enable the dataplane publisher
DATAPLANE_PUBLISHER_ENABLED=true
```

### Files Changed

- **New Service**: `mcpgateway/services/dataplane_publisher.py` (472 lines)
- **Tests**: `tests/unit/mcpgateway/services/test_dataplane_publisher.py` (510 lines)
- **Config**: Updated `.env.example` and `mcpgateway/config.py` with new settings
- **Integration**: Wired into `mcpgateway/main.py` lifespan
- **Tracking**: `dataplane-review-todo.md` for follow-up items

### Testing Strategy

The test suite validates:
- ✅ Background task lifecycle (start/stop/restart)
- ✅ Redis lock acquisition and release
- ✅ Payload structure and serialization
- ✅ Multi-worker coordination
- ✅ Error recovery (Redis unavailable, DB failures)
- ✅ Graceful shutdown with timeout handling

---

