### PR TITLE
fix: [Do not merge - pre rebase with main]eliminate multi-worker session-affinity forward amplification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/_internal/mcp/"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -127,6 +127,28 @@ def post_fork(server, worker):
     except ImportError:
         pass
 
+    # Recompute the session-affinity WORKER_ID per worker. Captured at import time,
+    # so under --preload every worker would otherwise inherit the master's id
+    # ({hostname}:1) and subscribe to the same Redis channel — collapsing point-to-point
+    # forwarding into a per-container broadcast that fans every request out to all
+    # workers and degrades throughput by an order of magnitude.
+    try:
+        import socket
+
+        from mcpgateway.services import session_affinity
+
+        session_affinity.WORKER_ID = f"{socket.gethostname()}:{worker.pid}"
+    except Exception as exc:  # noqa: BLE001 - fail loud, never crash the worker
+        # Silent fallback would re-introduce the per-container broadcast amplification.
+        server.log.warning(
+            "post_fork(pid=%s): failed to rebind session_affinity.WORKER_ID (%s: %s) — "
+            "workers may share the master's WORKER_ID and session-affinity forwarding "
+            "may broadcast each request to every worker in the container.",
+            worker.pid,
+            type(exc).__name__,
+            exc,
+        )
+
 
 def post_worker_init(worker):
     worker.log.info("worker initialization completed")

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -221,6 +221,25 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
     return None
 
 
+def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
+    """Encode an edge-validated auth context for forwarding to a trusted internal dispatcher.
+
+    Mirror of :func:`decode_internal_mcp_auth_context`. Packages the auth context
+    so a trusted internal dispatcher (e.g. ``/_internal/mcp/rpc``) can use it
+    without re-running authentication. The unpadded base64url shape keeps the
+    value header-safe.
+
+    Args:
+        auth_context: Auth-context dict to encode.
+
+    Returns:
+        Unpadded base64url-encoded JSON payload for the
+        ``x-contextforge-auth-context`` header.
+    """
+    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
+    return encoded.rstrip("=")
+
+
 def decode_internal_mcp_auth_context(header_value: str) -> Dict[str, Any]:
     """Decode the trusted internal MCP auth header payload.
 
@@ -289,6 +308,94 @@ def has_valid_internal_mcp_runtime_auth_header(request: Request) -> bool:
     if not provided:
         return False
     return hmac.compare_digest(provided, _expected_internal_mcp_runtime_auth_header())
+
+
+# Internal-dispatch trust gate, defined once and shared by all callers.
+INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
+INTERNAL_A2A_PATH_PREFIX = "/_internal/a2a"
+INTERNAL_RUNTIME_MARKER_HEADER = "x-contextforge-mcp-runtime"
+INTERNAL_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
+TRUSTED_INTERNAL_RUNTIME_MARKERS = frozenset({"rust", "affinity"})
+
+
+def _internal_path_requires_auth_context(path: str) -> bool:
+    """Whether an internal route requires an auth context.
+
+    Only ``*/authenticate`` is exempt, since it creates the context; every
+    other internal route must carry one.
+
+    Args:
+        path: The request path to classify.
+
+    Returns:
+        ``False`` for ``*/authenticate``, otherwise ``True``.
+    """
+    return not path.rstrip("/").endswith("/authenticate")
+
+
+def is_trusted_internal_runtime_request(
+    request: Request,
+    *,
+    allowed_prefixes: tuple[str, ...],
+    require_auth_context: bool,
+    path: Optional[str] = None,
+) -> bool:
+    """Return whether a request is a trusted in-process internal-runtime hop.
+
+    The trust boundary is the HMAC header and, when required, the encoded
+    ``x-contextforge-auth-context``. The loopback check is defense in depth,
+    not an independent gate: ProxyHeaders(trusted_hosts="*") lets a direct
+    external caller influence ``request.client.host`` (the replay is hardened
+    separately by stripping forwarded / client-IP headers).
+
+    Args:
+        request: Incoming request to inspect.
+        allowed_prefixes: Internal path prefixes this caller trusts.
+        require_auth_context: Require a non-empty ``x-contextforge-auth-context``.
+        path: Explicit path override for callers that strip a ``root_path``;
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` only when prefix, runtime marker, HMAC, optional auth context,
+        and loopback all hold; otherwise ``False``.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if not any(p == prefix or p.startswith(f"{prefix}/") for prefix in allowed_prefixes):
+        return False
+    if request.headers.get(INTERNAL_RUNTIME_MARKER_HEADER) not in TRUSTED_INTERNAL_RUNTIME_MARKERS:
+        return False
+    if not has_valid_internal_mcp_runtime_auth_header(request):
+        return False
+    if require_auth_context and not request.headers.get(INTERNAL_AUTH_CONTEXT_HEADER):
+        return False
+    client_host = getattr(getattr(request, "client", None), "host", None)
+    return client_host in ("127.0.0.1", "::1")
+
+
+def is_trusted_internal_mcp_request(request: Request, *, path: Optional[str] = None) -> bool:
+    """MCP + A2A internal trust gate with a path-aware auth-context requirement.
+
+    ``*/authenticate`` routes are exempt from the auth-context requirement;
+    every other internal route requires it. ``/_internal/a2a/*`` is trusted
+    only when the A2A feature is enabled.
+
+    Args:
+        request: Incoming request to inspect.
+        path: Explicit path override (e.g. a ``root_path``-stripped path);
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` when the request is a trusted internal MCP/A2A hop.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if p.startswith(f"{INTERNAL_A2A_PATH_PREFIX}/") and not settings.mcpgateway_a2a_enabled:
+        return False
+    return is_trusted_internal_runtime_request(
+        request,
+        allowed_prefixes=(INTERNAL_MCP_PATH_PREFIX, INTERNAL_A2A_PATH_PREFIX),
+        require_auth_context=_internal_path_requires_auth_context(p),
+        path=p,
+    )
 
 
 def get_token_teams_from_request(request: Request) -> Optional[List[str]]:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -458,6 +458,7 @@ class Settings(BaseSettings):
             "/sse",  # Exempt: SSE is a server-sent event stream, not vulnerable to CSRF
             "/message",  # Exempt: MCP SSE message endpoint
             "/rpc",  # Exempt: JSON-RPC is a programmatic protocol, not browser-based
+            "/_internal/mcp/",  # Exempt: loopback-only, HMAC-gated internal dispatch (affinity/Rust forwards); not browser-reachable
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -81,8 +81,8 @@ from mcpgateway.auth_context import (
     get_scoped_resource_access_context,
     get_token_teams_from_request,
     get_user_email,
-    has_valid_internal_mcp_runtime_auth_header,
     INTERNAL_MCP_SESSION_VALIDATED_HEADER,
+    is_trusted_internal_mcp_request,
 )
 from mcpgateway.cache import ResourceCache, SessionRegistry
 from mcpgateway.common.models import InitializeResult
@@ -277,26 +277,26 @@ _INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
 
 
 def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
-    """Return whether the request came from the local Rust runtime sidecar.
+    """Return whether the request came from a trusted local internal source.
+
+    Two callers are trusted today:
+
+    - ``"rust"`` — the local Rust runtime sidecar (over loopback).
+    - ``"affinity"`` — the in-process dispatch used by session-affinity
+      forwarding to reach the owner worker, carrying the identity the edge
+      already validated.
+
+    Both share the same gates: a shared-secret HMAC header AND a loopback client
+    address. Only the ``x-contextforge-mcp-runtime`` marker value differs.
 
     Args:
         request: Incoming request to inspect.
 
     Returns:
-        ``True`` when the request carries the trusted Rust runtime marker from
-        loopback, otherwise ``False``.
+        ``True`` when the request carries a trusted internal-runtime marker
+        from loopback, otherwise ``False``.
     """
-    runtime_marker = request.headers.get("x-contextforge-mcp-runtime")
-    client_host = getattr(getattr(request, "client", None), "host", None)
-    if runtime_marker != "rust" or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
-        return False
-    # Defense-in-depth: /_internal/a2a/* endpoints must refuse requests when
-    # A2A support is disabled, even from an otherwise-trusted local sidecar.
-    # A legitimate sidecar should not be running when the feature is off.
-    path = getattr(getattr(request, "url", None), "path", "") or ""
-    if path.startswith("/_internal/a2a/") and not settings.mcpgateway_a2a_enabled:
-        return False
-    return True
+    return is_trusted_internal_mcp_request(request)
 
 
 def _is_jwt_token(token: str) -> bool:

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -38,6 +38,7 @@ from starlette.responses import JSONResponse
 
 # First-Party
 from mcpgateway import auth
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.config import settings
 from mcpgateway.services.security_logger import SecurityEventType, SecurityLogger, SecuritySeverity
 
@@ -197,6 +198,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         """Process request with rate limiting."""
         if not self.enabled:
+            return await call_next(request)
+
+        # Skip rate limiting for the trusted-internal dispatch; the edge request was already counted.
+        if is_trusted_internal_mcp_request(request):
             return await call_next(request)
 
         tier = self.get_endpoint_tier(request.url.path)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -13,8 +13,6 @@ and time-based restrictions.
 # Standard
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
-import hashlib
-import hmac
 import ipaddress
 import re
 from typing import List, Optional, Pattern, Tuple
@@ -64,11 +62,6 @@ _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
-_INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
-_INTERNAL_MCP_RUNTIME_HEADER = "x-contextforge-mcp-runtime"
-_INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
-_INTERNAL_MCP_RUNTIME_AUTH_HEADER = "x-contextforge-mcp-runtime-auth"
-_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT = "contextforge-internal-mcp-runtime-v1"
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -1350,70 +1343,24 @@ class TokenScopingMiddleware:
             )
 
     def _is_trusted_internal_mcp_runtime_request(self, request: Request, normalized_path: str) -> bool:
-        """Return whether the request is a trusted loopback Rust MCP sidecar hop.
+        """Return whether the request is a trusted internal MCP/A2A runtime hop.
+
+        Delegates to the shared gate in ``auth_context`` so the trust decision is
+        defined in one place. Unlike the previous local check, this trusts both
+        the ``rust`` and ``affinity`` runtime markers — closing the gap where the
+        in-process session-affinity dispatch was still token-scoped.
 
         Args:
             request: Incoming HTTP request.
             normalized_path: Canonicalized request path used for route matching.
 
         Returns:
-            ``True`` when the request originated from the local Rust MCP runtime and
-            includes the expected trusted headers.
+            ``True`` when the request is a trusted internal MCP/A2A hop.
         """
-        if normalized_path != _INTERNAL_MCP_PATH_PREFIX and not normalized_path.startswith(f"{_INTERNAL_MCP_PATH_PREFIX}/"):
-            return False
+        # First-Party
+        from mcpgateway.auth_context import is_trusted_internal_mcp_request  # pylint: disable=import-outside-toplevel
 
