### PR TITLE
fix(db): ensure on_error column exists before adding CHECK constraint

### DIFF
--- a/mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py
+++ b/mcpgateway/alembic/versions/926d3e07d098_add_on_error_check_constraint.py
@@ -34,6 +34,11 @@ def upgrade() -> None:
     if "tool_plugin_bindings" not in inspector.get_table_names():
         return
 
+    columns = [col["name"] for col in inspector.get_columns("tool_plugin_bindings")]
+    # The on error column will be removed when downgrading from 4842b831d24e
+    if "on_error" not in columns:
+        op.add_column("tool_plugin_bindings", sa.Column("on_error", sa.String(10), nullable=True))
+
     # SQLite: CHECK constraints are only applied at table creation time.
     # Fresh installs get the constraint from the ORM model in db.py.
     if bind.dialect.name == "sqlite":


### PR DESCRIPTION
## Description
Fixes #4945 

This PR resolves a PostgreSQL error where the migration  attempted to add a CHECK constraint to the `on_error` column in the `tool_plugin_bindings` table before ensuring the column exists.

## Root Cause
The migration assumed the `on_error` column would always be present, but it could be missing if:
- A database was downgraded from migration `4842b831d24e` (which adds the column)
- The migration order caused the constraint to be applied before the column was created

## Changes
- Added column existence check in `926d3e07d098_add_on_error_check_constraint.py`
- If `on_error` column is missing, it is now created before applying the CHECK constraint
- Maintains idempotent migration behavior

## Error Fixed
```
sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedColumn) column "on_error" does not exist
[SQL: ALTER TABLE tool_plugin_bindings ADD CONSTRAINT ck_tool_plugin_bindings_on_error_valid 
CHECK (on_error IN ('fail', 'ignore', 'disable') OR on_error IS NULL)]
```

## Testing
- [x] Migration runs successfully on PostgreSQL
- [x] Migration is idempotent (can be run multiple times)
- [x] Column is created if missing
- [x] CHECK constraint is applied correctly
- [x] Downgrade path works correctly

## Migration Path
1. Fresh install: Column created via ORM model in `db.py`, constraint applied by migration
2. Upgrade from older version: Column added by `4842b831d24e`, constraint added by `926d3e07d098`
3. Downgrade then upgrade: Column re-added by `926d3e07d098` if missing, then constraint applied

## Checklist
- [x] Code follows project style guidelines
- [x] Migration is idempotent
- [x] Migration handles all edge cases (fresh install, upgrade, downgrade-upgrade)
- [x] Commit is signed (DCO)
- [x] Related issue is referenced

## Investigation
The column is necessary and it control error handling when a plugin fails. It was added to support the integration with the new plugin manager from cpex. 
The new cpex mode separates the current CF mode "enforce_ignore_error" to "sequential" and an extra "on_error" field.

Signed-off-by: cafalchio <mcafalchio@gmail.com>