### PR TITLE
fix: standardise CSRF cookie name to mcpgateway_csrf_token

### DIFF
--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -121,56 +121,6 @@ class LoginRequest(BaseModel):
             raise ValueError("Either email or username must be provided")
 
 
-@auth_router.get("/csrf-token")
-async def get_csrf_token(request: Request, current_user: "EmailUser" = Depends(get_current_user)):
-    """Get a fresh CSRF token for the current authenticated user.
-
-    This endpoint generates a new CSRF token for the current session and sets it
-    as a cookie. Used by the frontend to refresh expired tokens.
-
-    Args:
-        request: FastAPI request object
-        current_user: Currently authenticated user
-
-    Returns:
-        dict: JSON response with csrf_token field
-
-    Raises:
-        HTTPException: If user authentication fails
-
-    Examples:
-        >>> # GET /auth/csrf-token
-        >>> # Headers: Authorization: Bearer <token>
-        >>> # Response: {"csrf_token": "abc123..."}
-    """
-    # Third-Party
-    from fastapi.responses import JSONResponse
-
-    # First-Party
-    from mcpgateway.config import settings
-    from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
-
-    try:
-        session_id = getattr(request.state, "jti", None)
-        if not session_id:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing session identifier")
-
-        # Generate fresh CSRF token
-        csrf_token = generate_csrf_token(user_id=current_user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
-
-        # Create response with CSRF cookie
-        response = JSONResponse(content={"csrf_token": csrf_token})
-        set_csrf_cookie(response, csrf_token, settings)
-
-        return response
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error generating CSRF token for {current_user.email}: {e}")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to generate CSRF token")
-
-
 @auth_router.post("/login", response_model=AuthenticationResponse)
 async def login(login_request: LoginRequest, request: Request, db: Session = Depends(get_db)):
     """Authenticate user and return session JWT token.
@@ -357,3 +307,8 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
     except Exception as e:
         logger.error(f"Logout error: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Logout service error")
+
+
+
+
+

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -307,8 +307,3 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
     except Exception as e:
         logger.error(f"Logout error: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Logout service error")
-
-
-
-
-

--- a/mcpgateway/services/csrf_service.py
+++ b/mcpgateway/services/csrf_service.py
@@ -252,7 +252,7 @@ def set_csrf_cookie(response: Any, token: str, settings: Any) -> None:
         >>> call_kwargs['path']
         '/'
     """
-    cookie_name = settings.csrf_cookie_name
+    cookie_name = getattr(settings, "csrf_cookie_name", "mcpgateway_csrf_token")
     response.set_cookie(
         key=cookie_name,
         value=token,
@@ -288,7 +288,7 @@ def clear_csrf_cookie(response: Any, settings: Any) -> None:
         >>> call_kwargs['secure']
         True
     """
-    cookie_name = settings.csrf_cookie_name
+    cookie_name = getattr(settings, "csrf_cookie_name", "mcpgateway_csrf_token")
     response.set_cookie(
         key=cookie_name,
         value="",

--- a/tests/unit/mcpgateway/routers/test_app.py
+++ b/tests/unit/mcpgateway/routers/test_app.py
@@ -250,8 +250,8 @@ class TestCSRFProtection:
 
         set_cookie_headers = [v.decode() if isinstance(v, bytes) else v for k, v in response.raw_headers if (k.decode() if isinstance(k, bytes) else k).lower() == "set-cookie"]
         assert set_cookie_headers, "No Set-Cookie header found"
-        csrf_cookie = next((h for h in set_cookie_headers if "csrf_token=" in h), "")
-        assert csrf_cookie, "csrf_token cookie not found in Set-Cookie"
+        csrf_cookie = next((h for h in set_cookie_headers if "mcpgateway_csrf_token=" in h), "")
+        assert csrf_cookie, "mcpgateway_csrf_token cookie not found in Set-Cookie"
         assert "samesite=strict" in csrf_cookie.lower()
         assert "httponly" not in csrf_cookie.lower(), "CSRF cookie must not be httpOnly — JS needs to read it"
         assert "path=/" in csrf_cookie.lower()


### PR DESCRIPTION
## What
- Standardised CSRF cookie fallback name from `csrf_token` → `mcpgateway_csrf_token`
- Removed dead `GET /auth/csrf-token` endpoint (never called by any client)

## Why
- Inconsistency between backend and frontend cookie names
- Addresses issue #4898

## Files Changed
- `mcpgateway/services/csrf_service.py` — updated default cookie name
- `mcpgateway/routers/auth.py` — deleted unused endpoint

Related #4898

@marekdano PR recreated with only my commit as requested. Ready for review! 