### PR TITLE
fix: Hardening container images on fast-test, slow-test, a2a-test-echo servers

### DIFF
--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -1,20 +1,21 @@
 # This build supports multi-platform builds through standard Docker Buildx
 # techniques, including the $TARGETPLATFORM environment variable.
-FROM golang:1.26.3 AS builder
-ENV PATH=/usr/local/go/bin:$PATH
+# Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+USER root
+RUN dnf install -y git && dnf clean all
+ENV GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/bin/a2a-echo-agent .
 
-# Use Debian slim so basic tooling exists without Alpine.
-FROM debian:bookworm-slim
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates tzdata wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd --uid 1001 --create-home --shell /usr/sbin/nologin app
-COPY --from=builder /usr/local/bin/a2a-echo-agent /usr/local/bin/a2a-echo-agent
+# Use scratch for minimal attack surface
+# Static binary (CGO_ENABLED=0) from builder stage contains everything needed.
+
+FROM scratch
+COPY --from=builder /usr/local/bin/a2a-echo-agent /a2a-echo-agent
 USER 1001:1001
 EXPOSE 9100
-ENTRYPOINT ["/usr/local/bin/a2a-echo-agent"]
+ENTRYPOINT ["/a2a-echo-agent"]

--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -3,7 +3,7 @@
 # Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
-RUN dnf install -y git && dnf clean all
+RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod ./
@@ -11,11 +11,19 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/bin/a2a-echo-agent .
 
-# Use scratch for minimal attack surface
 # Static binary (CGO_ENABLED=0) from builder stage contains everything needed.
 
 FROM scratch
+
+# Copy CA certificates for HTTPS calls
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy timezone data for time.LoadLocation()
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary
 COPY --from=builder /usr/local/bin/a2a-echo-agent /a2a-echo-agent
+
 USER 1001:1001
 EXPOSE 9100
 ENTRYPOINT ["/a2a-echo-agent"]

--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -4,7 +4,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=auto
+ENV GOTOOLCHAIN=go1.26.3
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -6,7 +6,7 @@ USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/bin/a2a-echo-agent .

--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -3,7 +3,7 @@
 # Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
-RUN dnf install -y git && dnf clean all
+RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod .
@@ -12,6 +12,15 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/bin/benchmark-server .
 
 FROM scratch
+
+# Copy CA certificates for HTTPS calls
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy timezone data for time.LoadLocation()
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary
 COPY --from=builder /usr/local/bin/benchmark-server /benchmark-server
+
 USER 1001:1001
 ENTRYPOINT ["/benchmark-server"]

--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -1,6 +1,10 @@
 # This build supports multi-platform builds through standard Docker Buildx
 # techniques, including the $TARGETPLATFORM environment variable.
-FROM golang:1.26.3 AS builder
+# Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+USER root
+RUN dnf install -y git && dnf clean all
+ENV GOTOOLCHAIN=auto
 WORKDIR /src
 COPY go.mod .
 RUN go mod download

--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -4,7 +4,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=auto
+ENV GOTOOLCHAIN=go1.26.3
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -6,7 +6,7 @@ USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
-COPY go.mod .
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/bin/benchmark-server .

--- a/mcp-servers/go/fast-time-server/Dockerfile
+++ b/mcp-servers/go/fast-time-server/Dockerfile
@@ -15,8 +15,12 @@
 
 # =============================================================================
 # 🏗️  STAGE 1 - BUILD STATIC BINARY (Go 1.23, CGO disabled)
+# Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 # =============================================================================
-FROM golang:1.26.3 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+USER root
+RUN dnf install -y git tzdata && dnf clean all
+ENV GOTOOLCHAIN=auto
 
 # Accept target architecture from buildx for cross-compilation
 ARG TARGETARCH

--- a/mcp-servers/go/fast-time-server/Dockerfile
+++ b/mcp-servers/go/fast-time-server/Dockerfile
@@ -19,7 +19,7 @@
 # =============================================================================
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
-RUN dnf install -y git tzdata && dnf clean all
+RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 
 # Accept target architecture from buildx for cross-compilation
