### PR TITLE
 feat: expose advanced tool configuration fields in Admin UI edit form

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12082,8 +12082,8 @@ async def admin_edit_tool(
                 status_code=422,
             )
 
-    # Handle expose_passthrough checkbox: always set value (checked -> True, unchecked -> False)
-    # Checkbox not present means unchecked -> explicitly set False
+    # Handle expose_passthrough checkbox: always set explicit boolean value
+    # Checkbox unchecked → field absent from form → explicitly set False
     tool_data["expose_passthrough"] = "expose_passthrough" in form and form.get("expose_passthrough") == "true"
 
     # Handle list fields: allow clearing to empty list

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11934,10 +11934,13 @@ def _validate_json_field(field_name: str, field_value: str) -> tuple[Optional[di
         return (parsed, None)
     except orjson.JSONDecodeError as ex:
         LOGGER.error(f"Invalid JSON in {field_name} field: {str(ex)}")
-        return (None, ORJSONResponse(
-            content={"message": f"Invalid JSON in {field_name} field: {str(ex)}", "success": False},
-            status_code=422,
-        ))
+        return (
+            None,
+            ORJSONResponse(
+                content={"message": f"Invalid JSON in {field_name} field: {str(ex)}", "success": False},
+                status_code=422,
+            ),
+        )
 
 
 def _parse_core_json_fields(form) -> tuple[Optional[dict], Optional[ORJSONResponse]]:
@@ -11976,10 +11979,13 @@ def _parse_core_json_fields(form) -> tuple[Optional[dict], Optional[ORJSONRespon
         )
     except orjson.JSONDecodeError as ex:
         LOGGER.error(f"Invalid JSON in form field: {str(ex)}")
-        return (None, ORJSONResponse(
-            content={"message": f"Invalid JSON in form field: {str(ex)}", "success": False},
-            status_code=422,
-        ))
+        return (
+            None,
+            ORJSONResponse(
+                content={"message": f"Invalid JSON in form field: {str(ex)}", "success": False},
+                status_code=422,
+            ),
+        )
 
 
 def _validate_allowlist_urls(allowlist_raw: str) -> tuple[Optional[list], Optional[ORJSONResponse]]:
@@ -12002,10 +12008,13 @@ def _validate_allowlist_urls(allowlist_raw: str) -> tuple[Optional[list], Option
             parsed = urlparse(url)
             if not parsed.scheme or not parsed.netloc:
                 error_msg = f"Invalid URL in allowlist: {url} (must include scheme and host)"
-                return (None, ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=400,
-                ))
+                return (
+                    None,
+                    ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=400,
+                    ),
+                )
 
             # Enhanced SSRF protection: validate against private IP ranges, cloud metadata, etc.
             if settings.ssrf_protection_enabled:
@@ -12019,16 +12028,22 @@ def _validate_allowlist_urls(allowlist_raw: str) -> tuple[Optional[list], Option
                 except ValueError as ssrf_err:
                     error_msg = f"Security violation in allowlist: {str(ssrf_err)}"
                     LOGGER.error(error_msg)
-                    return (None, ORJSONResponse(
-                        content={"message": error_msg, "success": False},
-                        status_code=400,
-                    ))
+                    return (
+                        None,
+                        ORJSONResponse(
+                            content={"message": error_msg, "success": False},
+                            status_code=400,
+                        ),
+                    )
         except Exception as ex:
             error_msg = f"Invalid URL in allowlist: {url} - {str(ex)}"
-            return (None, ORJSONResponse(
-                content={"message": error_msg, "success": False},
-                status_code=400,
-            ))
+            return (
+                None,
+                ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=400,
+                ),
+            )
     return (allowlist_entries, None)
 
 
@@ -12065,10 +12080,13 @@ def _validate_plugin_chains(plugin_chain_raw: str, field_name: str, available_pl
             if plugin_name not in available_plugins:
                 error_msg = f"Unknown plugin in {field_name}: {plugin_name}"
                 LOGGER.warning(error_msg)
-                return (None, ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                ))
+                return (
+                    None,
+                    ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=422,
+                    ),
+                )
     return (plugin_list, None)
 
 
@@ -12110,17 +12128,23 @@ def _validate_timeout_ms(timeout_value_str: str) -> tuple[Optional[int], Optiona
         if timeout_value <= 0:
             error_msg = "Invalid timeout_ms value: must be a positive integer (greater than 0)"
             LOGGER.error(error_msg)
-            return (None, ORJSONResponse(
-                content={"message": error_msg, "success": False},
-                status_code=422,
-            ))
+            return (
+                None,
+                ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                ),
+            )
         return (timeout_value, None)
     except ValueError as ex:
         LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
-        return (None, ORJSONResponse(
-            content={"message": "Invalid timeout_ms value: must be a positive integer", "success": False},
-            status_code=422,
-        ))
+        return (
+            None,
+            ORJSONResponse(
+                content={"message": "Invalid timeout_ms value: must be a positive integer", "success": False},
+                status_code=422,
+            ),
+        )
 
 
 @admin_router.post("/tools/{tool_id}/edit/", response_model=None)
@@ -12292,9 +12316,7 @@ async def admin_edit_tool(
             from mcpgateway.plugins import list_configured_plugin_names
 
             available_plugins = list_configured_plugin_names()
-            plugin_list, error_response = _validate_plugin_chains(
-                plugin_chain_pre_raw, "plugin_chain_pre", available_plugins, settings.plugins.enabled
-            )
+            plugin_list, error_response = _validate_plugin_chains(plugin_chain_pre_raw, "plugin_chain_pre", available_plugins, settings.plugins.enabled)
             if error_response:
                 return error_response
             tool_data["plugin_chain_pre"] = plugin_list
@@ -12309,9 +12331,7 @@ async def admin_edit_tool(
             from mcpgateway.plugins import list_configured_plugin_names
 
             available_plugins = list_configured_plugin_names()
-            plugin_list, error_response = _validate_plugin_chains(
-                plugin_chain_post_raw, "plugin_chain_post", available_plugins, settings.plugins.enabled
-            )
+            plugin_list, error_response = _validate_plugin_chains(plugin_chain_post_raw, "plugin_chain_post", available_plugins, settings.plugins.enabled)
             if error_response:
                 return error_response
             tool_data["plugin_chain_post"] = plugin_list

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12112,8 +12112,9 @@ async def admin_edit_tool(
                     if settings.ssrf_protection_enabled:
                         try:
                             # Extract hostname without port for SSRF validation
-                            # parsed.netloc can be "host:port", we need just the hostname
-                            hostname = parsed.hostname or parsed.netloc.split(":")[0]
+                            # parsed.hostname handles IPv6 correctly (e.g., "::1" from "http://[::1]:8080")
+                            # Only fall back to netloc if hostname is None (shouldn't happen for valid URLs)
+                            hostname = parsed.hostname or parsed.netloc
                             SecurityValidator._validate_ssrf(hostname, f"allowlist URL '{url}'")
                         except ValueError as ssrf_err:
                             error_msg = f"Security violation in allowlist: {str(ssrf_err)}"

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12046,11 +12046,8 @@ async def admin_edit_tool(
             )
 
     # Handle expose_passthrough checkbox: always set value (checked -> True, unchecked -> False)
-    if "expose_passthrough" in form:
-        tool_data["expose_passthrough"] = form.get("expose_passthrough") == "true"
-    else:
-        # Checkbox not present means unchecked -> explicitly set False
-        tool_data["expose_passthrough"] = False
+    # Checkbox not present means unchecked -> explicitly set False
+    tool_data["expose_passthrough"] = "expose_passthrough" in form and form.get("expose_passthrough") == "true"
 
     # Handle list fields: allow clearing to empty list
     if "allowlist" in form:
@@ -12058,6 +12055,9 @@ async def admin_edit_tool(
         if allowlist_raw and allowlist_raw.strip():
             # Standard
             from urllib.parse import urlparse
+
+            # First-Party
+            from mcpgateway.common.validators import SecurityValidator
 
             allowlist_entries = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
             # Validate each URL to prevent SSRF attacks
@@ -12070,8 +12070,23 @@ async def admin_edit_tool(
                             content={"message": error_msg, "success": False},
                             status_code=400,
                         )
-                except Exception:
-                    error_msg = f"Invalid URL in allowlist: {url}"
+
+                    # Enhanced SSRF protection: validate against private IP ranges, cloud metadata, etc.
+                    if settings.ssrf_protection_enabled:
+                        try:
+                            # Extract hostname without port for SSRF validation
+                            # parsed.netloc can be "host:port", we need just the hostname
+                            hostname = parsed.hostname or parsed.netloc.split(":")[0]
+                            SecurityValidator._validate_ssrf(hostname, f"allowlist URL '{url}'")
+                        except ValueError as ssrf_err:
+                            error_msg = f"Security violation in allowlist: {str(ssrf_err)}"
+                            LOGGER.error(error_msg)
+                            return ORJSONResponse(
+                                content={"message": error_msg, "success": False},
+                                status_code=400,
+                            )
+                except Exception as ex:
+                    error_msg = f"Invalid URL in allowlist: {url} - {str(ex)}"
                     return ORJSONResponse(
                         content={"message": error_msg, "success": False},
                         status_code=400,
@@ -12082,10 +12097,24 @@ async def admin_edit_tool(
             tool_data["allowlist"] = []
 
     # Add plugin chain fields: allow clearing to empty list
+    # Validate plugin names against configured plugins if plugins are enabled
     if "plugin_chain_pre" in form:
         plugin_chain_pre_raw = form.get("plugin_chain_pre")
         if plugin_chain_pre_raw and plugin_chain_pre_raw.strip():
-            tool_data["plugin_chain_pre"] = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
+            plugin_list = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
+            if settings.plugins.enabled:
+                # First-Party
+                from mcpgateway.plugins import list_configured_plugin_names
+
+                available_plugins = list_configured_plugin_names()
+                invalid_plugins = [p for p in plugin_list if p not in available_plugins]
+                if invalid_plugins:
+                    error_msg = f"Invalid plugin names in plugin_chain_pre: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
+                    return ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=422,
+                    )
+            tool_data["plugin_chain_pre"] = plugin_list
         else:
             # Empty field means clear the list
             tool_data["plugin_chain_pre"] = []
@@ -12093,7 +12122,20 @@ async def admin_edit_tool(
     if "plugin_chain_post" in form:
         plugin_chain_post_raw = form.get("plugin_chain_post")
         if plugin_chain_post_raw and plugin_chain_post_raw.strip():
-            tool_data["plugin_chain_post"] = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
+            plugin_list = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
+            if settings.plugins.enabled:
+                # First-Party
+                from mcpgateway.plugins import list_configured_plugin_names
+
+                available_plugins = list_configured_plugin_names()
+                invalid_plugins = [p for p in plugin_list if p not in available_plugins]
+                if invalid_plugins:
+                    error_msg = f"Invalid plugin names in plugin_chain_post: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
+                    return ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=422,
+                    )
+            tool_data["plugin_chain_post"] = plugin_list
         else:
             # Empty field means clear the list
             tool_data["plugin_chain_post"] = []

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11976,7 +11976,6 @@ async def admin_edit_tool(
         "input_schema": input_schema,
         "output_schema": output_schema,
         "annotations": annotations,
-        "jsonpath_filter": form.get("jsonpath_filter", ""),
         "auth": auth_obj,
         "tags": tags,
         "visibility": visibility,
@@ -11985,6 +11984,25 @@ async def admin_edit_tool(
     }
 
     # Add optional fields only if present in form
+    # Validate and add JSONPath filter
+    if "jsonpath_filter" in form and form.get("jsonpath_filter"):
+        jsonpath_expr = form.get("jsonpath_filter").strip()
+        if jsonpath_expr:
+            try:
+                from jsonpath_ng import parse as parse_jsonpath
+                parse_jsonpath(jsonpath_expr)  # Validate syntax
+                tool_data["jsonpath_filter"] = jsonpath_expr
+            except Exception as ex:
+                LOGGER.error(f"Invalid JSONPath expression: {str(ex)}")
+                return ORJSONResponse(
+                    content={"message": f"Invalid JSONPath expression: {str(ex)}", "success": False},
+                    status_code=422,
+                )
+        else:
+            tool_data["jsonpath_filter"] = ""
+    else:
+        tool_data["jsonpath_filter"] = ""
+
     if "timeout_ms" in form and form.get("timeout_ms"):
         try:
             tool_data["timeout_ms"] = int(form.get("timeout_ms"))

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11976,13 +11976,65 @@ async def admin_edit_tool(
         "input_schema": input_schema,
         "output_schema": output_schema,
         "annotations": annotations,
-        "jsonpath_filter": form.get("jsonpathFilter", ""),
+        "jsonpath_filter": form.get("jsonpath_filter", ""),
         "auth": auth_obj,
         "tags": tags,
         "visibility": visibility,
         # Note: owner_email is NOT included to prevent ownership changes during edits
         "team_id": team_id,
     }
+
+    # Add optional fields only if present in form
+    if "timeout_ms" in form and form.get("timeout_ms"):
+        tool_data["timeout_ms"] = int(form.get("timeout_ms"))
+
+    if "title" in form and form.get("title"):
+        tool_data["title"] = form.get("title")
+
+    # Add REST passthrough fields only if present in form (REST tools only)
+    if "base_url" in form and form.get("base_url"):
+        tool_data["base_url"] = form.get("base_url")
+
+    if "path_template" in form and form.get("path_template"):
+        tool_data["path_template"] = form.get("path_template")
+
+    if "query_mapping" in form and form.get("query_mapping"):
+        try:
+            query_mapping_raw = form.get("query_mapping")
+            tool_data["query_mapping"] = orjson.loads(query_mapping_raw) if isinstance(query_mapping_raw, str) else None
+        except orjson.JSONDecodeError as ex:
+            LOGGER.error(f"Invalid JSON in query_mapping field: {str(ex)}")
+            return ORJSONResponse(
+                content={"message": f"Invalid JSON in query_mapping field: {str(ex)}", "success": False},
+                status_code=422,
+            )
+
+    if "header_mapping" in form and form.get("header_mapping"):
+        try:
+            header_mapping_raw = form.get("header_mapping")
+            tool_data["header_mapping"] = orjson.loads(header_mapping_raw) if isinstance(header_mapping_raw, str) else None
+        except orjson.JSONDecodeError as ex:
+            LOGGER.error(f"Invalid JSON in header_mapping field: {str(ex)}")
+            return ORJSONResponse(
+                content={"message": f"Invalid JSON in header_mapping field: {str(ex)}", "success": False},
+                status_code=422,
+            )
+
+    if "expose_passthrough" in form:
+        tool_data["expose_passthrough"] = form.get("expose_passthrough") == "true"
+
+    if "allowlist" in form and form.get("allowlist"):
+        allowlist_raw = form.get("allowlist")
+        tool_data["allowlist"] = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+
+    # Add plugin chain fields only if present in form
+    if "plugin_chain_pre" in form and form.get("plugin_chain_pre"):
+        plugin_chain_pre_raw = form.get("plugin_chain_pre")
+        tool_data["plugin_chain_pre"] = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
+
+    if "plugin_chain_post" in form and form.get("plugin_chain_post"):
+        plugin_chain_post_raw = form.get("plugin_chain_post")
+        tool_data["plugin_chain_post"] = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
     # Only include integration_type if it's provided (not disabled in form)
     if "integrationType" in form:
         tool_data["integration_type"] = form.get("integrationType")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11989,6 +11989,7 @@ async def admin_edit_tool(
         jsonpath_expr = form.get("jsonpath_filter").strip()
         if jsonpath_expr:
             try:
+                # Third-Party
                 from jsonpath_ng import parse as parse_jsonpath
 
                 parse_jsonpath(jsonpath_expr)  # Validate syntax
@@ -12057,6 +12058,7 @@ async def admin_edit_tool(
     if "allowlist" in form:
         allowlist_raw = form.get("allowlist")
         if allowlist_raw and allowlist_raw.strip():
+            # Standard
             from urllib.parse import urlparse
 
             allowlist_entries = [x.strip() for x in allowlist_raw.split(",") if x.strip()]

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11986,23 +11986,20 @@ async def admin_edit_tool(
 
     # Add optional fields only if present in form
     # Validate and add JSONPath filter
-    if "jsonpath_filter" in form and form.get("jsonpath_filter"):
-        jsonpath_expr = form.get("jsonpath_filter").strip()
-        if jsonpath_expr:
-            try:
-                # Third-Party
-                from jsonpath_ng import parse as parse_jsonpath
+    jsonpath_expr = form.get("jsonpath_filter", "").strip() if "jsonpath_filter" in form else ""
+    if jsonpath_expr:
+        try:
+            # Third-Party
+            from jsonpath_ng import parse as parse_jsonpath
 
-                parse_jsonpath(jsonpath_expr)  # Validate syntax
-                tool_data["jsonpath_filter"] = jsonpath_expr
-            except Exception as ex:
-                LOGGER.error(f"Invalid JSONPath expression: {str(ex)}")
-                return ORJSONResponse(
-                    content={"message": f"Invalid JSONPath expression: {str(ex)}", "success": False},
-                    status_code=422,
-                )
-        else:
-            tool_data["jsonpath_filter"] = ""
+            parse_jsonpath(jsonpath_expr)  # Validate syntax
+            tool_data["jsonpath_filter"] = jsonpath_expr
+        except Exception as ex:
+            LOGGER.error(f"Invalid JSONPath expression: {str(ex)}")
+            return ORJSONResponse(
+                content={"message": f"Invalid JSONPath expression: {str(ex)}", "success": False},
+                status_code=422,
+            )
     else:
         tool_data["jsonpath_filter"] = ""
 
@@ -12069,10 +12066,16 @@ async def admin_edit_tool(
                     parsed = urlparse(url)
                     if not parsed.scheme or not parsed.netloc:
                         error_msg = f"Invalid URL in allowlist: {url} (must include scheme and host)"
-                        return JSONResponse({"error": error_msg}, status_code=400)
+                        return ORJSONResponse(
+                            content={"message": error_msg, "success": False},
+                            status_code=400,
+                        )
                 except Exception:
                     error_msg = f"Invalid URL in allowlist: {url}"
-                    return JSONResponse({"error": error_msg}, status_code=400)
+                    return ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=400,
+                    )
             tool_data["allowlist"] = allowlist_entries
         else:
             # Empty field means clear the list

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12005,7 +12005,15 @@ async def admin_edit_tool(
 
     if "timeout_ms" in form and form.get("timeout_ms"):
         try:
-            tool_data["timeout_ms"] = int(form.get("timeout_ms"))
+            timeout_value = int(form.get("timeout_ms"))
+            if timeout_value <= 0:
+                error_msg = "Invalid timeout_ms value: must be a positive integer (greater than 0)"
+                LOGGER.error(error_msg)
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
+            tool_data["timeout_ms"] = timeout_value
         except ValueError as ex:
             LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
             return ORJSONResponse(
@@ -12018,7 +12026,36 @@ async def admin_edit_tool(
 
     # Add REST passthrough fields only if present in form (REST tools only)
     if "base_url" in form and form.get("base_url"):
-        tool_data["base_url"] = form.get("base_url")
+        # Standard
+        from urllib.parse import urlparse
+
+        base_url = form.get("base_url")
+        try:
+            parsed_base_url = urlparse(base_url)
+            # Validate URL format: must have scheme and netloc
+            if not parsed_base_url.scheme or not parsed_base_url.netloc:
+                error_msg = f"Invalid base_url: {base_url} (must be a valid URL with scheme and host, e.g., https://api.example.com)"
+                LOGGER.error(error_msg)
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
+            # Validate scheme is http or https
+            if parsed_base_url.scheme not in ("http", "https"):
+                error_msg = f"Invalid base_url: {base_url} (scheme must be http or https)"
+                LOGGER.error(error_msg)
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
+        except Exception as ex:
+            error_msg = f"Invalid base_url: {base_url} - {str(ex)}"
+            LOGGER.error(error_msg)
+            return ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=422,
+            )
+        tool_data["base_url"] = base_url
 
     if "path_template" in form and form.get("path_template"):
         tool_data["path_template"] = form.get("path_template")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11980,7 +11980,7 @@ async def admin_edit_tool(
         "auth": auth_obj,
         "tags": tags,
         "visibility": visibility,
-        "owner_email": user_email,
+        # Note: owner_email is NOT included to prevent ownership changes during edits
         "team_id": team_id,
     }
     # Only include integration_type if it's provided (not disabled in form)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11986,7 +11986,14 @@ async def admin_edit_tool(
 
     # Add optional fields only if present in form
     if "timeout_ms" in form and form.get("timeout_ms"):
-        tool_data["timeout_ms"] = int(form.get("timeout_ms"))
+        try:
+            tool_data["timeout_ms"] = int(form.get("timeout_ms"))
+        except ValueError as ex:
+            LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
+            return ORJSONResponse(
+                content={"message": f"Invalid timeout_ms value: must be a positive integer", "success": False},
+                status_code=422,
+            )
 
     if "title" in form and form.get("title"):
         tool_data["title"] = form.get("title")
@@ -12020,21 +12027,38 @@ async def admin_edit_tool(
                 status_code=422,
             )
 
+    # Handle expose_passthrough checkbox: always set value (checked -> True, unchecked -> False)
     if "expose_passthrough" in form:
         tool_data["expose_passthrough"] = form.get("expose_passthrough") == "true"
+    else:
+        # Checkbox not present means unchecked -> explicitly set False
+        tool_data["expose_passthrough"] = False
 
-    if "allowlist" in form and form.get("allowlist"):
+    # Handle list fields: allow clearing to empty list
+    if "allowlist" in form:
         allowlist_raw = form.get("allowlist")
-        tool_data["allowlist"] = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+        if allowlist_raw and allowlist_raw.strip():
+            tool_data["allowlist"] = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+        else:
+            # Empty field means clear the list
+            tool_data["allowlist"] = []
 
-    # Add plugin chain fields only if present in form
-    if "plugin_chain_pre" in form and form.get("plugin_chain_pre"):
+    # Add plugin chain fields: allow clearing to empty list
+    if "plugin_chain_pre" in form:
         plugin_chain_pre_raw = form.get("plugin_chain_pre")
-        tool_data["plugin_chain_pre"] = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
+        if plugin_chain_pre_raw and plugin_chain_pre_raw.strip():
+            tool_data["plugin_chain_pre"] = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
+        else:
+            # Empty field means clear the list
+            tool_data["plugin_chain_pre"] = []
 
-    if "plugin_chain_post" in form and form.get("plugin_chain_post"):
+    if "plugin_chain_post" in form:
         plugin_chain_post_raw = form.get("plugin_chain_post")
-        tool_data["plugin_chain_post"] = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
+        if plugin_chain_post_raw and plugin_chain_post_raw.strip():
+            tool_data["plugin_chain_post"] = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
+        else:
+            # Empty field means clear the list
+            tool_data["plugin_chain_post"] = []
     # Only include integration_type if it's provided (not disabled in form)
     if "integrationType" in form:
         tool_data["integration_type"] = form.get("integrationType")

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11990,6 +11990,7 @@ async def admin_edit_tool(
         if jsonpath_expr:
             try:
                 from jsonpath_ng import parse as parse_jsonpath
+
                 parse_jsonpath(jsonpath_expr)  # Validate syntax
                 tool_data["jsonpath_filter"] = jsonpath_expr
             except Exception as ex:
@@ -12009,7 +12010,7 @@ async def admin_edit_tool(
         except ValueError as ex:
             LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
             return ORJSONResponse(
-                content={"message": f"Invalid timeout_ms value: must be a positive integer", "success": False},
+                content={"message": "Invalid timeout_ms value: must be a positive integer", "success": False},
                 status_code=422,
             )
 
@@ -12056,7 +12057,20 @@ async def admin_edit_tool(
     if "allowlist" in form:
         allowlist_raw = form.get("allowlist")
         if allowlist_raw and allowlist_raw.strip():
-            tool_data["allowlist"] = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+            from urllib.parse import urlparse
+
+            allowlist_entries = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+            # Validate each URL to prevent SSRF attacks
+            for url in allowlist_entries:
+                try:
+                    parsed = urlparse(url)
+                    if not parsed.scheme or not parsed.netloc:
+                        error_msg = f"Invalid URL in allowlist: {url} (must include scheme and host)"
+                        return JSONResponse({"error": error_msg}, status_code=400)
+                except Exception:
+                    error_msg = f"Invalid URL in allowlist: {url}"
+                    return JSONResponse({"error": error_msg}, status_code=400)
+            tool_data["allowlist"] = allowlist_entries
         else:
             # Empty field means clear the list
             tool_data["allowlist"] = []

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12044,27 +12044,31 @@ def _validate_plugin_chains(plugin_chain_raw: str, field_name: str, available_pl
     Returns:
         Tuple of (plugin_list, error_response). If validation fails, returns (None, error_response).
         If validation succeeds, returns (plugin_list, None).
+
+    Note:
+        Plugin chains can be configured even when plugins are globally disabled.
+        This allows pre-configuration of plugin chains before enabling the plugin system.
+        The chains will only execute when plugins are globally enabled.
     """
     plugin_list = [x.strip() for x in plugin_chain_raw.split(",") if x.strip()]
 
-    # Reject plugin chains when plugins are globally disabled
-    if not plugins_enabled:
-        error_msg = f"Cannot configure {field_name}: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
-        LOGGER.warning(f"Rejected {field_name} configuration: {plugin_list} (plugins disabled)")
-        return (None, ORJSONResponse(
-            content={"message": error_msg, "success": False},
-            status_code=422,
-        ))
+    # If plugins are disabled but user is configuring chains, log a warning but allow it
+    # The chains will be stored but won't execute until plugins are enabled
+    if not plugins_enabled and plugin_list:
+        LOGGER.info(f"Configuring {field_name}: {plugin_list} (plugins currently disabled - chains will execute when plugins are enabled)")
 
-    # Validate plugin names
-    for plugin_name in plugin_list:
-        if plugin_name not in available_plugins:
-            error_msg = f"Unknown plugin in {field_name}: {plugin_name}"
-            LOGGER.warning(error_msg)
-            return (None, ORJSONResponse(
-                content={"message": error_msg, "success": False},
-                status_code=422,
-            ))
+    # Validate plugin names only if plugins are enabled (so we can check available_plugins)
+    # If plugins are disabled, we can't validate against available plugins, so skip validation
+    # and allow any plugin names to be stored (they'll be validated when plugins are enabled)
+    if plugins_enabled:
+        for plugin_name in plugin_list:
+            if plugin_name not in available_plugins:
+                error_msg = f"Unknown plugin in {field_name}: {plugin_name}"
+                LOGGER.warning(error_msg)
+                return (None, ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                ))
     return (plugin_list, None)
 
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11878,6 +11878,247 @@ async def admin_add_tool(
         return ORJSONResponse(content={"message": str(ex), "success": False}, status_code=500)
 
 
+def _validate_base_url(base_url: str) -> Optional[ORJSONResponse]:
+    """Validate base_url format for REST passthrough.
+
+    Args:
+        base_url: The base URL to validate
+
+    Returns:
+        ORJSONResponse with error if validation fails, None if valid
+    """
+    try:
+        # Standard
+        from urllib.parse import urlparse
+
+        parsed_base_url = urlparse(base_url)
+        # Validate URL format: must have scheme and netloc
+        if not parsed_base_url.scheme or not parsed_base_url.netloc:
+            error_msg = f"Invalid base_url: {base_url} (must be a valid URL with scheme and host, e.g., https://api.example.com)"
+            LOGGER.error(error_msg)
+            return ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=422,
+            )
+        # Validate scheme is http or https
+        if parsed_base_url.scheme not in ("http", "https"):
+            error_msg = f"Invalid base_url: {base_url} (scheme must be http or https)"
+            LOGGER.error(error_msg)
+            return ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=422,
+            )
+    except Exception as ex:
+        error_msg = f"Invalid base_url: {base_url} - {str(ex)}"
+        LOGGER.error(error_msg)
+        return ORJSONResponse(
+            content={"message": error_msg, "success": False},
+            status_code=422,
+        )
+    return None
+
+
+def _validate_json_field(field_name: str, field_value: str) -> tuple[Optional[dict], Optional[ORJSONResponse]]:
+    """Validate and parse JSON field from form data.
+
+    Args:
+        field_name: Name of the field (for error messages)
+        field_value: Raw JSON string value
+
+    Returns:
+        Tuple of (parsed_json, error_response). If validation fails, returns (None, error_response).
+        If validation succeeds, returns (parsed_json, None).
+    """
+    try:
+        parsed = orjson.loads(field_value) if isinstance(field_value, str) else None
+        return (parsed, None)
+    except orjson.JSONDecodeError as ex:
+        LOGGER.error(f"Invalid JSON in {field_name} field: {str(ex)}")
+        return (None, ORJSONResponse(
+            content={"message": f"Invalid JSON in {field_name} field: {str(ex)}", "success": False},
+            status_code=422,
+        ))
+
+
+def _parse_core_json_fields(form) -> tuple[Optional[dict], Optional[ORJSONResponse]]:
+    """Parse and validate core JSON fields from form data.
+
+    Args:
+        form: Form data containing headers, input_schema, output_schema, annotations
+
+    Returns:
+        Tuple of (parsed_fields_dict, error_response). If parsing fails, returns (None, error_response).
+        If parsing succeeds, returns (parsed_fields_dict, None) where parsed_fields_dict contains:
+        - headers: parsed JSON object
+        - input_schema: parsed JSON object
+        - output_schema: parsed JSON object or None
+        - annotations: parsed JSON object
+    """
+    try:
+        headers_raw = form.get("headers")
+        input_schema_raw = form.get("input_schema")
+        output_schema_raw = form.get("output_schema")
+        annotations_raw = form.get("annotations")
+
+        headers = orjson.loads(headers_raw if isinstance(headers_raw, str) and headers_raw else "{}")
+        input_schema = orjson.loads(input_schema_raw if isinstance(input_schema_raw, str) and input_schema_raw else "{}")
+        output_schema = orjson.loads(output_schema_raw) if isinstance(output_schema_raw, str) and output_schema_raw else None
+        annotations = orjson.loads(annotations_raw if isinstance(annotations_raw, str) and annotations_raw else "{}")
+
+        return (
+            {
+                "headers": headers,
+                "input_schema": input_schema,
+                "output_schema": output_schema,
+                "annotations": annotations,
+            },
+            None,
+        )
+    except orjson.JSONDecodeError as ex:
+        LOGGER.error(f"Invalid JSON in form field: {str(ex)}")
+        return (None, ORJSONResponse(
+            content={"message": f"Invalid JSON in form field: {str(ex)}", "success": False},
+            status_code=422,
+        ))
+
+
+def _validate_allowlist_urls(allowlist_raw: str) -> tuple[Optional[list], Optional[ORJSONResponse]]:
+    """Validate allowlist URLs and check for SSRF vulnerabilities.
+
+    Args:
+        allowlist_raw: Comma-separated list of URLs
+
+    Returns:
+        Tuple of (allowlist_entries, error_response). If validation fails, returns (None, error_response).
+        If validation succeeds, returns (allowlist_entries, None).
+    """
+    # Standard
+    from urllib.parse import urlparse
+
+    allowlist_entries = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
+    # Validate each URL to prevent SSRF attacks
+    for url in allowlist_entries:
+        try:
+            parsed = urlparse(url)
+            if not parsed.scheme or not parsed.netloc:
+                error_msg = f"Invalid URL in allowlist: {url} (must include scheme and host)"
+                return (None, ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=400,
+                ))
+
+            # Enhanced SSRF protection: validate against private IP ranges, cloud metadata, etc.
+            if settings.ssrf_protection_enabled:
+                try:
+                    # Extract hostname without port for SSRF validation
+                    # parsed.hostname handles IPv6 correctly (e.g., "::1" from "http://[::1]:8080")
+                    # Only fall back to netloc if hostname is None (shouldn't happen for valid URLs)
+                    hostname = parsed.hostname or parsed.netloc
+                    # Call internal SSRF validator directly after URL parsing (avoid redundant scheme/netloc checks)
+                    SecurityValidator._validate_ssrf(hostname, f"allowlist URL '{url}'")  # pylint: disable=protected-access
+                except ValueError as ssrf_err:
+                    error_msg = f"Security violation in allowlist: {str(ssrf_err)}"
+                    LOGGER.error(error_msg)
+                    return (None, ORJSONResponse(
+                        content={"message": error_msg, "success": False},
+                        status_code=400,
+                    ))
+        except Exception as ex:
+            error_msg = f"Invalid URL in allowlist: {url} - {str(ex)}"
+            return (None, ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=400,
+            ))
+    return (allowlist_entries, None)
+
+
+def _validate_plugin_chains(plugin_chain_raw: str, field_name: str, available_plugins: list, plugins_enabled: bool) -> tuple[Optional[list], Optional[ORJSONResponse]]:
+    """Validate plugin chain field.
+
+    Args:
+        plugin_chain_raw: Comma-separated list of plugin names
+        field_name: Name of the field (for error messages)
+        available_plugins: List of available plugin names
+        plugins_enabled: Whether plugins are globally enabled
+
+    Returns:
+        Tuple of (plugin_list, error_response). If validation fails, returns (None, error_response).
+        If validation succeeds, returns (plugin_list, None).
+    """
+    plugin_list = [x.strip() for x in plugin_chain_raw.split(",") if x.strip()]
+
+    # Reject plugin chains when plugins are globally disabled
+    if not plugins_enabled:
+        error_msg = f"Cannot configure {field_name}: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
+        LOGGER.warning(f"Rejected {field_name} configuration: {plugin_list} (plugins disabled)")
+        return (None, ORJSONResponse(
+            content={"message": error_msg, "success": False},
+            status_code=422,
+        ))
+
+    # Validate plugin names
+    for plugin_name in plugin_list:
+        if plugin_name not in available_plugins:
+            error_msg = f"Unknown plugin in {field_name}: {plugin_name}"
+            LOGGER.warning(error_msg)
+            return (None, ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=422,
+            ))
+    return (plugin_list, None)
+
+
+def _validate_jsonpath_filter(jsonpath_expr: str) -> Optional[ORJSONResponse]:
+    """Validate JSONPath filter expression.
+
+    Args:
+        jsonpath_expr: JSONPath expression to validate
+
+    Returns:
+        ORJSONResponse with error if validation fails, None if valid
+    """
+    try:
+        # Third-Party
+        from jsonpath_ng import parse as parse_jsonpath
+
+        parse_jsonpath(jsonpath_expr)  # Validate syntax
+        return None
+    except Exception as ex:
+        LOGGER.error(f"Invalid JSONPath expression: {str(ex)}")
+        return ORJSONResponse(
+            content={"message": f"Invalid JSONPath expression: {str(ex)}", "success": False},
+            status_code=422,
+        )
+
+
+def _validate_timeout_ms(timeout_value_str: str) -> tuple[Optional[int], Optional[ORJSONResponse]]:
+    """Validate timeout_ms value.
+
+    Args:
+        timeout_value_str: String representation of timeout value
+
+    Returns:
+        Tuple of (timeout_value, error_response). If validation fails, returns (None, error_response).
+        If validation succeeds, returns (timeout_value, None).
+    """
+    try:
+        timeout_value = int(timeout_value_str)
+        if timeout_value <= 0:
+            error_msg = "Invalid timeout_ms value: must be a positive integer (greater than 0)"
+            LOGGER.error(error_msg)
+            return (None, ORJSONResponse(
+                content={"message": error_msg, "success": False},
+                status_code=422,
+            ))
+        return (timeout_value, None)
+    except ValueError as ex:
+        LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
+        return (None, ORJSONResponse(
+            content={"message": "Invalid timeout_ms value: must be a positive integer", "success": False},
+            status_code=422,
+        ))
+
+
 @admin_router.post("/tools/{tool_id}/edit/", response_model=None)
 @admin_router.post("/tools/{tool_id}/edit", response_model=None)
 @require_permission("tools.update", allow_admin_bypass=False)
@@ -11949,23 +12190,15 @@ async def admin_edit_tool(
     team_service = TeamManagementService(db)
     team_id = await team_service.verify_team_for_user(user_email, team_id)
 
-    headers_raw2 = form.get("headers")
-    input_schema_raw2 = form.get("input_schema")
-    output_schema_raw2 = form.get("output_schema")
-    annotations_raw2 = form.get("annotations")
-
     # Parse JSON fields with validation
-    try:
-        headers = orjson.loads(headers_raw2 if isinstance(headers_raw2, str) and headers_raw2 else "{}")
-        input_schema = orjson.loads(input_schema_raw2 if isinstance(input_schema_raw2, str) and input_schema_raw2 else "{}")
-        output_schema = orjson.loads(output_schema_raw2) if isinstance(output_schema_raw2, str) and output_schema_raw2 else None
-        annotations = orjson.loads(annotations_raw2 if isinstance(annotations_raw2, str) and annotations_raw2 else "{}")
-    except orjson.JSONDecodeError as ex:
-        LOGGER.error(f"Invalid JSON in form field: {str(ex)}")
-        return ORJSONResponse(
-            content={"message": f"Invalid JSON in form field: {str(ex)}", "success": False},
-            status_code=422,
-        )
+    parsed_fields, error_response = _parse_core_json_fields(form)
+    if error_response:
+        return error_response
+
+    headers = parsed_fields["headers"]
+    input_schema = parsed_fields["input_schema"]
+    output_schema = parsed_fields["output_schema"]
+    annotations = parsed_fields["annotations"]
 
     tool_data: dict[str, Any] = {
         "name": form.get("name"),
@@ -11988,99 +12221,46 @@ async def admin_edit_tool(
     # Validate and add JSONPath filter
     jsonpath_expr = form.get("jsonpath_filter", "").strip() if "jsonpath_filter" in form else ""
     if jsonpath_expr:
-        try:
-            # Third-Party
-            from jsonpath_ng import parse as parse_jsonpath
-
-            parse_jsonpath(jsonpath_expr)  # Validate syntax
-            tool_data["jsonpath_filter"] = jsonpath_expr
-        except Exception as ex:
-            LOGGER.error(f"Invalid JSONPath expression: {str(ex)}")
-            return ORJSONResponse(
-                content={"message": f"Invalid JSONPath expression: {str(ex)}", "success": False},
-                status_code=422,
-            )
+        error_response = _validate_jsonpath_filter(jsonpath_expr)
+        if error_response:
+            return error_response
+        tool_data["jsonpath_filter"] = jsonpath_expr
     else:
         tool_data["jsonpath_filter"] = ""
 
     if "timeout_ms" in form and form.get("timeout_ms"):
-        try:
-            timeout_value = int(form.get("timeout_ms"))
-            if timeout_value <= 0:
-                error_msg = "Invalid timeout_ms value: must be a positive integer (greater than 0)"
-                LOGGER.error(error_msg)
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
-            tool_data["timeout_ms"] = timeout_value
-        except ValueError as ex:
-            LOGGER.error(f"Invalid timeout_ms value: {str(ex)}")
-            return ORJSONResponse(
-                content={"message": "Invalid timeout_ms value: must be a positive integer", "success": False},
-                status_code=422,
-            )
+        timeout_value, error_response = _validate_timeout_ms(form.get("timeout_ms"))
+        if error_response:
+            return error_response
+        tool_data["timeout_ms"] = timeout_value
 
     if "title" in form and form.get("title"):
         tool_data["title"] = form.get("title")
 
     # Add REST passthrough fields only if present in form (REST tools only)
     if "base_url" in form and form.get("base_url"):
-        # Standard
-        from urllib.parse import urlparse
-
         base_url = form.get("base_url")
-        try:
-            parsed_base_url = urlparse(base_url)
-            # Validate URL format: must have scheme and netloc
-            if not parsed_base_url.scheme or not parsed_base_url.netloc:
-                error_msg = f"Invalid base_url: {base_url} (must be a valid URL with scheme and host, e.g., https://api.example.com)"
-                LOGGER.error(error_msg)
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
-            # Validate scheme is http or https
-            if parsed_base_url.scheme not in ("http", "https"):
-                error_msg = f"Invalid base_url: {base_url} (scheme must be http or https)"
-                LOGGER.error(error_msg)
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
-        except Exception as ex:
-            error_msg = f"Invalid base_url: {base_url} - {str(ex)}"
-            LOGGER.error(error_msg)
-            return ORJSONResponse(
-                content={"message": error_msg, "success": False},
-                status_code=422,
-            )
+        error_response = _validate_base_url(base_url)
+        if error_response:
+            return error_response
         tool_data["base_url"] = base_url
 
     if "path_template" in form and form.get("path_template"):
         tool_data["path_template"] = form.get("path_template")
 
     if "query_mapping" in form and form.get("query_mapping"):
-        try:
-            query_mapping_raw = form.get("query_mapping")
-            tool_data["query_mapping"] = orjson.loads(query_mapping_raw) if isinstance(query_mapping_raw, str) else None
-        except orjson.JSONDecodeError as ex:
-            LOGGER.error(f"Invalid JSON in query_mapping field: {str(ex)}")
-            return ORJSONResponse(
-                content={"message": f"Invalid JSON in query_mapping field: {str(ex)}", "success": False},
-                status_code=422,
-            )
+        query_mapping_raw = form.get("query_mapping")
+        parsed_json, error_response = _validate_json_field("query_mapping", query_mapping_raw)
+        if error_response:
+            return error_response
+        tool_data["query_mapping"] = parsed_json
 
     if "header_mapping" in form and form.get("header_mapping"):
-        try:
-            header_mapping_raw = form.get("header_mapping")
-            tool_data["header_mapping"] = orjson.loads(header_mapping_raw) if isinstance(header_mapping_raw, str) else None
-        except orjson.JSONDecodeError as ex:
-            LOGGER.error(f"Invalid JSON in header_mapping field: {str(ex)}")
-            return ORJSONResponse(
-                content={"message": f"Invalid JSON in header_mapping field: {str(ex)}", "success": False},
-                status_code=422,
-            )
+        header_mapping_raw = form.get("header_mapping")
+        parsed_json, error_response = _validate_json_field("header_mapping", header_mapping_raw)
+        if error_response:
+            return error_response
+        tool_data["header_mapping"] = parsed_json
 
     # Handle expose_passthrough checkbox: always set explicit boolean value
     # Checkbox unchecked → field absent from form → explicitly set False
@@ -12090,45 +12270,9 @@ async def admin_edit_tool(
     if "allowlist" in form:
         allowlist_raw = form.get("allowlist")
         if allowlist_raw and allowlist_raw.strip():
-            # Standard
-            from urllib.parse import urlparse
-
-            # First-Party
-            from mcpgateway.common.validators import SecurityValidator
-
-            allowlist_entries = [x.strip() for x in allowlist_raw.split(",") if x.strip()]
-            # Validate each URL to prevent SSRF attacks
-            for url in allowlist_entries:
-                try:
-                    parsed = urlparse(url)
-                    if not parsed.scheme or not parsed.netloc:
-                        error_msg = f"Invalid URL in allowlist: {url} (must include scheme and host)"
-                        return ORJSONResponse(
-                            content={"message": error_msg, "success": False},
-                            status_code=400,
-                        )
-
-                    # Enhanced SSRF protection: validate against private IP ranges, cloud metadata, etc.
-                    if settings.ssrf_protection_enabled:
-                        try:
-                            # Extract hostname without port for SSRF validation
-                            # parsed.hostname handles IPv6 correctly (e.g., "::1" from "http://[::1]:8080")
-                            # Only fall back to netloc if hostname is None (shouldn't happen for valid URLs)
-                            hostname = parsed.hostname or parsed.netloc
-                            SecurityValidator._validate_ssrf(hostname, f"allowlist URL '{url}'")
-                        except ValueError as ssrf_err:
-                            error_msg = f"Security violation in allowlist: {str(ssrf_err)}"
-                            LOGGER.error(error_msg)
-                            return ORJSONResponse(
-                                content={"message": error_msg, "success": False},
-                                status_code=400,
-                            )
-                except Exception as ex:
-                    error_msg = f"Invalid URL in allowlist: {url} - {str(ex)}"
-                    return ORJSONResponse(
-                        content={"message": error_msg, "success": False},
-                        status_code=400,
-                    )
+            allowlist_entries, error_response = _validate_allowlist_urls(allowlist_raw)
+            if error_response:
+                return error_response
             tool_data["allowlist"] = allowlist_entries
         else:
             # Empty field means clear the list
@@ -12140,29 +12284,15 @@ async def admin_edit_tool(
     if "plugin_chain_pre" in form:
         plugin_chain_pre_raw = form.get("plugin_chain_pre")
         if plugin_chain_pre_raw and plugin_chain_pre_raw.strip():
-            plugin_list = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
-
-            # Reject plugin chains when plugins are globally disabled
-            if not settings.plugins.enabled:
-                error_msg = "Cannot configure plugin_chain_pre: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
-                LOGGER.warning(f"Rejected plugin_chain_pre configuration: {plugin_list} (plugins disabled)")
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
-
-            # Validate plugin names against configured plugins
             # First-Party
             from mcpgateway.plugins import list_configured_plugin_names
 
             available_plugins = list_configured_plugin_names()
-            invalid_plugins = [p for p in plugin_list if p not in available_plugins]
-            if invalid_plugins:
-                error_msg = f"Invalid plugin names in plugin_chain_pre: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
+            plugin_list, error_response = _validate_plugin_chains(
+                plugin_chain_pre_raw, "plugin_chain_pre", available_plugins, settings.plugins.enabled
+            )
+            if error_response:
+                return error_response
             tool_data["plugin_chain_pre"] = plugin_list
         else:
             # Empty field means clear the list
@@ -12171,29 +12301,15 @@ async def admin_edit_tool(
     if "plugin_chain_post" in form:
         plugin_chain_post_raw = form.get("plugin_chain_post")
         if plugin_chain_post_raw and plugin_chain_post_raw.strip():
-            plugin_list = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
-
-            # Reject plugin chains when plugins are globally disabled
-            if not settings.plugins.enabled:
-                error_msg = "Cannot configure plugin_chain_post: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
-                LOGGER.warning(f"Rejected plugin_chain_post configuration: {plugin_list} (plugins disabled)")
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
-
-            # Validate plugin names against configured plugins
             # First-Party
             from mcpgateway.plugins import list_configured_plugin_names
 
             available_plugins = list_configured_plugin_names()
-            invalid_plugins = [p for p in plugin_list if p not in available_plugins]
-            if invalid_plugins:
-                error_msg = f"Invalid plugin names in plugin_chain_post: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
-                return ORJSONResponse(
-                    content={"message": error_msg, "success": False},
-                    status_code=422,
-                )
+            plugin_list, error_response = _validate_plugin_chains(
+                plugin_chain_post_raw, "plugin_chain_post", available_plugins, settings.plugins.enabled
+            )
+            if error_response:
+                return error_response
             tool_data["plugin_chain_post"] = plugin_list
         else:
             # Empty field means clear the list

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -12098,22 +12098,33 @@ async def admin_edit_tool(
 
     # Add plugin chain fields: allow clearing to empty list
     # Validate plugin names against configured plugins if plugins are enabled
+    # Reject non-empty plugin chains when plugins are globally disabled
     if "plugin_chain_pre" in form:
         plugin_chain_pre_raw = form.get("plugin_chain_pre")
         if plugin_chain_pre_raw and plugin_chain_pre_raw.strip():
             plugin_list = [x.strip() for x in plugin_chain_pre_raw.split(",") if x.strip()]
-            if settings.plugins.enabled:
-                # First-Party
-                from mcpgateway.plugins import list_configured_plugin_names
 
-                available_plugins = list_configured_plugin_names()
-                invalid_plugins = [p for p in plugin_list if p not in available_plugins]
-                if invalid_plugins:
-                    error_msg = f"Invalid plugin names in plugin_chain_pre: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
-                    return ORJSONResponse(
-                        content={"message": error_msg, "success": False},
-                        status_code=422,
-                    )
+            # Reject plugin chains when plugins are globally disabled
+            if not settings.plugins.enabled:
+                error_msg = "Cannot configure plugin_chain_pre: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
+                LOGGER.warning(f"Rejected plugin_chain_pre configuration: {plugin_list} (plugins disabled)")
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
+
+            # Validate plugin names against configured plugins
+            # First-Party
+            from mcpgateway.plugins import list_configured_plugin_names
+
+            available_plugins = list_configured_plugin_names()
+            invalid_plugins = [p for p in plugin_list if p not in available_plugins]
+            if invalid_plugins:
+                error_msg = f"Invalid plugin names in plugin_chain_pre: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
             tool_data["plugin_chain_pre"] = plugin_list
         else:
             # Empty field means clear the list
@@ -12123,18 +12134,28 @@ async def admin_edit_tool(
         plugin_chain_post_raw = form.get("plugin_chain_post")
         if plugin_chain_post_raw and plugin_chain_post_raw.strip():
             plugin_list = [x.strip() for x in plugin_chain_post_raw.split(",") if x.strip()]
-            if settings.plugins.enabled:
-                # First-Party
-                from mcpgateway.plugins import list_configured_plugin_names
 
-                available_plugins = list_configured_plugin_names()
-                invalid_plugins = [p for p in plugin_list if p not in available_plugins]
-                if invalid_plugins:
-                    error_msg = f"Invalid plugin names in plugin_chain_post: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
-                    return ORJSONResponse(
-                        content={"message": error_msg, "success": False},
-                        status_code=422,
-                    )
+            # Reject plugin chains when plugins are globally disabled
+            if not settings.plugins.enabled:
+                error_msg = "Cannot configure plugin_chain_post: plugins are globally disabled. Enable plugins via PLUGINS_ENABLED=true to use plugin chains."
+                LOGGER.warning(f"Rejected plugin_chain_post configuration: {plugin_list} (plugins disabled)")
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
+
+            # Validate plugin names against configured plugins
+            # First-Party
+            from mcpgateway.plugins import list_configured_plugin_names
+
+            available_plugins = list_configured_plugin_names()
+            invalid_plugins = [p for p in plugin_list if p not in available_plugins]
+            if invalid_plugins:
+                error_msg = f"Invalid plugin names in plugin_chain_post: {', '.join(invalid_plugins)}. Available plugins: {', '.join(available_plugins)}"
+                return ORJSONResponse(
+                    content={"message": error_msg, "success": False},
+                    status_code=422,
+                )
             tool_data["plugin_chain_post"] = plugin_list
         else:
             # Empty field means clear the list

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4113,6 +4113,7 @@ async def admin_ui(
             "toolops_enabled": getattr(settings, "toolops_enabled", False),
             "observability_enabled": getattr(settings, "observability_enabled", False),
             "performance_enabled": getattr(settings, "mcpgateway_performance_tracking", False),
+            "plugins_enabled": settings.plugins.enabled,
             "current_user": get_user_email(user),
             "email_auth_enabled": getattr(settings, "email_auth_enabled", False),
             "is_admin": is_admin,

--- a/mcpgateway/admin_ui/formFieldHandlers.js
+++ b/mcpgateway/admin_ui/formFieldHandlers.js
@@ -343,6 +343,50 @@ export const updateEditToolRequestTypes = function (selectedMethod = null) {
   }
 };
 
+// Handle integration type changes in edit form to show/hide REST passthrough button
+export const handleEditToolIntegrationTypeChange = function () {
+  const editToolTypeSelect = safeGetElement("edit-tool-type");
+  if (!editToolTypeSelect) {
+    return;
+  }
+
+  const selectedType = editToolTypeSelect.value;
+  const restPassthroughButtonWrapper = safeGetElement("edit-tool-rest-passthrough-button-wrapper");
+  const restPassthroughContainer = safeGetElement("edit-tool-passthrough-container");
+
+  // Show REST passthrough button only for REST integration type
+  if (restPassthroughButtonWrapper) {
+    if (selectedType === "REST") {
+      restPassthroughButtonWrapper.style.display = "block";
+    } else {
+      restPassthroughButtonWrapper.style.display = "none";
+      // Also hide the container if integration type changes away from REST
+      if (restPassthroughContainer) {
+        restPassthroughContainer.style.display = "none";
+      }
+    }
+  }
+};
+
+// Handle passthrough button click in edit form
+export const handleEditToolPassthrough = function () {
+  const passthroughContainer = safeGetElement("edit-tool-passthrough-container");
+  if (!passthroughContainer) {
+    console.error("Edit tool passthrough container not found");
+    return;
+  }
+
+  // Toggle visibility
+  if (
+    passthroughContainer.style.display === "none" ||
+    passthroughContainer.style.display === ""
+  ) {
+    passthroughContainer.style.display = "block";
+  } else {
+    passthroughContainer.style.display = "none";
+  }
+};
+
 // ===================================================================
 // ADVANCED TOOLS FIELDS
 // ===================================================================

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -319,11 +319,29 @@ export const handleEditPromptFormSubmit = async function (e) {
     }
 
     // Save CodeMirror editors' contents if present
-    if (window.promptToolHeadersEditor) {
-      window.promptToolHeadersEditor.save();
+    // Collect all errors to avoid partial save failures
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "promptToolHeadersEditor", editor: window.promptToolHeadersEditor },
+      { name: "promptToolSchemaEditor", editor: window.promptToolSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
     }
-    if (window.promptToolSchemaEditor) {
-      window.promptToolSchemaEditor.save();
+
+    // If any editor failed to save, report all errors and abort submission
+    if (editorSaveErrors.length > 0) {
+      throw new Error(
+        `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      );
     }
 
     const isInactiveCheckedBool = isInactiveChecked("prompts");
@@ -647,14 +665,30 @@ export const handleToolFormSubmit = async function (event) {
     }
 
     // Save CodeMirror editors' contents
-    if (window.headersEditor) {
-      window.headersEditor.save();
+    // Collect all errors to avoid partial save failures
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "headersEditor", editor: window.headersEditor },
+      { name: "schemaEditor", editor: window.schemaEditor },
+      { name: "outputSchemaEditor", editor: window.outputSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
     }
-    if (window.schemaEditor) {
-      window.schemaEditor.save();
-    }
-    if (window.outputSchemaEditor) {
-      window.outputSchemaEditor.save();
+
+    // If any editor failed to save, report all errors and abort submission
+    if (editorSaveErrors.length > 0) {
+      throw new Error(
+        `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      );
     }
 
     const isInactiveCheckedBool = isInactiveChecked("tools");
@@ -711,22 +745,33 @@ export const handleEditToolFormSubmit = async function (event) {
       throw new Error(urlValidation.error);
     }
 
-    // // Save CodeMirror editors' contents if present
+    // Save CodeMirror editors' contents if present
+    // Collect all errors to avoid partial save failures
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolHeadersEditor", editor: window.editToolHeadersEditor },
+      { name: "editToolSchemaEditor", editor: window.editToolSchemaEditor },
+      { name: "editToolOutputSchemaEditor", editor: window.editToolOutputSchemaEditor },
+      { name: "editToolQueryMappingEditor", editor: window.editToolQueryMappingEditor },
+      { name: "editToolHeaderMappingEditor", editor: window.editToolHeaderMappingEditor },
+    ];
 
-    if (window.editToolHeadersEditor) {
-      window.editToolHeadersEditor.save();
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
     }
-    if (window.editToolSchemaEditor) {
-      window.editToolSchemaEditor.save();
-    }
-    if (window.editToolOutputSchemaEditor) {
-      window.editToolOutputSchemaEditor.save();
-    }
-    if (window.editToolQueryMappingEditor) {
-      window.editToolQueryMappingEditor.save();
-    }
-    if (window.editToolHeaderMappingEditor) {
-      window.editToolHeaderMappingEditor.save();
+
+    // If any editor failed to save, report all errors and abort submission
+    if (editorSaveErrors.length > 0) {
+      throw new Error(
+        `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      );
     }
 
     const isInactiveCheckedBool = isInactiveChecked("tools");
@@ -979,11 +1024,29 @@ export const handleEditServerFormSubmit = async function (e) {
     }
 
     // Save CodeMirror editors' contents if present
-    if (window.promptToolHeadersEditor) {
-      window.promptToolHeadersEditor.save();
+    // Collect all errors to avoid partial save failures
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "promptToolHeadersEditor", editor: window.promptToolHeadersEditor },
+      { name: "promptToolSchemaEditor", editor: window.promptToolSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
     }
-    if (window.promptToolSchemaEditor) {
-      window.promptToolSchemaEditor.save();
+
+    // If any editor failed to save, report all errors and abort submission
+    if (editorSaveErrors.length > 0) {
+      throw new Error(
+        `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      );
     }
 
     const isInactiveCheckedBool = isInactiveChecked("servers");
@@ -1087,11 +1150,29 @@ export const handleEditResFormSubmit = async function (e) {
     }
 
     // Save CodeMirror editors' contents if present
-    if (window.promptToolHeadersEditor) {
-      window.promptToolHeadersEditor.save();
+    // Collect all errors to avoid partial save failures
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "promptToolHeadersEditor", editor: window.promptToolHeadersEditor },
+      { name: "promptToolSchemaEditor", editor: window.promptToolSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
     }
-    if (window.promptToolSchemaEditor) {
-      window.promptToolSchemaEditor.save();
+
+    // If any editor failed to save, report all errors and abort submission
+    if (editorSaveErrors.length > 0) {
+      throw new Error(
+        `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      );
     }
 
     const isInactiveCheckedBool = isInactiveChecked("resources");

--- a/mcpgateway/admin_ui/formSubmitHandlers.js
+++ b/mcpgateway/admin_ui/formSubmitHandlers.js
@@ -722,6 +722,12 @@ export const handleEditToolFormSubmit = async function (event) {
     if (window.editToolOutputSchemaEditor) {
       window.editToolOutputSchemaEditor.save();
     }
+    if (window.editToolQueryMappingEditor) {
+      window.editToolQueryMappingEditor.save();
+    }
+    if (window.editToolHeaderMappingEditor) {
+      window.editToolHeaderMappingEditor.save();
+    }
 
     const isInactiveCheckedBool = isInactiveChecked("tools");
     formData.append("is_inactive_checked", isInactiveCheckedBool);

--- a/mcpgateway/admin_ui/initialization.js
+++ b/mcpgateway/admin_ui/initialization.js
@@ -137,6 +137,16 @@ export const initializeCodeMirrorEditors = function () {
       mode: "application/json",
       varName: "editPromptArgumentsEditor",
     },
+    {
+      id: "edit-tool-query-mapping",
+      mode: "application/json",
+      varName: "editToolQueryMappingEditor",
+    },
+    {
+      id: "edit-tool-header-mapping",
+      mode: "application/json",
+      varName: "editToolHeaderMappingEditor",
+    },
   ];
 
   editorConfigs.forEach((config) => {

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -728,11 +728,7 @@ export const editTool = async function (toolId) {
       });
     }
 
-    // Handle REST passthrough button visibility and populate fields
-    const restPassthroughButtonWrapper = safeGetElement("edit-tool-rest-passthrough-button-wrapper");
-    const restPassthroughContainer = safeGetElement("edit-tool-passthrough-container");
-
-    // Always populate REST passthrough fields (they'll be hidden if not REST)
+    // Populate REST passthrough fields
     const baseUrlField = safeGetElement("edit-tool-base-url");
     if (baseUrlField) {
       baseUrlField.value = tool.baseUrl || "";
@@ -745,12 +741,22 @@ export const editTool = async function (toolId) {
 
     const queryMappingField = safeGetElement("edit-tool-query-mapping");
     if (queryMappingField) {
-      queryMappingField.value = tool.queryMapping ? JSON.stringify(tool.queryMapping, null, 2) : "";
+      const queryMappingValue = tool.queryMapping ? JSON.stringify(tool.queryMapping, null, 2) : "";
+      queryMappingField.value = queryMappingValue;
+      // Update CodeMirror editor if initialized
+      if (window.editToolQueryMappingEditor) {
+        window.editToolQueryMappingEditor.setValue(queryMappingValue);
+      }
     }
 
     const headerMappingField = safeGetElement("edit-tool-header-mapping");
     if (headerMappingField) {
-      headerMappingField.value = tool.headerMapping ? JSON.stringify(tool.headerMapping, null, 2) : "";
+      const headerMappingValue = tool.headerMapping ? JSON.stringify(tool.headerMapping, null, 2) : "";
+      headerMappingField.value = headerMappingValue;
+      // Update CodeMirror editor if initialized
+      if (window.editToolHeaderMappingEditor) {
+        window.editToolHeaderMappingEditor.setValue(headerMappingValue);
+      }
     }
 
     const exposePassthroughField = safeGetElement("edit-tool-expose-passthrough");
@@ -763,28 +769,10 @@ export const editTool = async function (toolId) {
       allowlistField.value = Array.isArray(tool.allowlist) ? tool.allowlist.join(", ") : "";
     }
 
-    // Show/hide button and container based on integration type
-    if (restPassthroughButtonWrapper) {
-      if (tool.integrationType === "REST") {
-        restPassthroughButtonWrapper.style.display = "block";
-        // Show container if any passthrough fields have values
-        if (restPassthroughContainer) {
-          const hasPassthroughData = tool.baseUrl || tool.pathTemplate ||
-                                     tool.queryMapping || tool.headerMapping ||
-                                     tool.exposePassthrough ||
-                                     (Array.isArray(tool.allowlist) && tool.allowlist.length > 0);
-          if (hasPassthroughData) {
-            restPassthroughContainer.style.display = "block";
-          } else {
-            restPassthroughContainer.style.display = "none";
-          }
-        }
-      } else {
-        restPassthroughButtonWrapper.style.display = "none";
-        if (restPassthroughContainer) {
-          restPassthroughContainer.style.display = "none";
-        }
-      }
+    // Show/hide REST passthrough section based on integration type
+    const restPassthroughSection = safeGetElement("edit-tool-rest-passthrough-section");
+    if (restPassthroughSection) {
+      restPassthroughSection.style.display = tool.integrationType === "REST" ? "block" : "none";
     }
 
     // Handle plugin section visibility

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -587,15 +587,9 @@ export const editTool = async function (toolId) {
       tagsField.value = rawTags.join(", ");
     }
 
-    const teamId = new URL(window.location.href).searchParams.get("team_id");
-
-    if (teamId) {
-      const hiddenInput = document.createElement("input");
-      hiddenInput.type = "hidden";
-      hiddenInput.name = "team_id";
-      hiddenInput.value = teamId;
-      editForm.appendChild(hiddenInput);
-    }
+    // Note: team_id is now handled by the edit-tool-team-id select dropdown
+    // which allows users to reassign tools to different teams.
+    // The dropdown value will be submitted with the form.
 
     const visibility = tool.visibility ? tool.visibility.toLowerCase() : null;
     const publicRadio = safeGetElement("edit-tool-visibility-public");
@@ -742,29 +736,21 @@ export const editTool = async function (toolId) {
       }
     }
 
-    // Populate team dropdown
+    // Populate team dropdown - only teams associated with logged-in user
+    // Use window.USER_TEAMS_DATA which is server-rendered and already filtered by user membership
     const teamField = safeGetElement("edit-tool-team-id");
     if (teamField) {
-      try {
-        const teamResponse = await fetchWithTimeout(
-          `${window.ROOT_PATH}/admin/teams`
-        );
-        if (teamResponse.ok) {
-          const teams = await teamResponse.json();
-          teamField.innerHTML = '<option value="">No Team (optional)</option>';
-          teams.forEach((team) => {
-            const option = document.createElement("option");
-            option.value = team.id;
-            option.textContent = team.name;
-            if (tool.teamId === team.id) {
-              option.selected = true;
-            }
-            teamField.appendChild(option);
-          });
+      const teams = window.USER_TEAMS_DATA || [];
+      teamField.innerHTML = '<option value="">No Team (optional)</option>';
+      teams.forEach((team) => {
+        const option = document.createElement("option");
+        option.value = team.id;
+        option.textContent = team.name;
+        if (tool.teamId === team.id) {
+          option.selected = true;
         }
-      } catch (error) {
-        console.warn("Could not fetch teams:", error);
-      }
+        teamField.appendChild(option);
+      });
     }
 
     // Handle REST passthrough button visibility and populate fields

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -1,7 +1,7 @@
 import { AppState } from "./appState.js";
 import { loadAuthHeaders, updateAuthHeadersJSON } from "./auth.js";
 import { escapeAttrValue } from "./security.js";
-import { updateEditToolRequestTypes } from "./formFieldHandlers.js";
+import { updateEditToolRequestTypes, handleEditToolIntegrationTypeChange, handleEditToolPassthrough } from "./formFieldHandlers.js";
 import { getSelectedGatewayIds } from "./gateways.js";
 import { closeModal, openModal } from "./modals.js";
 import {
@@ -701,6 +701,151 @@ export const editTool = async function (toolId) {
       window.editToolOutputSchemaEditor.refresh();
     }
 
+    // Populate advanced configuration fields
+    const titleField = safeGetElement("edit-tool-title");
+    if (titleField) {
+      titleField.value = tool.title || "";
+    }
+
+    const timeoutField = safeGetElement("edit-tool-timeout-ms");
+    if (timeoutField) {
+      timeoutField.value = tool.timeoutMs || "";
+    }
+
+    const jsonpathFilterField = safeGetElement("edit-tool-jsonpath-filter");
+    if (jsonpathFilterField) {
+      jsonpathFilterField.value = tool.jsonpathFilter || "";
+    }
+
+    // Populate gateway dropdown
+    const gatewayField = safeGetElement("edit-tool-gateway-id");
+    if (gatewayField) {
+      try {
+        const gatewayResponse = await fetchWithTimeout(
+          `${window.ROOT_PATH}/admin/gateways`
+        );
+        if (gatewayResponse.ok) {
+          const gateways = await gatewayResponse.json();
+          gatewayField.innerHTML = '<option value="">Select Gateway (optional)</option>';
+          gateways.forEach((gw) => {
+            const option = document.createElement("option");
+            option.value = gw.id;
+            option.textContent = `${gw.slug} (${gw.url})`;
+            if (tool.gatewayId === gw.id) {
+              option.selected = true;
+            }
+            gatewayField.appendChild(option);
+          });
+        }
+      } catch (error) {
+        console.warn("Could not fetch gateways:", error);
+      }
+    }
+
+    // Populate team dropdown
+    const teamField = safeGetElement("edit-tool-team-id");
+    if (teamField) {
+      try {
+        const teamResponse = await fetchWithTimeout(
+          `${window.ROOT_PATH}/admin/teams`
+        );
+        if (teamResponse.ok) {
+          const teams = await teamResponse.json();
+          teamField.innerHTML = '<option value="">No Team (optional)</option>';
+          teams.forEach((team) => {
+            const option = document.createElement("option");
+            option.value = team.id;
+            option.textContent = team.name;
+            if (tool.teamId === team.id) {
+              option.selected = true;
+            }
+            teamField.appendChild(option);
+          });
+        }
+      } catch (error) {
+        console.warn("Could not fetch teams:", error);
+      }
+    }
+
+    // Handle REST passthrough button visibility and populate fields
+    const restPassthroughButtonWrapper = safeGetElement("edit-tool-rest-passthrough-button-wrapper");
+    const restPassthroughContainer = safeGetElement("edit-tool-passthrough-container");
+
+    // Always populate REST passthrough fields (they'll be hidden if not REST)
+    const baseUrlField = safeGetElement("edit-tool-base-url");
+    if (baseUrlField) {
+      baseUrlField.value = tool.baseUrl || "";
+    }
+
+    const pathTemplateField = safeGetElement("edit-tool-path-template");
+    if (pathTemplateField) {
+      pathTemplateField.value = tool.pathTemplate || "";
+    }
+
+    const queryMappingField = safeGetElement("edit-tool-query-mapping");
+    if (queryMappingField) {
+      queryMappingField.value = tool.queryMapping ? JSON.stringify(tool.queryMapping, null, 2) : "";
+    }
+
+    const headerMappingField = safeGetElement("edit-tool-header-mapping");
+    if (headerMappingField) {
+      headerMappingField.value = tool.headerMapping ? JSON.stringify(tool.headerMapping, null, 2) : "";
+    }
+
+    const exposePassthroughField = safeGetElement("edit-tool-expose-passthrough");
+    if (exposePassthroughField) {
+      exposePassthroughField.checked = tool.exposePassthrough || false;
+    }
+
+    const allowlistField = safeGetElement("edit-tool-allowlist");
+    if (allowlistField) {
+      allowlistField.value = Array.isArray(tool.allowlist) ? tool.allowlist.join(", ") : "";
+    }
+
+    // Show/hide button and container based on integration type
+    if (restPassthroughButtonWrapper) {
+      if (tool.integrationType === "REST") {
+        restPassthroughButtonWrapper.style.display = "block";
+        // Show container if any passthrough fields have values
+        if (restPassthroughContainer) {
+          const hasPassthroughData = tool.baseUrl || tool.pathTemplate ||
+                                     tool.queryMapping || tool.headerMapping ||
+                                     tool.exposePassthrough ||
+                                     (Array.isArray(tool.allowlist) && tool.allowlist.length > 0);
+          if (hasPassthroughData) {
+            restPassthroughContainer.style.display = "block";
+          } else {
+            restPassthroughContainer.style.display = "none";
+          }
+        }
+      } else {
+        restPassthroughButtonWrapper.style.display = "none";
+        if (restPassthroughContainer) {
+          restPassthroughContainer.style.display = "none";
+        }
+      }
+    }
+
+    // Handle plugin section visibility
+    const pluginSection = safeGetElement("edit-tool-plugin-section");
+    if (pluginSection) {
+      if (window.PLUGINS_ENABLED) {
+        pluginSection.style.display = "block";
+
+        const pluginChainPreField = safeGetElement("edit-tool-plugin-chain-pre");
+        if (pluginChainPreField) {
+          pluginChainPreField.value = Array.isArray(tool.pluginChainPre) ? tool.pluginChainPre.join(", ") : "";
+        }
+
+        const pluginChainPostField = safeGetElement("edit-tool-plugin-chain-post");
+        if (pluginChainPostField) {
+          pluginChainPostField.value = Array.isArray(tool.pluginChainPost) ? tool.pluginChainPost.join(", ") : "";
+        }
+      } else {
+        pluginSection.style.display = "none";
+      }
+    }
+
     // Prefill integration type from DB and set request types accordingly
     if (typeField) {
       typeField.value = tool.integrationType || "REST";
@@ -933,6 +1078,24 @@ export const editTool = async function (toolId) {
       default:
         // No auth – keep everything hidden
         break;
+    }
+
+    // Set up event listener for integration type changes
+    const editToolTypeSelect = safeGetElement("edit-tool-type");
+    if (editToolTypeSelect) {
+      // Remove any existing listener to avoid duplicates
+      editToolTypeSelect.removeEventListener("change", handleEditToolIntegrationTypeChange);
+      // Add the listener
+      editToolTypeSelect.addEventListener("change", handleEditToolIntegrationTypeChange);
+    }
+
+    // Set up event listener for passthrough button
+    const editToolPassthroughBtn = safeGetElement("edit-tool-passthrough-btn");
+    if (editToolPassthroughBtn) {
+      // Remove any existing listener to avoid duplicates
+      editToolPassthroughBtn.removeEventListener("click", handleEditToolPassthrough);
+      // Add the listener
+      editToolPassthroughBtn.addEventListener("click", handleEditToolPassthrough);
     }
 
     openModal("tool-edit-modal");

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -775,23 +775,19 @@ export const editTool = async function (toolId) {
       restPassthroughSection.style.display = tool.integrationType === "REST" ? "block" : "none";
     }
 
-    // Handle plugin section visibility
+    // Handle plugin section visibility - always show to match add form behavior
     const pluginSection = safeGetElement("edit-tool-plugin-section");
     if (pluginSection) {
-      if (window.PLUGINS_ENABLED) {
-        pluginSection.style.display = "block";
+      pluginSection.style.display = "block";
 
-        const pluginChainPreField = safeGetElement("edit-tool-plugin-chain-pre");
-        if (pluginChainPreField) {
-          pluginChainPreField.value = Array.isArray(tool.pluginChainPre) ? tool.pluginChainPre.join(", ") : "";
-        }
+      const pluginChainPreField = safeGetElement("edit-tool-plugin-chain-pre");
+      if (pluginChainPreField) {
+        pluginChainPreField.value = Array.isArray(tool.pluginChainPre) ? tool.pluginChainPre.join(", ") : "";
+      }
 
-        const pluginChainPostField = safeGetElement("edit-tool-plugin-chain-post");
-        if (pluginChainPostField) {
-          pluginChainPostField.value = Array.isArray(tool.pluginChainPost) ? tool.pluginChainPost.join(", ") : "";
-        }
-      } else {
-        pluginSection.style.display = "none";
+      const pluginChainPostField = safeGetElement("edit-tool-plugin-chain-post");
+      if (pluginChainPostField) {
+        pluginChainPostField.value = Array.isArray(tool.pluginChainPost) ? tool.pluginChainPost.join(", ") : "";
       }
     }
 

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -807,6 +807,20 @@ export const editTool = async function (toolId) {
       }
     }
 
+    // Auto-expand advanced configuration accordion if any advanced field has a value
+    const advancedConfigDetails = document.querySelector('#edit-tool-modal details');
+    if (advancedConfigDetails) {
+      const hasAdvancedData = tool.title || tool.timeoutMs || tool.jsonpathFilter ||
+                              tool.teamId || tool.baseUrl || tool.pathTemplate ||
+                              tool.queryMapping || tool.headerMapping || tool.exposePassthrough ||
+                              (Array.isArray(tool.allowlist) && tool.allowlist.length > 0) ||
+                              (Array.isArray(tool.pluginChainPre) && tool.pluginChainPre.length > 0) ||
+                              (Array.isArray(tool.pluginChainPost) && tool.pluginChainPost.length > 0);
+      if (hasAdvancedData) {
+        advancedConfigDetails.open = true;
+      }
+    }
+
     // Prefill integration type from DB and set request types accordingly
     if (typeField) {
       typeField.value = tool.integrationType || "REST";

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -711,31 +711,6 @@ export const editTool = async function (toolId) {
       jsonpathFilterField.value = tool.jsonpathFilter || "";
     }
 
-    // Populate gateway dropdown
-    const gatewayField = safeGetElement("edit-tool-gateway-id");
-    if (gatewayField) {
-      try {
-        const gatewayResponse = await fetchWithTimeout(
-          `${window.ROOT_PATH}/admin/gateways`
-        );
-        if (gatewayResponse.ok) {
-          const gateways = await gatewayResponse.json();
-          gatewayField.innerHTML = '<option value="">Select Gateway (optional)</option>';
-          gateways.forEach((gw) => {
-            const option = document.createElement("option");
-            option.value = gw.id;
-            option.textContent = `${gw.slug} (${gw.url})`;
-            if (tool.gatewayId === gw.id) {
-              option.selected = true;
-            }
-            gatewayField.appendChild(option);
-          });
-        }
-      } catch (error) {
-        console.warn("Could not fetch gateways:", error);
-      }
-    }
-
     // Populate team dropdown - only teams associated with logged-in user
     // Use window.USER_TEAMS_DATA which is server-rendered and already filtered by user membership
     const teamField = safeGetElement("edit-tool-team-id");

--- a/mcpgateway/admin_ui/tools.js
+++ b/mcpgateway/admin_ui/tools.js
@@ -745,7 +745,12 @@ export const editTool = async function (toolId) {
       queryMappingField.value = queryMappingValue;
       // Update CodeMirror editor if initialized
       if (window.editToolQueryMappingEditor) {
-        window.editToolQueryMappingEditor.setValue(queryMappingValue);
+        try {
+          window.editToolQueryMappingEditor.setValue(queryMappingValue);
+        } catch (err) {
+          console.error("Failed to set query mapping editor value:", err);
+          // Fallback to textarea value already set above
+        }
       }
     }
 
@@ -755,7 +760,12 @@ export const editTool = async function (toolId) {
       headerMappingField.value = headerMappingValue;
       // Update CodeMirror editor if initialized
       if (window.editToolHeaderMappingEditor) {
-        window.editToolHeaderMappingEditor.setValue(headerMappingValue);
+        try {
+          window.editToolHeaderMappingEditor.setValue(headerMappingValue);
+        } catch (err) {
+          console.error("Failed to set header mapping editor value:", err);
+          // Fallback to textarea value already set above
+        }
       }
     }
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1104,7 +1104,16 @@ class ToolCreate(BaseModel):
 
         Raises:
             ValueError: If any plugin is not in the allowed set.
+
+        Note:
+            When plugins are globally disabled (settings.plugins.enabled = False),
+            plugin chain validation is skipped to allow pre-configuration of plugin chains.
+            The chains will be validated when plugins are enabled.
         """
+        # Skip validation if plugins are globally disabled (allows pre-configuration)
+        if not settings.plugins.enabled:
+            return v
+
         allowed_plugins = {"deny_filter", "rate_limit", "pii_filter", "response_shape", "regex_filter", "resource_filter"}
         if v is not None:
             for plugin in v:
@@ -1556,7 +1565,16 @@ class ToolUpdate(BaseModelWithConfigDict):
 
         Raises:
             ValueError: If any plugin is not in the allowed set.
+
+        Note:
+            When plugins are globally disabled (settings.plugins.enabled = False),
+            plugin chain validation is skipped to allow pre-configuration of plugin chains.
+            The chains will be validated when plugins are enabled.
         """
+        # Skip validation if plugins are globally disabled (allows pre-configuration)
+        if not settings.plugins.enabled:
+            return v
+
         allowed_plugins = {"deny_filter", "rate_limit", "pii_filter", "response_shape", "regex_filter", "resource_filter"}
         if v is not None:
             for plugin in v:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1161,6 +1161,8 @@ class ToolUpdate(BaseModelWithConfigDict):
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
     visibility: Optional[Literal["private", "team", "public"]] = Field(None, description="Visibility level: private, team, or public")
+    team_id: Optional[str] = Field(None, description="Team ID for team-scoped tools")
+    owner_email: Optional[str] = Field(None, description="Email of the tool owner")
 
     # Passthrough REST fields
     base_url: Optional[str] = Field(None, description="Base URL for REST passthrough")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -1162,7 +1162,7 @@ class ToolUpdate(BaseModelWithConfigDict):
     deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
     visibility: Optional[Literal["private", "team", "public"]] = Field(None, description="Visibility level: private, team, or public")
     team_id: Optional[str] = Field(None, description="Team ID for team-scoped tools")
-    owner_email: Optional[str] = Field(None, description="Email of the tool owner")
+    owner_email: Optional[str] = Field(None, description="Email of the tool owner (not updated via admin edit form for security - use dedicated ownership transfer endpoint)")
 
     # Passthrough REST fields
     base_url: Optional[str] = Field(None, description="Base URL for REST passthrough")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6360,7 +6360,12 @@ class ToolService(BaseService):
                     custom_name_ref = tool_update.name  # custom_name will track the rename
                 else:
                     custom_name_ref = tool.custom_name  # custom_name stays unchanged
-                self._check_tool_name_conflict(db, custom_name_ref, tool_visibility_ref, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
+
+                # Determine which team_id to check against
+                # If team is also changing, check against the NEW team; otherwise use current team
+                team_id_for_check = tool_update.team_id if (tool_update.team_id is not None and tool_update.team_id != tool.team_id) else tool.team_id
+
+                self._check_tool_name_conflict(db, custom_name_ref, tool_visibility_ref, tool.id, team_id=team_id_for_check, owner_email=tool.owner_email)
                 if tool_update.custom_name is None and tool.name == tool.custom_name:
                     tool.custom_name = tool_update.name
                 tool.name = tool_update.name

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6396,6 +6396,10 @@ class ToolService(BaseService):
                 tool.jsonpath_filter = tool_update.jsonpath_filter
             if tool_update.visibility is not None:
                 tool.visibility = tool_update.visibility
+            if tool_update.team_id is not None:
+                tool.team_id = tool_update.team_id
+            # Note: owner_email is intentionally NOT updated here to prevent ownership changes
+            # during regular edits. Ownership transfer would require a separate endpoint.
 
             if tool_update.auth is not None:
                 if tool_update.auth.auth_type is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6370,6 +6370,12 @@ class ToolService(BaseService):
                 new_visibility = tool_update.visibility.lower()
                 self._check_tool_name_conflict(db, tool.custom_name, new_visibility, tool.id, team_id=tool.team_id, owner_email=tool.owner_email)
 
+            # Check for conflicts when team assignment changes without a name change
+            # This prevents duplicate tool names within the target team
+            if tool_update.team_id is not None and tool_update.team_id != tool.team_id and not name_is_changing:
+                tool_visibility_ref = tool.visibility if tool_update.visibility is None else tool_update.visibility.lower()
+                self._check_tool_name_conflict(db, tool.custom_name, tool_visibility_ref, tool.id, team_id=tool_update.team_id, owner_email=tool.owner_email)
+
             if tool_update.custom_name is not None:
                 tool.custom_name = tool_update.custom_name
             if tool_update.displayName is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -6411,6 +6411,26 @@ class ToolService(BaseService):
             if tool_update.tags is not None:
                 tool.tags = tool_update.tags
 
+            # Update REST passthrough fields
+            if tool_update.timeout_ms is not None:
+                tool.timeout_ms = tool_update.timeout_ms
+            if tool_update.base_url is not None:
+                tool.base_url = tool_update.base_url
+            if tool_update.path_template is not None:
+                tool.path_template = tool_update.path_template
+            if tool_update.query_mapping is not None:
+                tool.query_mapping = tool_update.query_mapping
+            if tool_update.header_mapping is not None:
+                tool.header_mapping = tool_update.header_mapping
+            if tool_update.expose_passthrough is not None:
+                tool.expose_passthrough = tool_update.expose_passthrough
+            if tool_update.allowlist is not None:
+                tool.allowlist = tool_update.allowlist
+            if tool_update.plugin_chain_pre is not None:
+                tool.plugin_chain_pre = tool_update.plugin_chain_pre
+            if tool_update.plugin_chain_post is not None:
+                tool.plugin_chain_post = tool_update.plugin_chain_post
+
             # Update modification metadata
             if modified_by is not None:
                 tool.modified_by = modified_by

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8795,7 +8795,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                     <!-- Advanced Configuration Fields -->
                     <details class="border border-gray-300 dark:border-gray-600 rounded-lg p-4 mt-4">
                       <summary class="cursor-pointer text-md font-semibold text-gray-900 dark:text-gray-100 hover:text-indigo-600 dark:hover:text-indigo-400 select-none">
-                        Advanced Configuration
+                        Advanced: Add Passthrough
                       </summary>
                       <div class="mt-4 space-y-6">
                     <div>
@@ -8869,24 +8869,13 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                       </p>
                     </div>
 
-                    <!-- REST Passthrough Button (shown only for REST integration type) -->
-                    <div id="edit-tool-rest-passthrough-button-wrapper" style="display: none;">
-                      <button
-                        type="button"
-                        id="edit-tool-passthrough-btn"
-                        class="mt-2 inline-flex justify-center py-1 px-2 border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700"
-                      >
-                        Advanced: Add Passthrough
-                      </button>
-                    </div>
-
-                    <!-- REST Passthrough Fields Container -->
-                    <fieldset id="edit-tool-passthrough-container" class="mt-2 border p-4 rounded-lg dark:border-gray-600" style="display: none;">
-                      <legend class="text-md font-semibold text-gray-900 dark:text-gray-100 px-2">
+                    <!-- REST Passthrough Fields -->
+                    <div id="edit-tool-rest-passthrough-section" style="display: none;">
+                      <h4 class="text-md font-semibold text-gray-900 dark:text-gray-100 mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">
                         REST Passthrough Configuration
-                      </legend>
+                      </h4>
 
-                      <div class="space-y-6 mt-4">
+                      <div class="space-y-6">
                         <div>
                           <label
                             class="block text-sm font-medium text-gray-700 dark:text-gray-300"
@@ -8991,7 +8980,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           </p>
                         </div>
                       </div>
-                    </fieldset>
+                    </div>
 
                     <!-- Plugin Chain Fields (shown when plugins enabled) -->
                     <div id="edit-tool-plugin-section" style="display: none;">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8791,6 +8791,263 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         generally provided by the MCP server.
                       </p>
                     </div>
+
+                    <!-- Advanced Configuration Fields -->
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Title</label
+                      >
+                      <input
+                        type="text"
+                        name="title"
+                        id="edit-tool-title"
+                        placeholder="Human-readable title (MCP BaseMetadata)"
+                        maxlength="255"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Optional MCP BaseMetadata title field, distinct from display name.
+                      </p>
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Timeout (ms)</label
+                      >
+                      <input
+                        type="number"
+                        name="timeout_ms"
+                        id="edit-tool-timeout-ms"
+                        placeholder="Tool timeout in milliseconds (e.g., 30000)"
+                        min="1"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Per-tool timeout override. Leave empty to use global default.
+                      </p>
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >JSONPath Filter</label
+                      >
+                      <input
+                        type="text"
+                        name="jsonpath_filter"
+                        id="edit-tool-jsonpath-filter"
+                        placeholder="$.data.result"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      />
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        JSONPath expression to filter tool responses.
+                      </p>
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Gateway</label
+                      >
+                      <select
+                        name="gateway_id"
+                        id="edit-tool-gateway-id"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      >
+                        <option value="">-- Select Gateway --</option>
+                        <!-- Options will be populated dynamically -->
+                      </select>
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Reassign this tool to a different gateway.
+                      </p>
+                    </div>
+
+                    <div>
+                      <label
+                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                        >Team</label
+                      >
+                      <select
+                        name="team_id"
+                        id="edit-tool-team-id"
+                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                      >
+                        <option value="">-- No Team --</option>
+                        <!-- Options will be populated dynamically -->
+                      </select>
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Reassign this tool to a different team.
+                      </p>
+                    </div>
+
+                    <!-- REST Passthrough Button (shown only for REST integration type) -->
+                    <div id="edit-tool-rest-passthrough-button-wrapper" style="display: none;">
+                      <button
+                        type="button"
+                        id="edit-tool-passthrough-btn"
+                        class="mt-2 inline-flex justify-center py-1 px-2 border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700"
+                      >
+                        Advanced: Add Passthrough
+                      </button>
+                    </div>
+
+                    <!-- REST Passthrough Fields Container -->
+                    <fieldset id="edit-tool-passthrough-container" class="mt-2 border p-4 rounded-lg dark:border-gray-600" style="display: none;">
+                      <legend class="text-md font-semibold text-gray-900 dark:text-gray-100 px-2">
+                        REST Passthrough Configuration
+                      </legend>
+
+                      <div class="space-y-6 mt-4">
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Base URL</label
+                          >
+                          <input
+                            type="url"
+                            name="base_url"
+                            id="edit-tool-base-url"
+                            placeholder="https://api.example.com"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          />
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Base URL for REST passthrough (must include scheme and host).
+                          </p>
+                        </div>
+
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Path Template</label
+                          >
+                          <input
+                            type="text"
+                            name="path_template"
+                            id="edit-tool-path-template"
+                            placeholder="/api/v1/resource/{id}"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          />
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Path template for REST passthrough (must start with '/').
+                          </p>
+                        </div>
+
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Query Mapping (JSON)</label
+                          >
+                          <textarea
+                            name="query_mapping"
+                            id="edit-tool-query-mapping"
+                            placeholder='{"param": "inputField"}'
+                            rows="3"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          ></textarea>
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Map input fields to query parameters (JSON object).
+                          </p>
+                        </div>
+
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Header Mapping (JSON)</label
+                          >
+                          <textarea
+                            name="header_mapping"
+                            id="edit-tool-header-mapping"
+                            placeholder='{"X-Custom-Header": "inputField"}'
+                            rows="3"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          ></textarea>
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Map input fields to HTTP headers (JSON object).
+                          </p>
+                        </div>
+
+                        <div class="flex items-center">
+                          <input
+                            type="checkbox"
+                            name="expose_passthrough"
+                            id="edit-tool-expose-passthrough"
+                            class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                          />
+                          <label
+                            for="edit-tool-expose-passthrough"
+                            class="ml-2 block text-sm text-gray-700 dark:text-gray-300"
+                          >
+                            Expose Passthrough Endpoint
+                          </label>
+                        </div>
+                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          Make this tool available as a passthrough endpoint.
+                        </p>
+
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Allowlist (Comma-separated)</label
+                          >
+                          <input
+                            type="text"
+                            name="allowlist"
+                            id="edit-tool-allowlist"
+                            placeholder="https://api.example.com, https://api2.example.org"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          />
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Allowed upstream hosts/schemes for passthrough (comma-separated URLs).
+                          </p>
+                        </div>
+                      </div>
+                    </fieldset>
+
+                    <!-- Plugin Chain Fields (shown when plugins enabled) -->
+                    <div id="edit-tool-plugin-section" style="display: none;">
+                      <h4 class="text-md font-semibold text-gray-900 dark:text-gray-100 mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">
+                        Plugin Chains
+                      </h4>
+
+                      <div class="space-y-6">
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Pre-processing Plugins (Comma-separated)</label
+                          >
+                          <input
+                            type="text"
+                            name="plugin_chain_pre"
+                            id="edit-tool-plugin-chain-pre"
+                            placeholder="plugin1, plugin2, plugin3"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          />
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Plugins to run before tool invocation.
+                          </p>
+                        </div>
+
+                        <div>
+                          <label
+                            class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >Post-processing Plugins (Comma-separated)</label
+                          >
+                          <input
+                            type="text"
+                            name="plugin_chain_post"
+                            id="edit-tool-plugin-chain-post"
+                            placeholder="plugin1, plugin2, plugin3"
+                            class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
+                          />
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            Plugins to run after tool invocation.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
                     <!-- Authentication Section -->
                     <div>
                       <label

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8849,24 +8849,6 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                     <div>
                       <label
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                        >Gateway</label
-                      >
-                      <select
-                        name="gateway_id"
-                        id="edit-tool-gateway-id"
-                        class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
-                      >
-                        <option value="">-- Select Gateway --</option>
-                        <!-- Options will be populated dynamically -->
-                      </select>
-                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                        Reassign this tool to a different gateway.
-                      </p>
-                    </div>
-
-                    <div>
-                      <label
-                        class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                         >Team</label
                       >
                       <select

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8955,6 +8955,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                             type="checkbox"
                             name="expose_passthrough"
                             id="edit-tool-expose-passthrough"
+                            value="true"
                             class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
                           />
                           <label

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8870,12 +8870,25 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                     </div>
 
                     <!-- REST Passthrough Fields -->
-                    <div id="edit-tool-rest-passthrough-section" style="display: none;">
-                      <h4 class="text-md font-semibold text-gray-900 dark:text-gray-100 mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">
-                        REST Passthrough Configuration
-                      </h4>
+                    <!-- Button to show passthrough configuration -->
+                    <div id="edit-tool-rest-passthrough-button-wrapper" style="display: none;">
+                      <button
+                        type="button"
+                        id="edit-tool-passthrough-btn"
+                        class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
+                        onclick="document.getElementById('edit-tool-passthrough-container').style.display='block'; this.parentElement.style.display='none';"
+                      >
+                        Add Passthrough Configuration
+                      </button>
+                    </div>
 
-                      <div class="space-y-6">
+                    <!-- Passthrough configuration container -->
+                    <fieldset id="edit-tool-passthrough-container" style="display: none;" class="border border-gray-300 dark:border-gray-600 rounded-lg p-4">
+                      <legend class="text-md font-semibold text-gray-900 dark:text-gray-100 px-2">
+                        REST Passthrough Configuration
+                      </legend>
+
+                      <div class="space-y-6 mt-4">
                         <div>
                           <label
                             class="block text-sm font-medium text-gray-700 dark:text-gray-300"
@@ -8980,7 +8993,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           </p>
                         </div>
                       </div>
-                    </div>
+                    </fieldset>
 
                     <!-- Plugin Chain Fields (shown when plugins enabled) -->
                     <div id="edit-tool-plugin-section" style="display: none;">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -12357,6 +12357,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
       window.UI_HIDDEN_SECTIONS = {{ ui_hidden_sections | default([]) | tojson }};
       window.UI_HIDDEN_HEADER_ITEMS = {{ ui_hidden_header_items | default([]) | tojson }};
       window.UI_HIDDEN_TABS = {{ ui_hidden_tabs | default([]) | tojson }};
+      window.PLUGINS_ENABLED = {{ plugins_enabled | default(false) | tojson }};
 
       // Display flash messages from URL parameters
       (function() {

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8793,6 +8793,11 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                     </div>
 
                     <!-- Advanced Configuration Fields -->
+                    <details class="border border-gray-300 dark:border-gray-600 rounded-lg p-4 mt-4">
+                      <summary class="cursor-pointer text-md font-semibold text-gray-900 dark:text-gray-100 hover:text-indigo-600 dark:hover:text-indigo-400 select-none">
+                        Advanced Configuration
+                      </summary>
+                      <div class="mt-4 space-y-6">
                     <div>
                       <label
                         class="block text-sm font-medium text-gray-700 dark:text-gray-300"
@@ -9030,6 +9035,8 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         </div>
                       </div>
                     </div>
+                      </div>
+                    </details>
 
                     <!-- Authentication Section -->
                     <div>

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -8924,7 +8924,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <textarea
                             name="query_mapping"
                             id="edit-tool-query-mapping"
-                            placeholder='{"param": "inputField"}'
+                            placeholder="{&quot;param&quot;: &quot;inputField&quot;}"
                             rows="3"
                             class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                           ></textarea>
@@ -8941,7 +8941,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           <textarea
                             name="header_mapping"
                             id="edit-tool-header-mapping"
-                            placeholder='{"X-Custom-Header": "inputField"}'
+                            placeholder="{&quot;X-Custom-Header&quot;: &quot;inputField&quot;}"
                             rows="3"
                             class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                           ></textarea>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "mcp-context-forge",
             "dependencies": {
                 "@alpinejs/csp": "^3.15.8",
                 "htmx.org": "^2.0.3"
@@ -39,15 +40,11 @@
         },
         "node_modules/@acemir/cssom": {
             "version": "0.9.31",
-            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@alloc/quick-lru": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-            "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -59,23 +56,18 @@
         },
         "node_modules/@alpinejs/csp": {
             "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/csp/-/csp-3.15.12.tgz",
-            "integrity": "sha512-9jielHzVPqMlO9zQ6K1WtdhSHVX5OZfq5ZDUSVZfY10VnXRoRBx8nOadWjsG1xev/kz4EPaNN9eDFWtZSvJHxA==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
-            "version": "5.1.11",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "version": "5.1.9",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@asamuzakjp/generational-cache": "^1.0.1",
-                "@csstools/css-calc": "^3.2.0",
-                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-calc": "^3.1.1",
+                "@csstools/css-color-parser": "^4.0.2",
                 "@csstools/css-parser-algorithms": "^4.0.0",
                 "@csstools/css-tokenizer": "^4.0.0"
             },
@@ -85,8 +77,6 @@
         },
         "node_modules/@asamuzakjp/dom-selector": {
             "version": "6.8.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -99,28 +89,14 @@
         },
         "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
             "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
             }
         },
-        "node_modules/@asamuzakjp/generational-cache": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
         "node_modules/@asamuzakjp/nwsapi": {
             "version": "2.3.9",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -180,6 +156,16 @@
                 "url": "https://opencollective.com/babel"
             }
         },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -212,6 +198,16 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-globals": {
@@ -365,9 +361,7 @@
             }
         },
         "node_modules/@biomejs/biome": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
-            "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
+            "version": "2.4.4",
             "dev": true,
             "license": "MIT OR Apache-2.0",
             "bin": {
@@ -381,20 +375,18 @@
                 "url": "https://opencollective.com/biome"
             },
             "optionalDependencies": {
-                "@biomejs/cli-darwin-arm64": "2.4.16",
-                "@biomejs/cli-darwin-x64": "2.4.16",
-                "@biomejs/cli-linux-arm64": "2.4.16",
-                "@biomejs/cli-linux-arm64-musl": "2.4.16",
-                "@biomejs/cli-linux-x64": "2.4.16",
-                "@biomejs/cli-linux-x64-musl": "2.4.16",
-                "@biomejs/cli-win32-arm64": "2.4.16",
-                "@biomejs/cli-win32-x64": "2.4.16"
+                "@biomejs/cli-darwin-arm64": "2.4.4",
+                "@biomejs/cli-darwin-x64": "2.4.4",
+                "@biomejs/cli-linux-arm64": "2.4.4",
+                "@biomejs/cli-linux-arm64-musl": "2.4.4",
+                "@biomejs/cli-linux-x64": "2.4.4",
+                "@biomejs/cli-linux-x64-musl": "2.4.4",
+                "@biomejs/cli-win32-arm64": "2.4.4",
+                "@biomejs/cli-win32-x64": "2.4.4"
             }
         },
         "node_modules/@biomejs/cli-darwin-arm64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
-            "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==",
+            "version": "2.4.4",
             "cpu": [
                 "arm64"
             ],
@@ -409,9 +401,9 @@
             }
         },
         "node_modules/@biomejs/cli-darwin-x64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
-            "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz",
+            "integrity": "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==",
             "cpu": [
                 "x64"
             ],
@@ -426,13 +418,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
-            "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz",
+            "integrity": "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -443,13 +438,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-arm64-musl": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
-            "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz",
+            "integrity": "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -460,13 +458,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
-            "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz",
+            "integrity": "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -477,13 +478,16 @@
             }
         },
         "node_modules/@biomejs/cli-linux-x64-musl": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
-            "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz",
+            "integrity": "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -494,9 +498,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-arm64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
-            "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz",
+            "integrity": "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==",
             "cpu": [
                 "arm64"
             ],
@@ -511,9 +515,9 @@
             }
         },
         "node_modules/@biomejs/cli-win32-x64": {
-            "version": "2.4.16",
-            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
-            "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz",
+            "integrity": "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==",
             "cpu": [
                 "x64"
             ],
@@ -529,8 +533,6 @@
         },
         "node_modules/@bramus/specificity": {
             "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -566,15 +568,11 @@
         },
         "node_modules/@colordx/core": {
             "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-            "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@csstools/color-helpers": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
             "dev": true,
             "funding": [
                 {
@@ -592,9 +590,7 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "version": "3.1.1",
             "dev": true,
             "funding": [
                 {
@@ -616,9 +612,7 @@
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-            "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+            "version": "4.0.2",
             "dev": true,
             "funding": [
                 {
@@ -633,7 +627,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csstools/color-helpers": "^6.0.2",
-                "@csstools/css-calc": "^3.2.1"
+                "@csstools/css-calc": "^3.1.1"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -645,8 +639,6 @@
         },
         "node_modules/@csstools/css-parser-algorithms": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
             "dev": true,
             "funding": [
                 {
@@ -667,9 +659,7 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-            "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+            "version": "1.1.2",
             "dev": true,
             "funding": [
                 {
@@ -693,8 +683,6 @@
         },
         "node_modules/@csstools/css-tokenizer": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
             "dev": true,
             "funding": [
                 {
@@ -713,8 +701,6 @@
         },
         "node_modules/@csstools/media-query-list-parser": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
-            "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
             "dev": true,
             "funding": [
                 {
@@ -737,8 +723,6 @@
         },
         "node_modules/@csstools/selector-resolve-nested": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
-            "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
             "dev": true,
             "funding": [
                 {
@@ -760,8 +744,6 @@
         },
         "node_modules/@csstools/selector-specificity": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
-            "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
             "dev": true,
             "funding": [
                 {
@@ -783,8 +765,6 @@
         },
         "node_modules/@emnapi/core": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -795,8 +775,6 @@
         },
         "node_modules/@emnapi/runtime": {
             "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -806,8 +784,6 @@
         },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -817,8 +793,6 @@
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -836,8 +810,6 @@
         },
         "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -849,8 +821,6 @@
         },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -858,15 +828,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+            "version": "0.21.1",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^2.1.7",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.5"
+                "minimatch": "^3.1.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -874,8 +842,6 @@
         },
         "node_modules/@eslint/config-helpers": {
             "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -887,8 +853,6 @@
         },
         "node_modules/@eslint/core": {
             "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -899,20 +863,18 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ajv": "^6.14.0",
+                "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^10.0.1",
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.5",
+                "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
@@ -922,10 +884,21 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "9.39.3",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -937,8 +910,6 @@
         },
         "node_modules/@eslint/object-schema": {
             "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -947,8 +918,6 @@
         },
         "node_modules/@eslint/plugin-kit": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -960,9 +929,7 @@
             }
         },
         "node_modules/@exodus/bytes": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
-            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "version": "1.15.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -978,47 +945,27 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
-            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+            "version": "0.19.1",
             "dev": true,
             "license": "Apache-2.0",
-            "dependencies": {
-                "@humanfs/types": "^0.15.0"
-            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
-            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+            "version": "0.16.7",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.2",
-                "@humanfs/types": "^0.15.0",
+                "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/@humanfs/types": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
-            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18.0"
-            }
-        },
         "node_modules/@humanwhocodes/gitignore-to-minimatch": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz",
-            "integrity": "sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==",
             "dev": true,
             "license": "Apache-2.0",
             "funding": {
@@ -1028,8 +975,6 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1042,8 +987,6 @@
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1055,9 +998,7 @@
             }
         },
         "node_modules/@istanbuljs/schema": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-            "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+            "version": "0.1.3",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1066,8 +1007,6 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1077,8 +1016,6 @@
         },
         "node_modules/@jridgewell/remapping": {
             "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1088,8 +1025,6 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1098,8 +1033,6 @@
         },
         "node_modules/@jridgewell/source-map": {
             "version": "0.3.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1109,15 +1042,11 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1144,34 +1073,11 @@
         },
         "node_modules/@keyv/serialize": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
-            "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1184,8 +1090,6 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1194,8 +1098,6 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1208,8 +1110,6 @@
         },
         "node_modules/@nolyfill/is-core-module": {
             "version": "1.0.39",
-            "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-            "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1217,30 +1117,19 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.133.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-            "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+            "version": "0.137.0",
             "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
-        "node_modules/@package-json/types": {
-            "version": "0.0.12",
-            "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
-            "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@pkgr/core": {
-            "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-            "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+            "version": "0.2.9",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/pkgr"
@@ -1248,32 +1137,11 @@
         },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.29",
-            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
-            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-            "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-            "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+            "version": "1.1.3",
             "cpu": [
                 "arm64"
             ],
@@ -1282,229 +1150,6 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-            "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-            "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-            "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-            "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-            "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-            "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-            "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-            "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-            "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-            "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-            "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-            "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-            "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -1512,22 +1157,16 @@
         },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-            "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1545,9 +1184,7 @@
             "license": "MIT"
         },
         "node_modules/@stylistic/eslint-plugin": {
-            "version": "5.10.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
-            "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+            "version": "5.9.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1565,10 +1202,22 @@
                 "eslint": "^9.0.0 || ^10.0.0"
             }
         },
+        "node_modules/@stylistic/eslint-plugin/node_modules/@typescript-eslint/types": {
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+            "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/@stylistic/stylelint-config": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/stylelint-config/-/stylelint-config-4.0.0.tgz",
-            "integrity": "sha512-04H8xfsIR/pWpAPQI5aGxwgjeikb8vy4OSNvzRdRcAITYSfX1UUTgGL5jm8iZxN8MSWfN77hMlV1LknE0Ho6tg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1582,9 +1231,7 @@
             }
         },
         "node_modules/@stylistic/stylelint-plugin": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/stylelint-plugin/-/stylelint-plugin-5.2.0.tgz",
-            "integrity": "sha512-pfa2PMvlH87qwoOMUH4rqz7x/vuO5Kh+r/R1Pe+/5T8sukDPe/VfF6mbdUGE5gwZPlj5O1X56qw55IZrFFRF0g==",
+            "version": "5.1.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1596,21 +1243,20 @@
                 "postcss-value-parser": "^4.2.0",
                 "style-search": "^0.1.0"
             },
+            "engines": {
+                "node": ">=20.19.0"
+            },
             "peerDependencies": {
                 "stylelint": "^17.6.0"
             }
         },
         "node_modules/@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1645,40 +1291,32 @@
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-            "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/sarif": {
             "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-            "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/type-utils": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.53.1",
+                "@typescript-eslint/type-utils": "8.53.1",
+                "@typescript-eslint/utils": "8.53.1",
+                "@typescript-eslint/visitor-keys": "8.53.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.5.0"
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1688,15 +1326,13 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.60.1",
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
+                "@typescript-eslint/parser": "^8.53.1",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1704,16 +1340,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.53.1",
+                "@typescript-eslint/types": "8.53.1",
+                "@typescript-eslint/typescript-estree": "8.53.1",
+                "@typescript-eslint/visitor-keys": "8.53.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1724,19 +1358,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.53.1",
+                "@typescript-eslint/types": "^8.53.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1747,18 +1379,16 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.53.1",
+                "@typescript-eslint/visitor-keys": "8.53.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1769,9 +1399,7 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1782,21 +1410,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/types": "8.53.1",
+                "@typescript-eslint/typescript-estree": "8.53.1",
+                "@typescript-eslint/utils": "8.53.1",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.5.0"
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1806,14 +1432,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1825,21 +1449,19 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.53.1",
+                "@typescript-eslint/tsconfig-utils": "8.53.1",
+                "@typescript-eslint/types": "8.53.1",
+                "@typescript-eslint/visitor-keys": "8.53.1",
                 "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
+                "minimatch": "^9.0.5",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1849,13 +1471,11 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1866,16 +1486,14 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.53.1",
+                "@typescript-eslint/types": "8.53.1",
+                "@typescript-eslint/typescript-estree": "8.53.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1885,19 +1503,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "eslint-visitor-keys": "^5.0.0"
+                "@typescript-eslint/types": "8.53.1",
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1909,8 +1525,6 @@
         },
         "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1921,9 +1535,9 @@
             }
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
-            "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
             "cpu": [
                 "arm"
             ],
@@ -1935,9 +1549,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
-            "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
             "cpu": [
                 "arm64"
             ],
@@ -1949,9 +1563,7 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
-            "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+            "version": "1.11.1",
             "cpu": [
                 "arm64"
             ],
@@ -1963,9 +1575,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
-            "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
             "cpu": [
                 "x64"
             ],
@@ -1977,9 +1589,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
-            "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
             "cpu": [
                 "x64"
             ],
@@ -1991,9 +1603,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
-            "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
             "cpu": [
                 "arm"
             ],
@@ -2005,9 +1617,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
-            "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
             "cpu": [
                 "arm"
             ],
@@ -2019,13 +1631,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
-            "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2033,41 +1648,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
-            "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
-            "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
-            "cpu": [
-                "loong64"
+            "libc": [
+                "musl"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
-            "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2075,13 +1665,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
-            "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2089,13 +1682,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
-            "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2103,13 +1699,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
-            "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2117,13 +1716,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
-            "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2131,13 +1733,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
-            "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2145,37 +1750,26 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
-            "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
-        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
-            "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ]
-        },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
-            "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -2183,18 +1777,29 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
+                "@napi-rs/wasm-runtime": "^0.2.11"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
-            "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
             "cpu": [
                 "arm64"
             ],
@@ -2206,9 +1811,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
-            "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2220,9 +1825,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
-            "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
             "cpu": [
                 "x64"
             ],
@@ -2234,9 +1839,9 @@
             ]
         },
         "node_modules/@vitest/coverage-istanbul": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.8.tgz",
-            "integrity": "sha512-/h514nMZMKI6foh21mVgO1zlCH6pdDamwKMbla1uLU2GMxTlfp0PQMxovWozmzQdCIQYZ2XXEzg2zNZom2zAOg==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-4.1.9.tgz",
+            "integrity": "sha512-4a7DsIwycTf4eYwEDtnMfMV8H80KSKH9PuMHhqL5SwPZzDyUKq2X/TPCVZ7NqIuSz7UbZckmEmkip6iZBI/gEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2255,20 +1860,20 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.8"
+                "vitest": "4.1.9"
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-            "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.8",
-                "@vitest/utils": "4.1.8",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2277,13 +1882,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-            "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.8",
+                "@vitest/spy": "4.1.9",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -2304,9 +1909,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-            "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2317,13 +1922,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-            "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.8",
+                "@vitest/utils": "4.1.9",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -2331,14 +1936,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-            "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.8",
-                "@vitest/utils": "4.1.8",
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/utils": "4.1.9",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -2347,9 +1952,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-            "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2357,13 +1962,13 @@
             }
         },
         "node_modules/@vitest/ui": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.8.tgz",
-            "integrity": "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.9.tgz",
+            "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.8",
+                "@vitest/utils": "4.1.9",
                 "fflate": "^0.8.2",
                 "flatted": "^3.4.2",
                 "pathe": "^2.0.3",
@@ -2375,17 +1980,17 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": "4.1.8"
+                "vitest": "4.1.9"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-            "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.8",
+                "@vitest/pretty-format": "4.1.9",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2395,8 +2000,6 @@
         },
         "node_modules/@vue/reactivity": {
             "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/shared": "3.1.5"
@@ -2404,14 +2007,10 @@
         },
         "node_modules/@vue/shared": {
             "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
             "license": "MIT"
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.15.0",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2423,8 +2022,6 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -2433,8 +2030,6 @@
         },
         "node_modules/agent-base": {
             "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2460,8 +2055,6 @@
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2470,8 +2063,6 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2483,8 +2074,6 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2499,15 +2088,11 @@
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2520,22 +2105,16 @@
         },
         "node_modules/arg": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2551,8 +2130,6 @@
         },
         "node_modules/array-includes": {
             "version": "3.1.9",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-            "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2574,8 +2151,6 @@
         },
         "node_modules/array.prototype.findlast": {
             "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-            "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2595,8 +2170,6 @@
         },
         "node_modules/array.prototype.findlastindex": {
             "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
-            "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2617,8 +2190,6 @@
         },
         "node_modules/array.prototype.flat": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-            "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2636,8 +2207,6 @@
         },
         "node_modules/array.prototype.flatmap": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-            "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2655,8 +2224,6 @@
         },
         "node_modules/array.prototype.tosorted": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-            "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2672,8 +2239,6 @@
         },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2704,8 +2269,6 @@
         },
         "node_modules/ast-types": {
             "version": "0.13.4",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2717,8 +2280,6 @@
         },
         "node_modules/astral-regex": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2726,26 +2287,20 @@
             }
         },
         "node_modules/astronomical": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/astronomical/-/astronomical-3.0.6.tgz",
-            "integrity": "sha512-2WzHIp4LnbpNwoVsYVsgSBVEl9OSFkfM5G/HWto75mzHjXZd3DMd7tVw5pjb02jVlaWS2SpEwKFc8Q0IYhQ22Q==",
+            "version": "3.0.0",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "meriyah": "^7.1.0"
+                "meriyah": "^6.0.3"
             }
         },
         "node_modules/async": {
             "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/async-function": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2754,8 +2309,6 @@
         },
         "node_modules/autoprefixer": {
             "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-            "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
             "dev": true,
             "funding": [
                 {
@@ -2791,8 +2344,6 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2816,9 +2367,7 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.34",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-            "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+            "version": "2.10.29",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2840,8 +2389,6 @@
         },
         "node_modules/bidi-js": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2850,8 +2397,6 @@
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2863,8 +2408,6 @@
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "dev": true,
             "license": "ISC"
         },
@@ -2883,8 +2426,6 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2896,8 +2437,6 @@
         },
         "node_modules/browserslist": {
             "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "dev": true,
             "funding": [
                 {
@@ -2930,8 +2469,6 @@
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2950,15 +2487,13 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "version": "1.0.8",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "get-intrinsic": "^1.3.0",
+                "call-bind-apply-helpers": "^1.0.0",
+                "es-define-property": "^1.0.0",
+                "get-intrinsic": "^1.2.4",
                 "set-function-length": "^1.2.2"
             },
             "engines": {
@@ -2970,8 +2505,6 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2984,8 +2517,6 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3001,8 +2532,6 @@
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3011,8 +2540,6 @@
         },
         "node_modules/camelcase-css": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-            "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3021,8 +2548,6 @@
         },
         "node_modules/caniuse-api": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-            "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3033,9 +2558,7 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001797",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+            "version": "1.0.30001792",
             "dev": true,
             "funding": [
                 {
@@ -3065,8 +2588,6 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3082,8 +2603,6 @@
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3107,8 +2626,6 @@
         },
         "node_modules/chokidar/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3120,8 +2637,6 @@
         },
         "node_modules/cliui": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3133,48 +2648,8 @@
                 "node": ">=12"
             }
         },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3186,22 +2661,16 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/colord": {
             "version": "2.9.3",
-            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-            "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/commander": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3209,9 +2678,7 @@
             }
         },
         "node_modules/comment-parser": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-            "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+            "version": "1.4.4",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3220,15 +2687,11 @@
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+            "version": "9.0.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3254,8 +2717,6 @@
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3269,8 +2730,6 @@
         },
         "node_modules/css-declaration-sorter": {
             "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
-            "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -3282,8 +2741,6 @@
         },
         "node_modules/css-functions-list": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
-            "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3292,8 +2749,6 @@
         },
         "node_modules/css-select": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3309,8 +2764,6 @@
         },
         "node_modules/css-tree": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3323,8 +2776,6 @@
         },
         "node_modules/css-what": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -3336,8 +2787,6 @@
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3349,8 +2798,6 @@
         },
         "node_modules/cssnano": {
             "version": "7.1.9",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.9.tgz",
-            "integrity": "sha512-uPR75+5Dk/WJ/YSPR1/YDHdwMM9c5FsaARljfKWgeCKLKOtJ0we21xy/RcCjn53fZnD/f6yYEIZ8pu18+GnbNQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3370,8 +2817,6 @@
         },
         "node_modules/cssnano-preset-default": {
             "version": "7.0.17",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.17.tgz",
-            "integrity": "sha512-11qO63A+czwguQFJCaTdICvbaxn0pJzz/XghLlv+OT7WyToDxAMR0Xb3/26/l0y0hQJywwNbj/SLSQlGBHE1OA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3415,8 +2860,6 @@
         },
         "node_modules/cssnano-utils": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.3.tgz",
-            "integrity": "sha512-ynIREMICLxkxm7e9bCR9sh75s4Q5drICi0ua1yxo5jH2XPBqSKkl4dOh4EbFqtUmnTMhRffHgYL0EKKkMjtJTg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3428,8 +2871,6 @@
         },
         "node_modules/csso": {
             "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3442,8 +2883,6 @@
         },
         "node_modules/csso/node_modules/css-tree": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3457,15 +2896,11 @@
         },
         "node_modules/csso/node_modules/mdn-data": {
             "version": "2.0.28",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
             "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/cssstyle": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3480,8 +2915,6 @@
         },
         "node_modules/cssstyle/node_modules/lru-cache": {
             "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -3490,8 +2923,6 @@
         },
         "node_modules/data-uri-to-buffer": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3500,8 +2931,6 @@
         },
         "node_modules/data-urls": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3514,8 +2943,6 @@
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3532,8 +2959,6 @@
         },
         "node_modules/data-view-byte-length": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3550,8 +2975,6 @@
         },
         "node_modules/data-view-byte-offset": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3568,8 +2991,6 @@
         },
         "node_modules/debug": {
             "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3586,22 +3007,16 @@
         },
         "node_modules/decimal.js": {
             "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3618,8 +3033,6 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3636,8 +3049,6 @@
         },
         "node_modules/degenerator": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3651,8 +3062,6 @@
         },
         "node_modules/dependency-graph": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
-            "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3661,8 +3070,6 @@
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -3671,22 +3078,16 @@
         },
         "node_modules/didyoumean": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/dlv": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/doctrine": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3698,8 +3099,6 @@
         },
         "node_modules/dom-serializer": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3713,8 +3112,6 @@
         },
         "node_modules/dom-serializer/node_modules/entities": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -3726,8 +3123,6 @@
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "dev": true,
             "funding": [
                 {
@@ -3739,8 +3134,6 @@
         },
         "node_modules/domhandler": {
             "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3755,8 +3148,6 @@
         },
         "node_modules/domutils": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -3770,8 +3161,6 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3784,41 +3173,33 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.368",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
-            "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+            "version": "1.5.356",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.23.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
-            "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+            "version": "5.18.4",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.3.3"
+                "tapable": "^2.2.0"
             },
             "engines": {
                 "node": ">=10.13.0"
             }
         },
         "node_modules/entities": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "version": "6.0.1",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=0.12"
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
@@ -3826,8 +3207,6 @@
         },
         "node_modules/env-paths": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3836,8 +3215,6 @@
         },
         "node_modules/error-ex": {
             "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3846,8 +3223,6 @@
         },
         "node_modules/es-abstract": {
             "version": "1.24.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3915,8 +3290,6 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3925,8 +3298,6 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3934,16 +3305,14 @@
             }
         },
         "node_modules/es-iterator-helpers": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-            "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+            "version": "1.2.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.9",
+                "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.24.2",
+                "es-abstract": "^1.24.1",
                 "es-errors": "^1.3.0",
                 "es-set-tostringtag": "^2.1.0",
                 "function-bind": "^1.1.2",
@@ -3955,7 +3324,7 @@
                 "has-symbols": "^1.1.0",
                 "internal-slot": "^1.1.0",
                 "iterator.prototype": "^1.1.5",
-                "math-intrinsics": "^1.1.0"
+                "safe-array-concat": "^1.1.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -3969,9 +3338,7 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "version": "1.1.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3983,8 +3350,6 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3999,8 +3364,6 @@
         },
         "node_modules/es-shim-unscopables": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-            "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4012,8 +3375,6 @@
         },
         "node_modules/es-to-primitive": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4030,8 +3391,6 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4040,8 +3399,6 @@
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4053,8 +3410,6 @@
         },
         "node_modules/escodegen": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4074,25 +3429,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "9.39.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-array": "^0.21.1",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.39.3",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "ajv": "^6.14.0",
+                "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
@@ -4111,7 +3464,7 @@
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.5",
+                "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -4135,8 +3488,6 @@
         },
         "node_modules/eslint-compat-utils": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-            "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4151,8 +3502,6 @@
         },
         "node_modules/eslint-compat-utils/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4164,8 +3513,6 @@
         },
         "node_modules/eslint-config-prettier": {
             "version": "10.1.8",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
-            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4180,8 +3527,6 @@
         },
         "node_modules/eslint-import-context": {
             "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
-            "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4204,21 +3549,17 @@
             }
         },
         "node_modules/eslint-import-resolver-node": {
-            "version": "0.3.10",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-            "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+            "version": "0.3.9",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^3.2.7",
-                "is-core-module": "^2.16.1",
-                "resolve": "^2.0.0-next.6"
+                "is-core-module": "^2.13.0",
+                "resolve": "^1.22.4"
             }
         },
         "node_modules/eslint-import-resolver-node/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4227,8 +3568,6 @@
         },
         "node_modules/eslint-import-resolver-typescript": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
-            "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4261,9 +3600,7 @@
             }
         },
         "node_modules/eslint-module-utils": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-            "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+            "version": "2.12.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4280,8 +3617,6 @@
         },
         "node_modules/eslint-module-utils/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4290,8 +3625,6 @@
         },
         "node_modules/eslint-plugin-es-x": {
             "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
-            "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/ota-meshi",
@@ -4312,8 +3645,6 @@
         },
         "node_modules/eslint-plugin-import": {
             "version": "2.32.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-            "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4345,19 +3676,16 @@
             }
         },
         "node_modules/eslint-plugin-import-x": {
-            "version": "4.16.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
-            "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+            "version": "4.16.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@package-json/types": "^0.0.12",
-                "@typescript-eslint/types": "^8.56.0",
+                "@typescript-eslint/types": "^8.35.0",
                 "comment-parser": "^1.4.1",
                 "debug": "^4.4.1",
                 "eslint-import-context": "^0.1.9",
                 "is-glob": "^4.0.3",
-                "minimatch": "^9.0.3 || ^10.1.2",
+                "minimatch": "^9.0.3 || ^10.0.1",
                 "semver": "^7.7.2",
                 "stable-hash-x": "^0.2.0",
                 "unrs-resolver": "^1.9.2"
@@ -4369,8 +3697,8 @@
                 "url": "https://opencollective.com/eslint-plugin-import-x"
             },
             "peerDependencies": {
-                "@typescript-eslint/utils": "^8.56.0",
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "@typescript-eslint/utils": "^8.0.0",
+                "eslint": "^8.57.0 || ^9.0.0",
                 "eslint-import-resolver-node": "*"
             },
             "peerDependenciesMeta": {
@@ -4384,8 +3712,6 @@
         },
         "node_modules/eslint-plugin-import-x/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4397,18 +3723,24 @@
         },
         "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-            "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
             }
         },
+        "node_modules/eslint-plugin-import/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/eslint-plugin-n": {
-            "version": "17.24.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
-            "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+            "version": "17.23.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4432,23 +3764,8 @@
                 "eslint": ">=8.23.0"
             }
         },
-        "node_modules/eslint-plugin-n/node_modules/globals": {
-            "version": "15.15.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-            "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/eslint-plugin-n/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4459,14 +3776,12 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.6",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
-            "integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
+            "version": "5.5.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.1",
-                "synckit": "^0.11.13"
+                "synckit": "^0.11.12"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -4490,9 +3805,7 @@
             }
         },
         "node_modules/eslint-plugin-promise": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
-            "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
+            "version": "7.2.1",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4505,13 +3818,11 @@
                 "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
             }
         },
         "node_modules/eslint-plugin-react": {
             "version": "7.37.5",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-            "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4541,10 +3852,42 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
+        "node_modules/eslint-plugin-react/node_modules/resolve": {
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.2",
+                "node-exports-info": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4560,8 +3903,6 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4573,8 +3914,6 @@
         },
         "node_modules/espree": {
             "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4591,8 +3930,6 @@
         },
         "node_modules/esprima": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
@@ -4605,8 +3942,6 @@
         },
         "node_modules/esquery": {
             "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -4618,8 +3953,6 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -4631,8 +3964,6 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -4651,8 +3982,6 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -4661,8 +3990,6 @@
         },
         "node_modules/expect-type": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -4671,22 +3998,16 @@
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-diff": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4702,8 +4023,6 @@
         },
         "node_modules/fast-glob/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4715,15 +4034,11 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4746,8 +4061,6 @@
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4756,8 +4069,6 @@
         },
         "node_modules/fastq": {
             "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4766,8 +4077,6 @@
         },
         "node_modules/fdir": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4783,16 +4092,12 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-            "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+            "version": "0.8.2",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4804,8 +4109,6 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4817,8 +4120,6 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4834,8 +4135,6 @@
         },
         "node_modules/flat-cache": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4855,8 +4154,6 @@
         },
         "node_modules/for-each": {
             "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4871,8 +4168,6 @@
         },
         "node_modules/fraction.js": {
             "version": "5.3.4",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
-            "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4884,9 +4179,7 @@
             }
         },
         "node_modules/fs-extra": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-            "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+            "version": "11.3.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4898,12 +4191,14 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
-            "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4915,8 +4210,6 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4925,8 +4218,6 @@
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4946,8 +4237,6 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4956,8 +4245,6 @@
         },
         "node_modules/generator-function": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4966,8 +4253,6 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4976,8 +4261,6 @@
         },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -4985,9 +4268,7 @@
             }
         },
         "node_modules/get-east-asian-width": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "version": "1.5.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4999,8 +4280,6 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5024,8 +4303,6 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5038,8 +4315,6 @@
         },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5055,9 +4330,7 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "version": "4.13.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5069,8 +4342,6 @@
         },
         "node_modules/get-uri": {
             "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-            "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5083,18 +4354,17 @@
             }
         },
         "node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "version": "9.3.5",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
+                "fs.realpath": "^1.0.0",
+                "minimatch": "^8.0.2",
+                "minipass": "^4.2.4",
+                "path-scurry": "^1.6.1"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -5102,8 +4372,6 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5115,8 +4383,6 @@
         },
         "node_modules/global-modules": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5128,8 +4394,6 @@
         },
         "node_modules/global-prefix": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5143,8 +4407,6 @@
         },
         "node_modules/global-prefix/node_modules/which": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5155,9 +4417,7 @@
             }
         },
         "node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "version": "15.15.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5169,8 +4429,6 @@
         },
         "node_modules/globalthis": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5186,8 +4444,6 @@
         },
         "node_modules/globby": {
             "version": "16.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-            "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5207,8 +4463,6 @@
         },
         "node_modules/globby/node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5217,22 +4471,16 @@
         },
         "node_modules/globjoin": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
-            "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/globrex": {
             "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-            "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5244,15 +4492,11 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5264,8 +4508,6 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5274,8 +4516,6 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5287,8 +4527,6 @@
         },
         "node_modules/has-proto": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5303,8 +4541,6 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5316,8 +4552,6 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5365,8 +4599,6 @@
         },
         "node_modules/html-encoding-sniffer": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5378,15 +4610,11 @@
         },
         "node_modules/html-escaper": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/html-tags": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
-            "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5397,18 +4625,16 @@
             }
         },
         "node_modules/htmlhint": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.9.2.tgz",
-            "integrity": "sha512-PweWSPA1Pb+AVFIOSpIGu5KhLdmtk/uf/0CpjvrDf6XUWmdTyqUljlylwSxQ0AWLvPGcBxK2n8uISsI4lCOkBQ==",
+            "version": "1.9.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "async": "3.2.6",
                 "chalk": "4.1.2",
                 "commander": "11.1.0",
-                "glob": "^13.0.6",
+                "glob": "^9.0.0",
                 "is-glob": "^4.0.3",
-                "node-sarif-builder": "3.2.0",
+                "node-sarif-builder": "^3.4.0",
                 "strip-json-comments": "3.1.1",
                 "xml": "1.0.1"
             },
@@ -5425,14 +4651,10 @@
         },
         "node_modules/htmx.org": {
             "version": "2.0.10",
-            "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.10.tgz",
-            "integrity": "sha512-kdeJe7ZVwaS6QMz/ebBIVtZdpwen6L0OQ5GOhPV9MKBb196TCZeZu4yA7ZIQsaLKv7EpXz+So7KSXNuHXhj7Cw==",
             "license": "0BSD"
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5445,8 +4667,6 @@
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5459,8 +4679,6 @@
         },
         "node_modules/ignore": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5469,8 +4687,6 @@
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5486,8 +4702,6 @@
         },
         "node_modules/import-meta-resolve": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-            "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5497,8 +4711,6 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5507,15 +4719,11 @@
         },
         "node_modules/ini": {
             "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5539,8 +4747,6 @@
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5557,15 +4763,11 @@
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5584,8 +4786,6 @@
         },
         "node_modules/is-bigint": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5600,8 +4800,6 @@
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5613,8 +4811,6 @@
         },
         "node_modules/is-boolean-object": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5630,8 +4826,6 @@
         },
         "node_modules/is-bun-module": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
-            "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5640,8 +4834,6 @@
         },
         "node_modules/is-bun-module/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5653,8 +4845,6 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5682,8 +4872,6 @@
         },
         "node_modules/is-data-view": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5700,8 +4888,6 @@
         },
         "node_modules/is-date-object": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5717,8 +4903,6 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5727,8 +4911,6 @@
         },
         "node_modules/is-finalizationregistry": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5743,8 +4925,6 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5753,8 +4933,6 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5773,8 +4951,6 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5786,8 +4962,6 @@
         },
         "node_modules/is-map": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5799,8 +4973,6 @@
         },
         "node_modules/is-negative-zero": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5812,8 +4984,6 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5822,8 +4992,6 @@
         },
         "node_modules/is-number-object": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5839,8 +5007,6 @@
         },
         "node_modules/is-path-inside": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-            "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5850,17 +5016,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/is-regex": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5878,8 +5048,6 @@
         },
         "node_modules/is-set": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5891,8 +5059,6 @@
         },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5907,8 +5073,6 @@
         },
         "node_modules/is-string": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5924,8 +5088,6 @@
         },
         "node_modules/is-symbol": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5942,8 +5104,6 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5958,8 +5118,6 @@
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5971,8 +5129,6 @@
         },
         "node_modules/is-weakref": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-            "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5987,8 +5143,6 @@
         },
         "node_modules/is-weakset": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6004,22 +5158,16 @@
         },
         "node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -6028,8 +5176,6 @@
         },
         "node_modules/istanbul-lib-instrument": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6045,8 +5191,6 @@
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6058,8 +5202,6 @@
         },
         "node_modules/istanbul-lib-report": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6073,8 +5215,6 @@
         },
         "node_modules/istanbul-reports": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6087,8 +5227,6 @@
         },
         "node_modules/iterator.prototype": {
             "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-            "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6105,8 +5243,6 @@
         },
         "node_modules/jiti": {
             "version": "1.21.7",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-            "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6115,8 +5251,6 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -6145,8 +5279,6 @@
         },
         "node_modules/jsdom": {
             "version": "28.1.0",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6199,29 +5331,21 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6232,9 +5356,7 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "version": "6.2.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6246,8 +5368,6 @@
         },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-            "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6272,8 +5392,6 @@
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6282,8 +5400,6 @@
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6296,8 +5412,6 @@
         },
         "node_modules/lightningcss": {
             "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -6347,8 +5461,6 @@
         },
         "node_modules/lightningcss-darwin-arm64": {
             "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6437,6 +5549,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6458,6 +5573,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6479,6 +5597,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6500,6 +5621,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6557,8 +5681,6 @@
         },
         "node_modules/lilconfig": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6570,15 +5692,11 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6593,36 +5711,26 @@
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-            "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.uniq": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6653,21 +5761,17 @@
             }
         },
         "node_modules/magicast": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
-            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "version": "0.5.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.3",
+                "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
                 "source-map-js": "^1.2.1"
             }
         },
         "node_modules/make-dir": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6682,8 +5786,6 @@
         },
         "node_modules/make-dir/node_modules/semver": {
             "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6695,8 +5797,6 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6705,8 +5805,6 @@
         },
         "node_modules/mathml-tag-names": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
-            "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -6716,15 +5814,11 @@
         },
         "node_modules/mdn-data": {
             "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "dev": true,
             "license": "CC0-1.0"
         },
         "node_modules/meow": {
             "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
-            "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6736,8 +5830,6 @@
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6745,19 +5837,15 @@
             }
         },
         "node_modules/meriyah": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-7.1.0.tgz",
-            "integrity": "sha512-4K/lV+RFSrM8vy9H58FSd+wrxrXlPhYOK8AOaNQ7iFaHugYRx4tHIAaRYLMtXx/spMByZ4S080di6lXSTDI9eg==",
+            "version": "6.1.4",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6786,8 +5874,6 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -6795,19 +5881,15 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "version": "4.2.8",
             "dev": true,
-            "license": "BlueOak-1.0.0",
+            "license": "ISC",
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=8"
             }
         },
         "node_modules/mrmime": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
-            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6816,15 +5898,11 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
             "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6834,9 +5912,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.13",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+            "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
             "dev": true,
             "funding": [
                 {
@@ -6854,8 +5932,6 @@
         },
         "node_modules/napi-postinstall": {
             "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-            "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6870,15 +5946,11 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/neostandard": {
             "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/neostandard/-/neostandard-0.12.2.tgz",
-            "integrity": "sha512-VZU8EZpSaNadp3rKEwBhVD1Kw8jE3AftQLkCyOaM7bWemL1LwsYRsBnAmXy2LjG9zO8t66qJdqB7ccwwORyrAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6906,8 +5978,6 @@
         },
         "node_modules/neostandard/node_modules/@stylistic/eslint-plugin": {
             "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-            "integrity": "sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6924,23 +5994,8 @@
                 "eslint": ">=8.40.0"
             }
         },
-        "node_modules/neostandard/node_modules/globals": {
-            "version": "15.15.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-            "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/netmask": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-            "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+            "version": "2.0.2",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6949,8 +6004,6 @@
         },
         "node_modules/node-exports-info": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-            "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6966,20 +6019,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+        "node_modules/node-exports-info/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
+        "node_modules/node-releases": {
+            "version": "2.0.44",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/node-sarif-builder": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
-            "integrity": "sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==",
+            "version": "3.4.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6987,13 +6043,11 @@
                 "fs-extra": "^11.1.1"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7002,8 +6056,6 @@
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -7015,8 +6067,6 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7025,8 +6075,6 @@
         },
         "node_modules/object-hash": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7035,8 +6083,6 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7048,8 +6094,6 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7058,8 +6102,6 @@
         },
         "node_modules/object.assign": {
             "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7079,8 +6121,6 @@
         },
         "node_modules/object.entries": {
             "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-            "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7095,8 +6135,6 @@
         },
         "node_modules/object.fromentries": {
             "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-            "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7114,8 +6152,6 @@
         },
         "node_modules/object.groupby": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-            "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7129,8 +6165,6 @@
         },
         "node_modules/object.values": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-            "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7147,23 +6181,16 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-            "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+            "version": "2.1.1",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
                 "https://opencollective.com/debug"
             ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.20.0"
-            }
+            "license": "MIT"
         },
         "node_modules/optionator": {
             "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7180,8 +6207,6 @@
         },
         "node_modules/own-keys": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7198,8 +6223,6 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7214,8 +6237,6 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7230,8 +6251,6 @@
         },
         "node_modules/pac-proxy-agent": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-            "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7250,8 +6269,6 @@
         },
         "node_modules/pac-resolver": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7264,8 +6281,6 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7277,8 +6292,6 @@
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7295,13 +6308,11 @@
             }
         },
         "node_modules/parse5": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "version": "8.0.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "entities": "^8.0.0"
+                "entities": "^6.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -7309,8 +6320,6 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7319,8 +6328,6 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7329,60 +6336,56 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "version": "1.11.1",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": ">=16 || 14 >=14.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/path-scurry/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
-                "node": "20 || >=22"
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/pathe": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/peowly": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/peowly/-/peowly-1.3.3.tgz",
-            "integrity": "sha512-5UmUtvuCv3KzBX2NuQw2uF28o0t8Eq4KkPRZfUCzJs+DiNVKw7OaYn29vNDgrt/Pggs23CPlSTqgzlhHJfpT0A==",
+            "version": "1.3.2",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18.6.0",
-                "typescript": ">=5.8"
+                "node": ">=18.6.0"
             }
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true,
             "license": "ISC"
         },
@@ -7401,8 +6404,6 @@
         },
         "node_modules/pify": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7411,8 +6412,6 @@
         },
         "node_modules/pirates": {
             "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7421,8 +6420,6 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7460,8 +6457,6 @@
         },
         "node_modules/postcss-calc": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
-            "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7477,8 +6472,6 @@
         },
         "node_modules/postcss-cli": {
             "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
-            "integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7506,8 +6499,6 @@
         },
         "node_modules/postcss-colormin": {
             "version": "7.0.10",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.10.tgz",
-            "integrity": "sha512-yFr6JezOolHLta/buLE71VKPh2mXursp4saVe98/ol8ZnEWhL+racShqPKlvd/DKWLre/39B6HhcMXf7RZ3hxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7525,8 +6516,6 @@
         },
         "node_modules/postcss-convert-values": {
             "version": "7.0.12",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.12.tgz",
-            "integrity": "sha512-xurKu5qqk4viR3Cp3p4xBR4KfnZm4w4ys6+UBwBmeuBSNkH7+DtLnYOYnOffgtE4yx8sH9S1VZ6RAAvROXzP2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7542,8 +6531,6 @@
         },
         "node_modules/postcss-discard-comments": {
             "version": "7.0.8",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.8.tgz",
-            "integrity": "sha512-CvvS5S9WrXblFXCEJ9nVo+4z+eA7zSC7Z88V1HEJuwlQhlFnYTIjg1xJY+BCUiG2bvICap2tXii4mP22BD108Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7558,8 +6545,6 @@
         },
         "node_modules/postcss-discard-duplicates": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.4.tgz",
-            "integrity": "sha512-VBNn1+EuMZkeGVVtz0gRfbNGtx9IFgAsAV+E2pHtXPrp4qfGBkhTIiAuE/wrb+Y6Pakg9NewAlfTpYIFAWODtw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7571,8 +6556,6 @@
         },
         "node_modules/postcss-discard-empty": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.3.tgz",
-            "integrity": "sha512-M2pyjQCU+/7cMHVtL6bKTHjv0lZnPLMpicgr67Dlth7AbuV9gjVTtUqaRwn6Pp6BwSDspUzhz8SaUrRykJU5Dw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7584,8 +6567,6 @@
         },
         "node_modules/postcss-discard-overridden": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.3.tgz",
-            "integrity": "sha512-aNovXo9UsZuRNLzHJtp13lHIvinDPfiXBPePpXkSjCbgp++iU2FqE+YxvjIsg6EdyPZsASFbfu+JcBFVsErXIQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7597,8 +6578,6 @@
         },
         "node_modules/postcss-import": {
             "version": "15.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-            "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7615,8 +6594,6 @@
         },
         "node_modules/postcss-import/node_modules/resolve": {
             "version": "1.22.12",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7637,8 +6614,6 @@
         },
         "node_modules/postcss-js": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-            "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
             "dev": true,
             "funding": [
                 {
@@ -7663,8 +6638,6 @@
         },
         "node_modules/postcss-load-config": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
-            "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
             "dev": true,
             "funding": [
                 {
@@ -7703,8 +6676,6 @@
         },
         "node_modules/postcss-merge-longhand": {
             "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.7.tgz",
-            "integrity": "sha512-b3mfYUxR388u5Pt0HPcVIUtUDn/k15UfTY9M+ORW+meCR6JLNxoZffiYvXyOYQoRYQNZyX/UFkMCM/mNHxe1qA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7720,8 +6691,6 @@
         },
         "node_modules/postcss-merge-rules": {
             "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.11.tgz",
-            "integrity": "sha512-SJUPM18g2BmPhf8BVlbwqWz4aK3pLu6u6xjfwEzra7xL6IBR10sUaiB++EzqcVfadPHrKBSMlNdP+XieykhI+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7739,8 +6708,6 @@
         },
         "node_modules/postcss-minify-font-values": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.3.tgz",
-            "integrity": "sha512-yilG/VOaNI74IylQvAQQxm3/wZVBkXyYUqNUAdxqwtbWUXPsbK1q8Ms0mL83v+f8YicgcyfYCRZtWACUdYajpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7755,8 +6722,6 @@
         },
         "node_modules/postcss-minify-gradients": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.5.tgz",
-            "integrity": "sha512-YraROyQRg3BI1+Hg8E05B/JPdnTm8EDSVu4P2BxdM+CRiOyfmou809+chGIqo6fQqwjPGQ947nbGncSjmTU1WQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7773,8 +6738,6 @@
         },
         "node_modules/postcss-minify-params": {
             "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.9.tgz",
-            "integrity": "sha512-R8itbB8BhlpoYyBm1ou0dD+vJnQ3F6adQipR4UnkCHUwlo+S9WXJaDRg1RHjC8YVAtIdrQzSWvJl40HnGDTKjA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7791,8 +6754,6 @@
         },
         "node_modules/postcss-minify-selectors": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.2.tgz",
-            "integrity": "sha512-aQtrEWKwqafNlExcKHQvPGsXR2+vlUqqJtf5XsCQcgsSb5PL4wlujWBYDJuWsP4UnQX1YHDHU8qRlD+1PzTQ+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7810,8 +6771,6 @@
         },
         "node_modules/postcss-nested": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-            "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
             "dev": true,
             "funding": [
                 {
@@ -7836,8 +6795,6 @@
         },
         "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
             "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7850,8 +6807,6 @@
         },
         "node_modules/postcss-normalize-charset": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
-            "integrity": "sha512-NoBfZu8PR4c2NlmjvrqQTzCzLY79hwcSRgNQ3ZiNK0ABzf9kYKloE/jNj+/8GQY1wsm8pRRgANk6ydLH8cwo0Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7863,8 +6818,6 @@
         },
         "node_modules/postcss-normalize-display-values": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.3.tgz",
-            "integrity": "sha512-ldsCX0QIt05pKIOobZtVQ48wXJecr+czw4+e1/YjVhLMqslShgpVxgPtI2CefURR8oyVoYaU/l829MMwExDMLw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7879,8 +6832,6 @@
         },
         "node_modules/postcss-normalize-positions": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.4.tgz",
-            "integrity": "sha512-VEvlpeGd3Ju1Hqa/oN4jaP3+ms4laYwkEL9N9u+B6k54PZjXbW1n6wI+aVprf1BQXlCYpS5+1pl/7/vHiKgARg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7895,8 +6846,6 @@
         },
         "node_modules/postcss-normalize-repeat-style": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.4.tgz",
-            "integrity": "sha512-6mPKlY/8cSaDHxX502wERADarJsccwlky6yIrOapHH2ZgfoKAV94SbiTKfKEs4EEpdazuc3J72WsqeYk7hp9+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7911,8 +6860,6 @@
         },
         "node_modules/postcss-normalize-string": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.3.tgz",
-            "integrity": "sha512-HnEQPUchi1eznmDKEYrKUTqrprEq97SrpUYClgUkv7V2zRODD9DFoUsYU+m9ZOetmD5ku7fEMZB/lwy8IT6xVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7927,8 +6874,6 @@
         },
         "node_modules/postcss-normalize-timing-functions": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.3.tgz",
-            "integrity": "sha512-zmEzHdvpZBZu0OKlbJSfgASQvaayyAoVuWtvyr34IJ/LyS+DaOKvvR3EvFJ9RWWtNIx+CMvO125OVophaxNYew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7943,8 +6888,6 @@
         },
         "node_modules/postcss-normalize-unicode": {
             "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.9.tgz",
-            "integrity": "sha512-DRAdWfeh/TjmhLJsw91vdiWCnUod9iwvM7xyS02/nF/sLsCR3A8l3pztrSUrWG8DSBqfX7yEk9FM0USaVJ2mSg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7960,8 +6903,6 @@
         },
         "node_modules/postcss-normalize-url": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.3.tgz",
-            "integrity": "sha512-CL93wmloq5qsffmFv+bw24MIRbmhHrp53qoh1LDAb/5TtjWEXI/np4xcP/Gw9oWCb2XyWnqHYLDUwiKRoJBA1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7976,8 +6917,6 @@
         },
         "node_modules/postcss-normalize-whitespace": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.3.tgz",
-            "integrity": "sha512-FdHjjn+Ht5Z2ZRjNOmeCbNq6lq09sUYKpmlF/Aq0XjVNSLTL6fmHlA/3swN2wP2caY9GV/tjSDcIIyS7aN7W0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7992,8 +6931,6 @@
         },
         "node_modules/postcss-ordered-values": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.4.tgz",
-            "integrity": "sha512-nubSi49hDHQk4E8KIj+IbLY8Bg+8OcSUEhgyolgM+atnOvXjV7EjaR6bac4YGZoFyPa9mWoAF3EaYbWdFkKqVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8009,8 +6946,6 @@
         },
         "node_modules/postcss-reduce-initial": {
             "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.9.tgz",
-            "integrity": "sha512-ztTNPdIxXTxtBcG03E9u8v44M4ElXbMIRT7pf2onlquGula0Y83nKKxqM22FA/hMgkfCjN7ohevkVlaNwI8iOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8026,8 +6961,6 @@
         },
         "node_modules/postcss-reduce-transforms": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.3.tgz",
-            "integrity": "sha512-FXsnN9ZwcZTT8Yf8cAHA8qIGUXcX6WfLd9JoYhrdDfmvsVhhfqkkv7m4AC3rwFOfz+GzkUa87OCKF9dUcicd+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8042,8 +6975,6 @@
         },
         "node_modules/postcss-reporter": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.1.0.tgz",
-            "integrity": "sha512-/eoEylGWyy6/DOiMP5lmFRdmDKThqgn7D6hP2dXKJI/0rJSO1ADFNngZfDzxL0YAxFvws+Rtpuji1YIHj4mySA==",
             "dev": true,
             "funding": [
                 {
@@ -8069,8 +7000,6 @@
         },
         "node_modules/postcss-safe-parser": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
-            "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
             "dev": true,
             "funding": [
                 {
@@ -8096,8 +7025,6 @@
         },
         "node_modules/postcss-selector-parser": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8110,8 +7037,6 @@
         },
         "node_modules/postcss-sorting": {
             "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-9.1.0.tgz",
-            "integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -8120,8 +7045,6 @@
         },
         "node_modules/postcss-svgo": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.3.tgz",
-            "integrity": "sha512-2QfoFOYMcj8lwcVEf9WeTlkVIAm7u2QvOEhMzkQU3KUhhGX/l8hVV9EtjMv4iq3E9iI3OeeMN0YoMLbGusuigw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8137,8 +7060,6 @@
         },
         "node_modules/postcss-unique-selectors": {
             "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.7.tgz",
-            "integrity": "sha512-d+sCkaRnSefghOUdH8CMJZV9yUQhj2ojpe8Nw/lA+LV1UOfeleGkLTl6XdCFFSai9UJ+DJPb69FFuqthXYsY8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8153,15 +7074,11 @@
         },
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8169,9 +7086,7 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "version": "3.8.1",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8186,8 +7101,6 @@
         },
         "node_modules/prettier-linter-helpers": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-            "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8199,8 +7112,6 @@
         },
         "node_modules/pretty-hrtime": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8209,8 +7120,6 @@
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8221,8 +7130,6 @@
         },
         "node_modules/proxy-agent": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-            "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8241,8 +7148,6 @@
         },
         "node_modules/proxy-agent/node_modules/lru-cache": {
             "version": "7.18.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -8251,15 +7156,11 @@
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8288,8 +7189,6 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -8309,15 +7208,11 @@
         },
         "node_modules/react-is": {
             "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-            "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8326,8 +7221,6 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8339,8 +7232,6 @@
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-            "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8362,8 +7253,6 @@
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8383,8 +7272,6 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8393,8 +7280,6 @@
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8402,16 +7287,11 @@
             }
         },
         "node_modules/resolve": {
-            "version": "2.0.0-next.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+            "version": "1.22.11",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.2",
-                "node-exports-info": "^1.6.0",
-                "object-keys": "^1.1.1",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -8427,8 +7307,6 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8437,8 +7315,6 @@
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -8446,9 +7322,7 @@
             }
         },
         "node_modules/retire": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/retire/-/retire-5.4.3.tgz",
-            "integrity": "sha512-a+CNXfbCTC/kAQLeFxfN9/kts1NlFMo5lrjBefmFssdOJy0XYPNpRN4k63hwIhhzyzPvHziZrQHWKdJNf6Lp5g==",
+            "version": "5.4.2",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -8456,6 +7330,7 @@
                 "astronomical": "^3.0.0",
                 "commander": "^10.0.1",
                 "proxy-agent": "^6.4.0",
+                "uuid": "^9.0.1",
                 "walkdir": "0.4.1",
                 "zod": "^3.22.4"
             },
@@ -8468,8 +7343,6 @@
         },
         "node_modules/retire/node_modules/commander": {
             "version": "10.0.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8478,8 +7351,6 @@
         },
         "node_modules/reusify": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8488,13 +7359,11 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-            "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+            "version": "1.1.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.133.0",
+                "@oxc-project/types": "=0.137.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -8504,27 +7373,81 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.3",
-                "@rolldown/binding-darwin-arm64": "1.0.3",
-                "@rolldown/binding-darwin-x64": "1.0.3",
-                "@rolldown/binding-freebsd-x64": "1.0.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-                "@rolldown/binding-linux-arm64-musl": "1.0.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-gnu": "1.0.3",
-                "@rolldown/binding-linux-x64-musl": "1.0.3",
-                "@rolldown/binding-openharmony-arm64": "1.0.3",
-                "@rolldown/binding-wasm32-wasi": "1.0.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-                "@rolldown/binding-win32-x64-msvc": "1.0.3"
+                "@rolldown/binding-android-arm64": "1.1.3",
+                "@rolldown/binding-darwin-arm64": "1.1.3",
+                "@rolldown/binding-darwin-x64": "1.1.3",
+                "@rolldown/binding-freebsd-x64": "1.1.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+                "@rolldown/binding-linux-arm64-musl": "1.1.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-gnu": "1.1.3",
+                "@rolldown/binding-linux-x64-musl": "1.1.3",
+                "@rolldown/binding-openharmony-arm64": "1.1.3",
+                "@rolldown/binding-wasm32-wasi": "1.1.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+                "@rolldown/binding-win32-x64-msvc": "1.1.3"
             }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-android-arm64": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-freebsd-x64": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-musl": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-musl": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-openharmony-arm64": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-wasm32-wasi": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-win32-x64-msvc": {
+            "dev": true,
+            "optional": true
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
                 {
@@ -8546,15 +7469,13 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
-            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+            "version": "1.1.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.9",
-                "call-bound": "^1.0.4",
-                "get-intrinsic": "^1.3.0",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
                 "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
@@ -8567,8 +7488,6 @@
         },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-            "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8584,8 +7503,6 @@
         },
         "node_modules/safe-regex-test": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8602,8 +7519,6 @@
         },
         "node_modules/sax": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -8612,8 +7527,6 @@
         },
         "node_modules/saxes": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -8623,20 +7536,8 @@
                 "node": ">=v12.22.7"
             }
         },
-        "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8653,8 +7554,6 @@
         },
         "node_modules/set-function-name": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8669,8 +7568,6 @@
         },
         "node_modules/set-proto": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-            "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8684,8 +7581,6 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8697,8 +7592,6 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8707,8 +7600,6 @@
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8726,14 +7617,12 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "version": "1.0.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.4"
+                "object-inspect": "^1.13.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -8744,8 +7633,6 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8763,8 +7650,6 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8783,15 +7668,11 @@
         },
         "node_modules/siginfo": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -8803,8 +7684,6 @@
         },
         "node_modules/sirv": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
-            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8818,8 +7697,6 @@
         },
         "node_modules/slash": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8831,8 +7708,6 @@
         },
         "node_modules/slice-ansi": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8849,8 +7724,6 @@
         },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8859,13 +7732,11 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.9",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+            "version": "2.8.7",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^10.1.1",
+                "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -8875,8 +7746,6 @@
         },
         "node_modules/socks-proxy-agent": {
             "version": "8.0.5",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-            "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8890,8 +7759,6 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -8900,8 +7767,6 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -8910,8 +7775,6 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8921,15 +7784,11 @@
         },
         "node_modules/stable-hash": {
             "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
-            "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/stable-hash-x": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
-            "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8938,8 +7797,6 @@
         },
         "node_modules/stackback": {
             "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8952,8 +7809,6 @@
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8965,26 +7820,20 @@
             }
         },
         "node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "4.2.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
             },
             "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-            "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9011,8 +7860,6 @@
         },
         "node_modules/string.prototype.repeat": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-            "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9021,20 +7868,17 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
-            "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+            "version": "1.2.10",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.9",
-                "call-bound": "^1.0.4",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
                 "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.24.2",
-                "es-object-atoms": "^1.1.2",
-                "has-property-descriptors": "^1.0.2",
-                "safe-regex-test": "^1.1.0"
+                "es-abstract": "^1.23.5",
+                "es-object-atoms": "^1.0.0",
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9044,16 +7888,14 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
-            "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+            "version": "1.0.9",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.9",
-                "call-bound": "^1.0.4",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
                 "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.1.2"
+                "es-object-atoms": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9064,8 +7906,6 @@
         },
         "node_modules/string.prototype.trimstart": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9081,25 +7921,28 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "version": "6.0.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.2.2"
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/strip-bom": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9108,8 +7951,6 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9121,15 +7962,11 @@
         },
         "node_modules/style-search": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-            "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/stylehacks": {
             "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.11.tgz",
-            "integrity": "sha512-iODNfhXVLqc5LADs+Y6Oh5wJuK5ZcHbVng8aiK3y9pjMQdc5hLrBW0eFU6FtnpNrE6PoEg/MmFTU4waotj5WNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9144,9 +7981,7 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "17.13.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.13.0.tgz",
-            "integrity": "sha512-G1WYzMerp7ihOaIe9VJCHLt12MoAD2QLf1AFerYP37+BCRBUK5UCpq8e/mN+zCIaJPKQcaxhE4WlPmqdiOx/gw==",
+            "version": "17.6.0",
             "dev": true,
             "funding": [
                 {
@@ -9160,9 +7995,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@csstools/css-calc": "^3.2.1",
+                "@csstools/css-calc": "^3.1.1",
                 "@csstools/css-parser-algorithms": "^4.0.0",
-                "@csstools/css-syntax-patches-for-csstree": "^1.1.4",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
                 "@csstools/css-tokenizer": "^4.0.0",
                 "@csstools/media-query-list-parser": "^5.0.0",
                 "@csstools/selector-resolve-nested": "^4.0.0",
@@ -9174,23 +8009,24 @@
                 "debug": "^4.4.3",
                 "fast-glob": "^3.3.3",
                 "fastest-levenshtein": "^1.0.16",
-                "file-entry-cache": "^11.1.3",
+                "file-entry-cache": "^11.1.2",
                 "global-modules": "^2.0.0",
-                "globby": "^16.2.0",
+                "globby": "^16.1.1",
                 "globjoin": "^0.1.4",
                 "html-tags": "^5.1.0",
                 "ignore": "^7.0.5",
                 "import-meta-resolve": "^4.2.0",
+                "is-plain-object": "^5.0.0",
                 "mathml-tag-names": "^4.0.0",
                 "meow": "^14.1.0",
                 "micromatch": "^4.0.8",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.1.1",
-                "postcss": "^8.5.15",
+                "postcss": "^8.5.8",
                 "postcss-safe-parser": "^7.0.1",
                 "postcss-selector-parser": "^7.1.1",
                 "postcss-value-parser": "^4.2.0",
-                "string-width": "^8.2.1",
+                "string-width": "^8.2.0",
                 "supports-hyperlinks": "^4.4.0",
                 "svg-tags": "^1.0.0",
                 "table": "^6.9.0",
@@ -9205,8 +8041,6 @@
         },
         "node_modules/stylelint-config-recommended": {
             "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
-            "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
             "dev": true,
             "funding": [
                 {
@@ -9228,8 +8062,6 @@
         },
         "node_modules/stylelint-config-standard": {
             "version": "40.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
-            "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
             "dev": true,
             "funding": [
                 {
@@ -9254,8 +8086,6 @@
         },
         "node_modules/stylelint-order": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-7.0.1.tgz",
-            "integrity": "sha512-GWPei1zBVDDjxM+/BmcSCiOcHNd8rSqW6FUZtqQGlTRpD0Z5nSzspzWD8rtKif5KPdzUG68DApKEV/y/I9VbTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9271,8 +8101,6 @@
         },
         "node_modules/stylelint/node_modules/file-entry-cache": {
             "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
-            "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9281,8 +8109,6 @@
         },
         "node_modules/stylelint/node_modules/flat-cache": {
             "version": "6.1.22",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
-            "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9293,18 +8119,47 @@
         },
         "node_modules/stylelint/node_modules/ignore": {
             "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
+        "node_modules/stylelint/node_modules/string-width": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stylelint/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
         "node_modules/sucrase": {
             "version": "3.35.1",
-            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9326,8 +8181,6 @@
         },
         "node_modules/sucrase/node_modules/commander": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9336,8 +8189,6 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9349,8 +8200,6 @@
         },
         "node_modules/supports-hyperlinks": {
             "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
-            "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9366,8 +8215,6 @@
         },
         "node_modules/supports-hyperlinks/node_modules/has-flag": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
-            "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9379,8 +8226,6 @@
         },
         "node_modules/supports-hyperlinks/node_modules/supports-color": {
             "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9392,8 +8237,6 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9405,14 +8248,10 @@
         },
         "node_modules/svg-tags": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
-            "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
             "dev": true
         },
         "node_modules/svgo": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9437,19 +8276,15 @@
         },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/synckit": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-            "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+            "version": "0.11.12",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@pkgr/core": "^0.3.6"
+                "@pkgr/core": "^0.2.9"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -9460,8 +8295,6 @@
         },
         "node_modules/table": {
             "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-            "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -9477,8 +8310,6 @@
         },
         "node_modules/table/node_modules/ajv": {
             "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9492,55 +8323,13 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/table/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/table/node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/table/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/table/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/tailwindcss": {
             "version": "3.4.19",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-            "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9577,8 +8366,6 @@
         },
         "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
             "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-            "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9591,8 +8378,6 @@
         },
         "node_modules/tailwindcss/node_modules/resolve": {
             "version": "1.22.12",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9612,9 +8397,7 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "version": "2.3.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9626,9 +8409,7 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.48.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-            "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+            "version": "5.46.0",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -9646,22 +8427,16 @@
         },
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/thenby": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.4.1.tgz",
-            "integrity": "sha512-D5a/bO0KdalOE3q8MlrRmSxjbKZHT3MQmXkJP+r97Vw8MMwOZKOwUSEyTtK7eSMj2y0kyAjpYMRMZmmLw1FtNQ==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/thenify": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9670,8 +8445,6 @@
         },
         "node_modules/thenify-all": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9683,15 +8456,11 @@
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+            "version": "1.0.2",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9726,29 +8495,23 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-            "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+            "version": "7.0.28",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.4.2"
+                "tldts-core": "^7.0.28"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-            "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+            "version": "7.0.28",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9760,8 +8523,6 @@
         },
         "node_modules/totalist": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9770,8 +8531,6 @@
         },
         "node_modules/tough-cookie": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -9783,8 +8542,6 @@
         },
         "node_modules/tr46": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9795,9 +8552,7 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+            "version": "2.4.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9809,8 +8564,6 @@
         },
         "node_modules/ts-declaration-location": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-            "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
             "dev": true,
             "funding": [
                 {
@@ -9832,15 +8585,11 @@
         },
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/tsconfig-paths": {
             "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-            "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9852,8 +8601,6 @@
         },
         "node_modules/tsconfig-paths/node_modules/json5": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9865,15 +8612,11 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
             "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9885,8 +8628,6 @@
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9900,8 +8641,6 @@
         },
         "node_modules/typed-array-byte-length": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9920,8 +8659,6 @@
         },
         "node_modules/typed-array-byte-offset": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9941,18 +8678,16 @@
             }
         },
         "node_modules/typed-array-length": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
-            "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+            "version": "1.0.7",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.9",
-                "for-each": "^0.3.5",
-                "gopd": "^1.2.0",
-                "is-typed-array": "^1.1.15",
-                "possible-typed-array-names": "^1.1.0",
-                "reflect.getprototypeof": "^1.0.10"
+                "call-bind": "^1.0.7",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "is-typed-array": "^1.1.13",
+                "possible-typed-array-names": "^1.0.0",
+                "reflect.getprototypeof": "^1.0.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9962,9 +8697,7 @@
             }
         },
         "node_modules/typescript": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "version": "5.9.3",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -9977,16 +8710,14 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+            "version": "8.53.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.60.1",
-                "@typescript-eslint/parser": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1"
+                "@typescript-eslint/eslint-plugin": "8.53.1",
+                "@typescript-eslint/parser": "8.53.1",
+                "@typescript-eslint/typescript-estree": "8.53.1",
+                "@typescript-eslint/utils": "8.53.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9996,14 +8727,12 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10020,9 +8749,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-            "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10031,8 +8760,6 @@
         },
         "node_modules/unicorn-magic": {
             "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
-            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10044,8 +8771,6 @@
         },
         "node_modules/universalify": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10053,47 +8778,40 @@
             }
         },
         "node_modules/unrs-resolver": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
-            "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+            "version": "1.11.1",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "napi-postinstall": "^0.3.4"
+                "napi-postinstall": "^0.3.0"
             },
             "funding": {
                 "url": "https://opencollective.com/unrs-resolver"
             },
             "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
-                "@unrs/resolver-binding-android-arm64": "1.12.2",
-                "@unrs/resolver-binding-darwin-arm64": "1.12.2",
-                "@unrs/resolver-binding-darwin-x64": "1.12.2",
-                "@unrs/resolver-binding-freebsd-x64": "1.12.2",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
-                "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
-                "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
-                "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
-                "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+                "@unrs/resolver-binding-android-arm64": "1.11.1",
+                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+                "@unrs/resolver-binding-darwin-x64": "1.11.1",
+                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
             }
         },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -10123,8 +8841,6 @@
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -10133,22 +8849,32 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/uuid": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+            "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist-node/bin/uuid"
+            }
+        },
         "node_modules/vite": {
-            "version": "8.0.16",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-            "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+            "version": "8.1.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
                 "postcss": "^8.5.15",
-                "rolldown": "1.0.3",
+                "rolldown": "~1.1.2",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -10165,7 +8891,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.1.18",
+                "@vitejs/devtools": "^0.3.0",
                 "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
@@ -10217,19 +8943,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-            "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.8",
-                "@vitest/mocker": "4.1.8",
-                "@vitest/pretty-format": "4.1.8",
-                "@vitest/runner": "4.1.8",
-                "@vitest/snapshot": "4.1.8",
-                "@vitest/spy": "4.1.8",
-                "@vitest/utils": "4.1.8",
+                "@vitest/expect": "4.1.9",
+                "@vitest/mocker": "4.1.9",
+                "@vitest/pretty-format": "4.1.9",
+                "@vitest/runner": "4.1.9",
+                "@vitest/snapshot": "4.1.9",
+                "@vitest/spy": "4.1.9",
+                "@vitest/utils": "4.1.9",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -10257,12 +8983,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.8",
-                "@vitest/browser-preview": "4.1.8",
-                "@vitest/browser-webdriverio": "4.1.8",
-                "@vitest/coverage-istanbul": "4.1.8",
-                "@vitest/coverage-v8": "4.1.8",
-                "@vitest/ui": "4.1.8",
+                "@vitest/browser-playwright": "4.1.9",
+                "@vitest/browser-preview": "4.1.9",
+                "@vitest/browser-webdriverio": "4.1.9",
+                "@vitest/coverage-istanbul": "4.1.9",
+                "@vitest/coverage-v8": "4.1.9",
+                "@vitest/ui": "4.1.9",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -10308,8 +9034,6 @@
         },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10321,8 +9045,6 @@
         },
         "node_modules/walkdir": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
-            "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10331,8 +9053,6 @@
         },
         "node_modules/webidl-conversions": {
             "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -10341,8 +9061,6 @@
         },
         "node_modules/whatwg-mimetype": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10351,8 +9069,6 @@
         },
         "node_modules/whatwg-url": {
             "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10366,8 +9082,6 @@
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -10382,8 +9096,6 @@
         },
         "node_modules/which-boxed-primitive": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10402,8 +9114,6 @@
         },
         "node_modules/which-builtin-type": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10430,8 +9140,6 @@
         },
         "node_modules/which-collection": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10448,14 +9156,12 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.22",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-            "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+            "version": "1.1.20",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.9",
+                "call-bind": "^1.0.8",
                 "call-bound": "^1.0.4",
                 "for-each": "^0.3.5",
                 "get-proto": "^1.0.1",
@@ -10471,8 +9177,6 @@
         },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10488,8 +9192,6 @@
         },
         "node_modules/word-wrap": {
             "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10498,8 +9200,6 @@
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10514,48 +9214,8 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/write-file-atomic": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
-            "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -10567,15 +9227,11 @@
         },
         "node_modules/xml": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-            "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -10584,15 +9240,11 @@
         },
         "node_modules/xmlchars": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/y18n": {
             "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -10607,9 +9259,7 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "version": "2.8.3",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -10624,8 +9274,6 @@
         },
         "node_modules/yargs": {
             "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10643,56 +9291,14 @@
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
-        "node_modules/yargs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/yargs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10704,8 +9310,6 @@
         },
         "node_modules/zod": {
             "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
             "funding": {

--- a/tests/js/admin-forms.test.js
+++ b/tests/js/admin-forms.test.js
@@ -605,3 +605,313 @@ describe("ALLOW_PUBLIC_VISIBILITY flag", () => {
     expect(checkedRadio.value).toBe("public");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Edit Tool Gateway Reassignment Removal
+// ---------------------------------------------------------------------------
+describe("Edit Tool Gateway Reassignment Removal - Issue #4061", () => {
+  function setupEditToolFormDOM() {
+    // Create the edit tool modal
+    const modal = doc.createElement("div");
+    modal.id = "edit-tool-modal";
+    doc.body.appendChild(modal);
+
+    // Create edit tool form
+    const form = doc.createElement("form");
+    form.id = "edit-tool-form";
+    modal.appendChild(form);
+
+    // Create other fields that should exist
+    const nameField = doc.createElement("input");
+    nameField.id = "edit-tool-name";
+    nameField.name = "name";
+    form.appendChild(nameField);
+
+    const urlField = doc.createElement("input");
+    urlField.id = "edit-tool-url";
+    urlField.name = "url";
+    form.appendChild(urlField);
+
+    const typeSelect = doc.createElement("select");
+    typeSelect.id = "edit-tool-type";
+    typeSelect.name = "integration_type";
+    form.appendChild(typeSelect);
+
+    // Gateway field should NOT exist (removed per issue #4061)
+    // const gatewayField = doc.createElement("select");
+    // gatewayField.id = "edit-tool-gateway-id";
+    // gatewayField.name = "gateway_id";
+    // form.appendChild(gatewayField);
+
+    return { modal, form, nameField, urlField, typeSelect };
+  }
+
+  test("edit tool form does not contain gateway_id field", () => {
+    setupEditToolFormDOM();
+    const gatewayField = doc.getElementById("edit-tool-gateway-id");
+    expect(gatewayField).toBeNull();
+  });
+
+  test("edit tool form does not contain gateway_id select element", () => {
+    const { form } = setupEditToolFormDOM();
+    const gatewaySelects = form.querySelectorAll('select[name="gateway_id"]');
+    expect(gatewaySelects.length).toBe(0);
+  });
+
+  test("edit tool form contains other essential fields but not gateway_id", () => {
+    const { form, nameField, urlField, typeSelect } = setupEditToolFormDOM();
+
+    expect(nameField).toBeDefined();
+    expect(nameField.name).toBe("name");
+
+    expect(urlField).toBeDefined();
+    expect(urlField.name).toBe("url");
+
+    expect(typeSelect).toBeDefined();
+    expect(typeSelect.name).toBe("integration_type");
+
+    // Gateway field should not exist
+    const gatewayField = form.querySelector('[name="gateway_id"]');
+    expect(gatewayField).toBeNull();
+  });
+
+  test("form data collection does not include gateway_id", () => {
+    const { form } = setupEditToolFormDOM();
+    const formData = new FormData(form);
+
+    expect(formData.has("gateway_id")).toBe(false);
+    expect(formData.has("name")).toBe(true);
+    expect(formData.has("url")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Advanced Configuration Fields - Conditional Collection
+// ---------------------------------------------------------------------------
+describe("Advanced Configuration Fields Conditional Collection - Issue #4061", () => {
+  function setupAdvancedFieldsDOM(integrationType = "REST") {
+    const form = doc.createElement("form");
+    form.id = "edit-tool-form";
+    doc.body.appendChild(form);
+
+    // Integration type selector
+    const typeSelect = doc.createElement("select");
+    typeSelect.id = "edit-tool-type";
+    typeSelect.name = "integration_type";
+    const typeOpt = doc.createElement("option");
+    typeOpt.value = integrationType;
+    typeOpt.selected = true;
+    typeSelect.appendChild(typeOpt);
+    form.appendChild(typeSelect);
+
+    // Common advanced fields (applicable to all tool types)
+    const titleField = doc.createElement("input");
+    titleField.id = "edit-tool-title";
+    titleField.name = "title";
+    titleField.value = "";
+    form.appendChild(titleField);
+
+    const timeoutField = doc.createElement("input");
+    timeoutField.id = "edit-tool-timeout-ms";
+    timeoutField.name = "timeout_ms";
+    timeoutField.type = "number";
+    timeoutField.value = "";
+    form.appendChild(timeoutField);
+
+    const jsonpathFilterField = doc.createElement("input");
+    jsonpathFilterField.id = "edit-tool-jsonpath-filter";
+    jsonpathFilterField.name = "jsonpath_filter";
+    jsonpathFilterField.value = "";
+    form.appendChild(jsonpathFilterField);
+
+    // REST passthrough fields (only applicable to REST tools)
+    const baseUrlField = doc.createElement("input");
+    baseUrlField.id = "edit-tool-base-url";
+    baseUrlField.name = "base_url";
+    baseUrlField.value = "";
+    form.appendChild(baseUrlField);
+
+    const pathTemplateField = doc.createElement("input");
+    pathTemplateField.id = "edit-tool-path-template";
+    pathTemplateField.name = "path_template";
+    pathTemplateField.value = "";
+    form.appendChild(pathTemplateField);
+
+    const queryMappingField = doc.createElement("textarea");
+    queryMappingField.id = "edit-tool-query-mapping";
+    queryMappingField.name = "query_mapping";
+    queryMappingField.value = "";
+    form.appendChild(queryMappingField);
+
+    const headerMappingField = doc.createElement("textarea");
+    headerMappingField.id = "edit-tool-header-mapping";
+    headerMappingField.name = "header_mapping";
+    headerMappingField.value = "";
+    form.appendChild(headerMappingField);
+
+    const exposePassthroughCheckbox = doc.createElement("input");
+    exposePassthroughCheckbox.id = "edit-tool-expose-passthrough";
+    exposePassthroughCheckbox.name = "expose_passthrough";
+    exposePassthroughCheckbox.type = "checkbox";
+    exposePassthroughCheckbox.checked = false;
+    form.appendChild(exposePassthroughCheckbox);
+
+    const allowlistField = doc.createElement("input");
+    allowlistField.id = "edit-tool-allowlist";
+    allowlistField.name = "allowlist";
+    allowlistField.value = "";
+    form.appendChild(allowlistField);
+
+    // Plugin chain fields
+    const pluginChainPreField = doc.createElement("input");
+    pluginChainPreField.id = "edit-tool-plugin-chain-pre";
+    pluginChainPreField.name = "plugin_chain_pre";
+    pluginChainPreField.value = "";
+    form.appendChild(pluginChainPreField);
+
+    const pluginChainPostField = doc.createElement("input");
+    pluginChainPostField.id = "edit-tool-plugin-chain-post";
+    pluginChainPostField.name = "plugin_chain_post";
+    pluginChainPostField.value = "";
+    form.appendChild(pluginChainPostField);
+
+    return {
+      form,
+      typeSelect,
+      titleField,
+      timeoutField,
+      jsonpathFilterField,
+      baseUrlField,
+      pathTemplateField,
+      queryMappingField,
+      headerMappingField,
+      exposePassthroughCheckbox,
+      allowlistField,
+      pluginChainPreField,
+      pluginChainPostField,
+    };
+  }
+
+  test("common advanced fields are collected when values are present", () => {
+    const { form, titleField, timeoutField, jsonpathFilterField } = setupAdvancedFieldsDOM("MCP");
+
+    titleField.value = "My Tool Title";
+    timeoutField.value = "5000";
+    jsonpathFilterField.value = "$.data[*]";
+
+    const formData = new FormData(form);
+
+    expect(formData.get("title")).toBe("My Tool Title");
+    expect(formData.get("timeout_ms")).toBe("5000");
+    expect(formData.get("jsonpath_filter")).toBe("$.data[*]");
+  });
+
+  test("common advanced fields are not collected when values are empty", () => {
+    const { form, titleField, timeoutField, jsonpathFilterField } = setupAdvancedFieldsDOM("MCP");
+
+    // Leave fields empty
+    titleField.value = "";
+    timeoutField.value = "";
+    jsonpathFilterField.value = "";
+
+    const formData = new FormData(form);
+
+    // Empty string values are still included in FormData, but backend should handle them conditionally
+    expect(formData.get("title")).toBe("");
+    expect(formData.get("timeout_ms")).toBe("");
+    expect(formData.get("jsonpath_filter")).toBe("");
+  });
+
+  test("REST passthrough fields exist in form for REST integration type", () => {
+    const { form, baseUrlField, pathTemplateField } = setupAdvancedFieldsDOM("REST");
+
+    expect(baseUrlField).toBeDefined();
+    expect(baseUrlField.name).toBe("base_url");
+    expect(pathTemplateField).toBeDefined();
+    expect(pathTemplateField.name).toBe("path_template");
+  });
+
+  test("REST passthrough fields are collected only when values are present", () => {
+    const { form, baseUrlField, pathTemplateField, queryMappingField } = setupAdvancedFieldsDOM("REST");
+
+    baseUrlField.value = "https://api.example.com";
+    pathTemplateField.value = "/v1/{resource}";
+    queryMappingField.value = '{"search": "q"}';
+
+    const formData = new FormData(form);
+
+    expect(formData.get("base_url")).toBe("https://api.example.com");
+    expect(formData.get("path_template")).toBe("/v1/{resource}");
+    expect(formData.get("query_mapping")).toBe('{"search": "q"}');
+  });
+
+  test("expose_passthrough checkbox value is collected correctly", () => {
+    const { form, exposePassthroughCheckbox } = setupAdvancedFieldsDOM("REST");
+
+    exposePassthroughCheckbox.checked = true;
+    const formData = new FormData(form);
+
+    expect(formData.has("expose_passthrough")).toBe(true);
+  });
+
+  test("plugin chain fields are collected when values are present", () => {
+    const { form, pluginChainPreField, pluginChainPostField } = setupAdvancedFieldsDOM("MCP");
+
+    pluginChainPreField.value = "auth_plugin,validation_plugin";
+    pluginChainPostField.value = "logging_plugin";
+
+    const formData = new FormData(form);
+
+    expect(formData.get("plugin_chain_pre")).toBe("auth_plugin,validation_plugin");
+    expect(formData.get("plugin_chain_post")).toBe("logging_plugin");
+  });
+
+  test("field name consistency: jsonpath_filter uses snake_case not camelCase", () => {
+    const { jsonpathFilterField } = setupAdvancedFieldsDOM("MCP");
+
+    // Critical: field name must be snake_case to match backend expectation
+    expect(jsonpathFilterField.name).toBe("jsonpath_filter");
+    expect(jsonpathFilterField.name).not.toBe("jsonpathFilter");
+  });
+
+  test("all REST passthrough field names use snake_case", () => {
+    const {
+      baseUrlField,
+      pathTemplateField,
+      queryMappingField,
+      headerMappingField,
+      exposePassthroughCheckbox,
+      allowlistField,
+    } = setupAdvancedFieldsDOM("REST");
+
+    expect(baseUrlField.name).toBe("base_url");
+    expect(pathTemplateField.name).toBe("path_template");
+    expect(queryMappingField.name).toBe("query_mapping");
+    expect(headerMappingField.name).toBe("header_mapping");
+    expect(exposePassthroughCheckbox.name).toBe("expose_passthrough");
+    expect(allowlistField.name).toBe("allowlist");
+  });
+
+  test("plugin chain field names use snake_case", () => {
+    const { pluginChainPreField, pluginChainPostField } = setupAdvancedFieldsDOM("MCP");
+
+    expect(pluginChainPreField.name).toBe("plugin_chain_pre");
+    expect(pluginChainPostField.name).toBe("plugin_chain_post");
+  });
+
+  test("all new advanced configuration field IDs follow naming convention", () => {
+    const fields = setupAdvancedFieldsDOM("REST");
+
+    expect(fields.titleField.id).toBe("edit-tool-title");
+    expect(fields.timeoutField.id).toBe("edit-tool-timeout-ms");
+    expect(fields.jsonpathFilterField.id).toBe("edit-tool-jsonpath-filter");
+    expect(fields.baseUrlField.id).toBe("edit-tool-base-url");
+    expect(fields.pathTemplateField.id).toBe("edit-tool-path-template");
+    expect(fields.queryMappingField.id).toBe("edit-tool-query-mapping");
+    expect(fields.headerMappingField.id).toBe("edit-tool-header-mapping");
+    expect(fields.exposePassthroughCheckbox.id).toBe("edit-tool-expose-passthrough");
+    expect(fields.allowlistField.id).toBe("edit-tool-allowlist");
+    expect(fields.pluginChainPreField.id).toBe("edit-tool-plugin-chain-pre");
+    expect(fields.pluginChainPostField.id).toBe("edit-tool-plugin-chain-post");
+  });
+});

--- a/tests/js/admin-forms.test.js
+++ b/tests/js/admin-forms.test.js
@@ -245,6 +245,159 @@ describe("updateEditToolRequestTypes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Edit Tool Advanced Configuration Fields
+// ---------------------------------------------------------------------------
+describe("Edit Tool Advanced Configuration Fields", () => {
+  function setupEditToolAdvancedFieldsDOM() {
+    // Create advanced configuration fields
+    const titleField = doc.createElement("input");
+    titleField.id = "edit-tool-title";
+    titleField.type = "text";
+    titleField.name = "title";
+    doc.body.appendChild(titleField);
+
+    const timeoutField = doc.createElement("input");
+    timeoutField.id = "edit-tool-timeout-ms";
+    timeoutField.type = "number";
+    timeoutField.name = "timeout_ms";
+    doc.body.appendChild(timeoutField);
+
+    const jsonpathFilterField = doc.createElement("input");
+    jsonpathFilterField.id = "edit-tool-jsonpath-filter";
+    jsonpathFilterField.type = "text";
+    jsonpathFilterField.name = "jsonpath_filter";
+    doc.body.appendChild(jsonpathFilterField);
+
+    const gatewayField = doc.createElement("select");
+    gatewayField.id = "edit-tool-gateway-id";
+    gatewayField.name = "gateway_id";
+    doc.body.appendChild(gatewayField);
+
+    const teamField = doc.createElement("select");
+    teamField.id = "edit-tool-team-id";
+    teamField.name = "team_id";
+    doc.body.appendChild(teamField);
+
+    return { titleField, timeoutField, jsonpathFilterField, gatewayField, teamField };
+  }
+
+  test("title field exists and is text input", () => {
+    const { titleField } = setupEditToolAdvancedFieldsDOM();
+    expect(titleField).toBeDefined();
+    expect(titleField.type).toBe("text");
+    expect(titleField.name).toBe("title");
+  });
+
+  test("timeout_ms field exists and is number input", () => {
+    const { timeoutField } = setupEditToolAdvancedFieldsDOM();
+    expect(timeoutField).toBeDefined();
+    expect(timeoutField.type).toBe("number");
+    expect(timeoutField.name).toBe("timeout_ms");
+  });
+
+  test("jsonpath_filter field exists and is text input", () => {
+    const { jsonpathFilterField } = setupEditToolAdvancedFieldsDOM();
+    expect(jsonpathFilterField).toBeDefined();
+    expect(jsonpathFilterField.type).toBe("text");
+    expect(jsonpathFilterField.name).toBe("jsonpath_filter");
+  });
+
+  test("gateway_id field exists and is select dropdown", () => {
+    const { gatewayField } = setupEditToolAdvancedFieldsDOM();
+    expect(gatewayField).toBeDefined();
+    expect(gatewayField.tagName.toLowerCase()).toBe("select");
+    expect(gatewayField.name).toBe("gateway_id");
+  });
+
+  test("team_id field exists and is select dropdown", () => {
+    const { teamField } = setupEditToolAdvancedFieldsDOM();
+    expect(teamField).toBeDefined();
+    expect(teamField.tagName.toLowerCase()).toBe("select");
+    expect(teamField.name).toBe("team_id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edit Tool REST Passthrough Fields
+// ---------------------------------------------------------------------------
+describe("Edit Tool REST Passthrough Fields", () => {
+  function setupRestPassthroughDOM(integrationType = "REST") {
+    // Create integration type select
+    const typeSelect = doc.createElement("select");
+    typeSelect.id = "edit-tool-type";
+    const opt = doc.createElement("option");
+    opt.value = integrationType;
+    opt.selected = true;
+    typeSelect.appendChild(opt);
+    doc.body.appendChild(typeSelect);
+
+    // Create REST passthrough button wrapper
+    const buttonWrapper = doc.createElement("div");
+    buttonWrapper.id = "edit-tool-rest-passthrough-button-wrapper";
+    buttonWrapper.style.display = integrationType === "REST" ? "block" : "none";
+    doc.body.appendChild(buttonWrapper);
+
+    // Create passthrough button
+    const button = doc.createElement("button");
+    button.id = "edit-tool-passthrough-btn";
+    button.type = "button";
+    button.textContent = "Advanced: Add Passthrough";
+    buttonWrapper.appendChild(button);
+
+    // Create passthrough container
+    const container = doc.createElement("fieldset");
+    container.id = "edit-tool-passthrough-container";
+    container.style.display = "none";
+    doc.body.appendChild(container);
+
+    // Add REST passthrough fields
+    const baseUrlField = doc.createElement("input");
+    baseUrlField.id = "edit-tool-base-url";
+    baseUrlField.name = "base_url";
+    container.appendChild(baseUrlField);
+
+    const pathTemplateField = doc.createElement("input");
+    pathTemplateField.id = "edit-tool-path-template";
+    pathTemplateField.name = "path_template";
+    container.appendChild(pathTemplateField);
+
+    const exposePassthroughCheckbox = doc.createElement("input");
+    exposePassthroughCheckbox.id = "edit-tool-expose-passthrough";
+    exposePassthroughCheckbox.type = "checkbox";
+    exposePassthroughCheckbox.name = "expose_passthrough";
+    container.appendChild(exposePassthroughCheckbox);
+
+    return { typeSelect, buttonWrapper, button, container, baseUrlField, pathTemplateField, exposePassthroughCheckbox };
+  }
+
+  test("passthrough button wrapper is shown for REST integration type", () => {
+    const { buttonWrapper } = setupRestPassthroughDOM("REST");
+    expect(buttonWrapper.style.display).toBe("block");
+  });
+
+  test("passthrough button wrapper is hidden for MCP integration type", () => {
+    const { buttonWrapper } = setupRestPassthroughDOM("MCP");
+    expect(buttonWrapper.style.display).toBe("none");
+  });
+
+  test("passthrough container is initially hidden", () => {
+    const { container } = setupRestPassthroughDOM("REST");
+    expect(container.style.display).toBe("none");
+  });
+
+  test("passthrough fields exist within container", () => {
+    const { baseUrlField, pathTemplateField, exposePassthroughCheckbox } = setupRestPassthroughDOM("REST");
+    expect(baseUrlField).toBeDefined();
+    expect(baseUrlField.name).toBe("base_url");
+    expect(pathTemplateField).toBeDefined();
+    expect(pathTemplateField.name).toBe("path_template");
+    expect(exposePassthroughCheckbox).toBeDefined();
+    expect(exposePassthroughCheckbox.type).toBe("checkbox");
+    expect(exposePassthroughCheckbox.name).toBe("expose_passthrough");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cleanUpUrlParamsForTab
 // ---------------------------------------------------------------------------
 describe("cleanUpUrlParamsForTab", () => {

--- a/tests/playwright/entities/test_tools_extended.py
+++ b/tests/playwright/entities/test_tools_extended.py
@@ -1124,3 +1124,192 @@ class TestToolsAnnotationBadges:
 
         badge = tools_page.tools_panel.locator('span:has-text("Destructive")')
         expect(badge).to_be_visible()
+
+
+# ---------------------------------------------------------------------------
+# Issue #4061: Advanced Configuration Fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ui
+@pytest.mark.tools
+@pytest.mark.issue_4061
+class TestToolsAdvancedConfigurationFields:
+    """Tests for issue #4061 - Advanced configuration fields in edit tool modal."""
+
+    def test_edit_modal_has_title_field(self, tools_page: ToolsPage):
+        """Test that edit modal contains the title field for MCP BaseMetadata."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        title_input = tools_page.tool_edit_modal.locator("#edit-tool-title")
+        expect(title_input).to_be_visible()
+        expect(title_input).to_have_attribute("name", "title")
+        expect(title_input).to_have_attribute("type", "text")
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_has_timeout_ms_field(self, tools_page: ToolsPage):
+        """Test that edit modal contains the timeout_ms field."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        timeout_input = tools_page.tool_edit_modal.locator("#edit-tool-timeout-ms")
+        expect(timeout_input).to_be_visible()
+        expect(timeout_input).to_have_attribute("name", "timeout_ms")
+        expect(timeout_input).to_have_attribute("type", "number")
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_has_jsonpath_filter_field(self, tools_page: ToolsPage):
+        """Test that edit modal contains the jsonpath_filter field."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        jsonpath_input = tools_page.tool_edit_modal.locator("#edit-tool-jsonpath-filter")
+        expect(jsonpath_input).to_be_visible()
+        expect(jsonpath_input).to_have_attribute("name", "jsonpath_filter")
+        expect(jsonpath_input).to_have_attribute("type", "text")
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_has_team_id_field(self, tools_page: ToolsPage):
+        """Test that edit modal contains the team_id select dropdown."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        team_select = tools_page.tool_edit_modal.locator("#edit-tool-team-id")
+        expect(team_select).to_be_visible()
+        expect(team_select).to_have_attribute("name", "team_id")
+
+        # Should have "No Team" option
+        no_team_option = team_select.locator('option[value=""]')
+        expect(no_team_option).to_be_attached()
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_does_not_have_gateway_id_field(self, tools_page: ToolsPage):
+        """Test that edit modal does NOT contain gateway_id field (removed in #4061)."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        # Gateway field should not exist by ID
+        gateway_by_id = tools_page.tool_edit_modal.locator("#edit-tool-gateway-id")
+        expect(gateway_by_id).not_to_be_attached()
+
+        # Gateway field should not exist by name
+        gateway_by_name = tools_page.tool_edit_modal.locator('[name="gateway_id"]')
+        expect(gateway_by_name).not_to_be_attached()
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_has_rest_passthrough_button(self, tools_page: ToolsPage):
+        """Test that edit modal contains REST passthrough button."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        passthrough_btn = tools_page.tool_edit_modal.locator("#edit-tool-passthrough-btn")
+        # Button exists but may be hidden if integration type is not REST
+        expect(passthrough_btn).to_be_attached()
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_rest_passthrough_fields_exist(self, tools_page: ToolsPage):
+        """Test that edit modal contains all REST passthrough fields."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        # All passthrough fields should exist (may be hidden by default)
+        base_url = tools_page.tool_edit_modal.locator("#edit-tool-base-url")
+        expect(base_url).to_be_attached()
+        expect(base_url).to_have_attribute("name", "base_url")
+
+        path_template = tools_page.tool_edit_modal.locator("#edit-tool-path-template")
+        expect(path_template).to_be_attached()
+        expect(path_template).to_have_attribute("name", "path_template")
+
+        query_mapping = tools_page.tool_edit_modal.locator("#edit-tool-query-mapping")
+        expect(query_mapping).to_be_attached()
+        expect(query_mapping).to_have_attribute("name", "query_mapping")
+
+        header_mapping = tools_page.tool_edit_modal.locator("#edit-tool-header-mapping")
+        expect(header_mapping).to_be_attached()
+        expect(header_mapping).to_have_attribute("name", "header_mapping")
+
+        expose_passthrough = tools_page.tool_edit_modal.locator("#edit-tool-expose-passthrough")
+        expect(expose_passthrough).to_be_attached()
+        expect(expose_passthrough).to_have_attribute("name", "expose_passthrough")
+
+        allowlist = tools_page.tool_edit_modal.locator("#edit-tool-allowlist")
+        expect(allowlist).to_be_attached()
+        expect(allowlist).to_have_attribute("name", "allowlist")
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_plugin_chain_fields_exist(self, tools_page: ToolsPage):
+        """Test that edit modal contains plugin chain fields."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        # Plugin chain fields should exist (may be hidden if plugins disabled)
+        plugin_chain_pre = tools_page.tool_edit_modal.locator("#edit-tool-plugin-chain-pre")
+        expect(plugin_chain_pre).to_be_attached()
+        expect(plugin_chain_pre).to_have_attribute("name", "plugin_chain_pre")
+
+        plugin_chain_post = tools_page.tool_edit_modal.locator("#edit-tool-plugin-chain-post")
+        expect(plugin_chain_post).to_be_attached()
+        expect(plugin_chain_post).to_have_attribute("name", "plugin_chain_post")
+
+        tools_page.cancel_tool_edit()
+
+    def test_edit_modal_advanced_fields_use_snake_case_names(self, tools_page: ToolsPage):
+        """Test that all advanced field names use snake_case not camelCase."""
+        tools_page.navigate_to_tools_tab()
+        tools_page.wait_for_tools_table_loaded()
+        _skip_if_no_tools(tools_page)
+
+        tools_page.open_tool_edit_modal(0)
+
+        # Verify snake_case field names
+        snake_case_fields = [
+            "timeout_ms",
+            "jsonpath_filter",
+            "team_id",
+            "base_url",
+            "path_template",
+            "query_mapping",
+            "header_mapping",
+            "expose_passthrough",
+            "plugin_chain_pre",
+            "plugin_chain_post",
+        ]
+
+        for field_name in snake_case_fields:
+            field = tools_page.tool_edit_modal.locator(f'[name="{field_name}"]')
+            expect(field).to_be_attached()
+
+        tools_page.cancel_tool_edit()

--- a/tests/unit/js/admin-html-issue-4061.test.js
+++ b/tests/unit/js/admin-html-issue-4061.test.js
@@ -1,0 +1,392 @@
+/**
+ * Unit tests for HTML structure changes in issue #4061.
+ *
+ * Tests verify that the edit tool form contains all required advanced
+ * configuration fields with correct attributes and does NOT contain
+ * the removed gateway_id field.
+ */
+
+import { describe, test, expect, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { JSDOM } from "jsdom";
+
+let adminHTML;
+let dom;
+let document;
+
+beforeEach(() => {
+  // Load the actual admin.html file
+  const htmlPath = join(process.cwd(), "mcpgateway", "templates", "admin.html");
+  adminHTML = readFileSync(htmlPath, "utf-8");
+  dom = new JSDOM(adminHTML);
+  document = dom.window.document;
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Advanced Configuration Field Presence in HTML
+// ---------------------------------------------------------------------------
+describe("Issue #4061: Advanced Configuration Field Presence in HTML", () => {
+  test("edit tool form contains title field with correct attributes", () => {
+    const titleField = document.getElementById("edit-tool-title");
+
+    expect(titleField).not.toBeNull();
+    expect(titleField.tagName).toBe("INPUT");
+    expect(titleField.getAttribute("name")).toBe("title");
+    expect(titleField.getAttribute("type")).toBe("text");
+    expect(titleField.getAttribute("maxlength")).toBe("255");
+    expect(titleField.getAttribute("placeholder")).toContain("Human-readable title");
+  });
+
+  test("edit tool form contains timeout_ms field with correct attributes", () => {
+    const timeoutField = document.getElementById("edit-tool-timeout-ms");
+
+    expect(timeoutField).not.toBeNull();
+    expect(timeoutField.tagName).toBe("INPUT");
+    expect(timeoutField.getAttribute("name")).toBe("timeout_ms");
+    expect(timeoutField.getAttribute("type")).toBe("number");
+    expect(timeoutField.getAttribute("min")).toBe("1");
+    expect(timeoutField.getAttribute("placeholder")).toContain("milliseconds");
+  });
+
+  test("edit tool form contains jsonpath_filter field with correct attributes", () => {
+    const jsonpathField = document.getElementById("edit-tool-jsonpath-filter");
+
+    expect(jsonpathField).not.toBeNull();
+    expect(jsonpathField.tagName).toBe("INPUT");
+    expect(jsonpathField.getAttribute("name")).toBe("jsonpath_filter");
+    expect(jsonpathField.getAttribute("type")).toBe("text");
+    expect(jsonpathField.getAttribute("placeholder")).toContain("$.data");
+  });
+
+  test("edit tool form contains team_id field with correct attributes", () => {
+    const teamField = document.getElementById("edit-tool-team-id");
+
+    expect(teamField).not.toBeNull();
+    expect(teamField.tagName).toBe("SELECT");
+    expect(teamField.getAttribute("name")).toBe("team_id");
+
+    // Check for "No Team" option
+    const noTeamOption = teamField.querySelector('option[value=""]');
+    expect(noTeamOption).not.toBeNull();
+    expect(noTeamOption.textContent).toContain("No Team");
+  });
+
+  test("edit tool form contains REST passthrough button", () => {
+    const buttonWrapper = document.getElementById("edit-tool-rest-passthrough-button-wrapper");
+    const button = document.getElementById("edit-tool-passthrough-btn");
+
+    expect(buttonWrapper).not.toBeNull();
+    expect(button).not.toBeNull();
+    expect(button.textContent).toContain("Add Passthrough");
+
+    // Button wrapper should be hidden by default
+    expect(buttonWrapper.getAttribute("style")).toContain("display: none");
+  });
+
+  test("edit tool form contains REST passthrough container with all fields", () => {
+    const container = document.getElementById("edit-tool-passthrough-container");
+
+    expect(container).not.toBeNull();
+    expect(container.tagName).toBe("FIELDSET");
+
+    // Container should be hidden by default
+    expect(container.getAttribute("style")).toContain("display: none");
+
+    // Check for legend
+    const legend = container.querySelector("legend");
+    expect(legend).not.toBeNull();
+    expect(legend.textContent).toContain("REST Passthrough Configuration");
+  });
+
+  test("REST passthrough container contains base_url field", () => {
+    const baseUrlField = document.getElementById("edit-tool-base-url");
+
+    expect(baseUrlField).not.toBeNull();
+    expect(baseUrlField.tagName).toBe("INPUT");
+    expect(baseUrlField.getAttribute("name")).toBe("base_url");
+    expect(baseUrlField.getAttribute("type")).toBe("url");
+    expect(baseUrlField.getAttribute("placeholder")).toContain("https://");
+  });
+
+  test("REST passthrough container contains path_template field", () => {
+    const pathField = document.getElementById("edit-tool-path-template");
+
+    expect(pathField).not.toBeNull();
+    expect(pathField.tagName).toBe("INPUT");
+    expect(pathField.getAttribute("name")).toBe("path_template");
+    expect(pathField.getAttribute("type")).toBe("text");
+    expect(pathField.getAttribute("placeholder")).toContain("/api");
+  });
+
+  test("REST passthrough container contains query_mapping textarea", () => {
+    const queryField = document.getElementById("edit-tool-query-mapping");
+
+    expect(queryField).not.toBeNull();
+    expect(queryField.tagName).toBe("TEXTAREA");
+    expect(queryField.getAttribute("name")).toBe("query_mapping");
+    expect(queryField.getAttribute("rows")).toBe("3");
+    expect(queryField.getAttribute("placeholder")).toContain('{"param"');
+  });
+
+  test("REST passthrough container contains header_mapping textarea", () => {
+    const headerField = document.getElementById("edit-tool-header-mapping");
+
+    expect(headerField).not.toBeNull();
+    expect(headerField.tagName).toBe("TEXTAREA");
+    expect(headerField.getAttribute("name")).toBe("header_mapping");
+    expect(headerField.getAttribute("rows")).toBe("3");
+  });
+
+  test("REST passthrough container contains expose_passthrough checkbox", () => {
+    const exposeField = document.getElementById("edit-tool-expose-passthrough");
+
+    expect(exposeField).not.toBeNull();
+    expect(exposeField.tagName).toBe("INPUT");
+    expect(exposeField.getAttribute("name")).toBe("expose_passthrough");
+    expect(exposeField.getAttribute("type")).toBe("checkbox");
+
+    // Check for associated label
+    const label = document.querySelector('label[for="edit-tool-expose-passthrough"]');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain("Expose");
+  });
+
+  test("REST passthrough container contains allowlist text input", () => {
+    const allowlistField = document.getElementById("edit-tool-allowlist");
+
+    expect(allowlistField).not.toBeNull();
+    expect(allowlistField.tagName).toBe("INPUT");
+    expect(allowlistField.getAttribute("name")).toBe("allowlist");
+    expect(allowlistField.getAttribute("type")).toBe("text");
+    expect(allowlistField.getAttribute("placeholder")).toContain("api.example.com");
+  });
+
+  test("edit tool form contains plugin section with pre and post chain fields", () => {
+    const pluginSection = document.getElementById("edit-tool-plugin-section");
+
+    expect(pluginSection).not.toBeNull();
+
+    // Plugin section should be hidden by default
+    expect(pluginSection.getAttribute("style")).toContain("display: none");
+
+    // Check plugin_chain_pre
+    const preChainField = document.getElementById("edit-tool-plugin-chain-pre");
+    expect(preChainField).not.toBeNull();
+    expect(preChainField.tagName).toBe("INPUT");
+    expect(preChainField.getAttribute("name")).toBe("plugin_chain_pre");
+    expect(preChainField.getAttribute("type")).toBe("text");
+
+    // Check plugin_chain_post
+    const postChainField = document.getElementById("edit-tool-plugin-chain-post");
+    expect(postChainField).not.toBeNull();
+    expect(postChainField.tagName).toBe("INPUT");
+    expect(postChainField.getAttribute("name")).toBe("plugin_chain_post");
+    expect(postChainField.getAttribute("type")).toBe("text");
+  });
+
+  test("all advanced field IDs follow edit-tool-* naming convention", () => {
+    const expectedIds = [
+      "edit-tool-title",
+      "edit-tool-timeout-ms",
+      "edit-tool-jsonpath-filter",
+      "edit-tool-team-id",
+      "edit-tool-passthrough-btn",
+      "edit-tool-base-url",
+      "edit-tool-path-template",
+      "edit-tool-query-mapping",
+      "edit-tool-header-mapping",
+      "edit-tool-expose-passthrough",
+      "edit-tool-allowlist",
+      "edit-tool-plugin-chain-pre",
+      "edit-tool-plugin-chain-post",
+    ];
+
+    expectedIds.forEach(id => {
+      const element = document.getElementById(id);
+      expect(element).not.toBeNull();
+      expect(id).toMatch(/^edit-tool-[a-z0-9-]+$/);
+    });
+  });
+
+  test("all advanced field names use snake_case not camelCase", () => {
+    const expectedNames = [
+      "title",
+      "timeout_ms",
+      "jsonpath_filter",
+      "team_id",
+      "base_url",
+      "path_template",
+      "query_mapping",
+      "header_mapping",
+      "expose_passthrough",
+      "allowlist",
+      "plugin_chain_pre",
+      "plugin_chain_post",
+    ];
+
+    expectedNames.forEach(name => {
+      const element = document.querySelector(`[name="${name}"]`);
+      expect(element).not.toBeNull();
+
+      // Verify it's snake_case (no camelCase)
+      expect(name).not.toMatch(/[A-Z]/);
+      if (name.includes("_")) {
+        expect(name).toMatch(/^[a-z0-9]+(_[a-z0-9]+)*$/);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Gateway Field Removal from HTML
+// ---------------------------------------------------------------------------
+describe("Issue #4061: Gateway Field Removal from HTML", () => {
+  test("edit tool form does NOT contain gateway_id field by ID", () => {
+    const gatewayField = document.getElementById("edit-tool-gateway-id");
+    expect(gatewayField).toBeNull();
+  });
+
+  test("edit tool form does NOT contain gateway_id field by name", () => {
+    const gatewayFields = document.querySelectorAll('[name="gateway_id"]');
+    expect(gatewayFields.length).toBe(0);
+  });
+
+  test("edit tool form does NOT contain gateway field in modal", () => {
+    // Check within edit-tool-modal if it exists
+    const modal = document.getElementById("edit-tool-modal");
+
+    if (modal) {
+      const gatewayInModal = modal.querySelector('[name="gateway_id"]');
+      expect(gatewayInModal).toBeNull();
+
+      const gatewayByIdInModal = modal.querySelector('#edit-tool-gateway-id');
+      expect(gatewayByIdInModal).toBeNull();
+    }
+  });
+
+  test("HTML does not reference gateway reassignment in edit tool section", () => {
+    // Find the edit tool form section
+    const editForm = document.getElementById("edit-tool-form");
+
+    if (editForm) {
+      const formHTML = editForm.innerHTML.toLowerCase();
+
+      // Should not contain references to gateway reassignment
+      expect(formHTML).not.toContain("reassign to gateway");
+      expect(formHTML).not.toContain("gateway reassignment");
+      expect(formHTML).not.toContain("change gateway");
+    }
+  });
+
+  test("edit tool modal contains advanced fields but NOT gateway_id", () => {
+    const modal = document.getElementById("edit-tool-modal");
+
+    if (modal) {
+      // Should have advanced fields
+      expect(modal.querySelector('#edit-tool-title')).not.toBeNull();
+      expect(modal.querySelector('#edit-tool-timeout-ms')).not.toBeNull();
+      expect(modal.querySelector('#edit-tool-jsonpath-filter')).not.toBeNull();
+      expect(modal.querySelector('#edit-tool-team-id')).not.toBeNull();
+
+      // Should NOT have gateway field
+      expect(modal.querySelector('[name="gateway_id"]')).toBeNull();
+      expect(modal.querySelector('#edit-tool-gateway-id')).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Field Label and Help Text Validation
+// ---------------------------------------------------------------------------
+describe("Issue #4061: Field Label and Help Text Validation", () => {
+  test("title field has appropriate label and help text", () => {
+    const titleField = document.getElementById("edit-tool-title");
+    const label = titleField.closest("div").querySelector("label");
+    const helpText = titleField.closest("div").querySelector("p");
+
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain("Title");
+    expect(helpText).not.toBeNull();
+    expect(helpText.textContent).toContain("MCP BaseMetadata");
+  });
+
+  test("timeout_ms field has appropriate label and help text", () => {
+    const timeoutField = document.getElementById("edit-tool-timeout-ms");
+    const label = timeoutField.closest("div").querySelector("label");
+    const helpText = timeoutField.closest("div").querySelector("p");
+
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain("Timeout");
+    expect(helpText).not.toBeNull();
+    expect(helpText.textContent).toContain("Leave empty to use global default");
+  });
+
+  test("jsonpath_filter field has appropriate label and help text", () => {
+    const jsonpathField = document.getElementById("edit-tool-jsonpath-filter");
+    const label = jsonpathField.closest("div").querySelector("label");
+    const helpText = jsonpathField.closest("div").querySelector("p");
+
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain("JSONPath");
+    expect(helpText).not.toBeNull();
+    expect(helpText.textContent).toContain("JSONPath expression");
+  });
+
+  test("team_id field has appropriate label and help text", () => {
+    const teamField = document.getElementById("edit-tool-team-id");
+    const label = teamField.closest("div").querySelector("label");
+    const helpText = teamField.closest("div").querySelector("p");
+
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain("Team");
+    expect(helpText).not.toBeNull();
+    expect(helpText.textContent).toContain("Reassign this tool");
+  });
+
+  test("REST passthrough fields have appropriate labels and help text", () => {
+    // Base URL
+    const baseUrlField = document.getElementById("edit-tool-base-url");
+    const baseUrlLabel = baseUrlField.closest("div").querySelector("label");
+    const baseUrlHelp = baseUrlField.closest("div").querySelector("p");
+
+    expect(baseUrlLabel.textContent).toContain("Base URL");
+    expect(baseUrlHelp.textContent).toContain("must include scheme and host");
+
+    // Path Template
+    const pathField = document.getElementById("edit-tool-path-template");
+    const pathLabel = pathField.closest("div").querySelector("label");
+    const pathHelp = pathField.closest("div").querySelector("p");
+
+    expect(pathLabel.textContent).toContain("Path Template");
+    expect(pathHelp.textContent).toContain("must start with '/'");
+
+    // Query Mapping
+    const queryField = document.getElementById("edit-tool-query-mapping");
+    const queryLabel = queryField.closest("div").querySelector("label");
+    const queryHelp = queryField.closest("div").querySelector("p");
+
+    expect(queryLabel.textContent).toContain("Query Mapping");
+    expect(queryHelp.textContent).toContain("JSON object");
+
+    // Header Mapping
+    const headerField = document.getElementById("edit-tool-header-mapping");
+    const headerLabel = headerField.closest("div").querySelector("label");
+
+    expect(headerLabel.textContent).toContain("Header Mapping");
+  });
+
+  test("plugin chain fields have appropriate labels", () => {
+    const preChainField = document.getElementById("edit-tool-plugin-chain-pre");
+    const preChainLabel = preChainField.closest("div").querySelector("label");
+
+    expect(preChainLabel).not.toBeNull();
+    expect(preChainLabel.textContent).toContain("Pre-processing Plugins");
+
+    const postChainField = document.getElementById("edit-tool-plugin-chain-post");
+    const postChainLabel = postChainField.closest("div").querySelector("label");
+
+    expect(postChainLabel).not.toBeNull();
+    expect(postChainLabel.textContent).toContain("Post-processing Plugins");
+  });
+});

--- a/tests/unit/js/formFieldHandlers.test.js
+++ b/tests/unit/js/formFieldHandlers.test.js
@@ -1175,3 +1175,166 @@ describe("handleEditToolPassthrough", () => {
     errorSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Advanced Configuration Fields - Field Naming Convention
+// ---------------------------------------------------------------------------
+describe("Issue #4061: Advanced Configuration Field Naming", () => {
+  function setupAdvancedFieldsDOM() {
+    const titleField = document.createElement("input");
+    titleField.id = "edit-tool-title";
+    titleField.name = "title";
+    document.body.appendChild(titleField);
+
+    const timeoutField = document.createElement("input");
+    timeoutField.id = "edit-tool-timeout-ms";
+    timeoutField.name = "timeout_ms";
+    timeoutField.type = "number";
+    document.body.appendChild(timeoutField);
+
+    const jsonpathFilterField = document.createElement("input");
+    jsonpathFilterField.id = "edit-tool-jsonpath-filter";
+    jsonpathFilterField.name = "jsonpath_filter";
+    document.body.appendChild(jsonpathFilterField);
+
+    const baseUrlField = document.createElement("input");
+    baseUrlField.id = "edit-tool-base-url";
+    baseUrlField.name = "base_url";
+    document.body.appendChild(baseUrlField);
+
+    const pathTemplateField = document.createElement("input");
+    pathTemplateField.id = "edit-tool-path-template";
+    pathTemplateField.name = "path_template";
+    document.body.appendChild(pathTemplateField);
+
+    const queryMappingField = document.createElement("textarea");
+    queryMappingField.id = "edit-tool-query-mapping";
+    queryMappingField.name = "query_mapping";
+    document.body.appendChild(queryMappingField);
+
+    const headerMappingField = document.createElement("textarea");
+    headerMappingField.id = "edit-tool-header-mapping";
+    headerMappingField.name = "header_mapping";
+    document.body.appendChild(headerMappingField);
+
+    const exposePassthroughCheckbox = document.createElement("input");
+    exposePassthroughCheckbox.id = "edit-tool-expose-passthrough";
+    exposePassthroughCheckbox.name = "expose_passthrough";
+    exposePassthroughCheckbox.type = "checkbox";
+    document.body.appendChild(exposePassthroughCheckbox);
+
+    const allowlistField = document.createElement("input");
+    allowlistField.id = "edit-tool-allowlist";
+    allowlistField.name = "allowlist";
+    document.body.appendChild(allowlistField);
+
+    const pluginChainPreField = document.createElement("input");
+    pluginChainPreField.id = "edit-tool-plugin-chain-pre";
+    pluginChainPreField.name = "plugin_chain_pre";
+    document.body.appendChild(pluginChainPreField);
+
+    const pluginChainPostField = document.createElement("input");
+    pluginChainPostField.id = "edit-tool-plugin-chain-post";
+    pluginChainPostField.name = "plugin_chain_post";
+    document.body.appendChild(pluginChainPostField);
+
+    return {
+      titleField,
+      timeoutField,
+      jsonpathFilterField,
+      baseUrlField,
+      pathTemplateField,
+      queryMappingField,
+      headerMappingField,
+      exposePassthroughCheckbox,
+      allowlistField,
+      pluginChainPreField,
+      pluginChainPostField,
+    };
+  }
+
+  test("jsonpath_filter field uses snake_case not camelCase", () => {
+    const { jsonpathFilterField } = setupAdvancedFieldsDOM();
+    expect(jsonpathFilterField.name).toBe("jsonpath_filter");
+    expect(jsonpathFilterField.id).toBe("edit-tool-jsonpath-filter");
+  });
+
+  test("timeout_ms field uses snake_case", () => {
+    const { timeoutField } = setupAdvancedFieldsDOM();
+    expect(timeoutField.name).toBe("timeout_ms");
+    expect(timeoutField.id).toBe("edit-tool-timeout-ms");
+  });
+
+  test("REST passthrough fields use snake_case", () => {
+    const {
+      baseUrlField,
+      pathTemplateField,
+      queryMappingField,
+      headerMappingField,
+      exposePassthroughCheckbox,
+    } = setupAdvancedFieldsDOM();
+
+    expect(baseUrlField.name).toBe("base_url");
+    expect(pathTemplateField.name).toBe("path_template");
+    expect(queryMappingField.name).toBe("query_mapping");
+    expect(headerMappingField.name).toBe("header_mapping");
+    expect(exposePassthroughCheckbox.name).toBe("expose_passthrough");
+  });
+
+  test("plugin chain fields use snake_case", () => {
+    const { pluginChainPreField, pluginChainPostField } = setupAdvancedFieldsDOM();
+
+    expect(pluginChainPreField.name).toBe("plugin_chain_pre");
+    expect(pluginChainPostField.name).toBe("plugin_chain_post");
+  });
+
+  test("all field IDs follow edit-tool-* convention with hyphens", () => {
+    const fields = setupAdvancedFieldsDOM();
+
+    expect(fields.titleField.id).toBe("edit-tool-title");
+    expect(fields.timeoutField.id).toBe("edit-tool-timeout-ms");
+    expect(fields.jsonpathFilterField.id).toBe("edit-tool-jsonpath-filter");
+    expect(fields.baseUrlField.id).toBe("edit-tool-base-url");
+    expect(fields.pathTemplateField.id).toBe("edit-tool-path-template");
+    expect(fields.queryMappingField.id).toBe("edit-tool-query-mapping");
+    expect(fields.headerMappingField.id).toBe("edit-tool-header-mapping");
+    expect(fields.exposePassthroughCheckbox.id).toBe("edit-tool-expose-passthrough");
+    expect(fields.allowlistField.id).toBe("edit-tool-allowlist");
+    expect(fields.pluginChainPreField.id).toBe("edit-tool-plugin-chain-pre");
+    expect(fields.pluginChainPostField.id).toBe("edit-tool-plugin-chain-post");
+  });
+
+  test("common advanced fields exist and have correct types", () => {
+    const { titleField, timeoutField, jsonpathFilterField } = setupAdvancedFieldsDOM();
+
+    expect(titleField.tagName).toBe("INPUT");
+    expect(titleField.type).toBe("text");
+
+    expect(timeoutField.tagName).toBe("INPUT");
+    expect(timeoutField.type).toBe("number");
+
+    expect(jsonpathFilterField.tagName).toBe("INPUT");
+    expect(jsonpathFilterField.type).toBe("text");
+  });
+
+  test("REST passthrough JSON fields are textarea elements", () => {
+    const { queryMappingField, headerMappingField } = setupAdvancedFieldsDOM();
+
+    expect(queryMappingField.tagName).toBe("TEXTAREA");
+    expect(headerMappingField.tagName).toBe("TEXTAREA");
+  });
+
+  test("expose_passthrough is checkbox type", () => {
+    const { exposePassthroughCheckbox } = setupAdvancedFieldsDOM();
+
+    expect(exposePassthroughCheckbox.tagName).toBe("INPUT");
+    expect(exposePassthroughCheckbox.type).toBe("checkbox");
+  });
+
+  test("allowlist field exists with correct name", () => {
+    const { allowlistField } = setupAdvancedFieldsDOM();
+
+    expect(allowlistField.name).toBe("allowlist");
+    expect(allowlistField.id).toBe("edit-tool-allowlist");
+  });
+});

--- a/tests/unit/js/formFieldHandlers.test.js
+++ b/tests/unit/js/formFieldHandlers.test.js
@@ -16,6 +16,8 @@ import {
   updateRequestTypeOptions,
   updateEditToolRequestTypes,
   handleAddPassthrough,
+  handleEditToolIntegrationTypeChange,
+  handleEditToolPassthrough,
   searchTeamSelector,
   performTeamSelectorSearch,
   selectTeamFromSelector,
@@ -1061,5 +1063,115 @@ describe("selectTeamFromSelector", () => {
     document.body.appendChild(btn);
 
     expect(() => selectTeamFromSelector(btn)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleEditToolIntegrationTypeChange
+// ---------------------------------------------------------------------------
+describe("handleEditToolIntegrationTypeChange", () => {
+  function setupEditToolIntegrationTypeDOM(integrationType = "REST") {
+    const typeSelect = document.createElement("select");
+    typeSelect.id = "edit-tool-type";
+    const opt = document.createElement("option");
+    opt.value = integrationType;
+    opt.selected = true;
+    typeSelect.appendChild(opt);
+    document.body.appendChild(typeSelect);
+
+    const buttonWrapper = document.createElement("div");
+    buttonWrapper.id = "edit-tool-rest-passthrough-button-wrapper";
+    buttonWrapper.style.display = "none";
+    document.body.appendChild(buttonWrapper);
+
+    const container = document.createElement("fieldset");
+    container.id = "edit-tool-passthrough-container";
+    container.style.display = "none";
+    document.body.appendChild(container);
+
+    return { typeSelect, buttonWrapper, container };
+  }
+
+  test("shows passthrough button wrapper for REST integration type", () => {
+    const { buttonWrapper } = setupEditToolIntegrationTypeDOM("REST");
+
+    handleEditToolIntegrationTypeChange();
+
+    expect(buttonWrapper.style.display).toBe("block");
+  });
+
+  test("hides passthrough button wrapper for MCP integration type", () => {
+    const { buttonWrapper } = setupEditToolIntegrationTypeDOM("MCP");
+
+    handleEditToolIntegrationTypeChange();
+
+    expect(buttonWrapper.style.display).toBe("none");
+  });
+
+  test("hides passthrough container when switching away from REST", () => {
+    const { container, typeSelect } = setupEditToolIntegrationTypeDOM("REST");
+
+    // First set container to visible
+    container.style.display = "block";
+
+    // Change type to MCP
+    typeSelect.value = "MCP";
+    handleEditToolIntegrationTypeChange();
+
+    expect(container.style.display).toBe("none");
+  });
+
+  test("does not throw when elements are missing", () => {
+    expect(() => handleEditToolIntegrationTypeChange()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleEditToolPassthrough
+// ---------------------------------------------------------------------------
+describe("handleEditToolPassthrough", () => {
+  function setupPassthroughButtonDOM() {
+    const container = document.createElement("fieldset");
+    container.id = "edit-tool-passthrough-container";
+    container.style.display = "none";
+    document.body.appendChild(container);
+
+    return { container };
+  }
+
+  test("toggles passthrough container from hidden to visible", () => {
+    const { container } = setupPassthroughButtonDOM();
+
+    container.style.display = "none";
+    handleEditToolPassthrough();
+
+    expect(container.style.display).toBe("block");
+  });
+
+  test("toggles passthrough container from visible to hidden", () => {
+    const { container } = setupPassthroughButtonDOM();
+
+    container.style.display = "block";
+    handleEditToolPassthrough();
+
+    expect(container.style.display).toBe("none");
+  });
+
+  test("treats empty display as hidden and toggles to visible", () => {
+    const { container } = setupPassthroughButtonDOM();
+
+    container.style.display = "";
+    handleEditToolPassthrough();
+
+    expect(container.style.display).toBe("block");
+  });
+
+  test("logs error when container is missing", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    handleEditToolPassthrough();
+
+    expect(errorSpy).toHaveBeenCalledWith("Edit tool passthrough container not found");
+    errorSpy.mockRestore();
   });
 });

--- a/tests/unit/js/formSubmitHandlers-editor-save.test.js
+++ b/tests/unit/js/formSubmitHandlers-editor-save.test.js
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for CodeMirror editor save error handling in form submit handlers.
+ *
+ * Tests verify that:
+ * 1. All editors are attempted to save even if one fails
+ * 2. All errors are collected and reported together
+ * 3. Form submission is aborted if any editor fails
+ * 4. Individual editor errors are logged for debugging
+ */
+
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { JSDOM } from "jsdom";
+
+let dom;
+let document;
+let window;
+
+beforeEach(() => {
+  dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  document = dom.window.document;
+  window = dom.window;
+  global.window = window;
+  global.document = document;
+
+  // Mock console methods
+  global.console.error = vi.fn();
+  global.console.log = vi.fn();
+});
+
+describe("CodeMirror Editor Save Error Handling", () => {
+  test("all editors attempt save even when one fails", () => {
+    // Simulate edit tool form with multiple editors
+    const editor1SaveSuccess = vi.fn();
+    const editor2SaveError = vi.fn(() => {
+      throw new Error("Editor 2 failed");
+    });
+    const editor3SaveSuccess = vi.fn();
+
+    window.editToolHeadersEditor = { save: editor1SaveSuccess };
+    window.editToolSchemaEditor = { save: editor2SaveError };
+    window.editToolOutputSchemaEditor = { save: editor3SaveSuccess };
+
+    // Simulate the error collection logic from formSubmitHandlers.js
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolHeadersEditor", editor: window.editToolHeadersEditor },
+      { name: "editToolSchemaEditor", editor: window.editToolSchemaEditor },
+      { name: "editToolOutputSchemaEditor", editor: window.editToolOutputSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Verify all editors were attempted
+    expect(editor1SaveSuccess).toHaveBeenCalledTimes(1);
+    expect(editor2SaveError).toHaveBeenCalledTimes(1);
+    expect(editor3SaveSuccess).toHaveBeenCalledTimes(1);
+
+    // Verify error was collected
+    expect(editorSaveErrors.length).toBe(1);
+    expect(editorSaveErrors[0]).toBe("editToolSchemaEditor: Editor 2 failed");
+
+    // Verify console.error was called
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to save editToolSchemaEditor:",
+      expect.any(Error)
+    );
+  });
+
+  test("multiple editor failures are all collected", () => {
+    // Simulate multiple failing editors
+    const editor1SaveError = vi.fn(() => {
+      throw new Error("Editor 1 failed");
+    });
+    const editor2SaveError = vi.fn(() => {
+      throw new Error("Editor 2 failed");
+    });
+    const editor3SaveError = vi.fn(() => {
+      throw new Error("Editor 3 failed");
+    });
+
+    window.editToolHeadersEditor = { save: editor1SaveError };
+    window.editToolSchemaEditor = { save: editor2SaveError };
+    window.editToolOutputSchemaEditor = { save: editor3SaveError };
+
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolHeadersEditor", editor: window.editToolHeadersEditor },
+      { name: "editToolSchemaEditor", editor: window.editToolSchemaEditor },
+      { name: "editToolOutputSchemaEditor", editor: window.editToolOutputSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Verify all errors were collected
+    expect(editorSaveErrors.length).toBe(3);
+    expect(editorSaveErrors[0]).toBe("editToolHeadersEditor: Editor 1 failed");
+    expect(editorSaveErrors[1]).toBe("editToolSchemaEditor: Editor 2 failed");
+    expect(editorSaveErrors[2]).toBe("editToolOutputSchemaEditor: Editor 3 failed");
+
+    // Verify console.error was called 3 times
+    expect(console.error).toHaveBeenCalledTimes(3);
+  });
+
+  test("missing editors are skipped without error", () => {
+    // Only set up one editor
+    const editor1SaveSuccess = vi.fn();
+    window.editToolHeadersEditor = { save: editor1SaveSuccess };
+    // Other editors undefined
+
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolHeadersEditor", editor: window.editToolHeadersEditor },
+      { name: "editToolSchemaEditor", editor: window.editToolSchemaEditor },
+      { name: "editToolOutputSchemaEditor", editor: window.editToolOutputSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Verify only the present editor was called
+    expect(editor1SaveSuccess).toHaveBeenCalledTimes(1);
+    expect(editorSaveErrors.length).toBe(0);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test("error message format is correct", () => {
+    // Simulate one failing editor
+    const editorSaveError = vi.fn(() => {
+      throw new Error("Invalid JSON syntax");
+    });
+
+    window.editToolQueryMappingEditor = { save: editorSaveError };
+
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolQueryMappingEditor", editor: window.editToolQueryMappingEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Build the error message as the code would
+    const errorMessage = editorSaveErrors.length > 0
+      ? `Failed to save editor content:\n${editorSaveErrors.join("\n")}`
+      : null;
+
+    expect(errorMessage).toBe("Failed to save editor content:\neditToolQueryMappingEditor: Invalid JSON syntax");
+  });
+
+  test("successful save with all editors present", () => {
+    // Simulate all editors saving successfully
+    const editor1Save = vi.fn();
+    const editor2Save = vi.fn();
+    const editor3Save = vi.fn();
+    const editor4Save = vi.fn();
+    const editor5Save = vi.fn();
+
+    window.editToolHeadersEditor = { save: editor1Save };
+    window.editToolSchemaEditor = { save: editor2Save };
+    window.editToolOutputSchemaEditor = { save: editor3Save };
+    window.editToolQueryMappingEditor = { save: editor4Save };
+    window.editToolHeaderMappingEditor = { save: editor5Save };
+
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "editToolHeadersEditor", editor: window.editToolHeadersEditor },
+      { name: "editToolSchemaEditor", editor: window.editToolSchemaEditor },
+      { name: "editToolOutputSchemaEditor", editor: window.editToolOutputSchemaEditor },
+      { name: "editToolQueryMappingEditor", editor: window.editToolQueryMappingEditor },
+      { name: "editToolHeaderMappingEditor", editor: window.editToolHeaderMappingEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Verify all editors were called
+    expect(editor1Save).toHaveBeenCalledTimes(1);
+    expect(editor2Save).toHaveBeenCalledTimes(1);
+    expect(editor3Save).toHaveBeenCalledTimes(1);
+    expect(editor4Save).toHaveBeenCalledTimes(1);
+    expect(editor5Save).toHaveBeenCalledTimes(1);
+
+    // Verify no errors
+    expect(editorSaveErrors.length).toBe(0);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  test("error in middle editor does not prevent later editors from saving", () => {
+    // First editor succeeds, second fails, third succeeds
+    const editor1Save = vi.fn();
+    const editor2SaveError = vi.fn(() => {
+      throw new Error("Middle editor failed");
+    });
+    const editor3Save = vi.fn();
+
+    window.headersEditor = { save: editor1Save };
+    window.schemaEditor = { save: editor2SaveError };
+    window.outputSchemaEditor = { save: editor3Save };
+
+    const editorSaveErrors = [];
+    const editors = [
+      { name: "headersEditor", editor: window.headersEditor },
+      { name: "schemaEditor", editor: window.schemaEditor },
+      { name: "outputSchemaEditor", editor: window.outputSchemaEditor },
+    ];
+
+    for (const { name, editor } of editors) {
+      if (editor) {
+        try {
+          editor.save();
+        } catch (error) {
+          console.error(`Failed to save ${name}:`, error);
+          editorSaveErrors.push(`${name}: ${error.message}`);
+        }
+      }
+    }
+
+    // Critical: All three editors should have been attempted
+    expect(editor1Save).toHaveBeenCalledTimes(1);
+    expect(editor2SaveError).toHaveBeenCalledTimes(1);
+    expect(editor3Save).toHaveBeenCalledTimes(1);
+
+    // Only the middle editor error should be collected
+    expect(editorSaveErrors.length).toBe(1);
+    expect(editorSaveErrors[0]).toBe("schemaEditor: Middle editor failed");
+  });
+});

--- a/tests/unit/js/tools.test.js
+++ b/tests/unit/js/tools.test.js
@@ -1123,7 +1123,7 @@ describe("editTool - enhanced", () => {
     consoleSpy.mockRestore();
   });
 
-  test("injects hidden team_id input when URL contains team_id param", async () => {
+  test("team_id is handled via select dropdown not hidden input", async () => {
     window.ROOT_PATH = "";
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.stubGlobal("location", { href: "http://localhost/?team_id=team-42" });
@@ -1142,12 +1142,22 @@ describe("editTool - enhanced", () => {
     editForm.id = "edit-tool-form";
     document.body.appendChild(editForm);
 
+    // Create the team_id select dropdown
+    const teamSelect = document.createElement("select");
+    teamSelect.id = "edit-tool-team-id";
+    teamSelect.name = "team_id";
+    editForm.appendChild(teamSelect);
+
     await editTool("t1");
 
-    const hidden = editForm.querySelector('input[name="team_id"]');
-    expect(hidden).not.toBeNull();
-    expect(hidden.type).toBe("hidden");
-    expect(hidden.value).toBe("team-42");
+    // Team ID should NOT be a hidden input (old behavior)
+    const hidden = editForm.querySelector('input[type="hidden"][name="team_id"]');
+    expect(hidden).toBeNull();
+
+    // Team ID should be handled by the select dropdown
+    const teamDropdown = editForm.querySelector('select[name="team_id"]');
+    expect(teamDropdown).not.toBeNull();
+    expect(teamDropdown.id).toBe("edit-tool-team-id");
 
     vi.unstubAllGlobals();
     consoleSpy.mockRestore();

--- a/tests/unit/js/tools.test.js
+++ b/tests/unit/js/tools.test.js
@@ -3560,3 +3560,164 @@ describe("invokeTool", () => {
     consoleSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #4061: Gateway Reassignment Removal
+// ---------------------------------------------------------------------------
+describe("Issue #4061: Gateway Reassignment Field Removal", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.ROOT_PATH = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete window.ROOT_PATH;
+  });
+
+  test("edit tool form should not contain gateway_id field", () => {
+    // Setup edit tool form
+    const form = document.createElement("form");
+    form.id = "edit-tool-form";
+    document.body.appendChild(form);
+
+    // Add expected fields
+    const nameField = document.createElement("input");
+    nameField.id = "edit-tool-name";
+    nameField.name = "name";
+    form.appendChild(nameField);
+
+    const typeField = document.createElement("select");
+    typeField.id = "edit-tool-type";
+    typeField.name = "integration_type";
+    form.appendChild(typeField);
+
+    // Gateway field should NOT exist (removed per issue #4061)
+    const gatewayField = document.getElementById("edit-tool-gateway-id");
+    expect(gatewayField).toBeNull();
+
+    // Verify no gateway_id input in form
+    const gatewayInputs = form.querySelectorAll('[name="gateway_id"]');
+    expect(gatewayInputs.length).toBe(0);
+  });
+
+  test("edit tool modal should not have gateway dropdown element", () => {
+    const modal = document.createElement("div");
+    modal.id = "edit-tool-modal";
+    document.body.appendChild(modal);
+
+    const form = document.createElement("form");
+    form.id = "edit-tool-form";
+    modal.appendChild(form);
+
+    // Check for gateway_id select element
+    const gatewaySelect = modal.querySelector('select[name="gateway_id"]');
+    expect(gatewaySelect).toBeNull();
+
+    // Check by ID
+    const gatewayById = document.getElementById("edit-tool-gateway-id");
+    expect(gatewayById).toBeNull();
+  });
+
+  test("gateway_id should not be in FormData when submitting edit tool form", () => {
+    const form = document.createElement("form");
+    form.id = "edit-tool-form";
+    document.body.appendChild(form);
+
+    const nameField = document.createElement("input");
+    nameField.name = "name";
+    nameField.value = "test_tool";
+    form.appendChild(nameField);
+
+    const typeField = document.createElement("select");
+    typeField.name = "integration_type";
+    const option = document.createElement("option");
+    option.value = "REST";
+    option.selected = true;
+    typeField.appendChild(option);
+    form.appendChild(typeField);
+
+    // Create FormData from form
+    const formData = new FormData(form);
+
+    // Gateway should not be in FormData
+    expect(formData.has("gateway_id")).toBe(false);
+
+    // Other fields should be present
+    expect(formData.has("name")).toBe(true);
+    expect(formData.has("integration_type")).toBe(true);
+  });
+
+  test("edit tool form has essential fields but not gateway_id", () => {
+    const form = document.createElement("form");
+    form.id = "edit-tool-form";
+    document.body.appendChild(form);
+
+    // Essential fields that should exist
+    const nameField = document.createElement("input");
+    nameField.id = "edit-tool-name";
+    nameField.name = "name";
+    form.appendChild(nameField);
+
+    const displayNameField = document.createElement("input");
+    displayNameField.id = "edit-tool-display-name";
+    displayNameField.name = "displayName";
+    form.appendChild(displayNameField);
+
+    const urlField = document.createElement("input");
+    urlField.id = "edit-tool-url";
+    urlField.name = "url";
+    form.appendChild(urlField);
+
+    const descriptionField = document.createElement("textarea");
+    descriptionField.id = "edit-tool-description";
+    descriptionField.name = "description";
+    form.appendChild(descriptionField);
+
+    const typeField = document.createElement("select");
+    typeField.id = "edit-tool-type";
+    typeField.name = "integration_type";
+    form.appendChild(typeField);
+
+    // Verify essential fields exist
+    expect(form.querySelector('[name="name"]')).not.toBeNull();
+    expect(form.querySelector('[name="displayName"]')).not.toBeNull();
+    expect(form.querySelector('[name="url"]')).not.toBeNull();
+    expect(form.querySelector('[name="description"]')).not.toBeNull();
+    expect(form.querySelector('[name="integration_type"]')).not.toBeNull();
+
+    // Verify gateway_id does not exist
+    expect(form.querySelector('[name="gateway_id"]')).toBeNull();
+  });
+
+  test("edit tool form includes advanced fields but not gateway_id", () => {
+    const form = document.createElement("form");
+    form.id = "edit-tool-form";
+    document.body.appendChild(form);
+
+    // Advanced configuration fields (from issue #4061)
+    const titleField = document.createElement("input");
+    titleField.id = "edit-tool-title";
+    titleField.name = "title";
+    form.appendChild(titleField);
+
+    const timeoutField = document.createElement("input");
+    timeoutField.id = "edit-tool-timeout-ms";
+    timeoutField.name = "timeout_ms";
+    form.appendChild(timeoutField);
+
+    const jsonpathFilterField = document.createElement("input");
+    jsonpathFilterField.id = "edit-tool-jsonpath-filter";
+    jsonpathFilterField.name = "jsonpath_filter";
+    form.appendChild(jsonpathFilterField);
+
+    // Verify advanced fields exist
+    expect(form.querySelector('[name="title"]')).not.toBeNull();
+    expect(form.querySelector('[name="timeout_ms"]')).not.toBeNull();
+    expect(form.querySelector('[name="jsonpath_filter"]')).not.toBeNull();
+
+    // Verify gateway_id does not exist
+    expect(form.querySelector('[name="gateway_id"]')).toBeNull();
+    expect(document.getElementById("edit-tool-gateway-id")).toBeNull();
+  });
+});

--- a/tests/unit/mcpgateway/services/test_row_level_locking.py
+++ b/tests/unit/mcpgateway/services/test_row_level_locking.py
@@ -514,6 +514,7 @@ class TestConcurrencyScenarios:
         mock_tool.visibility = "public"
         mock_tool.team_id = None
         mock_tool.owner_email = "test@example.com"
+        mock_tool.version = 1
 
         # Mock a conflicting tool
         mock_conflict = MagicMock(spec=Tool)
@@ -530,15 +531,37 @@ class TestConcurrencyScenarios:
         tool_update.visibility.lower.return_value = "public"
         tool_update.description = None
         tool_update.input_schema = None
+        tool_update.team_id = None
+        tool_update.displayName = None
+        tool_update.url = None
+        tool_update.title = None
+        tool_update.integration_type = None
+        tool_update.request_type = None
+        tool_update.headers = None
+        tool_update.output_schema = None
+        tool_update.annotations = None
+        tool_update.jsonpath_filter = None
+        tool_update.auth = None
+        tool_update.tags = None
+        tool_update.timeout_ms = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
 
         get_for_update_calls = []
 
         def track_get_for_update(*args, **kwargs):
             get_for_update_calls.append((args, kwargs))
-            # First call: return the tool being updated
-            if len(get_for_update_calls) == 1:
+            # First call (with just tool_id): return the tool being updated
+            # Check if this is the initial fetch (no 'where' clause)
+            if "where" not in kwargs or kwargs.get("where") is None:
                 return mock_tool
-            # Second call: return the conflicting tool
+            # Second call (with where clause for conflict check): return the conflicting tool
             return mock_conflict
 
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=track_get_for_update):

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -199,6 +199,16 @@ def mock_tool(mock_gateway):
         "avg_response_time": None,
         "last_execution_time": None,
     }
+    # REST passthrough fields
+    tool.timeout_ms = None
+    tool.base_url = None
+    tool.path_template = None
+    tool.query_mapping = None
+    tool.header_mapping = None
+    tool.expose_passthrough = None
+    tool.allowlist = None
+    tool.plugin_chain_pre = None
+    tool.plugin_chain_post = None
     return tool
 
 
@@ -222,6 +232,16 @@ def _make_tool_update(**overrides) -> MagicMock:
         visibility=None,
         auth=None,
         tags=None,
+        team_id=None,
+        timeout_ms=None,
+        base_url=None,
+        path_template=None,
+        query_mapping=None,
+        header_mapping=None,
+        expose_passthrough=None,
+        allowlist=None,
+        plugin_chain_pre=None,
+        plugin_chain_post=None,
     )
     defaults.update(overrides)
     for attr, value in defaults.items():
@@ -3830,6 +3850,19 @@ class TestToolNotificationMethods:
         tool.description = "A test tool"
         tool.enabled = True
         tool.reachable = True
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        # REST passthrough fields
+        tool.timeout_ms = None
+        tool.base_url = None
+        tool.path_template = None
+        tool.query_mapping = None
+        tool.header_mapping = None
+        tool.expose_passthrough = None
+        tool.allowlist = None
+        tool.plugin_chain_pre = None
+        tool.plugin_chain_post = None
         return tool
 
     @pytest.mark.asyncio
@@ -5523,6 +5556,16 @@ class TestUpdateToolBranches:
         tool_update.visibility = "team"
         tool_update.auth = None
         tool_update.tags = ["api", "v2"]
+        tool_update.team_id = None
+        tool_update.timeout_ms = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
 
         db = MagicMock()
 
@@ -5582,6 +5625,16 @@ class TestUpdateToolBranches:
         tool_update.visibility = None
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.team_id = None
+        tool_update.timeout_ms = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
 
         db = MagicMock()
         with (

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -6408,6 +6408,128 @@ class TestUpdateToolBranches:
         assert "Public" not in str(err)
 
     @pytest.mark.asyncio
+    async def test_update_tool_simultaneous_name_and_team_change_no_conflict(self, tool_service, mock_tool):
+        """Renaming a tool while changing teams should check for conflicts in the NEW team with the NEW name."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "old_tool_name"
+        tool.custom_name = "old_tool_name"
+        tool.team_id = "team-1"
+        tool.visibility = "team"
+        tool.version = 1
+
+        # Change both name AND team
+        tool_update = _make_tool_update(name="new_tool_name", team_id="team-2")
+
+        db = MagicMock()
+        # First call returns the tool being updated, second call checks for conflicts in team-2 with new_tool_name (returns None = no conflict)
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, None]),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1", "name": "new_tool_name"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.name == "new_tool_name"
+        assert tool.custom_name == "new_tool_name"  # Tracks the rename since name == custom_name
+        assert tool.team_id == "team-2"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_simultaneous_name_and_team_change_with_conflict(self, tool_service, mock_tool):
+        """Renaming a tool while changing teams should detect conflicts in the NEW team with the NEW name."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "old_tool_name"
+        tool.custom_name = "old_tool_name"
+        tool.team_id = "team-1"
+        tool.visibility = "team"
+        tool.version = 1
+
+        # Change both name AND team
+        tool_update = _make_tool_update(name="new_tool_name", team_id="team-2")
+
+        # Existing tool in team-2 with the same new name
+        existing_tool = MagicMock()
+        existing_tool.id = "t2"
+        existing_tool.custom_name = "new_tool_name"
+        existing_tool.team_id = "team-2"
+        existing_tool.visibility = "team"
+        existing_tool.enabled = True
+
+        db = MagicMock()
+        # First call returns the tool being updated, second call returns the conflicting tool in team-2
+        with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing_tool]):
+            with pytest.raises(ToolNameConflictError) as exc_info:
+                await tool_service.update_tool(db, "t1", tool_update)
+
+        # Verify the error message mentions the conflict
+        assert "new_tool_name" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_tool_name_change_with_same_team_checks_same_team(self, tool_service, mock_tool):
+        """Renaming a tool without changing teams should still check conflicts in the SAME team."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "old_tool_name"
+        tool.custom_name = "old_tool_name"
+        tool.team_id = "team-1"
+        tool.visibility = "team"
+        tool.version = 1
+
+        # Only change name, keep same team
+        tool_update = _make_tool_update(name="new_tool_name")
+
+        # Existing tool in team-1 with the same new name
+        existing_tool = MagicMock()
+        existing_tool.id = "t2"
+        existing_tool.custom_name = "new_tool_name"
+        existing_tool.team_id = "team-1"
+        existing_tool.visibility = "team"
+        existing_tool.enabled = True
+
+        db = MagicMock()
+        # First call returns the tool being updated, second call returns the conflicting tool in team-1
+        with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing_tool]):
+            with pytest.raises(ToolNameConflictError) as exc_info:
+                await tool_service.update_tool(db, "t1", tool_update)
+
+        # Verify the error message mentions the conflict
+        assert "new_tool_name" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_update_tool_team_change_without_name_change_checks_new_team(self, tool_service, mock_tool):
+        """Changing only the team (not the name) should check for conflicts in the NEW team."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "my_tool"
+        tool.custom_name = "my_tool"
+        tool.team_id = "team-1"
+        tool.visibility = "team"
+        tool.version = 1
+
+        # Only change team, keep same name
+        tool_update = _make_tool_update(team_id="team-2")
+
+        # Existing tool in team-2 with the same name
+        existing_tool = MagicMock()
+        existing_tool.id = "t2"
+        existing_tool.custom_name = "my_tool"
+        existing_tool.team_id = "team-2"
+        existing_tool.visibility = "team"
+        existing_tool.enabled = True
+
+        db = MagicMock()
+        # First call returns the tool being updated, second call returns the conflicting tool in team-2
+        with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing_tool]):
+            with pytest.raises(ToolNameConflictError) as exc_info:
+                await tool_service.update_tool(db, "t1", tool_update)
+
+        # Verify the error message mentions the conflict
+        assert "my_tool" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_permission_check_on_update(self, tool_service):
         """Non-owner user gets PermissionError on update."""
         tool = MagicMock(spec=DbTool)

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -5948,6 +5948,368 @@ class TestUpdateToolBranches:
                 await tool_service.update_tool(db, "t1", tool_update)
 
     @pytest.mark.asyncio
+    async def test_update_tool_timeout_ms(self, tool_service, mock_tool):
+        """Updating timeout_ms field should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.timeout_ms = None
+
+        tool_update = _make_tool_update(timeout_ms=5000)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.timeout_ms == 5000
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_title(self, tool_service, mock_tool):
+        """Updating title field should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.title = None
+
+        tool_update = _make_tool_update(title="My Custom Tool Title")
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.title == "My Custom Tool Title"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_jsonpath_filter(self, tool_service, mock_tool):
+        """Updating jsonpath_filter field should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.jsonpath_filter = ""
+
+        tool_update = _make_tool_update(jsonpath_filter="$.data[*].result")
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.jsonpath_filter == "$.data[*].result"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_team_id_reassignment(self, tool_service, mock_tool):
+        """Updating team_id field should reassign the tool to a different team."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = "team-1"
+        tool.visibility = "team"
+        tool.version = 1
+
+        tool_update = _make_tool_update(team_id="team-2")
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, None]),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.team_id == "team-2"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_base_url(self, tool_service, mock_tool):
+        """Updating base_url field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.base_url = None
+
+        tool_update = _make_tool_update(base_url="https://api.example.com")
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.base_url == "https://api.example.com"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_path_template(self, tool_service, mock_tool):
+        """Updating path_template field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.path_template = None
+
+        tool_update = _make_tool_update(path_template="/api/v1/{resource}/{id}")
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.path_template == "/api/v1/{resource}/{id}"
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_query_mapping(self, tool_service, mock_tool):
+        """Updating query_mapping field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.query_mapping = None
+
+        query_mapping_data = {"search": "q", "limit": "max_results"}
+        tool_update = _make_tool_update(query_mapping=query_mapping_data)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.query_mapping == query_mapping_data
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_header_mapping(self, tool_service, mock_tool):
+        """Updating header_mapping field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.header_mapping = None
+
+        header_mapping_data = {"Authorization": "api_key", "Content-Type": "content_type"}
+        tool_update = _make_tool_update(header_mapping=header_mapping_data)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.header_mapping == header_mapping_data
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_expose_passthrough(self, tool_service, mock_tool):
+        """Updating expose_passthrough field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.expose_passthrough = None
+
+        tool_update = _make_tool_update(expose_passthrough=True)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.expose_passthrough is True
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_rest_passthrough_allowlist(self, tool_service, mock_tool):
+        """Updating allowlist field for REST passthrough should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.allowlist = None
+
+        allowlist_data = ["domain1.com", "domain2.com"]
+        tool_update = _make_tool_update(allowlist=allowlist_data)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.allowlist == allowlist_data
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_plugin_chain_pre(self, tool_service, mock_tool):
+        """Updating plugin_chain_pre field should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.plugin_chain_pre = None
+
+        plugin_chain_data = ["auth_plugin", "validation_plugin"]
+        tool_update = _make_tool_update(plugin_chain_pre=plugin_chain_data)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.plugin_chain_pre == plugin_chain_data
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_plugin_chain_post(self, tool_service, mock_tool):
+        """Updating plugin_chain_post field should persist the value."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.plugin_chain_post = None
+
+        plugin_chain_data = ["logging_plugin", "metrics_plugin"]
+        tool_update = _make_tool_update(plugin_chain_post=plugin_chain_data)
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.plugin_chain_post == plugin_chain_data
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
+    async def test_update_tool_multiple_new_fields_combined(self, tool_service, mock_tool):
+        """Updating multiple new fields together should persist all values."""
+        tool = mock_tool
+        tool.id = "t1"
+        tool.name = "test_tool"
+        tool.custom_name = "test_tool"
+        tool.team_id = None
+        tool.visibility = "public"
+        tool.version = 1
+        tool.timeout_ms = None
+        tool.title = None
+        tool.jsonpath_filter = ""
+        tool.base_url = None
+        tool.path_template = None
+        tool.plugin_chain_pre = None
+        tool.plugin_chain_post = None
+
+        tool_update = _make_tool_update(
+            timeout_ms=3000,
+            title="REST API Tool",
+            jsonpath_filter="$.results[*]",
+            base_url="https://api.service.com",
+            path_template="/v2/{endpoint}",
+            plugin_chain_pre=["pre_plugin1"],
+            plugin_chain_post=["post_plugin1", "post_plugin2"],
+        )
+
+        db = MagicMock()
+        with (
+            patch("mcpgateway.services.tool_service.get_for_update", return_value=tool),
+            patch.object(tool_service, "_notify_tool_updated", AsyncMock()),
+            patch.object(tool_service, "convert_tool_to_read", return_value={"id": "t1"}),
+        ):
+            result = await tool_service.update_tool(db, "t1", tool_update)
+
+        assert result is not None
+        assert tool.timeout_ms == 3000
+        assert tool.title == "REST API Tool"
+        assert tool.jsonpath_filter == "$.results[*]"
+        assert tool.base_url == "https://api.service.com"
+        assert tool.path_template == "/v2/{endpoint}"
+        assert tool.plugin_chain_pre == ["pre_plugin1"]
+        assert tool.plugin_chain_post == ["post_plugin1", "post_plugin2"]
+        assert tool.version == 2
+
+    @pytest.mark.asyncio
     async def test_update_tool_rename_with_divergent_custom_name(self, tool_service, mock_tool):
         """When custom_name differs from name, renaming should check conflict against the existing custom_name (which won't change)."""
         tool = mock_tool

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -5676,7 +5676,9 @@ class TestUpdateToolBranches:
         tool.name = "old_name"
         tool.custom_name = "old_name"
         tool.team_id = "team-1"
+        tool.owner_email = "owner@example.com"
         tool.visibility = "team"
+        tool.version = 1
 
         tool_update = MagicMock(spec=ToolUpdate)
         tool_update.name = "conflict_name"
@@ -5692,15 +5694,28 @@ class TestUpdateToolBranches:
         tool_update.output_schema = None
         tool_update.annotations = None
         tool_update.jsonpath_filter = None
-        tool_update.visibility = "team"
+        # visibility must support .lower() method
+        tool_update.visibility = MagicMock()
+        tool_update.visibility.lower.return_value = "team"
+        tool_update.team_id = None
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.timeout_ms = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
 
         existing = MagicMock()
         existing.custom_name = "conflict_name"
         existing.enabled = True
         existing.id = "t2"
         existing.visibility = "team"
+        existing.team_id = "team-1"
 
         db = MagicMock()
         with patch("mcpgateway.services.tool_service.get_for_update", side_effect=[tool, existing]):

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -1393,6 +1393,17 @@ class TestUpdateTool:
         tool_update.visibility = None
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.timeout_ms = None
+        tool_update.title = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
+        tool_update.team_id = None
 
         with patch("mcpgateway.services.tool_service.get_for_update", return_value=mock_tool):
             with pytest.raises(IntegrityError):
@@ -1422,6 +1433,17 @@ class TestUpdateTool:
         tool_update.visibility = None
         tool_update.auth = None
         tool_update.tags = None
+        tool_update.timeout_ms = None
+        tool_update.title = None
+        tool_update.base_url = None
+        tool_update.path_template = None
+        tool_update.query_mapping = None
+        tool_update.header_mapping = None
+        tool_update.expose_passthrough = None
+        tool_update.allowlist = None
+        tool_update.plugin_chain_pre = None
+        tool_update.plugin_chain_post = None
+        tool_update.team_id = None
 
         with patch("mcpgateway.services.tool_service.get_for_update", return_value=mock_tool):
             with pytest.raises(ToolError, match="Failed to update tool"):

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -208,9 +208,15 @@ class TestAdminEditToolAdvancedFields:
         assert payload["success"] is False
         assert "Invalid JSON in header_mapping field" in payload["message"]
 
+    @patch("mcpgateway.plugins.list_configured_plugin_names")
+    @patch("mcpgateway.admin.settings")
     @patch.object(ToolService, "update_tool")
-    async def test_edit_tool_with_plugin_chains(self, mock_update_tool, mock_request, mock_db):
+    async def test_edit_tool_with_plugin_chains(self, mock_update_tool, mock_settings, mock_list_plugins, mock_request, mock_db):
         """Test editing tool with plugin_chain_pre and plugin_chain_post."""
+        # Mock plugins as enabled and available
+        mock_settings.plugins.enabled = True
+        mock_list_plugins.return_value = ["rate_limit", "pii_filter", "response_shape", "deny_filter"]
+
         form_data = FakeForm(
             {
                 "name": "test_tool",
@@ -983,3 +989,196 @@ async def test_valid_jsonpath_expression():
         call_args = mock_tool_service.call_args[0]
         tool_update = call_args[2]
         assert tool_update.jsonpath_filter == "$.data[*].result"
+
+
+# ---------------------------------------------------------------------------
+# Plugin Chain Validation When Plugins Disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPluginChainValidationWhenDisabled:
+    """Test that plugin chains are rejected when plugins are globally disabled."""
+
+    @patch("mcpgateway.config.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_reject_plugin_chain_pre_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that plugin_chain_pre is rejected when plugins are globally disabled."""
+        # Mock plugins as disabled
+        mock_settings.plugins.enabled = False
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "auth_plugin,validation_plugin",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "plugins are globally disabled" in payload["message"]
+        assert "PLUGINS_ENABLED=true" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch("mcpgateway.config.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_reject_plugin_chain_post_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that plugin_chain_post is rejected when plugins are globally disabled."""
+        # Mock plugins as disabled
+        mock_settings.plugins.enabled = False
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_post": "logging_plugin,metrics_plugin",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "plugins are globally disabled" in payload["message"]
+        assert "PLUGINS_ENABLED=true" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch("mcpgateway.config.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_reject_both_plugin_chains_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that both plugin chains are rejected when plugins are globally disabled."""
+        # Mock plugins as disabled
+        mock_settings.plugins.enabled = False
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "auth_plugin",
+                "plugin_chain_post": "logging_plugin",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        # Should fail on first plugin chain (pre)
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "plugins are globally disabled" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch("mcpgateway.config.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allow_empty_plugin_chains_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that empty plugin chains are allowed when plugins are disabled (clearing existing chains)."""
+        # Mock plugins as disabled
+        mock_settings.plugins.enabled = False
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "",  # Empty string to clear
+                "plugin_chain_post": "",  # Empty string to clear
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        # Should succeed - clearing plugin chains is allowed even when plugins disabled
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == []
+        assert tool_update.plugin_chain_post == []
+
+    @patch("mcpgateway.config.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allow_omitted_plugin_chains_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that omitting plugin chain fields is allowed when plugins are disabled."""
+        # Mock plugins as disabled
+        mock_settings.plugins.enabled = False
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                # plugin_chain_pre and plugin_chain_post NOT in form
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        # Should succeed - not providing plugin chains is fine
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        # plugin chains should be None (not provided in form)
+        assert tool_update.plugin_chain_pre is None
+        assert tool_update.plugin_chain_post is None

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -246,6 +246,44 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.plugin_chain_pre == ["rate_limit", "pii_filter"]
         assert tool_update.plugin_chain_post == ["response_shape", "deny_filter"]
 
+    @patch("mcpgateway.admin.settings")
+    @patch("mcpgateway.admin.list_plugins")
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_clear_plugin_chains(self, mock_update_tool, mock_list_plugins, mock_settings, mock_request, mock_db):
+        """Test that submitting empty plugin chain fields clears the chains to []."""
+        # Mock plugins as enabled
+        mock_settings.plugins.enabled = True
+        mock_list_plugins.return_value = ["rate_limit", "pii_filter"]
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "",  # Empty string should clear the list
+                "plugin_chain_post": "",  # Empty string should clear the list
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify plugin chains were cleared to empty lists
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == []
+        assert tool_update.plugin_chain_post == []
+
     @patch.object(ToolService, "update_tool")
     async def test_edit_tool_with_allowlist_parsing(self, mock_update_tool, mock_request, mock_db):
         """Test that allowlist field is correctly parsed from comma-separated string."""
@@ -384,6 +422,36 @@ class TestAdminEditToolAdvancedFields:
         assert result.status_code == 400
         assert "Invalid URL in allowlist: invalid-url" in result.body.decode()
         mock_update_tool.assert_not_called()
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_clear_allowlist(self, mock_update_tool, mock_request, mock_db):
+        """Test that submitting empty allowlist field clears the list to []."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "",  # Empty string should clear the list
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify allowlist was cleared to empty list
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == []
 
     @patch.object(ToolService, "update_tool")
     async def test_edit_tool_expose_passthrough_false(self, mock_update_tool, mock_request, mock_db):

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -126,7 +126,7 @@ class TestAdminEditToolAdvancedFields:
                 "query_mapping": '{"param1": "field1"}',
                 "header_mapping": '{"X-Custom": "field2"}',
                 "expose_passthrough": "true",
-                "allowlist": "GET, POST, PUT",
+                "allowlist": "https://api.example.com, https://api2.example.org, https://api3.example.net",
                 "requestType": "GET",
                 "integrationType": "REST",
             }
@@ -150,7 +150,7 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.query_mapping == {"param1": "field1"}
         assert tool_update.header_mapping == {"X-Custom": "field2"}
         assert tool_update.expose_passthrough is True
-        assert tool_update.allowlist == ["GET", "POST", "PUT"]
+        assert tool_update.allowlist == ["https://api.example.com", "https://api2.example.org", "https://api3.example.net"]
 
     @patch.object(ToolService, "update_tool")
     async def test_edit_tool_with_invalid_query_mapping_json(self, mock_update_tool, mock_request, mock_db):
@@ -249,7 +249,7 @@ class TestAdminEditToolAdvancedFields:
                 "customName": "test_tool",
                 "url": "http://example.com",
                 "description": "Test tool",
-                "allowlist": "  GET ,  POST  , DELETE  ",  # With extra spaces
+                "allowlist": "  https://api1.example.com ,  https://api2.example.org  , https://api3.example.net  ",  # With extra spaces
                 "requestType": "GET",
                 "integrationType": "REST",
             }
@@ -268,7 +268,116 @@ class TestAdminEditToolAdvancedFields:
         # Verify allowlist was parsed and trimmed correctly
         call_args = mock_update_tool.call_args[0]
         tool_update = call_args[2]
-        assert tool_update.allowlist == ["GET", "POST", "DELETE"]
+        assert tool_update.allowlist == ["https://api1.example.com", "https://api2.example.org", "https://api3.example.net"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_allowlist_valid_urls(self, mock_update_tool, mock_request, mock_db):
+        """Test that valid URLs in allowlist are accepted."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api.example.com, https://api2.example.org, http://localhost:8080",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == ["https://api.example.com", "https://api2.example.org", "http://localhost:8080"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_allowlist_invalid_url_missing_scheme(self, mock_update_tool, mock_request, mock_db):
+        """Test that URLs without scheme are rejected."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "api.example.com",  # Missing scheme
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 400
+        assert "Invalid URL in allowlist: api.example.com" in result.body.decode()
+        mock_update_tool.assert_not_called()
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_allowlist_invalid_url_missing_host(self, mock_update_tool, mock_request, mock_db):
+        """Test that URLs without host are rejected."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://",  # Missing host
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 400
+        assert "Invalid URL in allowlist: https://" in result.body.decode()
+        mock_update_tool.assert_not_called()
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_allowlist_mixed_valid_invalid(self, mock_update_tool, mock_request, mock_db):
+        """Test that having one invalid URL rejects the entire allowlist."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api.example.com, invalid-url, https://api2.example.org",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 400
+        assert "Invalid URL in allowlist: invalid-url" in result.body.decode()
+        mock_update_tool.assert_not_called()
 
     @patch.object(ToolService, "update_tool")
     async def test_edit_tool_expose_passthrough_false(self, mock_update_tool, mock_request, mock_db):
@@ -352,7 +461,7 @@ class TestAdminEditToolAdvancedFields:
                 "query_mapping": '{"q": "searchField"}',
                 "header_mapping": '{"Authorization": "tokenField"}',
                 "expose_passthrough": "true",
-                "allowlist": "GET,POST",
+                "allowlist": "https://api1.example.com,https://api2.example.org",
                 "plugin_chain_pre": "rate_limit,regex_filter",
                 "plugin_chain_post": "resource_filter,pii_filter",
                 "requestType": "GET",
@@ -381,7 +490,7 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.query_mapping == {"q": "searchField"}
         assert tool_update.header_mapping == {"Authorization": "tokenField"}
         assert tool_update.expose_passthrough is True
-        assert tool_update.allowlist == ["GET", "POST"]
+        assert tool_update.allowlist == ["https://api1.example.com", "https://api2.example.org"]
         assert tool_update.plugin_chain_pre == ["rate_limit", "regex_filter"]
         assert tool_update.plugin_chain_post == ["resource_filter", "pii_filter"]
 

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -1211,13 +1211,13 @@ async def test_valid_jsonpath_expression():
 
 @pytest.mark.asyncio
 class TestPluginChainValidationWhenDisabled:
-    """Test that plugin chains are rejected when plugins are globally disabled."""
+    """Test that plugin chains can be configured when plugins are globally disabled (for pre-configuration)."""
 
     @patch("mcpgateway.config.settings")
     @patch.object(TeamManagementService, "verify_team_for_user")
     @patch.object(ToolService, "update_tool")
-    async def test_reject_plugin_chain_pre_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
-        """Test that plugin_chain_pre is rejected when plugins are globally disabled."""
+    async def test_allow_plugin_chain_pre_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that plugin_chain_pre is allowed when plugins are globally disabled (for pre-configuration)."""
         # Mock plugins as disabled
         mock_settings.plugins.enabled = False
         mock_verify_team.return_value = None
@@ -1242,18 +1242,17 @@ class TestPluginChainValidationWhenDisabled:
             user={"email": "test@example.com", "db": mock_db},
         )
 
-        assert result.status_code == 422
-        payload = json.loads(result.body.decode())
-        assert payload["success"] is False
-        assert "plugins are globally disabled" in payload["message"]
-        assert "PLUGINS_ENABLED=true" in payload["message"]
-        mock_update_tool.assert_not_called()
+        # Should succeed - plugin chains can be pre-configured even when plugins are disabled
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == ["auth_plugin", "validation_plugin"]
 
     @patch("mcpgateway.config.settings")
     @patch.object(TeamManagementService, "verify_team_for_user")
     @patch.object(ToolService, "update_tool")
-    async def test_reject_plugin_chain_post_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
-        """Test that plugin_chain_post is rejected when plugins are globally disabled."""
+    async def test_allow_plugin_chain_post_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that plugin_chain_post is allowed when plugins are globally disabled (for pre-configuration)."""
         # Mock plugins as disabled
         mock_settings.plugins.enabled = False
         mock_verify_team.return_value = None
@@ -1278,18 +1277,17 @@ class TestPluginChainValidationWhenDisabled:
             user={"email": "test@example.com", "db": mock_db},
         )
 
-        assert result.status_code == 422
-        payload = json.loads(result.body.decode())
-        assert payload["success"] is False
-        assert "plugins are globally disabled" in payload["message"]
-        assert "PLUGINS_ENABLED=true" in payload["message"]
-        mock_update_tool.assert_not_called()
+        # Should succeed - plugin chains can be pre-configured even when plugins are disabled
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_post == ["logging_plugin", "metrics_plugin"]
 
     @patch("mcpgateway.config.settings")
     @patch.object(TeamManagementService, "verify_team_for_user")
     @patch.object(ToolService, "update_tool")
-    async def test_reject_both_plugin_chains_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
-        """Test that both plugin chains are rejected when plugins are globally disabled."""
+    async def test_allow_both_plugin_chains_when_plugins_disabled(self, mock_update_tool, mock_verify_team, mock_settings, mock_request, mock_db):
+        """Test that both plugin chains are allowed when plugins are globally disabled (for pre-configuration)."""
         # Mock plugins as disabled
         mock_settings.plugins.enabled = False
         mock_verify_team.return_value = None
@@ -1315,12 +1313,12 @@ class TestPluginChainValidationWhenDisabled:
             user={"email": "test@example.com", "db": mock_db},
         )
 
-        # Should fail on first plugin chain (pre)
-        assert result.status_code == 422
-        payload = json.loads(result.body.decode())
-        assert payload["success"] is False
-        assert "plugins are globally disabled" in payload["message"]
-        mock_update_tool.assert_not_called()
+        # Should succeed - plugin chains can be pre-configured even when plugins are disabled
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == ["auth_plugin"]
+        assert tool_update.plugin_chain_post == ["logging_plugin"]
 
     @patch("mcpgateway.config.settings")
     @patch.object(TeamManagementService, "verify_team_for_user")

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mcpgateway.admin import admin_edit_tool
+from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.orjson_response import ORJSONResponse
 
@@ -382,3 +383,105 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.allowlist == ["GET", "POST"]
         assert tool_update.plugin_chain_pre == ["rate_limit", "regex_filter"]
         assert tool_update.plugin_chain_post == ["resource_filter", "pii_filter"]
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_team_reassignment(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test editing tool with team_id reassignment."""
+        # Mock verify_team_for_user to return the team_id (user is member of team)
+        mock_verify_team.return_value = "team-456"
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "team_id": "team-456",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify team_id was included and verify_team_for_user was called
+        mock_verify_team.assert_called_once_with("test@example.com", "team-456")
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.team_id == "team-456"
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_invalid_team_reassignment(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test editing tool with team_id when user is not member of that team."""
+        # Mock verify_team_for_user to return empty list (user is not member)
+        mock_verify_team.return_value = []
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "team_id": "team-999",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        # Should return 422 validation error because team_id becomes []
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "team_id" in payload["message"].lower()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_without_team_reassignment(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test editing tool without providing team_id (no reassignment)."""
+        # Mock verify_team_for_user to return None (no team_id provided, user has no personal team)
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify verify_team_for_user was called with None team_id
+        mock_verify_team.assert_called_once_with("test@example.com", None)
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.team_id is None

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -1,0 +1,384 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_admin_advanced_fields.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Test coverage for advanced tool configuration fields in admin edit form.
+Tests the optional fields: timeout_ms, title, REST passthrough fields,
+plugin chains, and team_id reassignment.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcpgateway.admin import admin_edit_tool
+from mcpgateway.services.tool_service import ToolService
+from mcpgateway.utils.orjson_response import ORJSONResponse
+
+
+class FakeForm:
+    """Fake form data for testing."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def get(self, key: str, default=None):
+        return self._data.get(key, default)
+
+    def __contains__(self, key: str):
+        return key in self._data
+
+
+@pytest.fixture
+def mock_request():
+    """Mock FastAPI Request object."""
+    request = MagicMock()
+    request.headers = {}
+    return request
+
+
+@pytest.fixture
+def mock_db():
+    """Mock database session."""
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+class TestAdminEditToolAdvancedFields:
+    """Test advanced configuration fields in admin_edit_tool endpoint."""
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_timeout_ms(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with timeout_ms field."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "timeout_ms": "5000",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert isinstance(result, (ORJSONResponse, type(result)))
+        assert result.status_code == 200
+
+        # Verify timeout_ms was included in the update call
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.timeout_ms == 5000
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_title(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with title field (MCP BaseMetadata)."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "title": "My Tool Title",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify title was included in the update call
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.title == "My Tool Title"
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_rest_passthrough_fields(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with all REST passthrough fields."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "https://api.example.com",
+                "path_template": "/v1/{resource}",
+                "query_mapping": '{"param1": "field1"}',
+                "header_mapping": '{"X-Custom": "field2"}',
+                "expose_passthrough": "true",
+                "allowlist": "GET, POST, PUT",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify all passthrough fields were included
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.base_url == "https://api.example.com"
+        assert tool_update.path_template == "/v1/{resource}"
+        assert tool_update.query_mapping == {"param1": "field1"}
+        assert tool_update.header_mapping == {"X-Custom": "field2"}
+        assert tool_update.expose_passthrough is True
+        assert tool_update.allowlist == ["GET", "POST", "PUT"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_invalid_query_mapping_json(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with invalid JSON in query_mapping."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "query_mapping": "{invalid json}",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid JSON in query_mapping field" in payload["message"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_invalid_header_mapping_json(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with invalid JSON in header_mapping."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "header_mapping": "{invalid json}",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid JSON in header_mapping field" in payload["message"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_plugin_chains(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with plugin_chain_pre and plugin_chain_post."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "rate_limit, pii_filter",
+                "plugin_chain_post": "response_shape, deny_filter",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify plugin chains were included
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == ["rate_limit", "pii_filter"]
+        assert tool_update.plugin_chain_post == ["response_shape", "deny_filter"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_allowlist_parsing(self, mock_update_tool, mock_request, mock_db):
+        """Test that allowlist field is correctly parsed from comma-separated string."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "  GET ,  POST  , DELETE  ",  # With extra spaces
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify allowlist was parsed and trimmed correctly
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == ["GET", "POST", "DELETE"]
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_expose_passthrough_false(self, mock_update_tool, mock_request, mock_db):
+        """Test that expose_passthrough false is handled correctly."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "expose_passthrough": "false",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify expose_passthrough is False
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.expose_passthrough is False
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_without_optional_fields(self, mock_update_tool, mock_request, mock_db):
+        """Test that optional fields are not included when not present in form."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify optional fields are NOT included (should be None or extracted defaults)
+        # Note: base_url and path_template are auto-extracted from url for REST tools
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.timeout_ms is None
+        assert tool_update.title is None
+        assert tool_update.query_mapping is None
+        assert tool_update.header_mapping is None
+        assert tool_update.plugin_chain_pre is None
+        assert tool_update.plugin_chain_post is None
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_with_all_advanced_fields(self, mock_update_tool, mock_request, mock_db):
+        """Test editing tool with all advanced fields together."""
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "timeout_ms": "30000",
+                "title": "Advanced Tool",
+                "jsonpath_filter": "$.data[*]",
+                "base_url": "https://api.example.com",
+                "path_template": "/v2/{id}",
+                "query_mapping": '{"q": "searchField"}',
+                "header_mapping": '{"Authorization": "tokenField"}',
+                "expose_passthrough": "true",
+                "allowlist": "GET,POST",
+                "plugin_chain_pre": "rate_limit,regex_filter",
+                "plugin_chain_post": "resource_filter,pii_filter",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify all fields were included
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.timeout_ms == 30000
+        assert tool_update.title == "Advanced Tool"
+        assert tool_update.jsonpath_filter == "$.data[*]"
+        assert tool_update.base_url == "https://api.example.com"
+        assert tool_update.path_template == "/v2/{id}"
+        assert tool_update.query_mapping == {"q": "searchField"}
+        assert tool_update.header_mapping == {"Authorization": "tokenField"}
+        assert tool_update.expose_passthrough is True
+        assert tool_update.allowlist == ["GET", "POST"]
+        assert tool_update.plugin_chain_pre == ["rate_limit", "regex_filter"]
+        assert tool_update.plugin_chain_post == ["resource_filter", "pii_filter"]

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -452,7 +452,7 @@ class TestAdminEditToolAdvancedFields:
 
     @patch.object(ToolService, "update_tool")
     async def test_edit_tool_with_all_advanced_fields(self, mock_update_tool, mock_request, mock_db):
-        """Test editing tool with all advanced fields together."""
+        """Test editing tool with all advanced fields together (excluding plugin chains which require PLUGINS_ENABLED)."""
         form_data = FakeForm(
             {
                 "name": "test_tool",
@@ -468,8 +468,6 @@ class TestAdminEditToolAdvancedFields:
                 "header_mapping": '{"Authorization": "tokenField"}',
                 "expose_passthrough": "true",
                 "allowlist": "https://api1.example.com,https://api2.example.org",
-                "plugin_chain_pre": "rate_limit,regex_filter",
-                "plugin_chain_post": "resource_filter,pii_filter",
                 "requestType": "GET",
                 "integrationType": "REST",
             }
@@ -497,8 +495,7 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.header_mapping == {"Authorization": "tokenField"}
         assert tool_update.expose_passthrough is True
         assert tool_update.allowlist == ["https://api1.example.com", "https://api2.example.org"]
-        assert tool_update.plugin_chain_pre == ["rate_limit", "regex_filter"]
-        assert tool_update.plugin_chain_post == ["resource_filter", "pii_filter"]
+        # Note: plugin_chain_pre/post are tested separately in test_edit_tool_with_plugin_chains
 
     @patch.object(TeamManagementService, "verify_team_for_user")
     @patch.object(ToolService, "update_tool")
@@ -1479,3 +1476,136 @@ class TestFieldValidationConsistency:
         call_args = mock_update_tool.call_args[0]
         tool_update = call_args[2]
         assert tool_update.base_url == "https://api.example.com:8443"
+
+
+# ---------------------------------------------------------------------------
+# Hostname Extraction for SSRF Protection (IPv4 and domain names)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHostnameExtractionSSRF:
+    """Test that hostname extraction for SSRF validation uses parsed.hostname correctly."""
+
+    @patch("mcpgateway.admin.settings")
+    @patch("mcpgateway.common.validators.SecurityValidator._validate_ssrf")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allowlist_ipv4_with_port(self, mock_update_tool, mock_verify_team, mock_validate_ssrf, mock_settings, mock_request, mock_db):
+        """Test that IPv4 URLs with ports are correctly parsed (hostname without port)."""
+        mock_verify_team.return_value = None
+        mock_settings.ssrf_protection_enabled = True
+        mock_validate_ssrf.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "http://192.168.1.1:8080",  # IPv4 with port
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify SSRF validation was called for allowlist URL with correct hostname (without port)
+        # This verifies parsed.hostname is used, not netloc.split(":")[0]
+        assert mock_validate_ssrf.call_count >= 1
+        # Find the call for the allowlist URL (not the tool URL)
+        allowlist_calls = [call for call in mock_validate_ssrf.call_args_list if "allowlist" in str(call)]
+        assert len(allowlist_calls) == 1
+        hostname_arg = allowlist_calls[0][0][0]
+        assert hostname_arg == "192.168.1.1"
+
+    @patch("mcpgateway.admin.settings")
+    @patch("mcpgateway.common.validators.SecurityValidator._validate_ssrf")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allowlist_hostname_without_port(self, mock_update_tool, mock_verify_team, mock_validate_ssrf, mock_settings, mock_request, mock_db):
+        """Test that regular hostnames without port work correctly."""
+        mock_verify_team.return_value = None
+        mock_settings.ssrf_protection_enabled = True
+        mock_validate_ssrf.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api.example.com",  # No port
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify SSRF validation received correct hostname for allowlist URL
+        assert mock_validate_ssrf.call_count >= 1
+        allowlist_calls = [call for call in mock_validate_ssrf.call_args_list if "allowlist" in str(call)]
+        assert len(allowlist_calls) == 1
+        hostname_arg = allowlist_calls[0][0][0]
+        assert hostname_arg == "api.example.com"
+
+    @patch("mcpgateway.admin.settings")
+    @patch("mcpgateway.common.validators.SecurityValidator._validate_ssrf")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allowlist_multiple_urls_with_ports(self, mock_update_tool, mock_verify_team, mock_validate_ssrf, mock_settings, mock_request, mock_db):
+        """Test that multiple URLs with various formats are all validated correctly."""
+        mock_verify_team.return_value = None
+        mock_settings.ssrf_protection_enabled = True
+        mock_validate_ssrf.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api.example.com, http://localhost:8080, http://192.168.1.1:9000",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify SSRF validation was called for each allowlist URL
+        assert mock_validate_ssrf.call_count >= 3
+        # Filter for allowlist calls only (ignore tool URL validation)
+        allowlist_calls = [call for call in mock_validate_ssrf.call_args_list if "allowlist" in str(call)]
+        assert len(allowlist_calls) == 3
+
+        hostnames = [call[0][0] for call in allowlist_calls]
+        assert "api.example.com" in hostnames
+        assert "localhost" in hostnames
+        assert "192.168.1.1" in hostnames

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -1825,3 +1825,152 @@ class TestHostnameExtractionSSRF:
         assert "api.example.com" in hostnames
         assert "localhost" in hostnames
         assert "192.168.1.1" in hostnames
+
+    @patch("urllib.parse.urlparse")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_generic_exception(self, mock_update_tool, mock_verify_team, mock_urlparse, mock_request, mock_db):
+        """Test that generic exceptions in base_url validation are handled."""
+        mock_verify_team.return_value = None
+        # Make urlparse raise a generic exception
+        mock_urlparse.side_effect = RuntimeError("Unexpected error")
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "https://api.example.com",
+                "path_template": "/api/v1/resource",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        content = json.loads(result.body)
+        assert "Invalid base_url" in content["message"]
+        assert "Unexpected error" in content["message"]
+
+    @patch("mcpgateway.admin.settings")
+    @patch("mcpgateway.common.validators.SecurityValidator._validate_ssrf")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allowlist_ssrf_validation_error(self, mock_update_tool, mock_verify_team, mock_validate_ssrf, mock_settings, mock_request, mock_db):
+        """Test that SSRF validation errors in allowlist are properly handled."""
+        mock_verify_team.return_value = None
+        mock_settings.ssrf_protection_enabled = True
+        # Make SSRF validation raise ValueError for blocked IPs
+        mock_validate_ssrf.side_effect = ValueError("IP address blocked by SSRF protection: 169.254.169.254")
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "http://169.254.169.254/latest/meta-data",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 400
+        content = json.loads(result.body)
+        assert "Security violation in allowlist" in content["message"]
+        assert "SSRF protection" in content["message"]
+
+    @patch("urllib.parse.urlparse")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_allowlist_generic_exception(self, mock_update_tool, mock_verify_team, mock_urlparse, mock_request, mock_db):
+        """Test that generic exceptions in allowlist validation are handled."""
+        mock_verify_team.return_value = None
+
+        # Make urlparse raise a generic exception when called with allowlist URL
+        def urlparse_side_effect(url):
+            if "api.example.com" in url:
+                raise RuntimeError("Parsing failed unexpectedly")
+            # Return a real parsed result for other URLs (like the tool URL)
+            from urllib.parse import urlparse as real_urlparse
+            return real_urlparse(url)
+
+        mock_urlparse.side_effect = urlparse_side_effect
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api.example.com",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 400
+        content = json.loads(result.body)
+        assert "Invalid URL in allowlist" in content["message"]
+        assert "Parsing failed unexpectedly" in content["message"]
+
+    @patch("mcpgateway.plugins.list_configured_plugin_names")
+    @patch("mcpgateway.admin.settings")
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_unknown_plugin_in_chain(self, mock_update_tool, mock_verify_team, mock_settings, mock_list_plugins, mock_request, mock_db):
+        """Test that unknown plugins in plugin chains are rejected."""
+        mock_verify_team.return_value = None
+        mock_settings.plugins.enabled = True
+        # Mock the available plugins list
+        mock_list_plugins.return_value = ["plugin1", "plugin2"]
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "plugin1, unknown_plugin, plugin2",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        content = json.loads(result.body)
+        assert "Unknown plugin" in content["message"]
+        assert "unknown_plugin" in content["message"]

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -246,10 +246,10 @@ class TestAdminEditToolAdvancedFields:
         assert tool_update.plugin_chain_pre == ["rate_limit", "pii_filter"]
         assert tool_update.plugin_chain_post == ["response_shape", "deny_filter"]
 
+    @patch("mcpgateway.plugins.list_configured_plugin_names")
     @patch("mcpgateway.admin.settings")
-    @patch("mcpgateway.admin.list_plugins")
     @patch.object(ToolService, "update_tool")
-    async def test_edit_tool_clear_plugin_chains(self, mock_update_tool, mock_list_plugins, mock_settings, mock_request, mock_db):
+    async def test_edit_tool_clear_plugin_chains(self, mock_update_tool, mock_settings, mock_list_plugins, mock_request, mock_db):
         """Test that submitting empty plugin chain fields clears the chains to []."""
         # Mock plugins as enabled
         mock_settings.plugins.enabled = True
@@ -271,6 +271,85 @@ class TestAdminEditToolAdvancedFields:
 
         result = await admin_edit_tool(
             "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify plugin chains were cleared to empty lists
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == []
+        assert tool_update.plugin_chain_post == []
+
+    @patch("mcpgateway.plugins.list_configured_plugin_names")
+    @patch("mcpgateway.admin.settings")
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_workflow_set_then_clear_plugin_chains(self, mock_update_tool, mock_settings, mock_list_plugins, mock_request, mock_db):
+        """Test complete workflow: set plugin chains, then clear them by submitting empty fields.
+
+        This simulates the real user scenario:
+        1. User edits tool and sets plugin_chain_pre and plugin_chain_post
+        2. Later, user edits the same tool and clears both chains by leaving fields empty
+
+        Verifies that empty string in form field translates to [] in ToolUpdate,
+        which the service layer will interpret as "clear the existing chains".
+        """
+        # Mock plugins as enabled
+        mock_settings.plugins.enabled = True
+        mock_list_plugins.return_value = ["rate_limit", "pii_filter", "response_shape"]
+
+        tool_id = "550e8400e29b41d4a7164466554400b1"  # pragma: allowlist secret
+
+        # Step 1: First edit - set plugin chains
+        form_data_with_chains = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "rate_limit, pii_filter",
+                "plugin_chain_post": "response_shape",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data_with_chains)
+
+        result = await admin_edit_tool(
+            tool_id,
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify plugin chains were set
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == ["rate_limit", "pii_filter"]
+        assert tool_update.plugin_chain_post == ["response_shape"]
+
+        # Step 2: Second edit - clear plugin chains by submitting empty strings
+        form_data_clear_chains = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "plugin_chain_pre": "",  # Empty field clears the chain
+                "plugin_chain_post": "",  # Empty field clears the chain
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data_clear_chains)
+
+        result = await admin_edit_tool(
+            tool_id,
             mock_request,
             mock_db,
             user={"email": "test@example.com", "db": mock_db},
@@ -441,6 +520,75 @@ class TestAdminEditToolAdvancedFields:
 
         result = await admin_edit_tool(
             "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify allowlist was cleared to empty list
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == []
+
+    @patch.object(ToolService, "update_tool")
+    async def test_edit_tool_workflow_set_then_clear_allowlist(self, mock_update_tool, mock_request, mock_db):
+        """Test complete workflow: set allowlist, then clear it by submitting empty field.
+
+        This simulates the real user scenario:
+        1. User edits tool and sets allowlist with multiple URLs
+        2. Later, user edits the same tool and clears allowlist by leaving field empty
+
+        Verifies that empty string in form field translates to [] in ToolUpdate,
+        which the service layer will interpret as "clear the existing allowlist".
+        """
+        tool_id = "550e8400e29b41d4a7164466554400b1"  # pragma: allowlist secret
+
+        # Step 1: First edit - set allowlist
+        form_data_with_allowlist = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "https://api1.example.com, https://api2.example.com, https://api3.example.com",
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data_with_allowlist)
+
+        result = await admin_edit_tool(
+            tool_id,
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+
+        # Verify allowlist was set with 3 URLs
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == ["https://api1.example.com", "https://api2.example.com", "https://api3.example.com"]
+
+        # Step 2: Second edit - clear allowlist by submitting empty string
+        form_data_clear_allowlist = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "allowlist": "",  # Empty field clears the allowlist
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data_clear_allowlist)
+
+        result = await admin_edit_tool(
+            tool_id,
             mock_request,
             mock_db,
             user={"email": "test@example.com", "db": mock_db},

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mcpgateway.admin import admin_edit_tool
+from mcpgateway.db import Tool
 from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.utils.orjson_response import ORJSONResponse
@@ -642,3 +643,234 @@ class TestAdminEditToolAdvancedFields:
         payload = json.loads(result.body.decode())
         assert payload["success"] is False
         assert "must be a positive integer" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_query_mapping_json():
+    """Test that invalid JSON in query_mapping field returns 422 error."""
+    from mcpgateway.admin import admin_edit_tool
+    from unittest.mock import AsyncMock
+
+    mock_db = AsyncMock()
+    mock_request = AsyncMock()
+    mock_request.state = AsyncMock()
+    mock_request.state.user = {"email": "test@example.com", "db": mock_db}
+
+    with patch.object(TeamManagementService, "verify_team_for_user") as mock_verify_team:
+        mock_verify_team.return_value = None  # Pass team verification
+
+        # Mock tool exists
+        mock_tool = Tool(
+            id="550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            original_name="test-tool",
+            custom_name="test-tool",
+            custom_name_slug="test-tool",
+            url="http://example.com",
+            input_schema={},
+            team_id="team-123",
+            visibility="public",
+            integration_type="REST",
+        )
+        mock_db.execute = AsyncMock(return_value=AsyncMock(scalars=lambda: AsyncMock(first=lambda: mock_tool)))
+
+        # Form with invalid JSON in query_mapping
+        form_data = FakeForm(
+            {
+                "name": "test-tool",
+                "customName": "test-tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "input_schema": "{}",
+                "team_id": "team-123",
+                "visibility": "public",
+                "integrationType": "REST",
+                "query_mapping": "{invalid json}",  # Invalid JSON
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid JSON in query_mapping" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_header_mapping_json():
+    """Test that invalid JSON in header_mapping field returns 422 error."""
+    from mcpgateway.admin import admin_edit_tool
+    from unittest.mock import AsyncMock
+
+    mock_db = AsyncMock()
+    mock_request = AsyncMock()
+    mock_request.state = AsyncMock()
+    mock_request.state.user = {"email": "test@example.com", "db": mock_db}
+
+    with patch.object(TeamManagementService, "verify_team_for_user") as mock_verify_team:
+        mock_verify_team.return_value = None  # Pass team verification
+
+        # Mock tool exists
+        mock_tool = Tool(
+            id="550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            original_name="test-tool",
+            custom_name="test-tool",
+            custom_name_slug="test-tool",
+            url="http://example.com",
+            input_schema={},
+            team_id="team-123",
+            visibility="public",
+            integration_type="REST",
+        )
+        mock_db.execute = AsyncMock(return_value=AsyncMock(scalars=lambda: AsyncMock(first=lambda: mock_tool)))
+
+        # Form with invalid JSON in header_mapping
+        form_data = FakeForm(
+            {
+                "name": "test-tool",
+                "customName": "test-tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "input_schema": "{}",
+                "team_id": "team-123",
+                "visibility": "public",
+                "integrationType": "REST",
+                "header_mapping": '{"key": invalid}',  # Invalid JSON
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid JSON in header_mapping" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_jsonpath_expression():
+    """Test that invalid JSONPath expression returns 422 error."""
+    from mcpgateway.admin import admin_edit_tool
+    from unittest.mock import AsyncMock
+
+    mock_db = AsyncMock()
+    mock_request = AsyncMock()
+    mock_request.state = AsyncMock()
+    mock_request.state.user = {"email": "test@example.com", "db": mock_db}
+
+    with patch.object(TeamManagementService, "verify_team_for_user") as mock_verify_team:
+        mock_verify_team.return_value = None  # Pass team verification
+
+        # Mock tool exists
+        mock_tool = Tool(
+            id="550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            original_name="test-tool",
+            custom_name="test-tool",
+            custom_name_slug="test-tool",
+            url="http://example.com",
+            input_schema={},
+            team_id="team-123",
+            visibility="public",
+            integration_type="REST",
+        )
+        mock_db.execute = AsyncMock(return_value=AsyncMock(scalars=lambda: AsyncMock(first=lambda: mock_tool)))
+
+        # Form with invalid JSONPath expression
+        form_data = FakeForm(
+            {
+                "name": "test-tool",
+                "customName": "test-tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "input_schema": "{}",
+                "team_id": "team-123",
+                "visibility": "public",
+                "integrationType": "REST",
+                "jsonpath_filter": "$.[[[invalid",  # Invalid JSONPath
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid JSONPath expression" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_valid_jsonpath_expression():
+    """Test that valid JSONPath expression is accepted."""
+    from mcpgateway.admin import admin_edit_tool
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_db = AsyncMock()
+    mock_request = MagicMock()
+    mock_request.headers = {}
+    mock_request.state = AsyncMock()
+    mock_request.state.user = {"email": "test@example.com", "db": mock_db}
+
+    with patch.object(TeamManagementService, "verify_team_for_user") as mock_verify_team, patch.object(ToolService, "update_tool") as mock_tool_service:
+        mock_verify_team.return_value = None  # Pass team verification
+
+        # Mock tool exists
+        mock_tool = Tool(
+            id="550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            original_name="test-tool",
+            custom_name="test-tool",
+            custom_name_slug="test-tool",
+            url="http://example.com",
+            input_schema={},
+            team_id="team-123",
+            visibility="public",
+            integration_type="REST",
+        )
+        mock_db.execute = AsyncMock(return_value=AsyncMock(scalars=lambda: AsyncMock(first=lambda: mock_tool)))
+        mock_tool_service.update_tool = AsyncMock(return_value=mock_tool)
+
+        # Form with valid JSONPath expression
+        form_data = FakeForm(
+            {
+                "name": "test-tool",
+                "customName": "test-tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "input_schema": "{}",
+                "team_id": "team-123",
+                "visibility": "public",
+                "integrationType": "REST",
+                "jsonpath_filter": "$.data[*].result",  # Valid JSONPath
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        # Verify the jsonpath_filter was passed to the service
+        call_args = mock_tool_service.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.jsonpath_filter == "$.data[*].result"

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -485,3 +485,160 @@ class TestAdminEditToolAdvancedFields:
         call_args = mock_update_tool.call_args[0]
         tool_update = call_args[2]
         assert tool_update.team_id is None
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_expose_passthrough_checkbox_checked(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Bug fix: Verify expose_passthrough=True when checkbox is checked (value='true')."""
+        mock_verify_team.return_value = None  # No team_id in form
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                "expose_passthrough": "true",  # Checked state
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.expose_passthrough is True
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_expose_passthrough_checkbox_unchecked(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Bug fix: Verify expose_passthrough=False when checkbox is unchecked (field absent)."""
+        mock_verify_team.return_value = None  # No team_id in form
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                # expose_passthrough NOT in form = unchecked
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.expose_passthrough is False
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_clear_allowlist_to_empty(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Bug fix: Verify allowlist can be cleared to empty list with empty string."""
+        mock_verify_team.return_value = None  # No team_id in form
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                "allowlist": "",  # Empty string to clear
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.allowlist == []
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_clear_plugin_chains_to_empty(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Bug fix: Verify plugin_chain_pre and plugin_chain_post can be cleared to empty lists."""
+        mock_verify_team.return_value = None  # No team_id in form
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                "plugin_chain_pre": "",  # Clear
+                "plugin_chain_post": "",  # Clear
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.plugin_chain_pre == []
+        assert tool_update.plugin_chain_post == []
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_timeout_ms_invalid_input(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Bug fix: Verify timeout_ms rejects non-numeric input with clear error."""
+        mock_verify_team.return_value = None  # No team_id in form
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "requestType": "GET",
+                "integrationType": "REST",
+                "timeout_ms": "10seconds",  # Invalid non-numeric
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "must be a positive integer" in payload["message"]

--- a/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
+++ b/tests/unit/mcpgateway/test_admin_advanced_field_tools.py
@@ -1182,3 +1182,300 @@ class TestPluginChainValidationWhenDisabled:
         # plugin chains should be None (not provided in form)
         assert tool_update.plugin_chain_pre is None
         assert tool_update.plugin_chain_post is None
+
+
+# ---------------------------------------------------------------------------
+# Field Validation: timeout_ms and base_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFieldValidationConsistency:
+    """Test backend validation matches frontend constraints for timeout_ms and base_url."""
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_timeout_ms_rejects_zero(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that timeout_ms=0 is rejected (must be positive)."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "timeout_ms": "0",  # Invalid: must be > 0
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "must be a positive integer" in payload["message"]
+        assert "greater than 0" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_timeout_ms_rejects_negative(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that negative timeout_ms is rejected."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "timeout_ms": "-5000",  # Invalid: negative
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "must be a positive integer" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_timeout_ms_accepts_positive(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that positive timeout_ms values are accepted."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "timeout_ms": "5000",  # Valid
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.timeout_ms == 5000
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_rejects_missing_scheme(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that base_url without scheme is rejected."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "api.example.com",  # Invalid: missing scheme
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid base_url" in payload["message"]
+        assert "must be a valid URL with scheme and host" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_rejects_missing_host(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that base_url without host is rejected."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "https://",  # Invalid: missing host
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid base_url" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_rejects_invalid_scheme(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that base_url with non-http(s) scheme is rejected."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "ftp://api.example.com",  # Invalid: ftp scheme
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 422
+        payload = json.loads(result.body.decode())
+        assert payload["success"] is False
+        assert "Invalid base_url" in payload["message"]
+        assert "scheme must be http or https" in payload["message"]
+        mock_update_tool.assert_not_called()
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_accepts_valid_http(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that valid http base_url is accepted."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "http://api.example.com",  # Valid
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.base_url == "http://api.example.com"
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_accepts_valid_https(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that valid https base_url is accepted."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "https://api.example.com",  # Valid
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.base_url == "https://api.example.com"
+
+    @patch.object(TeamManagementService, "verify_team_for_user")
+    @patch.object(ToolService, "update_tool")
+    async def test_base_url_accepts_with_port(self, mock_update_tool, mock_verify_team, mock_request, mock_db):
+        """Test that base_url with port is accepted."""
+        mock_verify_team.return_value = None
+
+        form_data = FakeForm(
+            {
+                "name": "test_tool",
+                "customName": "test_tool",
+                "url": "http://example.com",
+                "description": "Test tool",
+                "base_url": "https://api.example.com:8443",  # Valid with port
+                "requestType": "GET",
+                "integrationType": "REST",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+
+        result = await admin_edit_tool(
+            "550e8400e29b41d4a7164466554400b1",  # pragma: allowlist secret
+            mock_request,
+            mock_db,
+            user={"email": "test@example.com", "db": mock_db},
+        )
+
+        assert result.status_code == 200
+        call_args = mock_update_tool.call_args[0]
+        tool_update = call_args[2]
+        assert tool_update.base_url == "https://api.example.com:8443"

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1285,28 +1285,44 @@ class TestSchemaValidators:
 
     def test_tool_update_validation_errors(self):
         """ToolUpdate validators should reject invalid passthrough configs."""
-        with pytest.raises(ValidationError, match="path_template must start"):
-            ToolUpdate(path_template="no-leading-slash")
+        # Standard
+        from unittest.mock import MagicMock, patch
 
-        with pytest.raises(ValidationError, match="timeout_ms must be a positive integer"):
-            ToolUpdate(timeout_ms=0)
+        # Mock settings with plugins enabled so validation runs
+        mock_settings = MagicMock()
+        mock_settings.plugins.enabled = True
 
-        with pytest.raises(ValidationError, match="Invalid host/scheme"):
-            ToolUpdate(allowlist=["not a host"])
+        with patch("mcpgateway.schemas.settings", mock_settings):
+            with pytest.raises(ValidationError, match="path_template must start"):
+                ToolUpdate(path_template="no-leading-slash")
 
-        with pytest.raises(ValidationError, match="Unknown plugin"):
-            ToolUpdate(plugin_chain_pre=["unknown_plugin"])
+            with pytest.raises(ValidationError, match="timeout_ms must be a positive integer"):
+                ToolUpdate(timeout_ms=0)
+
+            with pytest.raises(ValidationError, match="Invalid host/scheme"):
+                ToolUpdate(allowlist=["not a host"])
+
+            with pytest.raises(ValidationError, match="Unknown plugin"):
+                ToolUpdate(plugin_chain_pre=["unknown_plugin"])
 
     def test_tool_update_validator_helpers(self):
         """Directly exercise allowlist/plugin validators for edge cases."""
+        # Standard
+        from unittest.mock import MagicMock, patch
+
+        # Mock settings with plugins enabled so validation runs
+        mock_settings = MagicMock()
+        mock_settings.plugins.enabled = True
+
         assert ToolUpdate.validate_allowlist(None) is None
         with pytest.raises(ValueError, match="allowlist must be a list"):
             ToolUpdate.validate_allowlist("not-a-list")
         with pytest.raises(ValueError, match="Invalid type in allowlist"):
             ToolUpdate.validate_allowlist([123])
 
-        with pytest.raises(ValueError, match="Unknown plugin"):
-            ToolUpdate.validate_plugin_chain(["unknown_plugin"])
+        with patch("mcpgateway.schemas.settings", mock_settings):
+            with pytest.raises(ValueError, match="Unknown plugin"):
+                ToolUpdate.validate_plugin_chain(["unknown_plugin"])
 
     def test_resource_description_truncation(self):
         """ResourceCreate should truncate overly long descriptions."""

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -97,6 +97,13 @@ def test_tool_create_prevent_manual_and_passthrough_rules():
 
 
 def test_tool_create_passthrough_validators():
+    # Standard
+    from unittest.mock import MagicMock, patch
+
+    # Mock settings with plugins enabled so validation runs
+    mock_settings = MagicMock()
+    mock_settings.plugins.enabled = True
+
     values = ToolCreate.extract_base_url_and_path_template({"integration_type": "REST", "url": "http://example.com/api"})
     assert values["base_url"] == "http://example.com"
     assert values["path_template"] == "/api"
@@ -119,8 +126,9 @@ def test_tool_create_passthrough_validators():
     with pytest.raises(ValueError):
         ToolCreate.validate_allowlist(["not a host"])
 
-    with pytest.raises(ValueError):
-        ToolCreate.validate_plugin_chain(["unknown_plugin"])
+    with patch("mcpgateway.schemas.settings", mock_settings):
+        with pytest.raises(ValueError):
+            ToolCreate.validate_plugin_chain(["unknown_plugin"])
 
 
 def test_tool_request_type_validation_unknown_integration():


### PR DESCRIPTION
  Closes #4061
  
  Brings the Admin UI tool edit form to feature parity with the PATCH /tools/{id} API by exposing advanced configuration fields that were previously API-only. This allows platform operators to manage tool timeouts, REST passthrough settings,
  plugin chains, and other advanced options directly from the UI without requiring API access.

  Changes

  - Timeout configuration: Added timeout_ms field for per-tool timeout tuning
  - Title field: Exposed MCP BaseMetadata title field (distinct from displayName)
  - REST passthrough fields: Added base_url, path_template, query_mapping, header_mapping, expose_passthrough, and allowlist fields (conditionally shown for REST integration tools)
  - Plugin chain fields: Added plugin_chain_pre and plugin_chain_post configuration (shown when plugins enabled)
  - JSONPath filter: Fixed field name from jsonpathFilter to jsonpath_filter for schema consistency
  - Team reassignment: Added team_id field to allow reassigning tool ownership between teams
  - Security fix: Removed owner_email from update payload to prevent unauthorized ownership changes during edits

  Technical Details

  - Frontend: Enhanced tools.js with conditional field rendering and validation
  - Backend: Updated admin.py edit handler to accept and validate new optional fields
  - Service layer: Added get_tool_by_id_admin method in tool_service.py for admin-scoped tool retrieval
  - Schema alignment: All fields now match ToolUpdate Pydantic schema definitions

  Test Coverage

  - Playwright E2E tests: 189 lines covering full form workflows and field validation
  - Unit tests (JS): 1,311 lines across admin-forms.test.js, admin-html-issue-4061.test.js, formFieldHandlers.test.js, and tools.test.js
  - Unit tests (Python): 415 lines in test_tool_service_coverage.py
  - Total test additions: 2,215 lines


