### PR TITLE
fix(observability): resolve authenticated user email after call_next to fix anonymous traces

### DIFF
--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -104,6 +104,24 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         self.service = service or ObservabilityService()
         logger.info(f"Observability middleware initialized (enabled={self.enabled})")
 
+    @staticmethod
+    def _extract_user_email_from_state(request: Request) -> Optional[str]:
+        """Extract authenticated user email from request state.
+
+        Auth context may be available as request.state.user.email or as
+        request.state.user_email depending on middleware/dependency path.
+        """
+        user = getattr(request.state, "user", None)
+        email = getattr(user, "email", None)
+        if isinstance(email, str) and email:
+            return email
+
+        state_user_email = getattr(request.state, "user_email", None)
+        if isinstance(state_user_email, str) and state_user_email:
+            return state_user_email
+
+        return None
+
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request and create observability trace.
 
@@ -131,13 +149,9 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         # Extract request context
         http_method = request.method
         http_url = sanitize_header_for_storage(str(request.url), max_length=2000)
-        user_email = None
+        user_email = self._extract_user_email_from_state(request)
         ip_address = request.client.host if request.client else None
         user_agent = sanitize_header_for_storage(request.headers.get("user-agent"), max_length=500)
-
-        # Try to extract user from request state (set by auth middleware)
-        if hasattr(request.state, "user") and hasattr(request.state.user, "email"):
-            user_email = request.state.user.email
 
         # Extract W3C Trace Context from headers (for distributed tracing)
         external_trace_id = None
@@ -223,11 +237,13 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
             # End trace (creates independent observability session)
             if trace_id:
                 duration_ms = (time.time() - start_time) * 1000
+                resolved_user_email = self._extract_user_email_from_state(request)
                 try:
                     self.service.end_trace(
                         trace_id,
                         status="ok" if status_code < 400 else "error",
                         http_status_code=status_code,
+                        user_email=resolved_user_email,
                         attributes={"response_time_ms": duration_ms},
                     )
                 except Exception as end_trace_error:
@@ -265,6 +281,7 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
 
             # End trace with error (creates independent observability session)
             if trace_id:
+                resolved_user_email = self._extract_user_email_from_state(request)
                 try:
                     sanitized_error = sanitize_for_log(sanitize_trace_text(str(e)))
                     self.service.end_trace(
@@ -272,6 +289,7 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                         status="error",
                         status_message=sanitized_error,
                         http_status_code=500,
+                        user_email=resolved_user_email,
                     )
                 except Exception as trace_error:
                     logger.warning(f"Failed to end trace: {trace_error}")

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -358,6 +358,7 @@ class ObservabilityService:
         status: str = "ok",
         status_message: Optional[str] = None,
         http_status_code: Optional[int] = None,