@@ -43,10 +43,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
 FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/IBM/mcp-context-forge
 
-# copy tzdata so time.LoadLocation works
+# Copy CA certificates for HTTPS calls
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy tzdata so time.LoadLocation works
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-# copy binary
+# Copy binary
 COPY --from=builder /usr/local/bin/fast-time-server /fast-time-server
 
 # --- default: SSE + HTTP on 8080 ---

--- a/mcp-servers/go/fast-time-server/Dockerfile
+++ b/mcp-servers/go/fast-time-server/Dockerfile
@@ -20,7 +20,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=auto
+ENV GOTOOLCHAIN=go1.26.3
 
 # Accept target architecture from buildx for cross-compilation
 ARG TARGETARCH

--- a/mcp-servers/go/slow-time-server/Dockerfile
+++ b/mcp-servers/go/slow-time-server/Dockerfile
@@ -16,7 +16,7 @@
 # =============================================================================
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
-RUN dnf install -y git tzdata && dnf clean all
+RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 
 ARG TARGETARCH
@@ -38,10 +38,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
 FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/IBM/mcp-context-forge
 
-# copy tzdata so time.LoadLocation works
+# Copy CA certificates for HTTPS calls
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy tzdata so time.LoadLocation works
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-# copy binary
+# Copy binary
 COPY --from=builder /usr/local/bin/slow-time-server /slow-time-server
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \

--- a/mcp-servers/go/slow-time-server/Dockerfile
+++ b/mcp-servers/go/slow-time-server/Dockerfile
@@ -12,8 +12,12 @@
 
 # =============================================================================
 # STAGE 1 - BUILD STATIC BINARY (Go 1.23, CGO disabled)
+# Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 # =============================================================================
-FROM golang:1.26.3 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+USER root
+RUN dnf install -y git tzdata && dnf clean all
+ENV GOTOOLCHAIN=auto
 
 ARG TARGETARCH
 WORKDIR /src

--- a/mcp-servers/go/slow-time-server/Dockerfile
+++ b/mcp-servers/go/slow-time-server/Dockerfile
@@ -17,7 +17,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=auto
+ENV GOTOOLCHAIN=go1.26.3
 
 ARG TARGETARCH
 WORKDIR /src

--- a/mcp-servers/templates/go/cookiecutter.json
+++ b/mcp-servers/templates/go/cookiecutter.json
@@ -6,7 +6,7 @@
     "description": "Minimal Go MCP server (stdio) with a time tool",
     "version": "0.1.0",
     "license": ["Apache-2.0", "MIT"],
-    "go_version": "ubi9-go-toolset",
+    "go_version": "1.26",
     "toolchain": "go1.23.10",
     "include_container": true
 }

--- a/mcp-servers/templates/go/cookiecutter.json
+++ b/mcp-servers/templates/go/cookiecutter.json
@@ -6,7 +6,7 @@
     "description": "Minimal Go MCP server (stdio) with a time tool",
     "version": "0.1.0",
     "license": ["Apache-2.0", "MIT"],
-    "go_version": "1.23",
+    "go_version": "ubi9-go-toolset",
     "toolchain": "go1.23.10",
     "include_container": true
 }

--- a/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
+++ b/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
@@ -7,7 +7,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:{{ cookiecutter.go_version }} AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=auto
+ENV GOTOOLCHAIN=go1.26.3
 WORKDIR /src
 
 COPY go.mod go.sum ./

--- a/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
+++ b/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
@@ -4,7 +4,7 @@
 # techniques, including the $TARGETPLATFORM environment variable.
 # Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+FROM registry.access.redhat.com/{{ cookiecutter.go_version }} AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto

--- a/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
+++ b/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
-RUN dnf install -y git && dnf clean all
+RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
 
