### PR TITLE
Update CODEOWNERS to remove test ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,8 +16,5 @@
 /.github/workflows/rust.yml @lucarlig @dawid-nowak
 /.github/workflows/pytest-rust.yml @lucarlig @dawid-nowak
 
-# Ownership for all tests
-/tests/ @crivetimihai @madhav165
-
 # Tests for plugin framework
 /tests/unit/mcpgateway/plugins @araujof @terylt @jonpspri


### PR DESCRIPTION
Removed ownership for all tests from CODEOWNERS.
Following discussion with owning team, and that this isolated ownership causes delays in PR merge process, I'm removing this.

crivetimihai retains overall CODEOWNERship.

## 🔗 Related Issue
Closes # N/A

---

## 📝 Summary
Removes specific ownership of tests which result in delay in merge process as a change to tests requires CODEOWNERS for /tests/* to approve despite global CODEOWNERS having approved the PR.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |     N/A   |
| Unit tests                | `make test`     |     N/A   |
| Coverage ≥ 80%            | `make coverage` |     N/A   |

---

## ✅ Checklist
- N/A

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