-        if request.headers.get(_INTERNAL_MCP_RUNTIME_HEADER) != "rust":
-            return False
-
-        provided_auth = request.headers.get(_INTERNAL_MCP_RUNTIME_AUTH_HEADER)
-        if not provided_auth:
-            return False
-
-        expected_auth = self._expected_internal_mcp_runtime_auth_header()
-        if not hmac.compare_digest(provided_auth, expected_auth):
-            return False
-
-        if not request.headers.get(_INTERNAL_MCP_AUTH_CONTEXT_HEADER):
-            return False
-
-        client_host = getattr(getattr(request, "client", None), "host", None)
-        return client_host in ("127.0.0.1", "::1")
-
-    @staticmethod
-    def _auth_encryption_secret_value() -> str:
-        """Return the configured auth-encryption secret as a plain string.
-
-        Returns:
-            The auth-encryption secret, normalized to a regular string.
-        """
-        secret = settings.auth_encryption_secret
-        if hasattr(secret, "get_secret_value"):
-            return secret.get_secret_value()
-        return str(secret)
-
-    @staticmethod
-    @lru_cache(maxsize=8)
-    def _expected_internal_mcp_runtime_auth_header_for_secret(secret: str) -> str:
-        """Return the expected shared internal-auth header for a specific secret.
-
-        Args:
-            secret: Auth-encryption secret to derive the trust header from.
-
-        Returns:
-            Hex-encoded SHA-256 digest derived from the provided auth secret.
-        """
-        material = f"{secret}:{_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT}".encode("utf-8")
-        return hashlib.sha256(material).hexdigest()
-
-    @staticmethod
-    def _expected_internal_mcp_runtime_auth_header() -> str:
-        """Return the expected shared internal-auth header for Rust MCP hops.
-
-        Returns:
-            Shared secret-derived digest expected on trusted internal Rust MCP calls.
-        """
-        return TokenScopingMiddleware._expected_internal_mcp_runtime_auth_header_for_secret(TokenScopingMiddleware._auth_encryption_secret_value())
+        return is_trusted_internal_mcp_request(request, path=normalized_path)
 
 
 # Create middleware instance

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -30,6 +30,7 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.db import fresh_db_session
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.token_catalog_service import TokenCatalogService
@@ -84,6 +85,11 @@ class TokenUsageMiddleware:
         # Skip health checks and static files
         path = scope.get("path", "")
         if should_skip_auth_context(path):
+            await self.app(scope, receive, send)
+            return
+
+        # Skip usage logging for the trusted-internal dispatch; the edge request is already recorded.
+        if is_trusted_internal_mcp_request(Request(scope), path=path):
             await self.app(scope, receive, send)
             return
 

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -50,12 +50,17 @@ from mcpgateway.services.upstream_session_registry import (  # re-exported as th
 )
 from mcpgateway.utils.internal_http import (
     internal_loopback_base_url,
-    internal_loopback_verify,
+    post_rpc_in_process,
 )
 
 # Shared session-id validation (downstream MCP session IDs used for affinity).
 # Intentionally strict: protects Redis key/channel construction and log lines.
 _MCP_SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+# Extract the virtual server id from a Streamable HTTP path (/servers/{id}/mcp)
+# so a forwarded request can be re-routed to the local /rpc dispatcher. Mirrors
+# _SERVER_ID_RE in streamablehttp_transport; kept local to avoid a transport import.
+_SERVER_ID_RE = re.compile(r"^/servers/(?P<server_id>[^/]+)/mcp")
 
 # Worker ID for multi-worker session affinity
 # Uses hostname + PID to be unique across Docker containers (each container has PID 1)
@@ -949,65 +954,63 @@ class SessionAffinity:
 
             logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Received forwarded request, executing locally")
 
-            # Make internal HTTP/HTTPS call to local /rpc endpoint.
-            # This reuses ALL existing method handling logic without duplication.
-            internal_base_url = internal_loopback_base_url()
-            async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                # Build headers for internal request - forward original headers
-                # but add x-forwarded-internally to prevent infinite loops.
-                # Relies on the originating transport having already filtered
-                # passthrough headers via extract_headers_for_loopback (#3640).
-                internal_headers = dict(headers)
-                internal_headers["x-forwarded-internally"] = "true"
-                # Ensure content-type is set
-                internal_headers["content-type"] = "application/json"
+            # Build headers for the in-process /rpc call - forward original headers
+            # but add x-forwarded-internally to prevent infinite loops. Relies on the
+            # originating transport having already filtered passthrough headers via
+            # extract_headers_for_loopback (#3640).
+            internal_headers = dict(headers)
+            internal_headers["x-forwarded-internally"] = "true"
+            internal_headers["content-type"] = "application/json"
 
-                response = await client.post(
-                    f"{internal_base_url}/rpc",
-                    json={
+            # Dispatch IN-PROCESS so /rpc resolves the bound upstream session from
+            # this worker's registry instead of scattering over the shared socket.
+            response = await post_rpc_in_process(
+                content=orjson.dumps(
+                    {
                         "jsonrpc": "2.0",
                         "method": method,
                         "params": params,
                         "id": req_id,
-                    },
-                    headers=internal_headers,
-                    timeout=settings.mcpgateway_pool_rpc_forward_timeout,
-                )
-
-                # Gate on HTTP status first: non-2xx responses are errors
-                # even if the body parses as JSON.
-                if not response.is_success:
-                    try:
-                        response_data = response.json()
-                    except ValueError:
-                        response_data = {}
-                    if not isinstance(response_data, dict):
-                        response_data = {}
-
-                    # If body is a JSON-RPC error ({"error": {...}}), propagate it
-                    if "error" in response_data and isinstance(response_data["error"], dict):
-                        logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error (HTTP {response.status_code})")
-                        return {"error": response_data["error"]}
-
-                    # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
-                    detail = response_data.get("detail", response.text[:200] or "Unknown error")
-                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution failed with HTTP {response.status_code}")
-                    return {
-                        "error": {
-                            "code": -32603,
-                            "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
-                        }
                     }
+                ),
+                headers=internal_headers,
+                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
+            )
 
-                # Parse successful response
-                response_data = response.json()
+            # Gate on HTTP status first: non-2xx responses are errors
+            # even if the body parses as JSON.
+            if not response.is_success:
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    response_data = {}
+                if not isinstance(response_data, dict):
+                    response_data = {}
 
-                # Extract result or error from JSON-RPC response
-                if "error" in response_data:
-                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error")
+                # If body is a JSON-RPC error ({"error": {...}}), propagate it
+                if "error" in response_data and isinstance(response_data["error"], dict):
+                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error (HTTP {response.status_code})")
                     return {"error": response_data["error"]}
-                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed successfully")
-                return {"result": response_data.get("result", {})}
+
+                # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
+                detail = response_data.get("detail", response.text[:200] or "Unknown error")
+                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution failed with HTTP {response.status_code}")
+                return {
+                    "error": {
+                        "code": -32603,
+                        "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
+                    }
+                }
+
+            # Parse successful response
+            response_data = response.json()
+
+            # Extract result or error from JSON-RPC response
+            if "error" in response_data:
+                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error")
+                return {"error": response_data["error"]}
+            logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed successfully")
+            return {"result": response_data.get("result", {})}
 
         except httpx.TimeoutException:
             logger.warning(f"Timeout executing forwarded request: {request.get('method')}")
@@ -1017,89 +1020,148 @@ class SessionAffinity:
             return {"error": {"code": -32603, "message": str(e)}}
 
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
-        """Execute a forwarded HTTP request locally and return response via Redis.
+        """Execute a forwarded Streamable HTTP request on the owner worker and reply over Redis.
 
-        This method handles full HTTP requests forwarded from other workers for
-        Streamable HTTP transport session affinity. It reconstructs the HTTP request,
-        makes an internal call to the appropriate endpoint, and publishes the response
-        back through Redis.
+        The request lands on the worker that owns the downstream session, so the
+        bound upstream session in this process can serve it. It is dispatched
+        in-process to the trusted-internal ``/_internal/mcp/rpc`` endpoint rather
+        than the public ``/rpc``.
+
+        Public ``/rpc`` only understands ContextForge JWTs and cookies, so an
+        OAuth bearer or an ``MCP_REQUIRE_AUTH=false`` public-only request would
+        401 if re-authenticated there. Instead, the originating worker's
+        already-validated identity rides in ``auth_context`` (the encoded
+        ``x-contextforge-auth-context`` header); with the
+        ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret HMAC,
+        and the loopback client address, the trusted endpoint accepts the request
+        and reconstructs the same user the edge established.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
                 - type: "http_forward"
                 - response_channel: Redis channel to publish response to
                 - mcp_session_id: Session identifier
-                - method: HTTP method (GET, POST, DELETE)
-                - path: Request path (e.g., /mcp)
-                - query_string: Query parameters
-                - headers: Request headers dict
-                - body: Hex-encoded request body
-            redis: Redis client for publishing response
+                - method: HTTP method (POST primarily)
+                - path: Original request path (e.g., /servers/{id}/mcp)
+                - headers: Original request headers (lowercased keys)
+                - body: Hex-encoded JSON-RPC request body
+                - auth_context: base64url-encoded auth context from the
+                  originating worker's ``streamable_http_auth()`` result
+            redis: Redis client for publishing the response
         """
-        response_channel = None
+        response_channel = request.get("response_channel")
+
+        async def _publish(status: int, body: bytes, headers: Optional[Dict[str, str]] = None) -> None:
+            """Publish a serialized HTTP response back to the requesting worker."""
+            if redis and response_channel:
+                payload = {"status": status, "headers": headers or {"content-type": "application/json"}, "body": body.hex()}
+                await redis.publish(response_channel, orjson.dumps(payload))
+
         try:
-            response_channel = request.get("response_channel")
             method = request.get("method")
-            path = request.get("path")
-            query_string = request.get("query_string", "")
+            path = request.get("path") or ""
             headers = request.get("headers", {})
             body_hex = request.get("body", "")
             mcp_session_id = request.get("mcp_session_id")
-
-            # Decode hex body back to bytes
+            auth_context_header = request.get("auth_context") or ""
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
             logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Received forwarded HTTP request: {method} {path}")
 
-            # Add internal forwarding headers to prevent loops.
-            # Relies on the originating transport having already filtered
-            # passthrough headers via extract_headers_for_loopback (#3640).
-            internal_headers = dict(headers)
-            internal_headers["x-forwarded-internally"] = "true"
-            internal_headers["x-original-worker"] = request.get("original_worker", "unknown")
+            # Only POST carries a JSON-RPC body that needs upstream dispatch.
+            # DELETE/other lifecycle methods are handled by the originating worker; ack them.
+            if method != "POST":
+                await _publish(200, b'{"jsonrpc":"2.0","result":{}}')
+                return
+            if not body:
+                await _publish(202, b"")
+                return
 
-            # Make internal HTTP/HTTPS request to local endpoint
-            url = f"{internal_loopback_base_url()}{path}"
-            if query_string:
-                url = f"{url}?{query_string}"
+            json_body = orjson.loads(body)
+            rpc_method = json_body.get("method", "") if isinstance(json_body, dict) else ""
 
-            async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                response = await client.request(
-                    method=method,
-                    url=url,
-                    headers=internal_headers,
+            # Notifications need no upstream round-trip.
+            if isinstance(rpc_method, str) and rpc_method.startswith("notifications/"):
+                await _publish(202, b"")
+                return
+
+            # Inject the virtual server id (from the path) into params so the
+            # dispatcher routes to the right virtual server.
+            server_match = _SERVER_ID_RE.search(path)
+            if server_match and isinstance(json_body, dict):
+                if not isinstance(json_body.get("params"), dict):
+                    json_body["params"] = {}
+                json_body["params"]["server_id"] = server_match.group("server_id")
+                body = orjson.dumps(json_body)
+
+            # First-Party - lazy imports avoid a circular dependency with main/transport.
+            from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+            from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+            from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel,protected-access
+
+            # A forwarded payload may omit the auth context; fall back to an
+            # encoded public-only ({}) context so the endpoint applies default
+            # visibility instead of rejecting the dispatch with 400.
+            if not auth_context_header:
+                auth_context_header = encode_internal_mcp_auth_context({})
+
+            # Trust headers for the internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" caller marker
+            # - x-contextforge-mcp-runtime-auth: shared-secret HMAC
+            # - x-contextforge-auth-context: the encoded edge auth context, so the
+            #   endpoint reconstructs the same user without re-authenticating.
+            rpc_headers = {
+                "content-type": "application/json",
+                "x-mcp-session-id": mcp_session_id or "",
+                "x-contextforge-mcp-runtime": "affinity",
+                "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                "x-contextforge-auth-context": auth_context_header,
+            }
+            # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+            # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+            # the configured header, so a custom header would otherwise be dropped.
+            # This is defense-in-depth; the endpoint trusts the auth-context above.
+            auth_header_name = _resolve_auth_header_name(settings).lower()
+            original_auth = headers.get(auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+            if original_auth:
+                rpc_headers[auth_header_name] = original_auth
+            # Preserve passthrough headers destined for upstream MCP servers (#3640).
+            rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+
+            # Dispatch IN-PROCESS to the trusted internal endpoint. The explicit
+            # client=("127.0.0.1", 0) tells ASGITransport to set scope["client"]
+            # to a loopback address so the trust check accepts the request.
+            transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+            async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+                response = await client.post(
+                    "/_internal/mcp/rpc",
                     content=body,
+                    headers=rpc_headers,
                     timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                 )
 
-                logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed locally: {response.status_code}")
+            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process via /_internal/mcp/rpc: {response.status_code}")
 
-                # Serialize response for Redis transport
-                response_data = {
-                    "status": response.status_code,
-                    "headers": dict(response.headers),
-                    "body": response.content.hex(),  # Hex encode binary response
-                }
-
-                # Publish response back to requesting worker
-                if redis and response_channel:
-                    await redis.publish(response_channel, orjson.dumps(response_data))
-                    logger.debug(f"[HTTP_AFFINITY] Published HTTP response to Redis channel: {response_channel}")
+            resp_headers = {"content-type": "application/json"}
+            if mcp_session_id:
+                resp_headers["mcp-session-id"] = mcp_session_id
+            await _publish(response.status_code, response.content, resp_headers)
 
         except Exception as e:
-            logger.error(f"Error executing forwarded HTTP request: {e}")
-            # Try to send error response if possible
-            if redis and response_channel:
-                error_response = {
-                    "status": 500,
-                    "headers": {"content-type": "application/json"},
-                    "body": orjson.dumps({"error": "Internal forwarding error"}).hex(),
-                }
-                try:
-                    await redis.publish(response_channel, orjson.dumps(error_response))
-                except Exception as publish_error:
-                    logger.debug(f"Failed to publish error response via Redis: {publish_error}")
+            # Sanitise + truncate the exception message: this except catches anything from the
+            # inner /rpc dispatch (FastAPI handlers, middleware, services), so the exception may
+            # carry request fragments or newlines that would forge log entries (CWE-117).
+            logger.error(
+                "Error executing forwarded HTTP request: %s: %s",
+                type(e).__name__,
+                SecurityValidator.sanitize_log_message(str(e), max_length=500),
+            )
+            try:
+                await _publish(500, orjson.dumps({"error": "Internal forwarding error"}))
+            except Exception as publish_error:
+                logger.debug(f"Failed to publish error response via Redis: {publish_error}")
 
     async def get_session_owner(self, mcp_session_id: str) -> Optional[str]:
         """Get the worker ID that owns a Streamable HTTP session.
@@ -1124,6 +1186,7 @@ class SessionAffinity:
         headers: Dict[str, str],
         body: bytes,
         query_string: str = "",
+        auth_context: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Forward a Streamable HTTP request to the worker that owns the session via Redis Pub/Sub.
 
@@ -1140,6 +1203,10 @@ class SessionAffinity:
             headers: Request headers.
             body: Request body bytes.
             query_string: Query string if any.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying the
+                originating worker's already-validated identity, so the owner can
+                dispatch to the trusted internal endpoint without re-authenticating
+                (OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only survive).
 
         Returns:
             Dict with 'status', 'headers', and 'body' from the owner worker's response,
@@ -1181,6 +1248,8 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
+                # Encoded edge identity; lets the owner dispatch without re-authenticating.
+                "auth_context": auth_context,
             }
 
             # Subscribe to response channel BEFORE publishing request (prevent race)