+        user_email: Optional[str] = None,
         attributes: Optional[Dict[str, Any]] = None,
     ) -> None:
         """End a trace.
@@ -371,6 +372,7 @@ class ObservabilityService:
             status: Trace status (ok, error)
             status_message: Optional status message
             http_status_code: HTTP response status code
+            user_email: Authenticated user email resolved during request processing
             attributes: Additional attributes to merge
 
         Note:
@@ -402,6 +404,8 @@ class ObservabilityService:
             trace.status_message = status_message
             if http_status_code is not None:
                 trace.http_status_code = http_status_code
+            if user_email:
+                trace.user_email = user_email
             if attributes:
                 trace.attributes = {**(trace.attributes or {}), **attributes}
 

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -9,6 +9,7 @@ Unit tests for observability middleware.
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
 from starlette.requests import Request
 from starlette.responses import Response
 from mcpgateway.middleware.observability_middleware import ObservabilityMiddleware
@@ -196,6 +197,78 @@ async def test_dispatch_end_trace_error_failure_logs_warning(mock_request):
         with pytest.raises(RuntimeError):
             await middleware.dispatch(mock_request, failing_call_next)
         mock_warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_user_email_after_call_next(mock_request):
+    """Trace user attribution is resolved after downstream auth runs."""
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    mock_request.state = SimpleNamespace()
+
+    async def auth_populating_call_next(request):
+        request.state.user = SimpleNamespace(email="postauth@example.com")
+        return Response("OK", status_code=200)
+
+    with (
+        patch.object(middleware.service, "start_trace", return_value="trace123") as mock_start_trace,
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "end_trace") as mock_end_trace,
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        response = await middleware.dispatch(mock_request, auth_populating_call_next)
+        assert response.status_code == 200
+
+        assert mock_start_trace.call_args.kwargs.get("user_email") is None
+        assert mock_end_trace.call_args.kwargs.get("user_email") == "postauth@example.com"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_user_email_from_state_fallback(mock_request):
+    """Trace attribution falls back to request.state.user_email when user object is absent."""
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    mock_request.state = SimpleNamespace()
+
+    async def token_auth_call_next(request):
+        request.state.user_email = "token-user@example.com"
+        return Response("OK", status_code=200)
+
+    with (
+        patch.object(middleware.service, "start_trace", return_value="trace123") as mock_start_trace,
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "end_trace") as mock_end_trace,
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        response = await middleware.dispatch(mock_request, token_auth_call_next)
+        assert response.status_code == 200
+
+        assert mock_start_trace.call_args.kwargs.get("user_email") is None
+        assert mock_end_trace.call_args.kwargs.get("user_email") == "token-user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_exception_path_passes_user_email_to_end_trace(mock_request):
+    """Error-path end_trace() receives the authenticated user email even when call_next() raises."""
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+    mock_request.state = SimpleNamespace()
+
+    async def auth_then_raise_call_next(request):
+        request.state.user = SimpleNamespace(email="errpath@example.com")
+        raise RuntimeError("downstream failure")
+
+    with (
+        patch.object(middleware.service, "start_trace", return_value="trace123"),
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "add_event"),
+        patch.object(middleware.service, "end_trace") as mock_end_trace,
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        with pytest.raises(RuntimeError):
+            await middleware.dispatch(mock_request, auth_then_raise_call_next)
+
+        assert mock_end_trace.call_args.kwargs.get("user_email") == "errpath@example.com"
 
 
 # ============================================================================


### PR DESCRIPTION
## 📌 Summary

All traces in `/admin/observability` showed `anonymous` for the user, making per-user filtering and the User column non-functional. This is because `ObservabilityMiddleware` attempted to read `request.state.user` **before** auth had run, due to Starlette's LIFO middleware execution order.

## 🔗 Related Issue
Closes: #4886

## 🐞 Root Cause

`ObservabilityMiddleware` was registered after `HttpAuthMiddleware` in `main.py`. Because Starlette processes middleware in LIFO order, `ObservabilityMiddleware` runs **first** — before `HttpAuthMiddleware` has populated `request.state.user`. The `user_email` extracted at trace-start time was therefore always `None`, and the trace record was committed anonymously before auth had a chance to run.

```python
# observability_middleware.py — old behaviour
user_email = None
if hasattr(request.state, "user") and hasattr(request.state.user, "email"):
    user_email = request.state.user.email   # always None — auth hasn't run yet

trace_id = self.service.start_trace(user_email=user_email, ...)  # ← None

response = await call_next(request)   # auth runs here, sets request.state.user
# but trace is already committed with anonymous
```

## 💡 Fix Description

Rather than reordering middleware (fragile) or adding an `update_trace` method (API churn), the fix defers user-email resolution to **trace finalization**, which happens after `call_next()` returns and auth context is fully populated.

**Two targeted changes:**

1. **`ObservabilityMiddleware._extract_user_email_from_state()`** — a new static helper that reads auth context from either `request.state.user.email` or `request.state.user_email` (covering both the session-cookie and API-token auth paths). Called at trace end, after `call_next()`.

2. **`ObservabilityService.end_trace(user_email=…)`** — accepts an optional `user_email` argument and writes it to the trace record when present, overwriting the `None` that was stored at trace start.

Both the success path and the exception path (when `call_next()` raises) pass the resolved email to `end_trace()`.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |    Passed    |
| Unit tests                            | `make test`          |    Passed    |
| Coverage ≥ 90 %                       | `make coverage`      |    Passed    |
| Manual regression no longer fails     | steps / screenshots  |    Passed    |

New regression tests added in `tests/unit/mcpgateway/middleware/test_observability_middleware.py`:
- `test_dispatch_resolves_user_email_after_call_next` — asserts `start_trace` receives `None` but `end_trace` receives the email set by auth during `call_next`
- `test_dispatch_resolves_user_email_from_state_fallback` — covers the `request.state.user_email` fallback (API/token auth path)
- `test_dispatch_exception_path_passes_user_email_to_end_trace` — asserts the error-path `end_trace` also receives the correct email when `call_next` raises after auth

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed