### PR TITLE
chore(deps): pin libgnutls30 to latest patched release in a2a-echo-agent Dockerfile

### DIFF
--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -11,7 +11,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/b
 # Use Debian slim so basic tooling exists without Alpine.
 FROM debian:bookworm-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates tzdata wget && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libgnutls30=3.7.9-2+deb12u7 \
+        tzdata \
+        wget && \
     rm -rf /var/lib/apt/lists/* && \
     useradd --uid 1001 --create-home --shell /usr/sbin/nologin app
 COPY --from=builder /usr/local/bin/a2a-echo-agent /usr/local/bin/a2a-echo-agent


### PR DESCRIPTION
## Summary

- Explicitly pins `libgnutls30=3.7.9-2+deb12u7` in `a2a-agents/go/a2a-echo-agent/Dockerfile` to ensure the runtime stage uses the latest available patched release of the library (transitive dependency of `wget` in `debian:bookworm-slim`)
- Docker build verified — the pinned version resolves cleanly from Debian package repos

Closes #4942