--- a/mcpgateway/transports/rust_mcp_runtime_proxy.py
+++ b/mcpgateway/transports/rust_mcp_runtime_proxy.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 # Standard
 import asyncio
-import base64
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 import httpx
-import orjson
 from sqlalchemy import exists as sa_exists
 from starlette.types import Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import encode_internal_mcp_auth_context
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session
 from mcpgateway.db import Server as DbServer
@@ -338,5 +337,4 @@ def _build_forwarded_auth_context_header() -> str | None:
     auth_context = get_streamable_http_auth_context()
     if not auth_context:
         return None
-    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
-    return encoded.rstrip("=")
+    return encode_internal_mcp_auth_context(auth_context)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -91,7 +91,7 @@ from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers, GATEWAY_ID_HEADER
 from mcpgateway.utils.identity_propagation import build_identity_headers
-from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import post_rpc_in_process
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
@@ -4146,55 +4146,51 @@ class SessionManagerWrapper:
                     body = orjson.dumps(json_body)
                     logger.debug("[HTTP_AFFINITY_FORWARDED] Injected server_id %s into /rpc params", server_id)
 
-                async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                    rpc_headers = {
-                        "content-type": "application/json",
-                        "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
-                        "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                rpc_headers = {
+                    "content-type": "application/json",
+                    "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
+                    "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                }
+                # Forward the inbound gateway auth header (default: Authorization,
+                # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
+                # the same caller. Hardcoding "authorization" here would silently
+                # drop auth on deployments using a custom AUTH_HEADER_NAME.
+                _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+                if _gw_auth_lower in headers:
+                    rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                # Forward passthrough headers for upstream MCP servers (see #3640).
+                # First-Party
+                from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+
+                rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+
+                # Dispatch IN-PROCESS so /rpc executes in this worker (the session
+                # owner) rather than scattering over the shared socket.
+                response = await post_rpc_in_process(content=body, headers=rpc_headers, timeout=30.0)
+
+                # Return response to client
+                response_headers = [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(response.content)).encode()),
+                ]
+                if mcp_session_id != "not-provided":
+                    response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
+
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": response.status_code,
+                        "headers": response_headers,
                     }
-                    # Forward the inbound gateway auth header (default: Authorization,
-                    # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
-                    # the same caller. Hardcoding "authorization" here would silently
-                    # drop auth on deployments using a custom AUTH_HEADER_NAME.
-                    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                    if _gw_auth_lower in headers:
-                        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                    # Forward passthrough headers for upstream MCP servers (see #3640).
-                    # First-Party
-                    from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-
-                    rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
-
-                    response = await client.post(
-                        f"{internal_loopback_base_url()}/rpc",
-                        content=body,
-                        headers=rpc_headers,
-                        timeout=30.0,
-                    )
-
-                    # Return response to client
-                    response_headers = [
-                        (b"content-type", b"application/json"),
-                        (b"content-length", str(len(response.content)).encode()),
-                    ]
-                    if mcp_session_id != "not-provided":
-                        response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
-
-                    await send(
-                        {
-                            "type": "http.response.start",
-                            "status": response.status_code,
-                            "headers": response_headers,
-                        }
-                    )
-                    await send(
-                        {
-                            "type": "http.response.body",
-                            "body": response.content,
-                        }
-                    )
-                    logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
-                    return
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": response.content,
+                    }
+                )
+                logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
+                return
             except Exception as e:
                 logger.error("[HTTP_AFFINITY_FORWARDED] Error routing to /rpc: %s", e)
                 # Fall through to SDK handling as fallback
@@ -4212,6 +4208,14 @@ class SessionManagerWrapper:
                 if owner and owner != WORKER_ID:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
+
+                    # Package the edge-validated identity so the owner can dispatch via
+                    # the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating, letting OAuth and public-only sessions survive.
+                    # First-Party
+                    from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+                    encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
 
                     # Read request body
                     body_parts = []
@@ -4234,6 +4238,7 @@ class SessionManagerWrapper:
                         headers=headers,
                         body=body,
                         query_string=query_string,
+                        auth_context=encoded_auth_context,
                     )
 
                     if response:
@@ -4317,49 +4322,67 @@ class SessionManagerWrapper:
                             body = orjson.dumps(json_body)
                             logger.debug("[HTTP_AFFINITY_LOCAL] Injected server_id %s into /rpc params", server_id)
 
-                        async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                            rpc_headers = {
-                                "content-type": "application/json",
-                                "x-mcp-session-id": mcp_session_id,
-                                "x-forwarded-internally": "true",
-                            }
-                            _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                            if _gw_auth_lower in headers:
-                                rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                            # Forward passthrough headers for upstream MCP servers (see #3640).
-                            # First-Party
-                            from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+                        # Owner-direct path: dispatch to the trusted internal
+                        # /_internal/mcp/rpc endpoint carrying the edge-validated auth
+                        # context, so OAuth and public-only sessions are honored without
+                        # re-authenticating against public /rpc (JWTs/cookies only).
+                        # First-Party
+                        from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+                        from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.internal_http import internal_loopback_base_url  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
 
