### PR TITLE
bug/schema-preview-wrong-mode-4890

### DIFF
--- a/mcpgateway/admin_ui/formFieldHandlers.js
+++ b/mcpgateway/admin_ui/formFieldHandlers.js
@@ -67,7 +67,7 @@ export const updateSchemaPreview = function () {
     const modeRadio = document.querySelector(
       'input[name="schema_input_mode"]:checked',
     );
-    if (modeRadio && modeRadio.value === "json") {
+    if (modeRadio && modeRadio.value === "ui") {
       if (
         window.schemaEditor &&
         typeof window.schemaEditor.setValue === "function"

--- a/tests/unit/js/formFieldHandlers.test.js
+++ b/tests/unit/js/formFieldHandlers.test.js
@@ -207,11 +207,11 @@ describe("updateSchemaPreview", () => {
     expect(() => updateSchemaPreview()).not.toThrow();
   });
 
-  test("calls schemaEditor.setValue when mode is json", () => {
+  test("calls schemaEditor.setValue when mode is ui", () => {
     const radio = document.createElement("input");
     radio.type = "radio";
     radio.name = "schema_input_mode";
-    radio.value = "json";
+    radio.value = "ui";
     radio.checked = true;
     document.body.appendChild(radio);
 
@@ -222,11 +222,11 @@ describe("updateSchemaPreview", () => {
     expect(window.schemaEditor.setValue).toHaveBeenCalled();
   });
 
-  test("does not call setValue when mode is not json", () => {
+  test("does not call setValue when mode is not ui", () => {
     const radio = document.createElement("input");
     radio.type = "radio";
     radio.name = "schema_input_mode";
-    radio.value = "form";
+    radio.value = "json";
     radio.checked = true;
     document.body.appendChild(radio);
 
@@ -239,7 +239,7 @@ describe("updateSchemaPreview", () => {
     const radio = document.createElement("input");
     radio.type = "radio";
     radio.name = "schema_input_mode";
-    radio.value = "json";
+    radio.value = "ui";
     radio.checked = true;
     document.body.appendChild(radio);
 
@@ -251,7 +251,7 @@ describe("updateSchemaPreview", () => {
     const radio = document.createElement("input");
     radio.type = "radio";
     radio.name = "schema_input_mode";
-    radio.value = "json";
+    radio.value = "ui";
     radio.checked = true;
     document.body.appendChild(radio);
 


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #4890 

The Fix
Changed line 70 to:
AFTER (fixed):
if (modeRadio && modeRadio.value === "ui") {
Now when the user adds/removes parameters in Schema Builder mode, the JSON preview pane updates in real time.

1. Source (formFieldHandlers.js:70): The guard now matches the Schema Builder radio value ("ui"), so generateSchema() runs and window.schemaEditor.setValue() updates the preview whenever parameters change.
2. Tests (formFieldHandlers.test.js): All 3 relevant tests were updated:
 calls setValue when mode is ui" — verifies the happy path
 does not call setValue when mode is not ui" — verifies other modes (like "json") don't trigger spurious updates
 Error-handling tests now use "ui" — they exercise the actual code path instead of a dead branch