@@ -19,6 +19,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags "-s -w" -o /usr/local/b
 FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/contextforge/mcp-context-forge
 
+# Copy CA certificates for HTTPS calls
+COPY --from=builder /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy timezone data for time.LoadLocation()
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary
 COPY --from=builder /usr/local/bin/{{ cookiecutter.bin_name }} /{{ cookiecutter.bin_name }}
 
 USER 1001:1001

--- a/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
+++ b/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
@@ -2,8 +2,12 @@
 
 # This build supports multi-platform builds through standard Docker Buildx
 # techniques, including the $TARGETPLATFORM environment variable.
+# Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 
-FROM golang:{{ cookiecutter.go_version }} AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
+USER root
+RUN dnf install -y git && dnf clean all
+ENV GOTOOLCHAIN=auto
 WORKDIR /src
 
 COPY go.mod .

--- a/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
+++ b/mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile
@@ -4,13 +4,13 @@
 # techniques, including the $TARGETPLATFORM environment variable.
 # Using Red Hat UBI 9 Go Toolset for enterprise-grade security and IBM alignment
 
-FROM registry.access.redhat.com/{{ cookiecutter.go_version }} AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:{{ cookiecutter.go_version }} AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
 ENV GOTOOLCHAIN=auto
 WORKDIR /src
 
-COPY go.mod .
+COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 


### PR DESCRIPTION
## 🔗 Related Issue
Closes:  

---

## 📝 Summary

Migrated all Go-based Docker images from Debian bookworm to Red Hat Universal Base Image (UBI) 9 with scratch runtime to mitigate critical CVEs through architectural elimination:

All Go servers now use statically compiled binaries (CGO_ENABLED=0) running on scratch base images, completely eliminating system library dependencies and the associated vulnerabilities.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |
| Docker builds             | Manual testing  | ✅ Pass |
| Runtime functionality     | Manual testing  | ✅ Pass |

**Manual Testing Performed:**
- Built all 4 Go server images with `--no-cache`
- Verified health endpoints respond correctly
- Tested REST API endpoints for all servers
- Confirmed no runtime errors or crashes
- Validated timezone support (tzdata) works correctly

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (N/A - infrastructure change)
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Files Changed (6 total)
1. `a2a-agents/go/a2a-echo-agent/Dockerfile`
2. `mcp-servers/go/fast-time-server/Dockerfile`
3. `mcp-servers/go/slow-time-server/Dockerfile`
4. `mcp-servers/go/benchmark-server/Dockerfile`
5. `mcp-servers/templates/go/cookiecutter.json`
6. `mcp-servers/templates/go/{{cookiecutter.project_slug}}/Dockerfile`

### Technical Implementation
- **Base Image**: `registry.access.redhat.com/ubi9/go-toolset:1.26`
- **Runtime**: `scratch` (zero system libraries)
- **Binary Type**: Static (CGO_ENABLED=0)
- **Go Version**: 1.26.3 via `GOTOOLCHAIN=auto`
- **Timezone Support**: tzdata copied from builder to scratch for `time.LoadLocation()`

### Benefits
- **Architectural Mitigation**: No vulnerable libraries present in runtime
- **IBM Alignment**: Red Hat UBI provides enterprise-grade security and long-term support

### Production Readiness
✅ **Sustainable**: Red Hat long-term support, automatic Go toolchain upgrades  
✅ **Scalable**: Minimal container footprint (~10-20MB), fast startup times  
✅ **Secure**: Zero system library dependencies, static binaries eliminate dynamic linking vulnerabilities  
✅ **IBM Compliant**: Red Hat Universal Base Image (IBM subsidiary) with enterprise support

### Testing Evidence
All servers verified working:
- a2a-echo-agent: Health ✅, SendMessage ✅, ListTasks ✅
- fast-time-server: Health ✅, Version ✅, REST API ✅
- slow-time-server: Health ✅, Version ✅, REST API ✅
- benchmark-server: Health ✅, Version ✅, REST API ✅