-                            rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+                        rpc_headers = {
+                            "content-type": "application/json",
+                            "x-mcp-session-id": mcp_session_id,
+                            "x-contextforge-mcp-runtime": "affinity",
+                            "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                            "x-contextforge-auth-context": encode_internal_mcp_auth_context(get_streamable_http_auth_context()),
+                        }
+                        # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+                        # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+                        # the configured header, so a custom header would otherwise be dropped.
+                        # This is defense-in-depth; the endpoint trusts the auth-context above.
+                        _auth_header_name = _resolve_auth_header_name(settings).lower()
+                        _original_auth = headers.get(_auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+                        if _original_auth:
+                            rpc_headers[_auth_header_name] = _original_auth
+                        # Forward passthrough headers for upstream MCP servers (see #3640).
+                        rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
+                        # Dispatch in-process so the request runs on this worker, the
+                        # session owner that holds the bound upstream session, instead of
+                        # looping back over the shared socket to a random worker.
+                        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+                        async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                             response = await client.post(
-                                f"{internal_loopback_base_url()}/rpc",
+                                "/_internal/mcp/rpc",
                                 content=body,
                                 headers=rpc_headers,
-                                timeout=30.0,
+                                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                             )
 
-                            response_headers = [
-                                (b"content-type", b"application/json"),
-                                (b"content-length", str(len(response.content)).encode()),
-                                (b"mcp-session-id", mcp_session_id.encode()),
-                            ]
+                        response_headers = [
+                            (b"content-type", b"application/json"),
+                            (b"content-length", str(len(response.content)).encode()),
+                            (b"mcp-session-id", mcp_session_id.encode()),
+                        ]
 
-                            await send(
-                                {
-                                    "type": "http.response.start",
-                                    "status": response.status_code,
-                                    "headers": response_headers,
-                                }
-                            )
-                            await send(
-                                {
-                                    "type": "http.response.body",
-                                    "body": response.content,
-                                }
-                            )
-                            logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
-                            return
+                        await send(
+                            {
+                                "type": "http.response.start",
+                                "status": response.status_code,
+                                "headers": response_headers,
+                            }
+                        )
+                        await send(
+                            {
+                                "type": "http.response.body",
+                                "body": response.content,
+                            }
+                        )
+                        logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
+                        return
                     except Exception as e:
                         logger.error("[HTTP_AFFINITY_LOCAL] Error routing to /rpc: %s", e)
                         # Fall through to SDK handling as fallback

--- a/mcpgateway/utils/internal_http.py
+++ b/mcpgateway/utils/internal_http.py
@@ -13,6 +13,9 @@ self-calls to local endpoints like /rpc.
 # Standard
 import os
 
+# Third-Party
+import httpx
+
 # First-Party
 from mcpgateway.config import settings
 
@@ -48,3 +51,33 @@ def internal_loopback_verify() -> bool:
         bool: ``False`` when the loopback URL is HTTPS, ``True`` otherwise.
     """
     return not _is_ssl_enabled()
+
+
+async def post_rpc_in_process(*, content: bytes, headers: dict, timeout: float) -> httpx.Response:
+    """POST to the local ``/rpc`` route via an in-process ASGI transport.
+
+    Affinity-owned requests must execute on the worker that actually holds the
+    bound upstream session. A real loopback to ``127.0.0.1`` hits the shared
+    gunicorn socket, and the kernel routes it to an arbitrary worker that does
+    not hold the session — which breaks upstream-session reuse (and the #4205
+    isolation invariant for stateful upstreams). ``httpx.ASGITransport`` invokes
+    the FastAPI app in *this* process instead, so ``/rpc`` resolves the session
+    from this worker's ``UpstreamSessionRegistry``.
+
+    ``app`` is imported lazily to avoid a circular import at module load.
+
+    Args:
+        content: Serialized JSON-RPC request body.
+        headers: Request headers. Must include ``x-forwarded-internally: true``
+            so the re-entered handler does not forward again.
+        timeout: Per-call timeout in seconds.
+
+    Returns:
+        httpx.Response: The response from the in-process ``/rpc`` dispatch.
+    """
+    # First-Party
+    from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+        return await client.post("/rpc", content=content, headers=headers, timeout=timeout)

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -565,6 +565,25 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
         "upgrade",
         "x-mcp-session-id",
         "x-forwarded-internally",
+        # Gateway-internal trust headers for the /_internal/mcp/* dispatch: the
+        # server-established auth context, runtime marker, and HMAC. A client
+        # passthrough header must never overwrite them, or a caller could spoof
+        # the trusted identity while the server's valid HMAC still rides along.
+        "x-contextforge-auth-context",
+        "x-contextforge-mcp-runtime",
+        "x-contextforge-mcp-runtime-auth",
+        "x-contextforge-session-validated",
+        # Forwarded / client-IP headers: strip so a caller cannot spoof the loopback
+        # client address that ProxyHeaders(trusted_hosts="*") would otherwise trust.
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-forwarded-port",
+        "x-forwarded-prefix",
+        "x-real-ip",
+        "cf-connecting-ip",
+        "true-client-ip",
     }
 )
 

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -231,6 +231,39 @@ async def test_exempt_path_passes_without_token():
 
 
 @pytest.mark.asyncio
+async def test_internal_mcp_dispatch_is_csrf_exempt_by_default():
+    """``/_internal/mcp/*`` is CSRF-exempt by default (loopback-only, HMAC-gated).
+
+    The affinity dispatch posts to the trusted-internal endpoint, which must not
+    require a CSRF token. Without the exemption, custom AUTH_HEADER_NAME
+    deployments (whose bearer the CSRF short-circuit can't find) would 403 on the
+    inner dispatch.
+    """
+    # First-Party
+    from mcpgateway.config import settings as real_settings
+
+    # The shipped default must cover the internal MCP dispatch prefix.
+    assert "/_internal/mcp/" in real_settings.csrf_exempt_paths
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/_internal/mcp/rpc"
+    request.headers = {}  # no CSRF token, no bearer
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = real_settings.csrf_exempt_paths
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
 async def test_bearer_token_request_passes_without_csrf():
     """Test that requests with Authorization: Bearer header pass without CSRF token."""
     middleware = CSRFMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -16,6 +16,30 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _trusted_internal_request(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a real loopback internal request for trust-gate exemption tests."""
+    from starlette.requests import Request
+
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+    return Request(scope)
+
+
 class TestRateLimitMiddleware:
     """Tests for RateLimitMiddleware."""
 
@@ -57,6 +81,29 @@ class TestRateLimitMiddleware:
         request.state = MagicMock()
         request.scope = {"client": ("192.168.1.100", 12345)}
         return request
+
+    @pytest.mark.asyncio
+    async def test_trusted_internal_dispatch_skips_rate_limiting(self, middleware):
+        """A trusted-internal hop is not rate-limited; the edge request already was."""
+        request = _trusted_internal_request("/_internal/mcp/rpc")
+        call_next = AsyncMock(return_value="passthrough")
+        # If the exemption fires, tier computation is never reached.
+        middleware.get_endpoint_tier = MagicMock(side_effect=AssertionError("trusted internal must not be rate-limited"))
+
+        result = await middleware.dispatch(request, call_next)
+
+        assert result == "passthrough"
+        call_next.assert_awaited_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_forged_internal_request_is_still_rate_limited(self, middleware):
+        """A forged HMAC fails the trust gate, so the rate-limit path runs."""
+        request = _trusted_internal_request("/_internal/mcp/rpc", hmac_value="forged")
+        call_next = AsyncMock(return_value="passthrough")
+        middleware.get_endpoint_tier = MagicMock(side_effect=RuntimeError("reached rate-limit path"))
+
+        with pytest.raises(RuntimeError, match="reached rate-limit path"):
+            await middleware.dispatch(request, call_next)
 
     def test_endpoint_tier_critical(self, middleware):
         """Test CRITICAL tier detection for auth endpoints."""

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -27,6 +27,60 @@ async def _make_asgi_call(middleware, scope, receive=None, send=None):
     return send
 
 
+def _trusted_internal_scope(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a loopback internal ASGI scope for trust-gate exemption tests."""
+    # First-Party
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+
+
+@pytest.mark.asyncio
+async def test_trusted_internal_dispatch_skips_usage_logging():
+    """A trusted-internal hop is not recorded; the edge request already was.
+
+    The skip path forwards the original ``send`` unwrapped (no status capture, no
+    logging), which distinguishes it from the normal metered path.
+    """
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    app.assert_awaited_once_with(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_forged_internal_request_is_not_skipped_for_usage():
+    """A forged HMAC fails the trust gate, so the usage path runs (wrapped send)."""
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc", hmac_value="forged")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    assert app.await_count == 1
+    forwarded_send = app.await_args.args[2]
+    assert forwarded_send is not send
+
+
 @pytest.mark.asyncio
 async def test_skips_health_check_paths():
     """Middleware should skip health check and static paths."""

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1099,6 +1099,81 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
 
 
 @pytest.mark.asyncio
+async def test_forward_to_owner_includes_auth_context_in_redis_payload():
+    """The encoded auth context from the originating worker is carried in the forwarded Redis payload.
+
+    Without this, the owner worker cannot reconstruct the StreamableHTTP user
+    that ``streamable_http_auth()`` already validated at the edge, so forwarded
+    OAuth and ``MCP_REQUIRE_AUTH=false`` requests would re-authenticate against
+    the public ``/rpc`` and fail with 401.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    # Make the pubsub wait return immediately so we focus on the published payload.
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    encoded_ctx = "base64url-encoded-auth-ctx-from-edge"
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner(
+            owner_worker_id="other-worker",
+            mcp_session_id="sess-auth",
+            method="POST",
+            path="/servers/srv-9/mcp",
+            headers={"Authorization": "Bearer x"},
+            body=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            auth_context=encoded_ctx,
+        )
+
+    # Locate the forward payload published to the owner's HTTP channel.
+    owner_channels = [(chan, payload) for chan, payload in fake.published if chan == "mcpgw:pool_http:other-worker"]
+    assert owner_channels, "forward payload was not published to the owner channel"
+    forward_data = orjson.loads(owner_channels[0][1])
+    assert forward_data["type"] == "http_forward"
+    assert forward_data["auth_context"] == encoded_ctx
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_defaults_auth_context_to_none_when_omitted():
+    """Sender side: when no auth_context is supplied, the field is present and set to None.
+
+    The executor reads ``request.get("auth_context") or ""`` and forwards an
+    empty string header — equivalent to the pre-auth-context behaviour. This
+    test pins the shape so future signature changes don't silently break the
+    contract.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner("other-worker", "sess-no-ctx", "POST", "/mcp", {}, b"")
+
+    forward_data = orjson.loads(fake.published[0][1])
+    assert "auth_context" in forward_data
+    assert forward_data["auth_context"] is None
+
+
+@pytest.mark.asyncio
 async def test_forward_to_owner_times_out_and_returns_none_with_metric_bump():
     """No message arrives → asyncio.timeout fires → metric incremented, None returned."""
     # First-Party
@@ -1433,14 +1508,25 @@ class _FakeHttpxClient:
     async def __aexit__(self, *_exc):
         return False
 
-    async def post(self, url, *, json=None, headers=None, timeout=None):
-        self.last_post_kwargs = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+    async def post(self, url, *, json=None, content=None, headers=None, timeout=None):
+        self.last_post_kwargs = {"url": url, "json": json, "content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
 
     async def request(self, *, method, url, headers=None, content=None, timeout=None):
         self.last_request_kwargs = {"method": method, "url": url, "headers": headers, "content": content, "timeout": timeout}
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+    async def as_post_rpc(self, *, content=None, headers=None, timeout=None):
+        """Adapter so this fake can stand in for ``utils.internal_http.post_rpc_in_process``.
+
+        Patching the helper to this method lets the fake capture
+        ``content``/``headers``/``timeout`` for the call-site assertions.
+        """
+        self.last_post_kwargs = {"content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
@@ -1457,9 +1543,7 @@ async def test_execute_forwarded_request_success_returns_result():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
@@ -1483,9 +1567,7 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_in_response():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
@@ -1506,9 +1588,7 @@ async def test_execute_forwarded_request_maps_non_2xx_http_to_jsonrpc_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1533,9 +1613,7 @@ async def test_execute_forwarded_request_timeout_returns_timeout_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1554,9 +1632,7 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1571,7 +1647,10 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_response_via_redis():
-    """Happy path: make the internal HTTP call, hex-encode the response body, publish to Redis."""
+    """Happy path: dispatch in-process to the trusted internal endpoint and publish the response back."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1581,34 +1660,44 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
     response.headers = {"content-type": "application/json"}
     client = _FakeHttpxClient(response=response)
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-1",
         "method": "POST",
-        "path": "/mcp",
+        "path": "/servers/srv-9/mcp",
         "query_string": "",
         "headers": {"Authorization": "Bearer x"},
-        "body": b"upstream-body".hex(),
+        "body": jsonrpc_body.hex(),
         "original_worker": "origin-worker",
         "mcp_session_id": "sess-123456789",
+        "auth_context": "encoded-ctx",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Dispatched to the trusted-internal endpoint, NOT the public /rpc.
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == "encoded-ctx"
+    assert headers["x-mcp-session-id"] == "sess-123456789"
+    # server_id from the path is injected into JSON-RPC params before dispatch.
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"]["server_id"] == "srv-9"
 
     # Response published to the requester's channel.
     assert fake.published
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-1"
-    # Orjson round-trips the dict — body is hex-encoded.
-    # Third-Party
-    import orjson
-
     decoded = orjson.loads(payload)
     assert decoded["status"] == 200
     assert bytes.fromhex(decoded["body"]) == b"response-body"
@@ -1617,6 +1706,9 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_500_error_on_exception():
     """If the internal HTTP call raises, a 500 error envelope is still published to Redis."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1624,12 +1716,13 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
     fake = _FakeRedis()
     client = _FakeHttpxClient(raise_exc=RuntimeError("internal crash"))
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-2",
         "method": "POST",
         "path": "/mcp",
         "headers": {},
-        "body": "",
+        "body": jsonrpc_body.hex(),
         "mcp_session_id": "sess-abcdef",
     }
 
@@ -1637,15 +1730,12 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
     # Error response still published so the requester doesn't hang.
-    # Third-Party
-    import orjson
-
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-2"
     decoded = orjson.loads(payload)
@@ -2054,9 +2144,7 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_from_non_2xx_r
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess"})  # pylint: disable=protected-access
@@ -2077,9 +2165,7 @@ async def test_execute_forwarded_request_handles_non_dict_non_2xx_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -2100,9 +2186,7 @@ async def test_execute_forwarded_request_handles_non_2xx_with_non_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -2138,9 +2222,7 @@ async def test_execute_forwarded_http_request_skips_publish_when_redis_is_none()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         # Should complete without raising and without a redis.publish call.
@@ -2231,8 +2313,162 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
 
 
 @pytest.mark.asyncio
-async def test_execute_forwarded_http_request_appends_query_string():
-    """Query string from forwarded request is appended to the internal URL."""
+async def test_execute_forwarded_http_request_preserves_authorization_for_csrf_bypass():
+    """The originating ``Authorization`` bearer is copied onto the trusted-internal dispatch.
+
+    The CSRF middleware short-circuits on bearer-tokened requests; without
+    preserving the original ``Authorization`` header, the affinity dispatch to
+    ``/_internal/mcp/rpc`` 403s on CSRF even though the trusted-internal gate
+    itself is satisfied. Mirrors the Rust runtime forward path.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-auth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"authorization": "Bearer original-jwt"},  # lowercased like the wire
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-auth-bypass",
+        "auth_context": "ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    sent_headers = client.last_post_kwargs["headers"]
+    assert sent_headers.get("authorization") == "Bearer original-jwt"
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_synthesizes_public_context_when_missing():
+    """Executor side: a forwarded payload with no auth_context falls back to an encoded public-only ({}) context.
+
+    Old / mixed-version payloads (e.g. a worker on a pre-auth-context build
+    during a rolling deploy) may omit ``auth_context``. Rather than sending an
+    empty header — which ``_build_internal_mcp_forwarded_user`` rejects with 400
+    — the executor synthesizes an encoded public-only ({}) context so the
+    dispatch applies default visibility. The trust headers (runtime marker +
+    HMAC) are still set.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-noctx",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-ctx",
+        # No "auth_context" key on purpose.
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    # Missing context -> encoded public-only ({}) context, NOT an empty header
+    # (an empty header would 400 at _build_internal_mcp_forwarded_user).
+    # First-Party
+    from mcpgateway.auth_context import decode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+    assert headers["x-contextforge-auth-context"]
+    assert decode_internal_mcp_auth_context(headers["x-contextforge-auth-context"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_custom_auth_header():
+    """Executor side: the bearer is preserved under the CONFIGURED auth header.
+
+    On a deployment with ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the CSRF bearer
+    short-circuit keys on that header, so hardcoding ``authorization`` would drop
+    the bearer and risk a 403 on the inner dispatch.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-customauth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"x-mcp-gateway-auth": "Bearer custom-tok"},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-custom",
+        "auth_context": "encoded-ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    headers = client.last_post_kwargs["headers"]
+    # Configured header preserved (lowercased); hardcoded "authorization" is NOT used.
+    assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
+    """Lifecycle methods (DELETE, GET) don't carry a JSON-RPC body, so the owner just acks 200 without dispatching."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -2242,24 +2478,171 @@ async def test_execute_forwarded_http_request_appends_query_string():
 
     request = {
         "response_channel": "r",
-        "method": "GET",
+        "method": "DELETE",
         "path": "/mcp",
-        "query_string": "foo=bar&baz=qux",
+        "query_string": "",
         "headers": {},
         "body": "",
-        "mcp_session_id": "sess-qs",
+        "mcp_session_id": "sess-delete",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    assert client.last_request_kwargs["url"] == "http://localhost:4444/mcp?foo=bar&baz=qux"  # type: ignore[index]
+    # Acked without invoking the in-process dispatch.
+    assert client.last_post_kwargs is None
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_notification_method_without_dispatch():
+    """``notifications/*`` methods need no upstream round-trip — owner acks 202 without dispatching.
+
+    MCP notification messages are fire-and-forget; the originating worker
+    already accepted the notification. The owner just acknowledges receipt.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="should-not-be-used"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-notif",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-notif",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch helper was never invoked.
+    assert client.last_post_kwargs is None
+    # A 202 ack was published for the notification.
+    chan, payload = fake.published[0]
+    assert chan == "mcpgw:pool_http_response:req-notif"
+    decoded = orjson.loads(payload)
+    assert decoded["status"] == 202
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_initialises_params_when_missing_for_server_id_injection():
+    """When the JSON-RPC body has no ``params`` key, the executor synthesises one before injecting ``server_id``.
+
+    Pins the defensive branch in the server-id-injection path: a request body
+    that arrives without ``params`` (or with a non-dict params) still routes
+    to the correct virtual server because the executor populates an empty
+    dict and writes the server_id into it.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    # Body has NO "params" key — the executor must initialise it before writing server_id.
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-no-params",
+        "method": "POST",
+        "path": "/servers/srv-17/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-params",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch ran and the synthesised params carries the parsed server_id.
+    assert client.last_post_kwargs is not None
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"] == {"server_id": "srv-17"}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_dispatches_in_process_via_asgi_transport():
+    """The forward is dispatched IN-PROCESS via ``httpx.ASGITransport(app=app)``, not over the loopback socket.
+
+    This is the load-bearing change behind the #4557 fix. A real
+    ``httpx.AsyncClient`` to ``http://127.0.0.1:4444/_internal/mcp/rpc`` would
+    hit the shared gunicorn socket and let the kernel route it to an arbitrary
+    worker that didn't hold the upstream session. Dispatching in-process via
+    ASGITransport keeps the re-entered ``/_internal/mcp/rpc`` handler in *this*
+    worker, so the bound ``UpstreamSessionRegistry`` entry actually serves the
+    request.
+    """
+    # Third-Party
+    import httpx
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    captured_transport: list[Any] = []
+
+    def _capture_async_client(*args: Any, **kwargs: Any) -> _FakeHttpxClient:
+        captured_transport.append(kwargs.get("transport"))
+        return _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "r",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": "",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-asgi",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", side_effect=_capture_async_client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # AsyncClient was constructed with an ASGITransport — the in-process dispatch path.
+    assert captured_transport, "httpx.AsyncClient was never called"
+    assert isinstance(captured_transport[0], httpx.ASGITransport), (
+        f"expected ASGITransport for in-process dispatch, got {type(captured_transport[0]).__name__}"
+    )
 
 
 @pytest.mark.asyncio
@@ -2286,9 +2669,7 @@ async def test_execute_forwarded_http_request_logs_debug_when_error_publish_also
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
         caplog.at_level("DEBUG", logger="mcpgateway.services.session_affinity"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0

--- a/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
+++ b/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
@@ -1162,7 +1162,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1173,7 +1173,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1210,11 +1210,11 @@ class TestInternalA2ADenyPaths:
         # First-Party
         from mcpgateway.main import _is_trusted_internal_mcp_runtime_request
 
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(request) is True
 
         # And the equivalent /_internal/a2a/ path with the same headers
         # MUST still be rejected (the feature flag narrows correctly).
         a2a_scope = {**scope, "path": "/_internal/a2a/authenticate", "raw_path": b"/_internal/a2a/authenticate"}
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(Request(a2a_scope)) is False

--- a/tests/unit/mcpgateway/test_internal_runtime_trust.py
+++ b/tests/unit/mcpgateway/test_internal_runtime_trust.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the consolidated internal-runtime trust gate.
+
+Covers the shared helper in ``auth_context`` (``is_trusted_internal_runtime_request`` /
+``is_trusted_internal_mcp_request``), the path-aware auth-context rule, the A2A
+feature guard, the affinity marker, the HMAC-is-the-trust-boundary property, and
+that the forwarded/client-IP headers are stripped from loopback passthrough.
+"""
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+
+# First-Party
+from mcpgateway.auth_context import (
+    _expected_internal_mcp_runtime_auth_header,
+    _internal_path_requires_auth_context,
+    is_trusted_internal_mcp_request,
+    is_trusted_internal_runtime_request,
+)
+
+VALID_HMAC = _expected_internal_mcp_runtime_auth_header()
+
+
+def _req(path, *, marker="rust", hmac="valid", ctx="ctx", client="127.0.0.1", extra=None):
+    """Build a synthetic internal request."""
+    headers = []
+    if marker is not None:
+        headers.append((b"x-contextforge-mcp-runtime", marker.encode()))
+    if hmac is not None:
+        headers.append((b"x-contextforge-mcp-runtime-auth", (VALID_HMAC if hmac == "valid" else hmac).encode()))
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    for k, v in (extra or []):
+        headers.append((k, v))
+    scope = {"type": "http", "method": "POST", "path": path, "raw_path": path.encode(),
+             "query_string": b"", "headers": headers, "client": (client, 12345) if client else None}
+    return Request(scope)
+
+
+# --- path-aware auth-context rule ------------------------------------------
+
+@pytest.mark.parametrize("path,expected", [
+    ("/_internal/mcp/authenticate", False),
+    ("/_internal/mcp/authenticate/", False),
+    ("/_internal/a2a/authenticate", False),
+    ("/_internal/mcp/rpc", True),
+    ("/_internal/mcp/initialize", True),
+    ("/_internal/a2a/tasks/get", True),
+])
+def test_path_requires_auth_context(path, expected):
+    assert _internal_path_requires_auth_context(path) is expected
+
+
+# --- MCP gate: allow --------------------------------------------------------
+
+def test_rpc_trusted_with_rust_marker_hmac_and_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc")) is True
+
+
+def test_rpc_trusted_with_affinity_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="affinity")) is True
+
+
+def test_authenticate_trusted_without_ctx():
+    # /authenticate creates the context, so no ctx required.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/authenticate", ctx=None)) is True
+
+
+# --- MCP gate: deny ---------------------------------------------------------
+
+def test_deny_bad_hmac_even_on_loopback_with_ctx():
+    # The HMAC is the trust boundary: loopback + marker + ctx but a bad HMAC is denied.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", hmac="not-the-real-hmac")) is False
+
+
+def test_deny_wrong_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="bogus")) is False
+
+
+def test_deny_non_loopback_client():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", client="10.0.0.9")) is False
+
+
+def test_deny_rpc_missing_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", ctx=None)) is False
+
+
+def test_deny_non_internal_prefix():
+    assert is_trusted_internal_mcp_request(_req("/servers/x/mcp")) is False
+
+
+def test_xff_cannot_make_untrusted_request_trusted():
+    # Even with a spoofed X-Forwarded-For and a loopback client, a bad HMAC is denied:
+    # loopback is defense-in-depth, the HMAC is the boundary.
+    req = _req("/_internal/mcp/rpc", hmac="forged", extra=[(b"x-forwarded-for", b"127.0.0.1")])
+    assert is_trusted_internal_mcp_request(req) is False
+
+
+# --- A2A feature guard ------------------------------------------------------
+
+def test_a2a_trusted_when_enabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", True)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is True
+
+
+def test_a2a_denied_when_disabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", False)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is False
+
+
+# --- generic helper: explicit require_auth_context + prefixes ---------------
+
+def test_generic_helper_respects_prefix_allowlist():
+    req = _req("/_internal/mcp/rpc")
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/a2a",), require_auth_context=True) is False
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/mcp",), require_auth_context=True) is True
+
+
+# --- token_scoping now trusts the affinity marker ---------------------------
+
+def test_token_scoping_trusts_affinity_hop():
+    # First-Party
+    from mcpgateway.middleware.token_scoping import token_scoping_middleware
+
+    req = _req("/_internal/mcp/rpc", marker="affinity")
+    assert token_scoping_middleware._is_trusted_internal_mcp_runtime_request(req, "/_internal/mcp/rpc") is True
+
+
+# --- forwarded / client-IP headers are stripped from loopback passthrough ---
+
+@pytest.mark.parametrize("header", [
+    "forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
+    "x-forwarded-port", "x-forwarded-prefix", "x-real-ip", "cf-connecting-ip", "true-client-ip",
+])
+def test_loopback_passthrough_strips_forwarded_headers(header):
+    # First-Party
+    from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+    out = filter_loopback_skip_headers({header: "1.2.3.4", "x-keep": "ok"})
+    assert header not in {k.lower() for k in out}
+    assert out.get("x-keep") == "ok"

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -844,7 +844,11 @@ class TestInternalTrustedMcpTransportBridge:
 
         await bridge.handle_streamable_http(scope, receive, send)
 
-        assert events[0]["status"] == 400
+        # A missing auth context now fails the internal trust gate itself
+        # (require_auth_context is folded into is_trusted_internal_mcp_request),
+        # so the request is rejected as untrusted (403) before reaching the
+        # "missing auth context" (400) branch.
+        assert events[0]["status"] == 403
 
     def test_build_internal_mcp_auth_scope_uses_public_request_shape(self):
         """Synthetic auth scope should preserve the public MCP path and client IP."""

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8832,6 +8832,146 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_local_affinity_post_dispatches_to_internal_endpoint_with_auth_context(monkeypatch):
+    """Owner-direct affinity POST dispatches to the trusted-internal /_internal/mcp/rpc.
+
+    Closes the coverage gap for the local-owner path: instead of re-authenticating
+    against public /rpc (which only understands ContextForge JWTs/cookies and would
+    401 virtual-server OAuth or MCP_REQUIRE_AUTH=false public-only sessions), the
+    owner dispatches to the trusted-internal endpoint carrying the affinity runtime
+    marker, the HMAC, and the edge-validated auth context. The originating
+    Authorization header is preserved for the CSRF bearer short-circuit.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    # Deterministic auth context regardless of request-scoped state.
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"authorization", b"Bearer tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        # Routed to the trusted-internal endpoint, NOT public /rpc.
+        assert mock_client.post.call_args.args[0] == "/_internal/mcp/rpc"
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["x-contextforge-mcp-runtime"] == "affinity"
+        assert headers["x-contextforge-mcp-runtime-auth"]
+        assert headers["x-contextforge-auth-context"]
+        # Authorization preserved for the CSRF bearer short-circuit.
+        assert headers["authorization"] == "Bearer tok"
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
+    """Owner-direct dispatch preserves the bearer under the CONFIGURED auth header.
+
+    On ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the bearer rides that header and
+    the CSRF short-circuit keys on it, so hardcoding ``authorization`` would drop it.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_header_name", "X-MCP-Gateway-Auth")
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"x-mcp-gateway-auth", b"Bearer custom-tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        headers = mock_client.post.call_args.kwargs["headers"]
+        # Configured header preserved (lowercased); hardcoded "authorization" not used.
+        assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+        assert "authorization" not in headers
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "params_value,params_json",
     [
@@ -9011,6 +9151,65 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeypatch):
+    """The sender encodes the live ``get_streamable_http_auth_context()`` result and passes it through ``forward_to_owner``.
+
+    Without this, OAuth-enabled virtual servers and ``MCP_REQUIRE_AUTH=false``
+    public-only mode would 401 after a cross-worker forward, because the owner
+    would have nothing to reconstruct the edge-authenticated user from.
+    """
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    # Stand-in for the authenticated identity the edge worker already established.
+    edge_auth_ctx = {"email": "alice@example.com", "is_admin": False, "teams": ["t1"]}
+    expected_encoded = encode_internal_mcp_auth_context(edge_auth_ctx)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context", lambda: edge_auth_ctx)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-auth")])
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-2")
+    mock_pool.forward_to_owner = AsyncMock(
+        return_value={
+            "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body": b'{"jsonrpc":"2.0","result":{}}',
+        }
+    )
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+    ):
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
+
+    await wrapper.shutdown()
+    # auth_context kwarg is supplied and equals the encoded edge identity.
+    assert mock_pool.forward_to_owner.call_args.kwargs["auth_context"] == expected_encoded
+
+
+@pytest.mark.asyncio
 async def test_affinity_forward_failure_falls_through(monkeypatch):
     """Test affinity forward failure falls through to local handling (line 1525-1527)."""
 
@@ -9184,6 +9383,67 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
 
     await wrapper.shutdown()
     assert messages[0]["status"] == 200
+
+
+
+
+@pytest.mark.asyncio
+async def test_http_affinity_forwarded_path_dispatches_via_post_rpc_in_process(monkeypatch):
+    """``[HTTP_AFFINITY_FORWARDED]`` re-entry also goes through ``post_rpc_in_process`` (PR #4987).
+
+    When a worker receives a forwarded request (carrying
+    ``x-forwarded-internally: true``), it re-enters the /rpc dispatch. Before
+    PR #4987 that re-entry built its own ``httpx.AsyncClient`` and bounced
+    back through the shared socket — splitting the session across yet
+    another random worker. Routing through the helper keeps the dispatch
+    in-process on the worker that already owns the session, closing the last
+    remaining scatter point in the forward chain.
+    """
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+    # x-forwarded-internally: true triggers the [HTTP_AFFINITY_FORWARDED] re-entry branch.
+    # Use a server-less path so the handler doesn't try to validate server_id against the (un-initialised) DB.
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[
+            (b"mcp-session-id", b"sess-fwd"),
+            (b"x-forwarded-internally", b"true"),
+            (b"authorization", b"Bearer original-jwt"),
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{}}'
+
+    mock_post_rpc = AsyncMock(return_value=mock_response)
+
+    with patch("mcpgateway.transports.streamablehttp_transport.post_rpc_in_process", mock_post_rpc):
+        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+
+    await wrapper.shutdown()
+    mock_post_rpc.assert_awaited_once()
+    sent_headers = mock_post_rpc.await_args.kwargs["headers"]
+    assert sent_headers["x-forwarded-internally"] == "true"
+    assert sent_headers["x-mcp-session-id"] == "sess-fwd"
+    assert sent_headers["authorization"] == "Bearer original-jwt"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_internal_http.py
+++ b/tests/unit/mcpgateway/utils/test_internal_http.py
@@ -7,11 +7,16 @@ Authors: Mihai Criveti
 Unit tests for internal loopback HTTP helpers.
 """
 
+# Standard
+from typing import Any
+from unittest.mock import patch
+
 # Third-Party
+import httpx
 import pytest
 
 # First-Party
-from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify, post_rpc_in_process
 
 
 class TestIsSSLEnabled:
@@ -99,3 +104,97 @@ class TestInternalLoopbackVerify:
         monkeypatch.delenv("SSL", raising=False)
         monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
         assert internal_loopback_verify() is True
+
+
+class _CapturingAsyncClient:
+    """Async-CM ``httpx.AsyncClient`` stand-in that captures construction + post kwargs.
+
+    Records the ``transport`` and ``base_url`` passed to the constructor and the
+    ``url``/``content``/``headers``/``timeout`` of the inner ``.post`` call so
+    tests can assert on the in-process dispatch contract without touching the
+    real FastAPI app.
+    """
+
+    last_init_kwargs: dict[str, Any] = {}
+    last_post_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_init_kwargs = kwargs
+
+    async def __aenter__(self) -> "_CapturingAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def post(self, url: str, **kwargs: Any) -> Any:
+        type(self).last_post_kwargs = {"url": url, **kwargs}
+        # Return a minimal Response-like sentinel; the executor under test
+        # never inspects this object in the unit-test path.
+        return object()
+
+
+class TestPostRpcInProcess:
+    """Tests for ``post_rpc_in_process`` (PR #4987).
+
+    The helper centralises in-process ``/rpc`` dispatch so all four affinity
+    sites (cross-worker forward + cross-worker SSE/RPC + local-owned + the
+    HTTP-affinity-forwarded re-entry) execute on the worker that holds the
+    bound upstream session, instead of looping back over the shared gunicorn
+    socket and scattering to a random worker. The load-bearing details pinned
+    here: the transport is ``httpx.ASGITransport`` (proves in-process, not
+    network loopback), the path is exactly ``/rpc`` (not the original request
+    path), and ``content``/``headers``/``timeout`` pass through unchanged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dispatches_via_asgi_transport_in_process(self):
+        """Asserts the AsyncClient is constructed with an ``httpx.ASGITransport``.
+
+        This is the whole point of #4987 — a real ``httpx.AsyncClient(verify=...)``
+        to ``127.0.0.1`` would hit the shared gunicorn socket and the kernel
+        would route the call to an arbitrary worker that does not hold the
+        bound upstream session.
+        """
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0)
+        assert isinstance(_CapturingAsyncClient.last_init_kwargs.get("transport"), httpx.ASGITransport)
+
+    @pytest.mark.asyncio
+    async def test_posts_to_rpc_endpoint(self):
+        """The helper targets exactly ``/rpc`` — the public JSON-RPC handler."""
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0)
+        assert _CapturingAsyncClient.last_post_kwargs["url"] == "/rpc"
+
+    @pytest.mark.asyncio
+    async def test_propagates_content_headers_and_timeout(self):
+        """``content``, ``headers``, and ``timeout`` reach the inner ``.post`` unchanged.
+
+        Each caller builds its own loop-stop header set; the helper must not
+        mutate or replace them.
+        """
+        headers = {"x-forwarded-internally": "true", "x-mcp-session-id": "abc", "authorization": "Bearer x"}
+        body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=body, headers=headers, timeout=7.5)
+
+        captured = _CapturingAsyncClient.last_post_kwargs
+        assert captured["content"] == body
+        assert captured["headers"] == headers
+        assert captured["timeout"] == 7.5
+
+    @pytest.mark.asyncio
+    async def test_uses_loopback_base_url(self, monkeypatch):
+        """The AsyncClient's ``base_url`` is the gateway's loopback URL.
+
+        ASGITransport ignores ``base_url`` for routing — the FastAPI app sees
+        the request directly — but the base URL still appears in logs and in
+        observability scopes, so it must be the loopback.
+        """
+        monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
+        monkeypatch.delenv("SSL", raising=False)
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={}, timeout=1.0)
+        assert _CapturingAsyncClient.last_init_kwargs.get("base_url") == "http://127.0.0.1:4444"

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -497,3 +497,40 @@ class TestPassthroughHeaders:
 
         # Should log warning about conflict
         assert any("conflicts with pre-defined headers" in record.message for record in caplog.records)
+
+
+class TestLoopbackSkipTrustedInternalHeaders:
+    """Deny-path: client passthrough must never carry the gateway-internal trust headers.
+
+    The ``/_internal/mcp/*`` dispatch sets ``x-contextforge-auth-context`` (the
+    server-established identity), ``x-contextforge-mcp-runtime``, and the HMAC.
+    If the loopback passthrough echoed a client-supplied copy of those, a caller
+    could spoof the trusted identity while the server's valid HMAC still rode
+    along. The loopback skip set must strip them.
+    """
+
+    def test_filter_strips_trusted_internal_headers(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        spoofed = {
+            "x-contextforge-auth-context": "SPOOFED",
+            "x-contextforge-mcp-runtime": "affinity",
+            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",
+            "x-contextforge-session-validated": "rust",
+            "x-business-header": "kept",
+        }
+        out = filter_loopback_skip_headers(spoofed)
+        assert "x-contextforge-auth-context" not in out
+        assert "x-contextforge-mcp-runtime" not in out
+        assert "x-contextforge-mcp-runtime-auth" not in out
+        assert "x-contextforge-session-validated" not in out
+        # Non-trusted business headers are unaffected.
+        assert out.get("x-business-header") == "kept"
+
+    def test_filter_strips_trusted_headers_case_insensitively(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        out = filter_loopback_skip_headers({"X-ContextForge-Auth-Context": "SPOOFED"})
+        assert not any(k.lower() == "x-contextforge-auth-context" for k in out)

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/test_gunicorn_config.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Pratik Gandhi
+
+Tests for the ``gunicorn.config.py`` ``post_fork`` hook (#4557).
+
+The hook is the load-bearing fix behind PR #4981: with ``--preload``,
+``mcpgateway.services.session_affinity.WORKER_ID`` is captured at import
+time in the master process, so every forked worker would otherwise inherit
+``{hostname}:1`` (the master's PID). A shared WORKER_ID collapses the
+per-worker pub/sub channels and makes every forwarded request execute on
+all workers in the container (24x broadcast amplification observed in
+#4557). The ``post_fork`` hook recomputes WORKER_ID per worker to restore
+single-executor forwarding.
+
+The hook also wraps the rebind in a broad ``except Exception`` that logs
+a ``warning`` referencing #4557 — the F2 follow-up. Silent fallback would
+let production drift back into the amplification state without any signal.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import importlib.util
+import socket
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+# Third-Party
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GUNICORN_CONFIG_PATH = _REPO_ROOT / "gunicorn.config.py"
+
+
+def _load_gunicorn_config():
+    """Import ``gunicorn.config`` from the repo root by file path.
+
+    ``gunicorn.config.py`` sits at the repo root, not on ``sys.path``, so
+    a plain ``import gunicorn.config`` doesn't reach it. Loading via spec
+    keeps the test hermetic and avoids polluting ``sys.modules`` with a
+    name that collides with the real ``gunicorn`` package.
+    """
+    spec = importlib.util.spec_from_file_location("_gunicorn_config_under_test", _GUNICORN_CONFIG_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_fake_server() -> SimpleNamespace:
+    """Build a minimal gunicorn-server stand-in exposing ``log.info/warning/error``."""
+    return SimpleNamespace(log=MagicMock())
+
+
+@pytest.fixture
+def fake_worker() -> SimpleNamespace:
+    """A gunicorn-worker stand-in with a stable PID."""
+    return SimpleNamespace(pid=4242)
+
+
+def test_post_fork_rebinds_worker_id_per_worker(fake_worker):
+    """Happy path: ``post_fork`` overrides the master-frozen ``WORKER_ID`` with ``{hostname}:{worker.pid}``.
+
+    Without this, every forked gunicorn worker carries the master's
+    ``{hostname}:1``, so a forwarded request published to the owner's
+    pub/sub channel reaches every worker in the container.
+    """
+    # First-Party
+    from mcpgateway.services import session_affinity
+
+    cfg = _load_gunicorn_config()
+    original = session_affinity.WORKER_ID
+    try:
+        cfg.post_fork(_make_fake_server(), fake_worker)
+        assert session_affinity.WORKER_ID == f"{socket.gethostname()}:{fake_worker.pid}"
+    finally:
+        # Restore the module-level constant so other tests aren't affected.
+        session_affinity.WORKER_ID = original
+
+
+def test_post_fork_logs_warning_when_rebind_fails(fake_worker, monkeypatch):
+    """If the rebind raises, the hook must log a ``warning`` referencing #4557 and NOT crash the worker.
+
+    Regression test for the F2 follow-up: the original ``except ImportError: pass``
+    silently fell back to the master's frozen ``WORKER_ID``, so #4557's broadcast
+    amplification could return into production unnoticed. The fix broadens the
+    catch and surfaces the failure via ``server.log.warning(...)``.
+
+    To reproduce a rebind failure deterministically without depending on the
+    real module's internals, monkeypatch ``socket.gethostname`` (called inside
+    the try block) to raise.
+    """
+    # First-Party
+    from mcpgateway.services import session_affinity
+
+    original_worker_id = session_affinity.WORKER_ID
+
+    def _boom() -> str:
+        raise RuntimeError("simulated rebind failure")
+
+    monkeypatch.setattr(socket, "gethostname", _boom)
+
+    cfg = _load_gunicorn_config()
+    server = _make_fake_server()
+    try:
+        # Must not raise — the hook is expected to swallow + log, never propagate.
+        cfg.post_fork(server, fake_worker)
+    finally:
+        session_affinity.WORKER_ID = original_worker_id
+
+    # WORKER_ID was NOT silently rebound (the failure was real, not papered over).
+    assert session_affinity.WORKER_ID == original_worker_id
+
+    # A warning was emitted, mentioning the failing operation (rebind) and the consequence.
+    assert server.log.warning.called, "expected post_fork to log a warning on rebind failure"
+    call_args = server.log.warning.call_args
+    # First arg is the format string; subsequent args are the format params.
+    fmt = call_args.args[0] if call_args.args else ""
+    assert "WORKER_ID" in fmt
+    assert "broadcast" in fmt, "warning should describe the consequence (per-container broadcast) so operators can act on it"


### PR DESCRIPTION
## Summary

Fixes the session-affinity performance regression tracked in #4557 (follow-up
to #4352). On multi-worker deployments, stateful MCP requests (those carrying
`Mcp-Session-Id`) collapsed from ~180 RPS to single digits.

#4299 (fixing #4205) correctly made each upstream MCP session 1:1 with its
downstream session and **purely in-process**, so a request that lands on a
non-owner worker must be forwarded to the owner over Redis. Two defects made
that forwarding pathological — both are fixed here:

- **Per-container worker identity.** `WORKER_ID` (`{host}:{pid}`) is a
  module-level constant captured at import. Under gunicorn `--preload` the app
  imports once in the master (pid 1), so every worker in a container inherited
  `{host}:1` and subscribed to the *same* `pool_rpc`/`pool_http` channel. Redis
  pub/sub then delivered each forwarded request to *all* workers in the
  container (~N× duplicate execution, and the wrong worker "owned" the session
  on the local path). Fixed by recomputing `WORKER_ID` per worker in the
  gunicorn `post_fork` hook — each worker gets a unique id and its own channel,
  so a forward reaches exactly one owner.

- **Loopback re-dispatch scatters off the owner.** Once the owner received a
  forward, `_execute_forwarded_http_request` re-ran the request via a loopback
  HTTP call to `127.0.0.1`, which hits the shared gunicorn socket and is routed
  by the kernel to an *arbitrary* worker that doesn't hold the session's
  upstream connection — so the re-execution failed or spawned a duplicate
  upstream session. Fixed by dispatching the JSON-RPC call to `/rpc` via an
  in-process ASGI transport (`httpx.ASGITransport(app)`), so the owner executes
  it in its own process using its bound upstream session.

The affinity strategy (sticky session + forward-to-owner over Redis) is
unchanged; this makes the system actually deliver each forward to the single
process that owns the session and execute it there. The #4205 upstream-session
isolation invariant is preserved (its integration test stays green).

## Architecture

The session-affinity layer has one job: when a multi-worker deployment receives a stateful MCP request, route it to the worker that owns the upstream connection for that session. Two defects broke that routing in opposite ways.

### Defect 1 — All workers in a container shared one identity

`WORKER_ID = f"{hostname}:{pid}"` is captured at module import. Under gunicorn `--preload`, the app imports once in the master process (pid 1) before any workers fork. Every forked worker inherited the master's id and subscribed to the same Redis channel.

A forward meant for "the owner" reached every worker in the container:

```text
   Worker that received the request
            │
            │ PUBLISH  pool_http:{owner_id}
            ▼
        Redis pub/sub
            │
            │   all 24 workers share owner_id, so the
            │   channel has 24 subscribers
            ▼
   ┌────────┬────────┬────────┬───────────┬────────┐
   ▼        ▼        ▼        ▼           ▼        ▼
 Worker 1  Worker 2  Worker 3  ...   Worker 24
   │        │        │        │           │        │
   └────────┴────────┴── all execute the same forward
```

24× duplicate execution per call. The rate-limiter reproducer in #4674 surfaced this directly: a single user at 1 req/s drove the per-user counter up by ~24/s.

### Defect 2 — The forward was bounced back through the load balancer

Even when only one worker received the forward, that worker re-issued the JSON-RPC call as an HTTP request to `127.0.0.1:4444/rpc`. That call hits the shared gunicorn socket, so `SO_REUSEPORT` routed it to whichever worker the kernel picked — almost never the owner.

```text
   Worker that received the forward
            │
            │ httpx.post("http://127.0.0.1:4444/rpc", ...)
            ▼
        gunicorn shared socket  (SO_REUSEPORT)
            │
            │ kernel picks any worker
            ▼
        Random worker
            │
            │ doesn't hold the upstream session for this id
            ▼
        error  OR  spawns a duplicate upstream session
                   (weakening the #4205 isolation invariant)
```

The two defects masked each other. Pre-fix, 24× broadcast meant the owner was almost always one of the 24 receivers — so something usually worked, by luck. Fixing only the `WORKER_ID` collision made things worse because the single receiver still bounced through the LB. Both have to be fixed together.

### Fix — unique worker identity + in-process dispatch

```text
   Worker that received the request
            │
            │ PUBLISH  pool_http:{owner_id}     ◀── owner_id is now unique per worker
            ▼                                       (recomputed in gunicorn post_fork)
        Redis pub/sub
            │
            │ exactly 1 subscriber
            ▼
        Owner worker
            │
            │ in-process ASGI dispatch         ◀── httpx.ASGITransport(app)
            │ no socket, no kernel re-routing      runs /rpc in THIS process
            ▼
        /rpc handler
            │
            │ resolves the session from THIS
            │ worker's own UpstreamSessionRegistry
            ▼
        request executes once, against the live upstream session
        response returns over Redis to the originating worker → client
```

Two changes carry the fix:

1. **`gunicorn.config.py` `post_fork` hook** recomputes `WORKER_ID` per worker. Each worker now has a unique id and its own channel; `PUBSUB NUMSUB` returns 1 instead of 24.
2. **`_execute_forwarded_http_request` dispatches in-process** via `httpx.ASGITransport(app)`. The `/rpc` handler runs in the receiving worker, against its own `UpstreamSessionRegistry`, so the bound upstream session is right there.

The forward-to-owner architecture isn't changed; this makes it actually deliver each forward to one process and execute it there.

## Test results

`make benchmark-mcp-tools` (125 users / 60s) on the standard testing stack
(`GATEWAY_REPLICAS=3` × `GUNICORN_WORKERS=24`, `CACHE_TYPE=redis`,
`USE_STATEFUL_SESSIONS=true`, `MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`,
Python runtime), same machine before/after:

| Config | RPS | Failures | p99 |
|---|---|---|---|
| Before fix | ~9-11 | 14-30% (forward timeouts) | 30,000 ms |
| **After fix** | **~397** | **0%** | **1,600 ms** |

Independent confirmations:

- **Rate-limiter amplification gone.** Driving a per-tenant rate-limiter binding
  on the same multi-replica stack, the `rl:*` counter ticked `24, 48, 72, 97`
  per user call before the fix and exactly `1, 2, 3, 4, 5` after (1:1).
- **#4205 isolation preserved.**
  `tests/integration/test_issue_4205_upstream_session_isolation.py` passes
  (4/4).
- **Single-owner routing verified live.** `PUBSUB NUMSUB` on a worker's
  `pool_http` channel went from `24` → `1`; `worker_heartbeat` keys went from
  3 (one per container) → 72 (one per worker).

<details>
<summary><b>Load benchmark — Streamable HTTP tools throughput (16-core host, 535 RPS @ 0.00% failures)</b></summary>

Independent run on a dedicated 16-core / 32 GB host (Ubuntu 24.04). The image was
built from this branch (`make docker-prod`) and the standard testing stack
(3 gateway replicas behind nginx, Postgres + Redis + pgbouncer) was brought up via
`make testing-up`.

**Config:** `make benchmark-mcp-tools` — tools-only MCP Streamable HTTP, 125 concurrent
users, 30/s spawn rate, 60s run, against the registered `fast_time` virtual server
through nginx on `:8080`.

**Results**

| Metric | Value |
|---|---|
| Total requests | 32,139 |
| Failures | 0 (0.00%) |
| Throughput | 535.23 RPS |
| Avg latency | 165.4 ms |
| p50 / p90 / p95 / p99 | 110 / 270 / 460 / 1,200 ms |
| Max | 2,897 ms (no forward timeouts) |

**Endpoint breakdown**

| Endpoint | Reqs | Fails | RPS | Avg (ms) | p99 (ms) |
|---|---|---|---|---|---|
| `tools/call` [rapid] | 30,485 | 0 | 507.7 | 165.9 | 1,200 |
| `tools/list` [rapid] | 1,529 | 0 | 25.5 | 162.0 | 1,000 |
| `initialize` | 125 | 0 | 2.1 | 104.2 | 210 |

All 125 `initialize` calls and every tool call succeeded; ~535 RPS sustained with a
p99 of 1.2s and no forward timeouts.

</details>

<details>
<summary><b>#4205 counter reproducers — statefulness &amp; isolation under multi-worker affinity (5/5 PASS, 16-core host)</b></summary>

Ran the #4205 counter reproducers against this branch's stack on a 16-core host
(3 gateway replicas behind nginx, non-sticky round-robin, Redis pool ownership). A
minimal per-session counter MCP server is registered behind the gateway; a session
is incremented N times and must read back N. If forwarding scattered onto a fresh
upstream session, the counter would drop.

**Setup**

```python
# counter_server.py — per-session counter (state keyed by the upstream ServerSession)
from mcp.server.fastmcp import Context, FastMCP
mcp = FastMCP("repro-counter", host="0.0.0.0", port=9400)   # 2nd instance on :9401 for Test 4
_counters: dict[int, int] = {}

@mcp.tool()
def increment(ctx: Context) -> int:
    _counters[id(ctx.session)] = _counters.get(id(ctx.session), 0) + 1
    return _counters[id(ctx.session)]

@mcp.tool()
def get_value(ctx: Context) -> int:
    return _counters.get(id(ctx.session), 0)

mcp.run(transport="streamable-http")
```

1. Run the counter on the host (reachable from the gateway containers via
   `host.docker.internal`, mapped by compose `extra_hosts: host.docker.internal:host-gateway`).
2. `POST /gateways` → `{"name":"repro-counter","url":"http://host.docker.internal:9400/mcp","transport":"STREAMABLEHTTP"}`.
3. Wait for tool sync (`GET /tools` filtered by `gatewayId`), then
   `POST /servers` → `{"server":{"name":"repro-counter-vs","associated_tools":[…]}}`.
4. Admin token: `create_jwt_token --username admin@example.com --admin --secret $JWT_SECRET_KEY`.
5. Drive sessions against `/servers/{id}/mcp` (`initialize` → `notifications/initialized` →
   `tools/call increment` ×N → `tools/call get_value`); concurrent sessions via a thread pool.

**Results**

| Test | Steps | Result |
|---|---|---|
| 1 — single session | one session, `increment` ×25, then `get_value` | `increments=[1…25]`, `get_value=25`, `pool_owner → host:pid` (pid ≠ 1 → per-worker WORKER_ID) — **PASS** |
| 2 — same-user multi-session | 3 concurrent sessions, one token, ×10 each | 3 distinct sids, each `[1…10]` / `get_value=10` → 3 independent `pool_owner` keys — **PASS** |
| 3 — two tokens | two distinct tokens (same admin), parallel sessions, ×10 | both `[1…10]` / `get_value=10`, distinct sids, no cross-talk — **PASS** |
| 4 — multi-upstream | one session across two counters (`:9400`+`:9401`): A×5, B×3, A×2 | A `[1,2,3,4,5]` then `[6,7]` (`get_value=7`), B `[1,2,3]` (`get_value=3`) → `(session, gateway)` isolation — **PASS** |
| 5 — owner-worker kill | bind + ×5, read owner from Redis, `kill -9` the owning gunicorn worker, hit stale sid, then fresh `initialize` | stale sid → **HTTP 404 / JSON-RPC `-32600 "Session not found"` in 30.0s** (not a hang/5xx); killed worker auto-respawns; fresh init `[1,2,3]` — **PASS** |

Test 5 trace:

```
[1] bound sid=2baca9c5…  increments=[1, 2, 3, 4, 5]
[2] pool_owner -> ef36eab61e4f:105       # owner pid 105 (not :1 -> per-worker WORKER_ID active)
[3] owner worker pid 105 in mcp-context-forge-gateway-2
[4] kill -9 105 -> worker dead (gunicorn respawns a replacement)
[5] stale-sid request -> HTTP 404 in 30.0s | {"error":{"code":-32600,"message":"Session not found"}}
[6] fresh initialize bbc44380… increments=[1, 2, 3]
```

Per-session upstream state survives the cross-worker affinity forwarding (one upstream
session per downstream session, no scatter), isolation holds across sessions/tokens/upstreams,
and the owner-death failure mode returns a clean structured error rather than a hang.

</details>



