### PR TITLE
[BUG]: Event delegation misses functions defined on window (HTMX inline shim miss)

### DIFF
--- a/mcpgateway/admin_ui/eventDelegation.js
+++ b/mcpgateway/admin_ui/eventDelegation.js
@@ -106,9 +106,19 @@ function executeAction(action, args, event, eventFirst = false) {
       return fn(event, ...args);
     }
     return fn(...args, event);
-  } else {
-    console.error(`Action is not a function: ${action}`);
   }
+
+  // Fallback: check the global window scope for functions defined on window.*
+  // but only copied to window.Admin via inline shim (defensive against shim
+  // not executing, e.g. due to HTMX swaps that skip inline scripts).
+  if (typeof window[action] === 'function') {
+    if (eventFirst) {
+      return window[action](event, ...args);
+    }
+    return window[action](...args, event);
+  }
+
+  console.error(`Action is not a function: ${action}`);
 }
 
 /**


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4933

---

## 📝 Summary

When HTMX replaces DOM fragments, inline `<script>` shims that copy functions from `window.*` to `window.Admin.*` may not execute. The event delegation system (`executeAction()`) only checks `window.Admin[action]`, making functions like `toggleBulkImportDropdown` unreachable after a partial swap — the user sees `Action is not a function: toggleBulkImportDropdown` in the console and the UI element does nothing.

Added a `window[action]` fallback check in `executeAction()` before the error log, so functions defined directly on the global scope are found regardless of the Admin shim state. The `window.Admin[action]` check still runs first — no regression for Admin-scoped lookups.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command           | Status |
|---------------------------|-------------------|--------|
| Lint suite                | `make lint`       | ⏭️ JS only (no Python lint needed) |
| Unit tests                | `make test`       | ⏭️ UI change only |
| Coverage ≥ 80%            | `make coverage`   | ⏭️ No business logic changed |
| Bundle rebuild            | `make build-ui`   | ✅ Pass |
| Minified bundle contains fix | `rg window[e] bundle-*.js` | ✅ Confirmed |
| Manual: console error gone | HTMX partial swap → click bulk import | ✅ Verified |

---

## ✅ Checklist
- [x] Code formatted (JS file, follows existing patterns)
- [ ] Tests added/updated for changes — UI JS bundled/minified; no test harness for eventDelegation.js
- [ ] Documentation updated — not applicable (internal JS bundling fix)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The fix is in `mcpgateway/admin_ui/eventDelegation.js`. After rebuild with `make build-ui`, Terser mangles `action` → `e`, so the minified output reads `typeof window[e] === "function"`. Confirmed present in `bundle-CIZH2ce7.js`.