### PR TITLE
fix: dispatch affinity-owned /rpc in-process to preserve session reuse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/_internal/mcp/"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -221,6 +221,25 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
     return None
 
 
+def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
+    """Encode an edge-validated auth context for forwarding to a trusted internal dispatcher.
+
+    Mirror of :func:`decode_internal_mcp_auth_context`. Packages the auth context
+    so a trusted internal dispatcher (e.g. ``/_internal/mcp/rpc``) can use it
+    without re-running authentication. The unpadded base64url shape keeps the
+    value header-safe.
+
+    Args:
+        auth_context: Auth-context dict to encode.
+
+    Returns:
+        Unpadded base64url-encoded JSON payload for the
+        ``x-contextforge-auth-context`` header.
+    """
+    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
+    return encoded.rstrip("=")
+
+
 def decode_internal_mcp_auth_context(header_value: str) -> Dict[str, Any]:
     """Decode the trusted internal MCP auth header payload.
 
@@ -289,6 +308,94 @@ def has_valid_internal_mcp_runtime_auth_header(request: Request) -> bool:
     if not provided:
         return False
     return hmac.compare_digest(provided, _expected_internal_mcp_runtime_auth_header())
+
+
+# Internal-dispatch trust gate, defined once and shared by all callers.
+INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
+INTERNAL_A2A_PATH_PREFIX = "/_internal/a2a"
+INTERNAL_RUNTIME_MARKER_HEADER = "x-contextforge-mcp-runtime"
+INTERNAL_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
+TRUSTED_INTERNAL_RUNTIME_MARKERS = frozenset({"rust", "affinity"})
+
+
+def _internal_path_requires_auth_context(path: str) -> bool:
+    """Whether an internal route requires an auth context.
+
+    Only ``*/authenticate`` is exempt, since it creates the context; every
+    other internal route must carry one.
+
+    Args:
+        path: The request path to classify.
+
+    Returns:
+        ``False`` for ``*/authenticate``, otherwise ``True``.
+    """
+    return not path.rstrip("/").endswith("/authenticate")
+
+
+def is_trusted_internal_runtime_request(
+    request: Request,
+    *,
+    allowed_prefixes: tuple[str, ...],
+    require_auth_context: bool,
+    path: Optional[str] = None,
+) -> bool:
+    """Return whether a request is a trusted in-process internal-runtime hop.
+
+    The trust boundary is the HMAC header and, when required, the encoded
+    ``x-contextforge-auth-context``. The loopback check is defense in depth,
+    not an independent gate: ProxyHeaders(trusted_hosts="*") lets a direct
+    external caller influence ``request.client.host`` (the replay is hardened
+    separately by stripping forwarded / client-IP headers).
+
+    Args:
+        request: Incoming request to inspect.
+        allowed_prefixes: Internal path prefixes this caller trusts.
+        require_auth_context: Require a non-empty ``x-contextforge-auth-context``.
+        path: Explicit path override for callers that strip a ``root_path``;
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` only when prefix, runtime marker, HMAC, optional auth context,
+        and loopback all hold; otherwise ``False``.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if not any(p == prefix or p.startswith(f"{prefix}/") for prefix in allowed_prefixes):
+        return False
+    if request.headers.get(INTERNAL_RUNTIME_MARKER_HEADER) not in TRUSTED_INTERNAL_RUNTIME_MARKERS:
+        return False
+    if not has_valid_internal_mcp_runtime_auth_header(request):
+        return False
+    if require_auth_context and not request.headers.get(INTERNAL_AUTH_CONTEXT_HEADER):
+        return False
+    client_host = getattr(getattr(request, "client", None), "host", None)
+    return client_host in ("127.0.0.1", "::1")
+
+
+def is_trusted_internal_mcp_request(request: Request, *, path: Optional[str] = None) -> bool:
+    """MCP + A2A internal trust gate with a path-aware auth-context requirement.
+
+    ``*/authenticate`` routes are exempt from the auth-context requirement;
+    every other internal route requires it. ``/_internal/a2a/*`` is trusted
+    only when the A2A feature is enabled.
+
+    Args:
+        request: Incoming request to inspect.
+        path: Explicit path override (e.g. a ``root_path``-stripped path);
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` when the request is a trusted internal MCP/A2A hop.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if p.startswith(f"{INTERNAL_A2A_PATH_PREFIX}/") and not settings.mcpgateway_a2a_enabled:
+        return False
+    return is_trusted_internal_runtime_request(
+        request,
+        allowed_prefixes=(INTERNAL_MCP_PATH_PREFIX, INTERNAL_A2A_PATH_PREFIX),
+        require_auth_context=_internal_path_requires_auth_context(p),
+        path=p,
+    )
 
 
 def get_token_teams_from_request(request: Request) -> Optional[List[str]]:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -458,6 +458,7 @@ class Settings(BaseSettings):
             "/sse",  # Exempt: SSE is a server-sent event stream, not vulnerable to CSRF
             "/message",  # Exempt: MCP SSE message endpoint
             "/rpc",  # Exempt: JSON-RPC is a programmatic protocol, not browser-based
+            "/_internal/mcp/",  # Exempt: loopback-only, HMAC-gated internal dispatch (affinity/Rust forwards); not browser-reachable
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -81,8 +81,8 @@ from mcpgateway.auth_context import (
     get_scoped_resource_access_context,
     get_token_teams_from_request,
     get_user_email,
-    has_valid_internal_mcp_runtime_auth_header,
     INTERNAL_MCP_SESSION_VALIDATED_HEADER,
+    is_trusted_internal_mcp_request,
 )
 from mcpgateway.cache import ResourceCache, SessionRegistry
 from mcpgateway.common.models import InitializeResult
@@ -277,26 +277,26 @@ _INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
 
 
 def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
-    """Return whether the request came from the local Rust runtime sidecar.
+    """Return whether the request came from a trusted local internal source.
+
+    Two callers are trusted today:
+
+    - ``"rust"`` — the local Rust runtime sidecar (over loopback).
+    - ``"affinity"`` — the in-process dispatch used by session-affinity
+      forwarding to reach the owner worker, carrying the identity the edge
+      already validated.
+
+    Both share the same gates: a shared-secret HMAC header AND a loopback client
+    address. Only the ``x-contextforge-mcp-runtime`` marker value differs.
 
     Args:
         request: Incoming request to inspect.
 
     Returns:
-        ``True`` when the request carries the trusted Rust runtime marker from
-        loopback, otherwise ``False``.
+        ``True`` when the request carries a trusted internal-runtime marker
+        from loopback, otherwise ``False``.
     """
-    runtime_marker = request.headers.get("x-contextforge-mcp-runtime")
-    client_host = getattr(getattr(request, "client", None), "host", None)
-    if runtime_marker != "rust" or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
-        return False
-    # Defense-in-depth: /_internal/a2a/* endpoints must refuse requests when
-    # A2A support is disabled, even from an otherwise-trusted local sidecar.
-    # A legitimate sidecar should not be running when the feature is off.
-    path = getattr(getattr(request, "url", None), "path", "") or ""
-    if path.startswith("/_internal/a2a/") and not settings.mcpgateway_a2a_enabled:
-        return False
-    return True
+    return is_trusted_internal_mcp_request(request)
 
 
 def _is_jwt_token(token: str) -> bool:

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -38,6 +38,7 @@ from starlette.responses import JSONResponse
 
 # First-Party
 from mcpgateway import auth
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.config import settings
 from mcpgateway.services.security_logger import SecurityEventType, SecurityLogger, SecuritySeverity
 
@@ -197,6 +198,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         """Process request with rate limiting."""
         if not self.enabled:
+            return await call_next(request)
+
+        # Skip rate limiting for the trusted-internal dispatch; the edge request was already counted.
+        if is_trusted_internal_mcp_request(request):
             return await call_next(request)
 
         tier = self.get_endpoint_tier(request.url.path)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -13,8 +13,6 @@ and time-based restrictions.
 # Standard
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
-import hashlib
-import hmac
 import ipaddress
 import re
 from typing import List, Optional, Pattern, Tuple
@@ -64,11 +62,6 @@ _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
-_INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
-_INTERNAL_MCP_RUNTIME_HEADER = "x-contextforge-mcp-runtime"
-_INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
-_INTERNAL_MCP_RUNTIME_AUTH_HEADER = "x-contextforge-mcp-runtime-auth"
-_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT = "contextforge-internal-mcp-runtime-v1"
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -1350,70 +1343,24 @@ class TokenScopingMiddleware:
             )
 
     def _is_trusted_internal_mcp_runtime_request(self, request: Request, normalized_path: str) -> bool:
-        """Return whether the request is a trusted loopback Rust MCP sidecar hop.
+        """Return whether the request is a trusted internal MCP/A2A runtime hop.
+
+        Delegates to the shared gate in ``auth_context`` so the trust decision is
+        defined in one place. Unlike the previous local check, this trusts both
+        the ``rust`` and ``affinity`` runtime markers — closing the gap where the
+        in-process session-affinity dispatch was still token-scoped.
 
         Args:
             request: Incoming HTTP request.
             normalized_path: Canonicalized request path used for route matching.
 
         Returns:
-            ``True`` when the request originated from the local Rust MCP runtime and
-            includes the expected trusted headers.
+            ``True`` when the request is a trusted internal MCP/A2A hop.
         """
-        if normalized_path != _INTERNAL_MCP_PATH_PREFIX and not normalized_path.startswith(f"{_INTERNAL_MCP_PATH_PREFIX}/"):
-            return False
+        # First-Party
+        from mcpgateway.auth_context import is_trusted_internal_mcp_request  # pylint: disable=import-outside-toplevel
 
-        if request.headers.get(_INTERNAL_MCP_RUNTIME_HEADER) != "rust":
-            return False
-
-        provided_auth = request.headers.get(_INTERNAL_MCP_RUNTIME_AUTH_HEADER)
-        if not provided_auth:
-            return False
-
-        expected_auth = self._expected_internal_mcp_runtime_auth_header()
-        if not hmac.compare_digest(provided_auth, expected_auth):
-            return False
-
-        if not request.headers.get(_INTERNAL_MCP_AUTH_CONTEXT_HEADER):
-            return False
-
-        client_host = getattr(getattr(request, "client", None), "host", None)
-        return client_host in ("127.0.0.1", "::1")
-
-    @staticmethod
-    def _auth_encryption_secret_value() -> str:
-        """Return the configured auth-encryption secret as a plain string.
-
-        Returns:
-            The auth-encryption secret, normalized to a regular string.
-        """
-        secret = settings.auth_encryption_secret
-        if hasattr(secret, "get_secret_value"):
-            return secret.get_secret_value()
-        return str(secret)
-
-    @staticmethod
-    @lru_cache(maxsize=8)
-    def _expected_internal_mcp_runtime_auth_header_for_secret(secret: str) -> str:
-        """Return the expected shared internal-auth header for a specific secret.
-
-        Args:
-            secret: Auth-encryption secret to derive the trust header from.
-
-        Returns:
-            Hex-encoded SHA-256 digest derived from the provided auth secret.
-        """
-        material = f"{secret}:{_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT}".encode("utf-8")
-        return hashlib.sha256(material).hexdigest()
-
-    @staticmethod
-    def _expected_internal_mcp_runtime_auth_header() -> str:
-        """Return the expected shared internal-auth header for Rust MCP hops.
-
-        Returns:
-            Shared secret-derived digest expected on trusted internal Rust MCP calls.
-        """
-        return TokenScopingMiddleware._expected_internal_mcp_runtime_auth_header_for_secret(TokenScopingMiddleware._auth_encryption_secret_value())
+        return is_trusted_internal_mcp_request(request, path=normalized_path)
 
 
 # Create middleware instance

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -30,6 +30,7 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.db import fresh_db_session
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.token_catalog_service import TokenCatalogService
@@ -84,6 +85,11 @@ class TokenUsageMiddleware:
         # Skip health checks and static files
         path = scope.get("path", "")
         if should_skip_auth_context(path):
+            await self.app(scope, receive, send)
+            return
+
+        # Skip usage logging for the trusted-internal dispatch; the edge request is already recorded.
+        if is_trusted_internal_mcp_request(Request(scope), path=path):
             await self.app(scope, receive, send)
             return
 

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -50,7 +50,7 @@ from mcpgateway.services.upstream_session_registry import (  # re-exported as th
 )
 from mcpgateway.utils.internal_http import (
     internal_loopback_base_url,
-    internal_loopback_verify,
+    post_rpc_in_process,
 )
 
 # Shared session-id validation (downstream MCP session IDs used for affinity).
@@ -954,65 +954,63 @@ class SessionAffinity:
 
             logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Received forwarded request, executing locally")
 
-            # Make internal HTTP/HTTPS call to local /rpc endpoint.
-            # This reuses ALL existing method handling logic without duplication.
-            internal_base_url = internal_loopback_base_url()
-            async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                # Build headers for internal request - forward original headers
-                # but add x-forwarded-internally to prevent infinite loops.
-                # Relies on the originating transport having already filtered
-                # passthrough headers via extract_headers_for_loopback (#3640).
-                internal_headers = dict(headers)
-                internal_headers["x-forwarded-internally"] = "true"
-                # Ensure content-type is set
-                internal_headers["content-type"] = "application/json"
+            # Build headers for the in-process /rpc call - forward original headers
+            # but add x-forwarded-internally to prevent infinite loops. Relies on the
+            # originating transport having already filtered passthrough headers via
+            # extract_headers_for_loopback (#3640).
+            internal_headers = dict(headers)
+            internal_headers["x-forwarded-internally"] = "true"
+            internal_headers["content-type"] = "application/json"
 
-                response = await client.post(
-                    f"{internal_base_url}/rpc",
-                    json={
+            # Dispatch IN-PROCESS so /rpc resolves the bound upstream session from
+            # this worker's registry instead of scattering over the shared socket.
+            response = await post_rpc_in_process(
+                content=orjson.dumps(
+                    {
                         "jsonrpc": "2.0",
                         "method": method,
                         "params": params,
                         "id": req_id,
-                    },
-                    headers=internal_headers,
-                    timeout=settings.mcpgateway_pool_rpc_forward_timeout,
-                )
-
-                # Gate on HTTP status first: non-2xx responses are errors
-                # even if the body parses as JSON.
-                if not response.is_success:
-                    try:
-                        response_data = response.json()
-                    except ValueError:
-                        response_data = {}
-                    if not isinstance(response_data, dict):
-                        response_data = {}
-
-                    # If body is a JSON-RPC error ({"error": {...}}), propagate it
-                    if "error" in response_data and isinstance(response_data["error"], dict):
-                        logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error (HTTP {response.status_code})")
-                        return {"error": response_data["error"]}
-
-                    # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
-                    detail = response_data.get("detail", response.text[:200] or "Unknown error")
-                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution failed with HTTP {response.status_code}")
-                    return {
-                        "error": {
-                            "code": -32603,
-                            "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
-                        }
                     }
+                ),
+                headers=internal_headers,
+                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
+            )
 
-                # Parse successful response
-                response_data = response.json()
+            # Gate on HTTP status first: non-2xx responses are errors
+            # even if the body parses as JSON.
+            if not response.is_success:
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    response_data = {}
+                if not isinstance(response_data, dict):
+                    response_data = {}
 
-                # Extract result or error from JSON-RPC response
-                if "error" in response_data:
-                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error")
+                # If body is a JSON-RPC error ({"error": {...}}), propagate it
+                if "error" in response_data and isinstance(response_data["error"], dict):
+                    logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error (HTTP {response.status_code})")
                     return {"error": response_data["error"]}
-                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed successfully")
-                return {"result": response_data.get("result", {})}
+
+                # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
+                detail = response_data.get("detail", response.text[:200] or "Unknown error")
+                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution failed with HTTP {response.status_code}")
+                return {
+                    "error": {
+                        "code": -32603,
+                        "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
+                    }
+                }
+
+            # Parse successful response
+            response_data = response.json()
+
+            # Extract result or error from JSON-RPC response
+            if "error" in response_data:
+                logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed with error")
+                return {"error": response_data["error"]}
+            logger.info(f"[AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Method: {method} | Forwarded execution completed successfully")
+            return {"result": response_data.get("result", {})}
 
         except httpx.TimeoutException:
             logger.warning(f"Timeout executing forwarded request: {request.get('method')}")
@@ -1024,22 +1022,32 @@ class SessionAffinity:
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
         """Execute a forwarded Streamable HTTP request on the owner worker and reply over Redis.
 
-        Dispatches the JSON-RPC call to the local ``/rpc`` route via an in-process
-        ASGI transport so it runs in this worker against the bound upstream session.
-        A network loopback would scatter the call through the shared gunicorn socket
-        to an arbitrary worker. The ``x-forwarded-internally`` header on the inner
-        dispatch stops the re-entered handler from forwarding again.
+        The request lands on the worker that owns the downstream session, so the
+        bound upstream session in this process can serve it. It is dispatched
+        in-process to the trusted-internal ``/_internal/mcp/rpc`` endpoint rather
+        than the public ``/rpc``.
+
+        Public ``/rpc`` only understands ContextForge JWTs and cookies, so an
+        OAuth bearer or an ``MCP_REQUIRE_AUTH=false`` public-only request would
+        401 if re-authenticated there. Instead, the originating worker's
+        already-validated identity rides in ``auth_context`` (the encoded
+        ``x-contextforge-auth-context`` header); with the
+        ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret HMAC,
+        and the loopback client address, the trusted endpoint accepts the request
+        and reconstructs the same user the edge established.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
                 - type: "http_forward"
                 - response_channel: Redis channel to publish response to
                 - mcp_session_id: Session identifier
-                - method: HTTP method (GET, POST, DELETE)
-                - path: Request path (e.g., /servers/{id}/mcp)
-                - headers: Request headers dict (lowercased keys)
-                - body: Hex-encoded request body
-            redis: Redis client for publishing response
+                - method: HTTP method (POST primarily)
+                - path: Original request path (e.g., /servers/{id}/mcp)
+                - headers: Original request headers (lowercased keys)
+                - body: Hex-encoded JSON-RPC request body
+                - auth_context: base64url-encoded auth context from the
+                  originating worker's ``streamable_http_auth()`` result
+            redis: Redis client for publishing the response
         """
         response_channel = request.get("response_channel")
 
@@ -1055,6 +1063,7 @@ class SessionAffinity:
             headers = request.get("headers", {})
             body_hex = request.get("body", "")
             mcp_session_id = request.get("mcp_session_id")
+            auth_context_header = request.get("auth_context") or ""
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
@@ -1077,7 +1086,8 @@ class SessionAffinity:
                 await _publish(202, b"")
                 return
 
-            # Inject the virtual server id (from the path) into params so /rpc routes correctly.
+            # Inject the virtual server id (from the path) into params so the
+            # dispatcher routes to the right virtual server.
             server_match = _SERVER_ID_RE.search(path)
             if server_match and isinstance(json_body, dict):
                 if not isinstance(json_body.get("params"), dict):
@@ -1086,32 +1096,53 @@ class SessionAffinity:
                 body = orjson.dumps(json_body)
 
             # First-Party - lazy imports avoid a circular dependency with main/transport.
+            from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
             from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel
+            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel,protected-access
 
+            # A forwarded payload may omit the auth context; fall back to an
+            # encoded public-only ({}) context so the endpoint applies default
+            # visibility instead of rejecting the dispatch with 400.
+            if not auth_context_header:
+                auth_context_header = encode_internal_mcp_auth_context({})
+
+            # Trust headers for the internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" caller marker
+            # - x-contextforge-mcp-runtime-auth: shared-secret HMAC
+            # - x-contextforge-auth-context: the encoded edge auth context, so the
+            #   endpoint reconstructs the same user without re-authenticating.
             rpc_headers = {
                 "content-type": "application/json",
                 "x-mcp-session-id": mcp_session_id or "",
-                "x-forwarded-internally": "true",
+                "x-contextforge-mcp-runtime": "affinity",
+                "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                "x-contextforge-auth-context": auth_context_header,
             }
-            auth_header = _resolve_auth_header_name(settings).lower()
-            if auth_header in headers:
-                rpc_headers[auth_header] = headers[auth_header]
+            # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+            # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+            # the configured header, so a custom header would otherwise be dropped.
+            # This is defense-in-depth; the endpoint trusts the auth-context above.
+            auth_header_name = _resolve_auth_header_name(settings).lower()
+            original_auth = headers.get(auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+            if original_auth:
+                rpc_headers[auth_header_name] = original_auth
             # Preserve passthrough headers destined for upstream MCP servers (#3640).
             rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
-            # In-process dispatch — a network loopback would scatter through the shared gunicorn socket and miss the owner.
-            transport = httpx.ASGITransport(app=app)
+            # Dispatch IN-PROCESS to the trusted internal endpoint. The explicit
+            # client=("127.0.0.1", 0) tells ASGITransport to set scope["client"]
+            # to a loopback address so the trust check accepts the request.
+            transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
             async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                 response = await client.post(
-                    "/rpc",
+                    "/_internal/mcp/rpc",
                     content=body,
                     headers=rpc_headers,
                     timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                 )
 
-            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process: {response.status_code}")
+            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process via /_internal/mcp/rpc: {response.status_code}")
 
             resp_headers = {"content-type": "application/json"}
             if mcp_session_id:
@@ -1155,6 +1186,7 @@ class SessionAffinity:
         headers: Dict[str, str],
         body: bytes,
         query_string: str = "",
+        auth_context: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Forward a Streamable HTTP request to the worker that owns the session via Redis Pub/Sub.
 
@@ -1171,6 +1203,10 @@ class SessionAffinity:
             headers: Request headers.
             body: Request body bytes.
             query_string: Query string if any.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying the
+                originating worker's already-validated identity, so the owner can
+                dispatch to the trusted internal endpoint without re-authenticating
+                (OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only survive).
 
         Returns:
             Dict with 'status', 'headers', and 'body' from the owner worker's response,
@@ -1212,6 +1248,8 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
+                # Encoded edge identity; lets the owner dispatch without re-authenticating.
+                "auth_context": auth_context,
             }
 
             # Subscribe to response channel BEFORE publishing request (prevent race)

--- a/mcpgateway/transports/rust_mcp_runtime_proxy.py
+++ b/mcpgateway/transports/rust_mcp_runtime_proxy.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 # Standard
 import asyncio
-import base64
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 import httpx
-import orjson
 from sqlalchemy import exists as sa_exists
 from starlette.types import Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import encode_internal_mcp_auth_context
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session
 from mcpgateway.db import Server as DbServer
@@ -338,5 +337,4 @@ def _build_forwarded_auth_context_header() -> str | None:
     auth_context = get_streamable_http_auth_context()
     if not auth_context:
         return None
-    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
-    return encoded.rstrip("=")
+    return encode_internal_mcp_auth_context(auth_context)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -91,7 +91,7 @@ from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers, GATEWAY_ID_HEADER
 from mcpgateway.utils.identity_propagation import build_identity_headers
-from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import post_rpc_in_process
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
@@ -4146,55 +4146,51 @@ class SessionManagerWrapper:
                     body = orjson.dumps(json_body)
                     logger.debug("[HTTP_AFFINITY_FORWARDED] Injected server_id %s into /rpc params", server_id)
 
-                async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                    rpc_headers = {
-                        "content-type": "application/json",
-                        "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
-                        "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                rpc_headers = {
+                    "content-type": "application/json",
+                    "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
+                    "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                }
+                # Forward the inbound gateway auth header (default: Authorization,
+                # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
+                # the same caller. Hardcoding "authorization" here would silently
+                # drop auth on deployments using a custom AUTH_HEADER_NAME.
+                _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+                if _gw_auth_lower in headers:
+                    rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                # Forward passthrough headers for upstream MCP servers (see #3640).
+                # First-Party
+                from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+
+                rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+
+                # Dispatch IN-PROCESS so /rpc executes in this worker (the session
+                # owner) rather than scattering over the shared socket.
+                response = await post_rpc_in_process(content=body, headers=rpc_headers, timeout=30.0)
+
+                # Return response to client
+                response_headers = [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(response.content)).encode()),
+                ]
+                if mcp_session_id != "not-provided":
+                    response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
+
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": response.status_code,
+                        "headers": response_headers,
                     }
-                    # Forward the inbound gateway auth header (default: Authorization,
-                    # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
-                    # the same caller. Hardcoding "authorization" here would silently
-                    # drop auth on deployments using a custom AUTH_HEADER_NAME.
-                    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                    if _gw_auth_lower in headers:
-                        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                    # Forward passthrough headers for upstream MCP servers (see #3640).
-                    # First-Party
-                    from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-
-                    rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
-
-                    response = await client.post(
-                        f"{internal_loopback_base_url()}/rpc",
-                        content=body,
-                        headers=rpc_headers,
-                        timeout=30.0,
-                    )
-
-                    # Return response to client
-                    response_headers = [
-                        (b"content-type", b"application/json"),
-                        (b"content-length", str(len(response.content)).encode()),
-                    ]
-                    if mcp_session_id != "not-provided":
-                        response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
-
-                    await send(
-                        {
-                            "type": "http.response.start",
-                            "status": response.status_code,
-                            "headers": response_headers,
-                        }
-                    )
-                    await send(
-                        {
-                            "type": "http.response.body",
-                            "body": response.content,
-                        }
-                    )
-                    logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
-                    return
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": response.content,
+                    }
+                )
+                logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
+                return
             except Exception as e:
                 logger.error("[HTTP_AFFINITY_FORWARDED] Error routing to /rpc: %s", e)
                 # Fall through to SDK handling as fallback
@@ -4212,6 +4208,14 @@ class SessionManagerWrapper:
                 if owner and owner != WORKER_ID:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
+
+                    # Package the edge-validated identity so the owner can dispatch via
+                    # the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating, letting OAuth and public-only sessions survive.
+                    # First-Party
+                    from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+                    encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
 
                     # Read request body
                     body_parts = []
@@ -4234,6 +4238,7 @@ class SessionManagerWrapper:
                         headers=headers,
                         body=body,
                         query_string=query_string,
+                        auth_context=encoded_auth_context,
                     )
 
                     if response:
@@ -4317,49 +4322,67 @@ class SessionManagerWrapper:
                             body = orjson.dumps(json_body)
                             logger.debug("[HTTP_AFFINITY_LOCAL] Injected server_id %s into /rpc params", server_id)
 
-                        async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                            rpc_headers = {
-                                "content-type": "application/json",
-                                "x-mcp-session-id": mcp_session_id,
-                                "x-forwarded-internally": "true",
-                            }
-                            _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                            if _gw_auth_lower in headers:
-                                rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                            # Forward passthrough headers for upstream MCP servers (see #3640).
-                            # First-Party
-                            from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+                        # Owner-direct path: dispatch to the trusted internal
+                        # /_internal/mcp/rpc endpoint carrying the edge-validated auth
+                        # context, so OAuth and public-only sessions are honored without
+                        # re-authenticating against public /rpc (JWTs/cookies only).
+                        # First-Party
+                        from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+                        from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.internal_http import internal_loopback_base_url  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
 
-                            rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+                        rpc_headers = {
+                            "content-type": "application/json",
+                            "x-mcp-session-id": mcp_session_id,
+                            "x-contextforge-mcp-runtime": "affinity",
+                            "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                            "x-contextforge-auth-context": encode_internal_mcp_auth_context(get_streamable_http_auth_context()),
+                        }
+                        # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+                        # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+                        # the configured header, so a custom header would otherwise be dropped.
+                        # This is defense-in-depth; the endpoint trusts the auth-context above.
+                        _auth_header_name = _resolve_auth_header_name(settings).lower()
+                        _original_auth = headers.get(_auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+                        if _original_auth:
+                            rpc_headers[_auth_header_name] = _original_auth
+                        # Forward passthrough headers for upstream MCP servers (see #3640).
+                        rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
+                        # Dispatch in-process so the request runs on this worker, the
+                        # session owner that holds the bound upstream session, instead of
+                        # looping back over the shared socket to a random worker.
+                        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+                        async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                             response = await client.post(
-                                f"{internal_loopback_base_url()}/rpc",
+                                "/_internal/mcp/rpc",
                                 content=body,
                                 headers=rpc_headers,
-                                timeout=30.0,
+                                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                             )
 
-                            response_headers = [
-                                (b"content-type", b"application/json"),
-                                (b"content-length", str(len(response.content)).encode()),
-                                (b"mcp-session-id", mcp_session_id.encode()),
-                            ]
+                        response_headers = [
+                            (b"content-type", b"application/json"),
+                            (b"content-length", str(len(response.content)).encode()),
+                            (b"mcp-session-id", mcp_session_id.encode()),
+                        ]
 
-                            await send(
-                                {
-                                    "type": "http.response.start",
-                                    "status": response.status_code,
-                                    "headers": response_headers,
-                                }
-                            )
-                            await send(
-                                {
-                                    "type": "http.response.body",
-                                    "body": response.content,
-                                }
-                            )
-                            logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
-                            return
+                        await send(
+                            {
+                                "type": "http.response.start",
+                                "status": response.status_code,
+                                "headers": response_headers,
+                            }
+                        )
+                        await send(
+                            {
+                                "type": "http.response.body",
+                                "body": response.content,
+                            }
+                        )
+                        logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
+                        return
                     except Exception as e:
                         logger.error("[HTTP_AFFINITY_LOCAL] Error routing to /rpc: %s", e)
                         # Fall through to SDK handling as fallback

--- a/mcpgateway/utils/internal_http.py
+++ b/mcpgateway/utils/internal_http.py
@@ -13,6 +13,9 @@ self-calls to local endpoints like /rpc.
 # Standard
 import os
 
+# Third-Party
+import httpx
+
 # First-Party
 from mcpgateway.config import settings
 
@@ -48,3 +51,33 @@ def internal_loopback_verify() -> bool:
         bool: ``False`` when the loopback URL is HTTPS, ``True`` otherwise.
     """
     return not _is_ssl_enabled()
+
+
+async def post_rpc_in_process(*, content: bytes, headers: dict, timeout: float) -> httpx.Response:
+    """POST to the local ``/rpc`` route via an in-process ASGI transport.
+
+    Affinity-owned requests must execute on the worker that actually holds the
+    bound upstream session. A real loopback to ``127.0.0.1`` hits the shared
+    gunicorn socket, and the kernel routes it to an arbitrary worker that does
+    not hold the session — which breaks upstream-session reuse (and the #4205
+    isolation invariant for stateful upstreams). ``httpx.ASGITransport`` invokes
+    the FastAPI app in *this* process instead, so ``/rpc`` resolves the session
+    from this worker's ``UpstreamSessionRegistry``.
+
+    ``app`` is imported lazily to avoid a circular import at module load.
+
+    Args:
+        content: Serialized JSON-RPC request body.
+        headers: Request headers. Must include ``x-forwarded-internally: true``
+            so the re-entered handler does not forward again.
+        timeout: Per-call timeout in seconds.
+
+    Returns:
+        httpx.Response: The response from the in-process ``/rpc`` dispatch.
+    """
+    # First-Party
+    from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+        return await client.post("/rpc", content=content, headers=headers, timeout=timeout)

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -565,6 +565,25 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
         "upgrade",
         "x-mcp-session-id",
         "x-forwarded-internally",
+        # Gateway-internal trust headers for the /_internal/mcp/* dispatch: the
+        # server-established auth context, runtime marker, and HMAC. A client
+        # passthrough header must never overwrite them, or a caller could spoof
+        # the trusted identity while the server's valid HMAC still rides along.
+        "x-contextforge-auth-context",
+        "x-contextforge-mcp-runtime",
+        "x-contextforge-mcp-runtime-auth",
+        "x-contextforge-session-validated",
+        # Forwarded / client-IP headers: strip so a caller cannot spoof the loopback
+        # client address that ProxyHeaders(trusted_hosts="*") would otherwise trust.
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-forwarded-port",
+        "x-forwarded-prefix",
+        "x-real-ip",
+        "cf-connecting-ip",
+        "true-client-ip",
     }
 )
 

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -231,6 +231,39 @@ async def test_exempt_path_passes_without_token():
 
 
 @pytest.mark.asyncio
+async def test_internal_mcp_dispatch_is_csrf_exempt_by_default():
+    """``/_internal/mcp/*`` is CSRF-exempt by default (loopback-only, HMAC-gated).
+
+    The affinity dispatch posts to the trusted-internal endpoint, which must not
+    require a CSRF token. Without the exemption, custom AUTH_HEADER_NAME
+    deployments (whose bearer the CSRF short-circuit can't find) would 403 on the
+    inner dispatch.
+    """
+    # First-Party
+    from mcpgateway.config import settings as real_settings
+
+    # The shipped default must cover the internal MCP dispatch prefix.
+    assert "/_internal/mcp/" in real_settings.csrf_exempt_paths
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/_internal/mcp/rpc"
+    request.headers = {}  # no CSRF token, no bearer
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = real_settings.csrf_exempt_paths
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
 async def test_bearer_token_request_passes_without_csrf():
     """Test that requests with Authorization: Bearer header pass without CSRF token."""
     middleware = CSRFMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -16,6 +16,30 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _trusted_internal_request(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a real loopback internal request for trust-gate exemption tests."""
+    from starlette.requests import Request
+
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+    return Request(scope)
+
+
 class TestRateLimitMiddleware:
     """Tests for RateLimitMiddleware."""
 
@@ -57,6 +81,29 @@ class TestRateLimitMiddleware:
         request.state = MagicMock()
         request.scope = {"client": ("192.168.1.100", 12345)}
         return request
+
+    @pytest.mark.asyncio
+    async def test_trusted_internal_dispatch_skips_rate_limiting(self, middleware):
+        """A trusted-internal hop is not rate-limited; the edge request already was."""
+        request = _trusted_internal_request("/_internal/mcp/rpc")
+        call_next = AsyncMock(return_value="passthrough")
+        # If the exemption fires, tier computation is never reached.
+        middleware.get_endpoint_tier = MagicMock(side_effect=AssertionError("trusted internal must not be rate-limited"))
+
+        result = await middleware.dispatch(request, call_next)
+
+        assert result == "passthrough"
+        call_next.assert_awaited_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_forged_internal_request_is_still_rate_limited(self, middleware):
+        """A forged HMAC fails the trust gate, so the rate-limit path runs."""
+        request = _trusted_internal_request("/_internal/mcp/rpc", hmac_value="forged")
+        call_next = AsyncMock(return_value="passthrough")
+        middleware.get_endpoint_tier = MagicMock(side_effect=RuntimeError("reached rate-limit path"))
+
+        with pytest.raises(RuntimeError, match="reached rate-limit path"):
+            await middleware.dispatch(request, call_next)
 
     def test_endpoint_tier_critical(self, middleware):
         """Test CRITICAL tier detection for auth endpoints."""

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -27,6 +27,60 @@ async def _make_asgi_call(middleware, scope, receive=None, send=None):
     return send
 
 
+def _trusted_internal_scope(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a loopback internal ASGI scope for trust-gate exemption tests."""
+    # First-Party
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+
+
+@pytest.mark.asyncio
+async def test_trusted_internal_dispatch_skips_usage_logging():
+    """A trusted-internal hop is not recorded; the edge request already was.
+
+    The skip path forwards the original ``send`` unwrapped (no status capture, no
+    logging), which distinguishes it from the normal metered path.
+    """
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    app.assert_awaited_once_with(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_forged_internal_request_is_not_skipped_for_usage():
+    """A forged HMAC fails the trust gate, so the usage path runs (wrapped send)."""
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc", hmac_value="forged")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    assert app.await_count == 1
+    forwarded_send = app.await_args.args[2]
+    assert forwarded_send is not send
+
+
 @pytest.mark.asyncio
 async def test_skips_health_check_paths():
     """Middleware should skip health check and static paths."""

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1099,6 +1099,81 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
 
 
 @pytest.mark.asyncio
+async def test_forward_to_owner_includes_auth_context_in_redis_payload():
+    """The encoded auth context from the originating worker is carried in the forwarded Redis payload.
+
+    Without this, the owner worker cannot reconstruct the StreamableHTTP user
+    that ``streamable_http_auth()`` already validated at the edge, so forwarded
+    OAuth and ``MCP_REQUIRE_AUTH=false`` requests would re-authenticate against
+    the public ``/rpc`` and fail with 401.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    # Make the pubsub wait return immediately so we focus on the published payload.
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    encoded_ctx = "base64url-encoded-auth-ctx-from-edge"
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner(
+            owner_worker_id="other-worker",
+            mcp_session_id="sess-auth",
+            method="POST",
+            path="/servers/srv-9/mcp",
+            headers={"Authorization": "Bearer x"},
+            body=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            auth_context=encoded_ctx,
+        )
+
+    # Locate the forward payload published to the owner's HTTP channel.
+    owner_channels = [(chan, payload) for chan, payload in fake.published if chan == "mcpgw:pool_http:other-worker"]
+    assert owner_channels, "forward payload was not published to the owner channel"
+    forward_data = orjson.loads(owner_channels[0][1])
+    assert forward_data["type"] == "http_forward"
+    assert forward_data["auth_context"] == encoded_ctx
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_defaults_auth_context_to_none_when_omitted():
+    """Sender side: when no auth_context is supplied, the field is present and set to None.
+
+    The executor reads ``request.get("auth_context") or ""`` and forwards an
+    empty string header — equivalent to the pre-auth-context behaviour. This
+    test pins the shape so future signature changes don't silently break the
+    contract.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner("other-worker", "sess-no-ctx", "POST", "/mcp", {}, b"")
+
+    forward_data = orjson.loads(fake.published[0][1])
+    assert "auth_context" in forward_data
+    assert forward_data["auth_context"] is None
+
+
+@pytest.mark.asyncio
 async def test_forward_to_owner_times_out_and_returns_none_with_metric_bump():
     """No message arrives → asyncio.timeout fires → metric incremented, None returned."""
     # First-Party
@@ -1445,6 +1520,17 @@ class _FakeHttpxClient:
             raise self._raise_exc
         return self._response
 
+    async def as_post_rpc(self, *, content=None, headers=None, timeout=None):
+        """Adapter so this fake can stand in for ``utils.internal_http.post_rpc_in_process``.
+
+        Patching the helper to this method lets the fake capture
+        ``content``/``headers``/``timeout`` for the call-site assertions.
+        """
+        self.last_post_kwargs = {"content": content, "headers": headers, "timeout": timeout}
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_request_success_returns_result():
@@ -1457,9 +1543,7 @@ async def test_execute_forwarded_request_success_returns_result():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
@@ -1483,9 +1567,7 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_in_response():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
@@ -1506,9 +1588,7 @@ async def test_execute_forwarded_request_maps_non_2xx_http_to_jsonrpc_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1533,9 +1613,7 @@ async def test_execute_forwarded_request_timeout_returns_timeout_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1554,9 +1632,7 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -1571,13 +1647,7 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_response_via_redis():
-    """Happy path: in-process dispatch to ``/rpc``, hex-encode the response body, publish to Redis.
-
-    Pins the new contract introduced by the WORKER_ID + in-process-dispatch
-    fix (#4557): the executor must POST to ``/rpc`` (not the original
-    ``/mcp`` path) with ``x-forwarded-internally: true`` so the re-entered
-    handler doesn't forward again.
-    """
+    """Happy path: dispatch in-process to the trusted internal endpoint and publish the response back."""
     # Third-Party
     import orjson
 
@@ -1596,27 +1666,31 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
         "method": "POST",
         "path": "/servers/srv-9/mcp",
         "query_string": "",
-        "headers": {"authorization": "Bearer original-jwt"},
+        "headers": {"Authorization": "Bearer x"},
         "body": jsonrpc_body.hex(),
         "original_worker": "origin-worker",
         "mcp_session_id": "sess-123456789",
+        "auth_context": "encoded-ctx",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    # Dispatched to /rpc with the loop-stop header.
+    # Dispatched to the trusted-internal endpoint, NOT the public /rpc.
     assert client.last_post_kwargs is not None
-    assert client.last_post_kwargs["url"] == "/rpc"
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
     headers = client.last_post_kwargs["headers"]
-    assert headers["x-forwarded-internally"] == "true"
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == "encoded-ctx"
     assert headers["x-mcp-session-id"] == "sess-123456789"
-    # server_id parsed from the path is injected so the dispatcher routes to the right virtual server.
+    # server_id from the path is injected into JSON-RPC params before dispatch.
     sent_body = orjson.loads(client.last_post_kwargs["content"])
     assert sent_body["params"]["server_id"] == "srv-9"
 
@@ -1631,12 +1705,7 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_500_error_on_exception():
-    """If the in-process dispatch raises, a 500 error envelope is still published to Redis.
-
-    The body must carry a real JSON-RPC payload so the dispatch path is
-    actually exercised (an empty body short-circuits to a 202 ack and the
-    raise is never reached).
-    """
+    """If the internal HTTP call raises, a 500 error envelope is still published to Redis."""
     # Third-Party
     import orjson
 
@@ -1661,6 +1730,7 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
@@ -1670,140 +1740,6 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
     assert chan == "mcpgw:pool_http_response:req-2"
     decoded = orjson.loads(payload)
     assert decoded["status"] == 500
-
-
-@pytest.mark.asyncio
-async def test_execute_forwarded_http_request_acks_non_post_lifecycle_method():
-    """Non-POST methods (DELETE, GET) carry no JSON-RPC body, so the owner acks 200 without dispatching.
-
-    The in-process dispatch is only for JSON-RPC POSTs; lifecycle methods are
-    handled by the originating worker. This test pins that short-circuit.
-    """
-    # Third-Party
-    import orjson
-
-    # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity
-
-    affinity = SessionAffinity()
-    fake = _FakeRedis()
-    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="should-not-be-used"))
-
-    request = {
-        "response_channel": "mcpgw:pool_http_response:req-del",
-        "method": "DELETE",
-        "path": "/mcp",
-        "headers": {},
-        "body": "",
-        "mcp_session_id": "sess-delete",
-    }
-
-    with (
-        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-    ):
-        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
-
-    # The dispatch helper was never invoked.
-    assert client.last_post_kwargs is None
-    # A 200 ack was published for the lifecycle method.
-    chan, payload = fake.published[0]
-    assert chan == "mcpgw:pool_http_response:req-del"
-    decoded = orjson.loads(payload)
-    assert decoded["status"] == 200
-
-
-@pytest.mark.asyncio
-async def test_execute_forwarded_http_request_acks_notification_method_without_dispatch():
-    """``notifications/*`` methods need no upstream round-trip — owner acks 202 without dispatching.
-
-    MCP notification messages are fire-and-forget; the originating worker
-    already accepted the notification. The owner just acknowledges receipt.
-    """
-    # Third-Party
-    import orjson
-
-    # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity
-
-    affinity = SessionAffinity()
-    fake = _FakeRedis()
-    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="should-not-be-used"))
-
-    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
-    request = {
-        "response_channel": "mcpgw:pool_http_response:req-notif",
-        "method": "POST",
-        "path": "/mcp",
-        "headers": {},
-        "body": jsonrpc_body.hex(),
-        "mcp_session_id": "sess-notif",
-    }
-
-    with (
-        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-    ):
-        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
-
-    # The dispatch helper was never invoked.
-    assert client.last_post_kwargs is None
-    # A 202 ack was published for the notification.
-    chan, payload = fake.published[0]
-    assert chan == "mcpgw:pool_http_response:req-notif"
-    decoded = orjson.loads(payload)
-    assert decoded["status"] == 202
-
-
-@pytest.mark.asyncio
-async def test_execute_forwarded_http_request_initialises_params_when_missing_for_server_id_injection():
-    """When the JSON-RPC body has no ``params`` key, the executor synthesises one before injecting ``server_id``.
-
-    Pins the defensive branch in the server-id-injection path: a request body
-    that arrives without ``params`` (or with a non-dict params) still routes
-    to the correct virtual server because the executor populates an empty
-    dict and writes the server_id into it.
-    """
-    # Third-Party
-    import orjson
-
-    # First-Party
-    from mcpgateway.services.session_affinity import SessionAffinity
-
-    affinity = SessionAffinity()
-    fake = _FakeRedis()
-    response = _FakeHttpResponse(200, text_body="ok")
-    response.headers = {"content-type": "application/json"}
-    client = _FakeHttpxClient(response=response)
-
-    # Body has NO "params" key — the executor must initialise it before writing server_id.
-    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1})
-    request = {
-        "response_channel": "mcpgw:pool_http_response:req-no-params",
-        "method": "POST",
-        "path": "/servers/srv-17/mcp",
-        "headers": {},
-        "body": jsonrpc_body.hex(),
-        "mcp_session_id": "sess-no-params",
-    }
-
-    with (
-        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-    ):
-        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
-
-    # The dispatch ran and the synthesised params carries the parsed server_id.
-    assert client.last_post_kwargs is not None
-    sent_body = orjson.loads(client.last_post_kwargs["content"])
-    assert sent_body["params"] == {"server_id": "srv-17"}
-
 
 
 # ---------------------------------------------------------------------------
@@ -2208,9 +2144,7 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_from_non_2xx_r
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess"})  # pylint: disable=protected-access
@@ -2231,9 +2165,7 @@ async def test_execute_forwarded_request_handles_non_dict_non_2xx_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -2254,9 +2186,7 @@ async def test_execute_forwarded_request_handles_non_2xx_with_non_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
@@ -2292,9 +2222,7 @@ async def test_execute_forwarded_http_request_skips_publish_when_redis_is_none()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         # Should complete without raising and without a redis.publish call.
@@ -2385,16 +2313,295 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
 
 
 @pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_authorization_for_csrf_bypass():
+    """The originating ``Authorization`` bearer is copied onto the trusted-internal dispatch.
+
+    The CSRF middleware short-circuits on bearer-tokened requests; without
+    preserving the original ``Authorization`` header, the affinity dispatch to
+    ``/_internal/mcp/rpc`` 403s on CSRF even though the trusted-internal gate
+    itself is satisfied. Mirrors the Rust runtime forward path.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-auth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"authorization": "Bearer original-jwt"},  # lowercased like the wire
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-auth-bypass",
+        "auth_context": "ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    sent_headers = client.last_post_kwargs["headers"]
+    assert sent_headers.get("authorization") == "Bearer original-jwt"
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_synthesizes_public_context_when_missing():
+    """Executor side: a forwarded payload with no auth_context falls back to an encoded public-only ({}) context.
+
+    Old / mixed-version payloads (e.g. a worker on a pre-auth-context build
+    during a rolling deploy) may omit ``auth_context``. Rather than sending an
+    empty header — which ``_build_internal_mcp_forwarded_user`` rejects with 400
+    — the executor synthesizes an encoded public-only ({}) context so the
+    dispatch applies default visibility. The trust headers (runtime marker +
+    HMAC) are still set.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-noctx",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-ctx",
+        # No "auth_context" key on purpose.
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    # Missing context -> encoded public-only ({}) context, NOT an empty header
+    # (an empty header would 400 at _build_internal_mcp_forwarded_user).
+    # First-Party
+    from mcpgateway.auth_context import decode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+    assert headers["x-contextforge-auth-context"]
+    assert decode_internal_mcp_auth_context(headers["x-contextforge-auth-context"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_custom_auth_header():
+    """Executor side: the bearer is preserved under the CONFIGURED auth header.
+
+    On a deployment with ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the CSRF bearer
+    short-circuit keys on that header, so hardcoding ``authorization`` would drop
+    the bearer and risk a 403 on the inner dispatch.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-customauth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"x-mcp-gateway-auth": "Bearer custom-tok"},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-custom",
+        "auth_context": "encoded-ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    headers = client.last_post_kwargs["headers"]
+    # Configured header preserved (lowercased); hardcoded "authorization" is NOT used.
+    assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
+    """Lifecycle methods (DELETE, GET) don't carry a JSON-RPC body, so the owner just acks 200 without dispatching."""
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+
+    request = {
+        "response_channel": "r",
+        "method": "DELETE",
+        "path": "/mcp",
+        "query_string": "",
+        "headers": {},
+        "body": "",
+        "mcp_session_id": "sess-delete",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Acked without invoking the in-process dispatch.
+    assert client.last_post_kwargs is None
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_notification_method_without_dispatch():
+    """``notifications/*`` methods need no upstream round-trip — owner acks 202 without dispatching.
+
+    MCP notification messages are fire-and-forget; the originating worker
+    already accepted the notification. The owner just acknowledges receipt.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="should-not-be-used"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-notif",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-notif",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch helper was never invoked.
+    assert client.last_post_kwargs is None
+    # A 202 ack was published for the notification.
+    chan, payload = fake.published[0]
+    assert chan == "mcpgw:pool_http_response:req-notif"
+    decoded = orjson.loads(payload)
+    assert decoded["status"] == 202
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_initialises_params_when_missing_for_server_id_injection():
+    """When the JSON-RPC body has no ``params`` key, the executor synthesises one before injecting ``server_id``.
+
+    Pins the defensive branch in the server-id-injection path: a request body
+    that arrives without ``params`` (or with a non-dict params) still routes
+    to the correct virtual server because the executor populates an empty
+    dict and writes the server_id into it.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    # Body has NO "params" key — the executor must initialise it before writing server_id.
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-no-params",
+        "method": "POST",
+        "path": "/servers/srv-17/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-params",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch ran and the synthesised params carries the parsed server_id.
+    assert client.last_post_kwargs is not None
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"] == {"server_id": "srv-17"}
+
+
+@pytest.mark.asyncio
 async def test_execute_forwarded_http_request_dispatches_in_process_via_asgi_transport():
     """The forward is dispatched IN-PROCESS via ``httpx.ASGITransport(app=app)``, not over the loopback socket.
 
-    This is the load-bearing change behind the #4557 fix. Before PR #4981 the
-    executor opened a real ``httpx.AsyncClient(verify=...)`` to
-    ``http://127.0.0.1:4444/rpc``, which hit the shared gunicorn socket and
-    let the kernel route it to an arbitrary worker that didn't hold the
-    upstream session. Dispatching in-process via ASGITransport keeps the
-    re-entered ``/rpc`` handler in *this* worker, so the bound
-    ``UpstreamSessionRegistry`` entry actually serves the request.
+    This is the load-bearing change behind the #4557 fix. A real
+    ``httpx.AsyncClient`` to ``http://127.0.0.1:4444/_internal/mcp/rpc`` would
+    hit the shared gunicorn socket and let the kernel route it to an arbitrary
+    worker that didn't hold the upstream session. Dispatching in-process via
+    ASGITransport keeps the re-entered ``/_internal/mcp/rpc`` handler in *this*
+    worker, so the bound ``UpstreamSessionRegistry`` entry actually serves the
+    request.
     """
     # Third-Party
     import httpx
@@ -2426,6 +2633,7 @@ async def test_execute_forwarded_http_request_dispatches_in_process_via_asgi_tra
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", side_effect=_capture_async_client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
@@ -2461,9 +2669,7 @@ async def test_execute_forwarded_http_request_logs_debug_when_error_publish_also
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
         caplog.at_level("DEBUG", logger="mcpgateway.services.session_affinity"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0

--- a/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
+++ b/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
@@ -1162,7 +1162,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1173,7 +1173,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1210,11 +1210,11 @@ class TestInternalA2ADenyPaths:
         # First-Party
         from mcpgateway.main import _is_trusted_internal_mcp_runtime_request
 
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(request) is True
 
         # And the equivalent /_internal/a2a/ path with the same headers
         # MUST still be rejected (the feature flag narrows correctly).
         a2a_scope = {**scope, "path": "/_internal/a2a/authenticate", "raw_path": b"/_internal/a2a/authenticate"}
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(Request(a2a_scope)) is False

--- a/tests/unit/mcpgateway/test_internal_runtime_trust.py
+++ b/tests/unit/mcpgateway/test_internal_runtime_trust.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the consolidated internal-runtime trust gate.
+
+Covers the shared helper in ``auth_context`` (``is_trusted_internal_runtime_request`` /
+``is_trusted_internal_mcp_request``), the path-aware auth-context rule, the A2A
+feature guard, the affinity marker, the HMAC-is-the-trust-boundary property, and
+that the forwarded/client-IP headers are stripped from loopback passthrough.
+"""
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+
+# First-Party
+from mcpgateway.auth_context import (
+    _expected_internal_mcp_runtime_auth_header,
+    _internal_path_requires_auth_context,
+    is_trusted_internal_mcp_request,
+    is_trusted_internal_runtime_request,
+)
+
+VALID_HMAC = _expected_internal_mcp_runtime_auth_header()
+
+
+def _req(path, *, marker="rust", hmac="valid", ctx="ctx", client="127.0.0.1", extra=None):
+    """Build a synthetic internal request."""
+    headers = []
+    if marker is not None:
+        headers.append((b"x-contextforge-mcp-runtime", marker.encode()))
+    if hmac is not None:
+        headers.append((b"x-contextforge-mcp-runtime-auth", (VALID_HMAC if hmac == "valid" else hmac).encode()))
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    for k, v in (extra or []):
+        headers.append((k, v))
+    scope = {"type": "http", "method": "POST", "path": path, "raw_path": path.encode(),
+             "query_string": b"", "headers": headers, "client": (client, 12345) if client else None}
+    return Request(scope)
+
+
+# --- path-aware auth-context rule ------------------------------------------
+
+@pytest.mark.parametrize("path,expected", [
+    ("/_internal/mcp/authenticate", False),
+    ("/_internal/mcp/authenticate/", False),
+    ("/_internal/a2a/authenticate", False),
+    ("/_internal/mcp/rpc", True),
+    ("/_internal/mcp/initialize", True),
+    ("/_internal/a2a/tasks/get", True),
+])
+def test_path_requires_auth_context(path, expected):
+    assert _internal_path_requires_auth_context(path) is expected
+
+
+# --- MCP gate: allow --------------------------------------------------------
+
+def test_rpc_trusted_with_rust_marker_hmac_and_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc")) is True
+
+
+def test_rpc_trusted_with_affinity_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="affinity")) is True
+
+
+def test_authenticate_trusted_without_ctx():
+    # /authenticate creates the context, so no ctx required.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/authenticate", ctx=None)) is True
+
+
+# --- MCP gate: deny ---------------------------------------------------------
+
+def test_deny_bad_hmac_even_on_loopback_with_ctx():
+    # The HMAC is the trust boundary: loopback + marker + ctx but a bad HMAC is denied.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", hmac="not-the-real-hmac")) is False
+
+
+def test_deny_wrong_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="bogus")) is False
+
+
+def test_deny_non_loopback_client():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", client="10.0.0.9")) is False
+
+
+def test_deny_rpc_missing_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", ctx=None)) is False
+
+
+def test_deny_non_internal_prefix():
+    assert is_trusted_internal_mcp_request(_req("/servers/x/mcp")) is False
+
+
+def test_xff_cannot_make_untrusted_request_trusted():
+    # Even with a spoofed X-Forwarded-For and a loopback client, a bad HMAC is denied:
+    # loopback is defense-in-depth, the HMAC is the boundary.
+    req = _req("/_internal/mcp/rpc", hmac="forged", extra=[(b"x-forwarded-for", b"127.0.0.1")])
+    assert is_trusted_internal_mcp_request(req) is False
+
+
+# --- A2A feature guard ------------------------------------------------------
+
+def test_a2a_trusted_when_enabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", True)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is True
+
+
+def test_a2a_denied_when_disabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", False)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is False
+
+
+# --- generic helper: explicit require_auth_context + prefixes ---------------
+
+def test_generic_helper_respects_prefix_allowlist():
+    req = _req("/_internal/mcp/rpc")
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/a2a",), require_auth_context=True) is False
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/mcp",), require_auth_context=True) is True
+
+
+# --- token_scoping now trusts the affinity marker ---------------------------
+
+def test_token_scoping_trusts_affinity_hop():
+    # First-Party
+    from mcpgateway.middleware.token_scoping import token_scoping_middleware
+
+    req = _req("/_internal/mcp/rpc", marker="affinity")
+    assert token_scoping_middleware._is_trusted_internal_mcp_runtime_request(req, "/_internal/mcp/rpc") is True
+
+
+# --- forwarded / client-IP headers are stripped from loopback passthrough ---
+
+@pytest.mark.parametrize("header", [
+    "forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
+    "x-forwarded-port", "x-forwarded-prefix", "x-real-ip", "cf-connecting-ip", "true-client-ip",
+])
+def test_loopback_passthrough_strips_forwarded_headers(header):
+    # First-Party
+    from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+    out = filter_loopback_skip_headers({header: "1.2.3.4", "x-keep": "ok"})
+    assert header not in {k.lower() for k in out}
+    assert out.get("x-keep") == "ok"

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -844,7 +844,11 @@ class TestInternalTrustedMcpTransportBridge:
 
         await bridge.handle_streamable_http(scope, receive, send)
 
-        assert events[0]["status"] == 400
+        # A missing auth context now fails the internal trust gate itself
+        # (require_auth_context is folded into is_trusted_internal_mcp_request),
+        # so the request is rejected as untrusted (403) before reaching the
+        # "missing auth context" (400) branch.
+        assert events[0]["status"] == 403
 
     def test_build_internal_mcp_auth_scope_uses_public_request_shape(self):
         """Synthetic auth scope should preserve the public MCP path and client IP."""

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8832,6 +8832,146 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_local_affinity_post_dispatches_to_internal_endpoint_with_auth_context(monkeypatch):
+    """Owner-direct affinity POST dispatches to the trusted-internal /_internal/mcp/rpc.
+
+    Closes the coverage gap for the local-owner path: instead of re-authenticating
+    against public /rpc (which only understands ContextForge JWTs/cookies and would
+    401 virtual-server OAuth or MCP_REQUIRE_AUTH=false public-only sessions), the
+    owner dispatches to the trusted-internal endpoint carrying the affinity runtime
+    marker, the HMAC, and the edge-validated auth context. The originating
+    Authorization header is preserved for the CSRF bearer short-circuit.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    # Deterministic auth context regardless of request-scoped state.
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"authorization", b"Bearer tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        # Routed to the trusted-internal endpoint, NOT public /rpc.
+        assert mock_client.post.call_args.args[0] == "/_internal/mcp/rpc"
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["x-contextforge-mcp-runtime"] == "affinity"
+        assert headers["x-contextforge-mcp-runtime-auth"]
+        assert headers["x-contextforge-auth-context"]
+        # Authorization preserved for the CSRF bearer short-circuit.
+        assert headers["authorization"] == "Bearer tok"
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
+    """Owner-direct dispatch preserves the bearer under the CONFIGURED auth header.
+
+    On ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the bearer rides that header and
+    the CSRF short-circuit keys on it, so hardcoding ``authorization`` would drop it.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_header_name", "X-MCP-Gateway-Auth")
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"x-mcp-gateway-auth", b"Bearer custom-tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        headers = mock_client.post.call_args.kwargs["headers"]
+        # Configured header preserved (lowercased); hardcoded "authorization" not used.
+        assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+        assert "authorization" not in headers
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "params_value,params_json",
     [
@@ -9011,6 +9151,65 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeypatch):
+    """The sender encodes the live ``get_streamable_http_auth_context()`` result and passes it through ``forward_to_owner``.
+
+    Without this, OAuth-enabled virtual servers and ``MCP_REQUIRE_AUTH=false``
+    public-only mode would 401 after a cross-worker forward, because the owner
+    would have nothing to reconstruct the edge-authenticated user from.
+    """
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    # Stand-in for the authenticated identity the edge worker already established.
+    edge_auth_ctx = {"email": "alice@example.com", "is_admin": False, "teams": ["t1"]}
+    expected_encoded = encode_internal_mcp_auth_context(edge_auth_ctx)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context", lambda: edge_auth_ctx)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-auth")])
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-2")
+    mock_pool.forward_to_owner = AsyncMock(
+        return_value={
+            "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body": b'{"jsonrpc":"2.0","result":{}}',
+        }
+    )
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+    ):
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
+
+    await wrapper.shutdown()
+    # auth_context kwarg is supplied and equals the encoded edge identity.
+    assert mock_pool.forward_to_owner.call_args.kwargs["auth_context"] == expected_encoded
+
+
+@pytest.mark.asyncio
 async def test_affinity_forward_failure_falls_through(monkeypatch):
     """Test affinity forward failure falls through to local handling (line 1525-1527)."""
 
@@ -9184,6 +9383,67 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
 
     await wrapper.shutdown()
     assert messages[0]["status"] == 200
+
+
+
+
+@pytest.mark.asyncio
+async def test_http_affinity_forwarded_path_dispatches_via_post_rpc_in_process(monkeypatch):
+    """``[HTTP_AFFINITY_FORWARDED]`` re-entry also goes through ``post_rpc_in_process`` (PR #4987).
+
+    When a worker receives a forwarded request (carrying
+    ``x-forwarded-internally: true``), it re-enters the /rpc dispatch. Before
+    PR #4987 that re-entry built its own ``httpx.AsyncClient`` and bounced
+    back through the shared socket — splitting the session across yet
+    another random worker. Routing through the helper keeps the dispatch
+    in-process on the worker that already owns the session, closing the last
+    remaining scatter point in the forward chain.
+    """
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+    # x-forwarded-internally: true triggers the [HTTP_AFFINITY_FORWARDED] re-entry branch.
+    # Use a server-less path so the handler doesn't try to validate server_id against the (un-initialised) DB.
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[
+            (b"mcp-session-id", b"sess-fwd"),
+            (b"x-forwarded-internally", b"true"),
+            (b"authorization", b"Bearer original-jwt"),
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{}}'
+
+    mock_post_rpc = AsyncMock(return_value=mock_response)
+
+    with patch("mcpgateway.transports.streamablehttp_transport.post_rpc_in_process", mock_post_rpc):
+        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+
+    await wrapper.shutdown()
+    mock_post_rpc.assert_awaited_once()
+    sent_headers = mock_post_rpc.await_args.kwargs["headers"]
+    assert sent_headers["x-forwarded-internally"] == "true"
+    assert sent_headers["x-mcp-session-id"] == "sess-fwd"
+    assert sent_headers["authorization"] == "Bearer original-jwt"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_internal_http.py
+++ b/tests/unit/mcpgateway/utils/test_internal_http.py
@@ -7,11 +7,16 @@ Authors: Mihai Criveti
 Unit tests for internal loopback HTTP helpers.
 """
 
+# Standard
+from typing import Any
+from unittest.mock import patch
+
 # Third-Party
+import httpx
 import pytest
 
 # First-Party
-from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify, post_rpc_in_process
 
 
 class TestIsSSLEnabled:
@@ -99,3 +104,97 @@ class TestInternalLoopbackVerify:
         monkeypatch.delenv("SSL", raising=False)
         monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
         assert internal_loopback_verify() is True
+
+
+class _CapturingAsyncClient:
+    """Async-CM ``httpx.AsyncClient`` stand-in that captures construction + post kwargs.
+
+    Records the ``transport`` and ``base_url`` passed to the constructor and the
+    ``url``/``content``/``headers``/``timeout`` of the inner ``.post`` call so
+    tests can assert on the in-process dispatch contract without touching the
+    real FastAPI app.
+    """
+
+    last_init_kwargs: dict[str, Any] = {}
+    last_post_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_init_kwargs = kwargs
+
+    async def __aenter__(self) -> "_CapturingAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def post(self, url: str, **kwargs: Any) -> Any:
+        type(self).last_post_kwargs = {"url": url, **kwargs}
+        # Return a minimal Response-like sentinel; the executor under test
+        # never inspects this object in the unit-test path.
+        return object()
+
+
+class TestPostRpcInProcess:
+    """Tests for ``post_rpc_in_process`` (PR #4987).
+
+    The helper centralises in-process ``/rpc`` dispatch so all four affinity
+    sites (cross-worker forward + cross-worker SSE/RPC + local-owned + the
+    HTTP-affinity-forwarded re-entry) execute on the worker that holds the
+    bound upstream session, instead of looping back over the shared gunicorn
+    socket and scattering to a random worker. The load-bearing details pinned
+    here: the transport is ``httpx.ASGITransport`` (proves in-process, not
+    network loopback), the path is exactly ``/rpc`` (not the original request
+    path), and ``content``/``headers``/``timeout`` pass through unchanged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dispatches_via_asgi_transport_in_process(self):
+        """Asserts the AsyncClient is constructed with an ``httpx.ASGITransport``.
+
+        This is the whole point of #4987 — a real ``httpx.AsyncClient(verify=...)``
+        to ``127.0.0.1`` would hit the shared gunicorn socket and the kernel
+        would route the call to an arbitrary worker that does not hold the
+        bound upstream session.
+        """
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0)
+        assert isinstance(_CapturingAsyncClient.last_init_kwargs.get("transport"), httpx.ASGITransport)
+
+    @pytest.mark.asyncio
+    async def test_posts_to_rpc_endpoint(self):
+        """The helper targets exactly ``/rpc`` — the public JSON-RPC handler."""
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0)
+        assert _CapturingAsyncClient.last_post_kwargs["url"] == "/rpc"
+
+    @pytest.mark.asyncio
+    async def test_propagates_content_headers_and_timeout(self):
+        """``content``, ``headers``, and ``timeout`` reach the inner ``.post`` unchanged.
+
+        Each caller builds its own loop-stop header set; the helper must not
+        mutate or replace them.
+        """
+        headers = {"x-forwarded-internally": "true", "x-mcp-session-id": "abc", "authorization": "Bearer x"}
+        body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=body, headers=headers, timeout=7.5)
+
+        captured = _CapturingAsyncClient.last_post_kwargs
+        assert captured["content"] == body
+        assert captured["headers"] == headers
+        assert captured["timeout"] == 7.5
+
+    @pytest.mark.asyncio
+    async def test_uses_loopback_base_url(self, monkeypatch):
+        """The AsyncClient's ``base_url`` is the gateway's loopback URL.
+
+        ASGITransport ignores ``base_url`` for routing — the FastAPI app sees
+        the request directly — but the base URL still appears in logs and in
+        observability scopes, so it must be the loopback.
+        """
+        monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
+        monkeypatch.delenv("SSL", raising=False)
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={}, timeout=1.0)
+        assert _CapturingAsyncClient.last_init_kwargs.get("base_url") == "http://127.0.0.1:4444"

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -497,3 +497,40 @@ class TestPassthroughHeaders:
 
         # Should log warning about conflict
         assert any("conflicts with pre-defined headers" in record.message for record in caplog.records)
+
+
+class TestLoopbackSkipTrustedInternalHeaders:
+    """Deny-path: client passthrough must never carry the gateway-internal trust headers.
+
+    The ``/_internal/mcp/*`` dispatch sets ``x-contextforge-auth-context`` (the
+    server-established identity), ``x-contextforge-mcp-runtime``, and the HMAC.
+    If the loopback passthrough echoed a client-supplied copy of those, a caller
+    could spoof the trusted identity while the server's valid HMAC still rode
+    along. The loopback skip set must strip them.
+    """
+
+    def test_filter_strips_trusted_internal_headers(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        spoofed = {
+            "x-contextforge-auth-context": "SPOOFED",
+            "x-contextforge-mcp-runtime": "affinity",
+            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",
+            "x-contextforge-session-validated": "rust",
+            "x-business-header": "kept",
+        }
+        out = filter_loopback_skip_headers(spoofed)
+        assert "x-contextforge-auth-context" not in out
+        assert "x-contextforge-mcp-runtime" not in out
+        assert "x-contextforge-mcp-runtime-auth" not in out
+        assert "x-contextforge-session-validated" not in out
+        # Non-trusted business headers are unaffected.
+        assert out.get("x-business-header") == "kept"
+
+    def test_filter_strips_trusted_headers_case_insensitively(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        out = filter_loopback_skip_headers({"X-ContextForge-Auth-Context": "SPOOFED"})
+        assert not any(k.lower() == "x-contextforge-auth-context" for k in out)


### PR DESCRIPTION
## Summary

Companion to #4981 — **stacked on it** (this PR's base is that branch; retarget
to `main` once #4981 merges).

#4981 fixed the two defects that made cross-worker MCP forwarding collapse
(per-container `WORKER_ID` broadcast + the forwarded-HTTP loopback scatter). It
left three *other* affinity dispatch sites still re-running requests via a
**network loopback to `127.0.0.1`**, which hits the shared gunicorn socket and is
routed by the kernel to an *arbitrary* worker that does not hold the bound
upstream session. That scatters off the session owner and, for **stateful**
upstreams, spawns duplicate upstream sessions — weakening the #4205 isolation
invariant on the owner-direct and SSE paths (it "works" only because stateless
tools tolerate a fresh upstream connection).

This PR introduces a shared in-process dispatch helper and routes **all four**
`/rpc` dispatch sites through it, so an affinity-owned request always executes in
the worker that actually holds the session:

- `post_rpc_in_process()` in `mcpgateway/utils/internal_http.py` — runs the
  FastAPI app via `httpx.ASGITransport(app)` in the current process (no socket,
  no kernel re-routing), so `/rpc` resolves the session from *this* worker's
  `UpstreamSessionRegistry`.
- Converted sites: `_execute_forwarded_http_request` and
  `_execute_forwarded_request` (`session_affinity.py`); the local-owned path and
  the `[HTTP_AFFINITY_FORWARDED]` block (`streamablehttp_transport.py`).

## Architecture

`OWNER(S)` = the worker holding session S's bound upstream connection. A request
for S can arrive at a non-owner worker, which forwards it to the owner via Redis
pub/sub. Both diagrams below start the same way; only how the owner *executes*
the request differs.

### Before — the owner re-dispatches over the loopback socket → scatters to a random worker

```text
   request for session S arrives at Worker 1 (a non-owner)
                 │
   ┌──────────────────┐   forward to owner    ┌────────────────────────┐
   │ Worker 1         │ ──(Redis pub/sub)───► │ Worker 2  = OWNER(S)    │
   │ no session S     │                       │ bound upstream sess S   │
   └──────────────────┘                       └───────────┬────────────┘
                                                          │ executes via loopback
                                                          ▼ POST 127.0.0.1:4444/rpc
                                          shared gunicorn socket → kernel picks a RANDOM worker
                                                          │
                       ┌──────────────────────────────────┘
                       ▼
   ┌──────────────────┐
   │ Worker 1 (random)│  no session S  →  opens a NEW upstream session
   └──────────────────┘  ✗ state split — stateful counter resets
```

### After — the owner dispatches in-process → stays on the owner, reuses the bound session

```text
   request for session S arrives at Worker 1 (a non-owner)
                 │
   ┌──────────────────┐   forward to owner    ┌────────────────────────┐
   │ Worker 1         │ ──(Redis pub/sub)───► │ Worker 2  = OWNER(S)    │
   │ no session S     │                       │ bound upstream sess S   │
   └──────────────────┘                       └───────────┬────────────┘
                                                          │ dispatches IN-PROCESS (stays on W2)
                                                          ▼ httpx.ASGITransport(app, 127.0.0.1:0)
                                          POST /_internal/mcp/rpc   (this process — no socket)
                                            + x-contextforge-auth-context  (edge identity, no re-auth)
                                                          │
                                                          ▼
                                          reuses the SAME bound upstream session  ✓ state preserved
```

## Test results

On the standard testing stack (`GATEWAY_REPLICAS=3` × `GUNICORN_WORKERS=24`,
`CACHE_TYPE=redis`, `USE_STATEFUL_SESSIONS=true`,
`MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`):

- `make benchmark-mcp-tools`: **0 failures**, with **zero**
  `Error executing forwarded HTTP request` and zero
  `[HTTP_AFFINITY_LOCAL] Error routing to /rpc` across all three replicas
  (the local-owned path no longer scatters).
- Manual single-session probe: forwarded `tools/list` all return `200`.
- `tests/integration/test_issue_4205_upstream_session_isolation.py`: **4/4 pass**.


## Manual reproducer (#4205 pattern)

End-to-end check that the per-session isolation invariant holds with this PR's
in-process dispatch applied to all four affinity sites.

**Setup**

The reproducer needs four moving parts: the upstream counter, Redis (for the
affinity directory), the gateway, and a registered virtual server scoping the
counter's tools.

1. Start the upstream counter MCP server (rust-sdk `servers_counter_streamhttp` example):

   ```bash
   git clone https://github.com/modelcontextprotocol/rust-sdk
   cd rust-sdk/examples/servers
   cargo run --release --example servers_counter_streamhttp
   # binds 127.0.0.1:8000
   ```

2. Start Redis (standalone container, no docker-compose):

   ```bash
   docker run -d --rm --name reproducer-redis -p 6379:6379 redis:latest
   ```

3. Start ContextForge with stateful sessions and affinity enabled:

   ```bash
   USE_STATEFUL_SESSIONS=true \
   MCPGATEWAY_SESSION_AFFINITY_ENABLED=true \
   make serve
   # serves on http://127.0.0.1:4444
   ```

4. Register the counter as a federated gateway and create a virtual server
   scoping its tools (via `POST /gateways` and `POST /servers` + `PUT /servers/{id}`
   with `associated_tools`). The remainder of the test assumes the virtual server
   id is in `$VIRTUAL_SERVER_ID`.

**Test (curl)**

```bash
TOK=$(python -m mcpgateway.utils.create_jwt_token \
  --username admin@example.com --exp 60 --secret "$JWT_SECRET_KEY")
URL="http://127.0.0.1:4444/servers/$VIRTUAL_SERVER_ID/mcp"

# 1. initialize, capture Mcp-Session-Id from response headers
SID=$(curl -sS -D - -o /dev/null -X POST "$URL" \
  -H "Authorization: Bearer $TOK" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"initialize","id":1,
       "params":{"protocolVersion":"2025-03-26","capabilities":{},
                 "clientInfo":{"name":"curl","version":"1.0"}}}' \
  | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')

# 2. notifications/initialized
curl -sS -X POST "$URL" \
  -H "Authorization: Bearer $TOK" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -H "Mcp-Session-Id: $SID" \
  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'

# 3. increment N times
for i in $(seq 1 25); do
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" \
    -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((1+i)),
         \"params\":{\"name\":\"rust-counter-increment\",\"arguments\":{}}}"
done

# 4. get_value should be N
curl -sS -X POST "$URL" \
  -H "Authorization: Bearer $TOK" \
  -H "Mcp-Session-Id: $SID" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":99,
       "params":{"name":"rust-counter-get-value","arguments":{}}}'
```

**Expected** — and observed with this PR applied:

```
increments returned:   1, 2, 3, ..., 25
get_value returned:    25
```

Without this PR (on `test-session-affinity-performance-impact` alone), the same
test under rapid send saw the counter occasionally drop back to 1 mid-stream
because forwarded requests were re-creating upstream sessions through the
three loopback dispatch sites this PR closes.


<details>
<summary><b>Manual reproducer — multi-upstream isolation (two federated counters, interleaved calls in one downstream session)</b></summary>

Extends the #4205 check to the multi-gateway federation case: one downstream
`Mcp-Session-Id` binds **two independent** upstream sessions, one per federated
gateway. Verifies the in-process ASGI dispatch correctly resolves to the right
upstream session keyed on `(downstream_session_id, gateway_id)` when a single
downstream session interleaves calls between two upstreams.

**Setup (delta from the reproducer above)**

- Two rust-sdk counter servers, same example, different ports — `BIND_ADDRESS`
  patched to `127.0.0.1:9000` in one clone and `127.0.0.1:9001` in another:

  ```bash
  git clone https://github.com/modelcontextprotocol/rust-sdk ~/rust-sdk
  git clone ~/rust-sdk ~/rust-sdk-b   # local clone for the second copy

  # Patch BIND_ADDRESS in each:
  #   ~/rust-sdk/examples/servers/src/counter_streamhttp.rs   → 127.0.0.1:9000
  #   ~/rust-sdk-b/examples/servers/src/counter_streamhttp.rs → 127.0.0.1:9001

  (cd ~/rust-sdk/examples/servers   && cargo run --release --example servers_counter_streamhttp) &
  (cd ~/rust-sdk-b/examples/servers && cargo run --release --example servers_counter_streamhttp) &
  ```

- Both registered as federated gateways via `POST /gateways`
  (here: `rust-counter` on `:9000`, `counter-b-iso` on `:9001`).
- One virtual server scoping the `increment` and `get-value` tools from **both**
  gateways (4 tools total). The remainder assumes the virtual server id is in
  `$VIRTUAL_SERVER_ID`.

Everything else (Redis container, `make serve`, JWT minting, `initialize` +
`notifications/initialized`) is identical to the single-counter reproducer above.

**Test (curl)**

```bash
TOK=$(python -m mcpgateway.utils.create_jwt_token \
  --username admin@example.com --exp 60 --secret "$JWT_SECRET_KEY")
URL="http://127.0.0.1:4444/servers/$VIRTUAL_SERVER_ID/mcp"

# (steps 1 + 2 — initialize + notifications/initialized — same as above, captures $SID)

# 3. Increment Counter A × 5  (expected 1,2,3,4,5)
for i in $(seq 1 5); do
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((10+i)),
         \"params\":{\"name\":\"rust-counter-increment\",\"arguments\":{}}}"
done

# 4. Increment Counter B × 3  (expected 1,2,3 — NOT 6,7,8; B is independent)
for i in $(seq 1 3); do
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((20+i)),
         \"params\":{\"name\":\"counter-b-iso-increment\",\"arguments\":{}}}"
done

# 5. Increment Counter A × 2 more  (expected 6,7 — continues from A's prior 5)
for i in $(seq 1 2); do
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((30+i)),
         \"params\":{\"name\":\"rust-counter-increment\",\"arguments\":{}}}"
done

# 6. get_value on both
curl -sS -X POST "$URL" \
  -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":41,
       "params":{"name":"rust-counter-get-value","arguments":{}}}'

curl -sS -X POST "$URL" \
  -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":42,
       "params":{"name":"counter-b-iso-get-value","arguments":{}}}'
```

**Expected**

```
Counter A increments:        1 2 3 4 5   ...then 6 7
Counter B increments:        1 2 3
Counter A final get_value:   7
Counter B final get_value:   3
```

**Actual output (verbatim from the probe run with this PR applied)**

```
=== STEP 1: initialize ===
sid=<sid>

=== STEP 2: increment Counter A × 5 (expect 1,2,3,4,5) ===
Counter A increments: 1 2 3 4 5

=== STEP 3: increment Counter B × 3 (expect 1,2,3 — independent of A) ===
Counter B increments: 1 2 3

=== STEP 4: increment Counter A × 2 more (expect 6,7) ===
Counter A more increments: 6 7

=== STEP 5: get_value both ===
Counter A final: "text":"7"
Counter B final: "text":"3"

=== verdict ===
✓ PASS — counters incremented independently (A=7, B=3)
```

**Structural verification**

- Redis directory has exactly **one** `mcpgw:pool_owner:{sid}` key — the single
  downstream session is owned by one worker:
  ```
  $ redis-cli --scan --pattern 'mcpgw:pool_owner:*'
  mcpgw:pool_owner:<sid>
  ```
- The two rust counter debug logs show **two distinct upstream session ids**:
  ```
  counter-a (rust-sdk on :9000)  upstream session id = <upstream-A>
  counter-b (rust-sdk on :9001)  upstream session id = <upstream-B>
  ```

One downstream `Mcp-Session-Id` → two independent upstream `ClientSession`s,
one per federated gateway. Same `(downstream_sid, gateway_id)` registry keying
routes each `tools/call` to the correct upstream regardless of which order the
calls arrive in. Without this PR's in-process dispatch on the four affinity
sites, a misrouted call could land on the wrong upstream and either bump the
other counter or spawn a duplicate session — neither was observed.

**Summary**

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| Counter A sequence (5 + 2 interleaved increments) | 1, 2, 3, 4, 5, 6, 7 | 1, 2, 3, 4, 5, 6, 7 | ✓ |
| Counter B sequence (3 increments, between A's batches) | 1, 2, 3 | 1, 2, 3 | ✓ |
| Counter A final `get_value` | 7 | 7 | ✓ |
| Counter B final `get_value` | 3 | 3 | ✓ |
| Downstream session count in Redis (`pool_owner` keys) | 1 | 1 | ✓ |
| Distinct upstream session ids (one per federated gateway) | 2 | 2 | ✓ |

**Verdict: PASS.** Multi-gateway federation preserves the #4205 isolation invariant. One downstream `Mcp-Session-Id` correctly holds two independent upstream `ClientSession`s, one per federated gateway, and every `tools/call` is routed to the right upstream by the `(downstream_session_id, gateway_id)` registry keying — regardless of interleave order. Without this PR's in-process dispatch on the four affinity sites, a misrouted call could land on the wrong upstream and either bump the other counter or spawn a duplicate session; neither was observed.

</details>


<details>
<summary><b>Manual reproducer — cross-user isolation (two distinct tokens, one upstream counter, parallel sessions)</b></summary>

Verifies the #4205 isolation invariant in its purest form: two different
bearer tokens (two distinct users from the gateway's perspective) each
open their own MCP session against the **same** upstream counter server,
and the per-user state stays completely independent. Tests the
`(downstream_session_id, gateway_id)` registry keying when
`downstream_session_id` is the discriminator (both users hit one upstream
gateway, so only the downstream sid varies between the two upstream
sessions).

**Setup (delta from the reproducer above)**

- Single rust-sdk counter server is enough — just `127.0.0.1:9000`,
  registered as the federated gateway (e.g. `rust-counter`).
- Single virtual server scoping `rust-counter-increment` and
  `rust-counter-get-value`. The remainder assumes the virtual server id
  is in `$VIRTUAL_SERVER_ID`.
- Two distinct admin JWTs — same `admin@example.com` identity, different
  `--exp` values produce two different token strings:

  ```bash
  TOK_A=$(python -m mcpgateway.utils.create_jwt_token \
    --username admin@example.com --exp 1440 --secret "$JWT_SECRET_KEY")
  TOK_B=$(python -m mcpgateway.utils.create_jwt_token \
    --username admin@example.com --exp 720  --secret "$JWT_SECRET_KEY")
  ```

Everything else (Redis container, `make serve`) is identical to the
single-counter reproducer above.

**Test (curl, two users in parallel)**

```bash
URL="http://127.0.0.1:4444/servers/$VIRTUAL_SERVER_ID/mcp"

run_user() {
  local NAME="$1" TOK="$2" N=10

  # 1. initialize, capture sid
  local INIT SID
  INIT=$(curl -sS -D - -o /dev/null -X POST "$URL" \
    -H "Authorization: Bearer $TOK" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,
         \"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},
                     \"clientInfo\":{\"name\":\"$NAME\",\"version\":\"0.1\"}}}")
  SID=$(echo "$INIT" | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')

  # 2. notifications/initialized
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'

  # 3. 10 increments
  for i in $(seq 1 $N); do
    curl -sS -X POST "$URL" \
      -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
      -H "Accept: application/json, text/event-stream" \
      -H "Content-Type: application/json" \
      -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((10+i)),
           \"params\":{\"name\":\"rust-counter-increment\",\"arguments\":{}}}"
  done

  # 4. get_value
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"tools/call","id":99,
         "params":{"name":"rust-counter-get-value","arguments":{}}}'
}

# Run both users in parallel
run_user A "$TOK_A" &
run_user B "$TOK_B" &
wait
```

**Expected**

```
Both users: increments  1, 2, 3, …, 10   (each user's own monotonic sequence)
Both users: final get_value = 10          (independent — no leakage)
Two distinct Mcp-Session-Ids on the response headers
Two distinct upstream session ids in the rust counter's debug log
```

**Actual output (verbatim from the probe run with this PR applied, rust counter restarted just before the run for a clean log; sids redacted)**

```
=== User A ===
sid = <sid-A>
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
final get_value = 10

=== User B ===
sid = <sid-B>
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
final get_value = 10

=== verdict ===
User A 1..10 & final 10: True
User B 1..10 & final 10: True
sids distinct: True

✓ PASS
```

**Structural verification**

```
$ # Rust counter's debug log shows exactly two distinct upstream session ids
$ grep -oE 'streamable_http_session\{id="[0-9a-f-]+"\}' /tmp/counter-a.log | sort -u
streamable_http_session{id="<upstream-A>"}
streamable_http_session{id="<upstream-B>"}

Pre-test session count:        0
Post-test session count:       2
Net new sessions from this run: 2   (expected 2)
```

Two downstream `Mcp-Session-Id`s → two completely independent upstream
`ClientSession`s on the same upstream gateway, each with its own counter
state. Same `(downstream_sid, gateway_id)` registry keying as the
multi-upstream test, but here it is `downstream_sid` that varies while the
`gateway_id` stays fixed.

**Summary**

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| Two distinct `Mcp-Session-Id`s | 2 | 2 | ✓ |
| User A increments | 1, 2, …, 10 | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | ✓ |
| User B increments | 1, 2, …, 10 | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | ✓ |
| User A final `get_value` | 10 | 10 | ✓ |
| User B final `get_value` (independent of A) | 10 | 10 | ✓ |
| Distinct upstream session ids on the rust counter | 2 | 2 | ✓ |
| Net new upstream sessions during this test | 2 | 2 | ✓ |

**Verdict: PASS.** Cross-user isolation holds on #4987. With no sticky-LB
hashing in play, two different users' requests can land on any gunicorn
worker, and the affinity layer plus the
`(downstream_session_id, gateway_id)` registry keying together guarantee
that each user's tool calls reach exactly the one upstream `ClientSession`
bound to their downstream session.

</details>


<details>
<summary><b>Manual reproducer — same-user multi-session (one token, three parallel sessions, one upstream counter)</b></summary>

Verifies that even though three concurrent MCP sessions share the **same**
bearer token (identical `Authorization` header), each `initialize` call
produces its own `Mcp-Session-Id` and binds its own independent upstream
`ClientSession`. Tests the `(downstream_session_id, gateway_id)` registry
keying when only `downstream_session_id` varies and the upstream
`gateway_id` and the auth identity both stay fixed.

This is the third axis of the keying — alongside the multi-upstream test
(one downstream sid, many gateway_ids) and the cross-user test (different
sids from different users, one gateway_id), this confirms isolation
holds when the only discriminator is the gateway-generated downstream sid
itself.

**Setup (delta from the cross-user reproducer above)**

- Same single rust-sdk counter on `127.0.0.1:9000`, same registered
  federated gateway, same single virtual server scoping
  `rust-counter-increment` and `rust-counter-get-value`.
- **One** admin JWT (no need for two — the point is that the same token
  is used for all sessions):

  ```bash
  TOK=$(python -m mcpgateway.utils.create_jwt_token \
    --username admin@example.com --exp 1440 --secret "$JWT_SECRET_KEY")
  ```

Everything else (Redis container, `make serve`) is identical.

**Test (curl, three sessions in parallel — same token)**

```bash
URL="http://127.0.0.1:4444/servers/$VIRTUAL_SERVER_ID/mcp"

run_session() {
  local NAME="$1" N=10

  # 1. initialize, capture sid
  local INIT SID
  INIT=$(curl -sS -D - -o /dev/null -X POST "$URL" \
    -H "Authorization: Bearer $TOK" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1,
         \"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},
                     \"clientInfo\":{\"name\":\"$NAME\",\"version\":\"0.1\"}}}")
  SID=$(echo "$INIT" | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')

  # 2. notifications/initialized
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'

  # 3. 10 increments
  for i in $(seq 1 $N); do
    curl -sS -X POST "$URL" \
      -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
      -H "Accept: application/json, text/event-stream" \
      -H "Content-Type: application/json" \
      -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":$((10+i)),
           \"params\":{\"name\":\"rust-counter-increment\",\"arguments\":{}}}"
  done

  # 4. get_value
  curl -sS -X POST "$URL" \
    -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","method":"tools/call","id":99,
         "params":{"name":"rust-counter-get-value","arguments":{}}}'
}

# Three sessions in parallel, all under the same token
run_session S1 &
run_session S2 &
run_session S3 &
wait
```

**Expected**

```
Three sessions: each gets its own monotonic increments 1, 2, …, 10
Three sessions: each final get_value = 10  (independent — no leakage)
Three distinct Mcp-Session-Ids on the response headers
Three distinct upstream session ids in the rust counter's debug log
```

**Actual output (verbatim from the probe run with this PR applied, rust counter restarted just before the run for a clean log; sids redacted)**

```
=== Session S1 ===
sid = <sid-1>
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
final get_value = 10

=== Session S2 ===
sid = <sid-2>
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
final get_value = 10

=== Session S3 ===
sid = <sid-3>
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
final get_value = 10

=== verdict ===
All three sessions hit 1..10 monotonic with final 10: True
All three sids distinct (count = 3): True

✓ PASS
```

**Structural verification**

```
$ # Rust counter's debug log shows exactly three distinct upstream session ids
$ grep -oE 'streamable_http_session\{id="[0-9a-f-]+"\}' /tmp/counter-a.log | sort -u
streamable_http_session{id="<upstream-1>"}
streamable_http_session{id="<upstream-2>"}
streamable_http_session{id="<upstream-3>"}

Pre-test session count:        0
Post-test session count:       3
Net new sessions from this run: 3   (expected 3)

$ # Redis directory: one pool_owner key per downstream sid
$ redis-cli --scan --pattern 'mcpgw:pool_owner:*' | wc -l
3
```

Three downstream `Mcp-Session-Id`s from the same token bind three completely
independent upstream `ClientSession`s on the same upstream gateway. Same
`(downstream_sid, gateway_id)` keying as the other two manual reproducers —
this time exercising the path where the auth identity is identical across
sessions and the *only* discriminator is the gateway-generated downstream sid.

**Summary**

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| Three distinct `Mcp-Session-Id`s from one token | 3 | 3 | ✓ |
| Session S1 increments | 1, 2, …, 10 | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | ✓ |
| Session S2 increments | 1, 2, …, 10 | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | ✓ |
| Session S3 increments | 1, 2, …, 10 | 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 | ✓ |
| Each session's final `get_value` | 10 | 10 / 10 / 10 | ✓ |
| Distinct upstream session ids on the rust counter | 3 | 3 | ✓ |
| Net new upstream sessions during this test | 3 | 3 | ✓ |
| Distinct `pool_owner` keys in Redis | 3 | 3 | ✓ |

**Verdict: PASS.** Same-user multi-session isolation holds on #4987.
Three concurrent sessions from one token spread across whichever
gunicorn workers `least_conn` LB happened to pick; the affinity layer's
pub/sub forwarding plus the `(downstream_session_id, gateway_id)`
registry keying together guarantee that each session's tool calls reach
exactly the one upstream `ClientSession` bound to its downstream sid —
not the other two sessions' upstreams. If the gateway had treated
"same auth identity" as "same session", all three counters would have
ended at 30; if the affinity forwarding had scattered, the sequences
would have shown gaps. Neither happened.

</details>


<details>
<summary><b>Manual reproducer — worker-kill / failover (verify the affinity-layer recovery contract under owner-worker death)</b></summary>

Verifies the failure-mode contract when the gunicorn worker that owns a
downstream session dies abruptly (SIGKILL). The intent is **not** a
property this PR changes — the in-process ASGI dispatch fix affects the
happy-path execution after a forward succeeds, not the dead-owner path —
but the worker-kill behaviour on top of this PR's code is documented
here so reviewers can see the recovery contract is preserved and the
operational characteristics are clear.

**Setup**

Identical to the single-counter reproducer above. No new processes
needed; the test just identifies which gunicorn worker owns a bound
session and kills it.

**Test (bash)**

```bash
TOK=$(python -m mcpgateway.utils.create_jwt_token \
  --username admin@example.com --exp 60 --secret "$JWT_SECRET_KEY")
URL="http://127.0.0.1:4444/servers/$VIRTUAL_SERVER_ID/mcp"

# 1. Initialize + 5 increments (captures $SID and exercises ownership binding)
# ... (same initialize / notifications/initialized / 5 increment steps as the
#      single-counter reproducer above) ...

# 2. Find the gunicorn worker that owns this session
OWNER=$(redis-cli get "mcpgw:pool_owner:$SID")           # → '<hostname>:<pid>'
OWNER_PID=${OWNER##*:}

# 3. SIGKILL that worker
kill -KILL "$OWNER_PID"
# gunicorn master will respawn a replacement worker immediately

# 4. Send another request with the same (now-stale) sid; capture HTTP code + timing
curl -sS -o /dev/null -w "HTTP %{http_code} | time_total=%{time_total}s\n" \
  --max-time 40 -X POST "$URL" \
  -H "Authorization: Bearer $TOK" -H "Mcp-Session-Id: $SID" \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/call","id":101,
       "params":{"name":"rust-counter-increment","arguments":{}}}'

# 5. Send a fresh initialize and confirm the gateway accepts new sessions
# ... (standard initialize / notifications/initialized / 3 increments) ...
```

**Expected (the recovery contract)**

```
- SIGKILL on the owner gunicorn worker:  worker dies; gunicorn master respawns within seconds.
- Request with the stale-owner sid:      receiving worker tries to forward to the dead
                                         owner over pub/sub, times out after
                                         mcpgateway_pool_rpc_forward_timeout (default 30s),
                                         returns HTTP 404 + JSON-RPC -32600 "Session not found".
- Stale `mcpgw:pool_owner:{sid}` key:    persists until natural Redis TTL expiry (heartbeat
                                         reclaim is bounded by the key's TTL — ~3 minutes
                                         with the default config).
- Fresh initialize:                       binds cleanly to a different worker; new upstream
                                          session is opened; counter increments monotonically.
- Recovery contract for the dead sid:    client receives a clear error, re-initializes.
```

**Actual output (verbatim from the probe run with this PR applied; sids and PIDs redacted)**

```
=== STEP 1: SIGKILL the owner worker PID=<pid-A> ===
  PID COMMAND
  (no row — process is gone)

=== STEP 2: gunicorn respawn? ===
old owner PID alive? NO
workers under gunicorn master ppid currently: 16  (was 16 — replacement spawned)

=== STEP 3: pool_owner key + TTL over a 60s window after kill ===
right now: pool_owner='<host>:<pid-A>'  TTL=195
  +5s:   pool_owner='<host>:<pid-A>'  TTL=190
  +10s:  pool_owner='<host>:<pid-A>'  TTL=185
  +30s:  pool_owner='<host>:<pid-A>'  TTL=165
  +60s:  pool_owner='<host>:<pid-A>'  TTL=149
  (key did NOT expire within the 60s observation window — natural TTL is ~3 min)

=== STEP 4: retry the increment with the same (stale-owner) sid ===
HTTP 404 | time_total=30.019149s
wall: 30s
body: {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}

=== STEP 5: fresh initialize + 3 increments (recovery sanity) ===
new sid=<sid-recovery>
  increment 1 → 1
  increment 2 → 2
  increment 3 → 3
```

**Structural verification**

```
$ # Counter A's upstream session ids over the whole run
$ grep -oE 'streamable_http_session\{id="[0-9a-f-]+"\}' /tmp/counter-a.log | sort -u
streamable_http_session{id="<upstream-original>"}     # bound by the pre-kill 5 increments
streamable_http_session{id="<upstream-stray>"}        # left by the failed-forward path during the 30s timeout
streamable_http_session{id="<upstream-recovery>"}     # bound by the post-kill fresh initialize

Total: 3
```

The original upstream session is orphaned by the worker death and is not
reused; the recovery `initialize` opens its own independent upstream
`ClientSession` on a different gunicorn worker. The stray middle session
is an artefact of the failed-forward attempt during the 30s timeout
window and is also orphaned (no further calls land on it).

**Summary**

| Check | Expected | Actual | Verdict |
|---|---|---|---|
| SIGKILL of owner worker | dies immediately | dies immediately | ✓ |
| Gunicorn master respawns replacement | yes, fast | replacement up within ~seconds | ✓ |
| Stale-sid request returns a structured error (not a hang, not 5xx) | HTTP 404 + JSON-RPC `-32600 "Session not found"` | exactly that | ✓ |
| Failure-window latency for the first request after worker death | ≤ `mcpgateway_pool_rpc_forward_timeout` (default 30s) | ~30s | ✓ |
| Fresh `initialize` after the failed retry | binds cleanly to a different worker | new sid, new upstream session, increments 1, 2, 3 | ✓ |
| Stale `mcpgw:pool_owner:{sid}` key cleanup | natural Redis TTL (~3 min default) | TTL decremented normally; not observed to expire within 60s | ✓ (as designed) |

**Verdict: PASS — recovery contract is preserved.** The gateway does not
crash, the failed-forward request gets a clean structured error rather
than a hang or 5xx, gunicorn auto-recovers the worker, the stale
`pool_owner` key is bounded by Redis TTL, and a fresh `initialize` works
immediately. Session-loss is correctly the client's responsibility
("client re-initializes after a session error") — the same contract that
applies to any sticky-routing failure mode.

**Operational note on the 30s failure window**

The first request that lands on the dead owner's sid after the kill
pays the `mcpgateway_pool_rpc_forward_timeout` (default 30s) before
returning `Session not found`. This timeout pre-dates this PR — it
governs the pub/sub forward path that this PR's in-process dispatch
fix does *not* touch. Operators who want a faster fail signal can
either tune this setting down (with awareness that legitimate slow
forwards under load also get truncated), or layer a faster-fail
check on the receiving worker that consults the dead-owner's
`mcpgw:worker_heartbeat` key before attempting the forward — a
separate follow-up worth exploring after this PR lands.

</details>

<details>
<summary><b>Load benchmark — Streamable HTTP tools throughput (16-core host, 526 RPS @ 0.00% failures)</b></summary>

Re-run on a dedicated 16-core / 32 GB host (Ubuntu 24.04) to measure the in-process
dispatch path under sustained concurrency without single-laptop VM saturation. The
image was built from this branch (`make docker-prod`) and the standard testing stack
(3 gateway replicas behind nginx, Postgres + Redis + pgbouncer) was brought up via
`make testing-up`.

**Config:** `make benchmark-mcp-tools` — tools-only MCP Streamable HTTP, 125 concurrent
users, 30/s spawn rate, 60s run, against the registered `fast_time` virtual server
through nginx on `:8080`.

**Results**

| Metric | Value |
|---|---|
| Total requests | 31,601 |
| Failures | 1 (0.00%) |
| Throughput | 526.29 RPS |
| Avg latency | 168.6 ms |
| p50 / p90 / p95 / p99 | 110 / 270 / 470 / 1,300 ms |
| Max | 30,001 ms (single client-side timeout = the lone failure) |

**Endpoint breakdown**

| Endpoint | Reqs | Fails | RPS | Avg (ms) | p99 (ms) |
|---|---|---|---|---|---|
| `tools/call` [rapid] | 29,946 | 1 | 498.7 | 169.4 | 1,300 |
| `tools/list` [rapid] | 1,530 | 0 | 25.5 | 158.0 | 1,100 |
| `initialize` | 125 | 0 | 2.1 | 115.5 | 390 |

All 125 `initialize` calls succeeded (0 failures), confirming the session-affinity
binding path stays stable under load: the in-process `/_internal/mcp/rpc` dispatch
sustains ~526 RPS with effectively zero failures and a p99 of 1.3s.

</details>

<details>
<summary><b>#4205 counter reproducers — statefulness &amp; isolation under multi-worker affinity (5/5 PASS, 16-core host)</b></summary>

Re-ran the #4205 counter reproducers against this branch's stack on a 16-core host
(3 gateway replicas behind nginx, non-sticky round-robin, Redis pool ownership). A
minimal per-session counter MCP server is registered behind the gateway; a session
is incremented N times and must read back N. If forwarding scattered onto a fresh
upstream session, the counter would drop.

**Setup**

```python
# counter_server.py — per-session counter (state keyed by the upstream ServerSession)
from mcp.server.fastmcp import Context, FastMCP
mcp = FastMCP("repro-counter", host="0.0.0.0", port=9400)   # 2nd instance on :9401 for Test 4
_counters: dict[int, int] = {}

@mcp.tool()
def increment(ctx: Context) -> int:
    _counters[id(ctx.session)] = _counters.get(id(ctx.session), 0) + 1
    return _counters[id(ctx.session)]

@mcp.tool()
def get_value(ctx: Context) -> int:
    return _counters.get(id(ctx.session), 0)

mcp.run(transport="streamable-http")
```

1. Run the counter on the host (reachable from the gateway containers via
   `host.docker.internal`, mapped by compose `extra_hosts: host.docker.internal:host-gateway`).
2. `POST /gateways` → `{"name":"repro-counter","url":"http://host.docker.internal:9400/mcp","transport":"STREAMABLEHTTP"}`.
3. Wait for tool sync (`GET /tools` filtered by `gatewayId`), then
   `POST /servers` → `{"server":{"name":"repro-counter-vs","associated_tools":[…]}}`.
4. Admin token: `create_jwt_token --username admin@example.com --admin --secret $JWT_SECRET_KEY`.
5. Drive sessions against `/servers/{id}/mcp` (`initialize` → `notifications/initialized` →
   `tools/call increment` ×N → `tools/call get_value`); concurrent sessions via a thread pool.

**Results**

| Test | Steps | Result |
|---|---|---|
| 1 — single session | one session, `increment` ×25, then `get_value` | `increments=[1…25]`, `get_value=25`, `pool_owner → host:pid` (pid ≠ 1 → per-worker WORKER_ID) — **PASS** |
| 2 — same-user multi-session | 3 concurrent sessions, one token, ×10 each | 3 distinct sids, each `[1…10]` / `get_value=10` → 3 independent `pool_owner` keys — **PASS** |
| 3 — two tokens | two distinct tokens (same admin), parallel sessions, ×10 | both `[1…10]` / `get_value=10`, distinct sids, no cross-talk — **PASS** |
| 4 — multi-upstream | one session across two counters (`:9400`+`:9401`): A×5, B×3, A×2 | A `[1,2,3,4,5]` then `[6,7]` (`get_value=7`), B `[1,2,3]` (`get_value=3`) → `(session, gateway)` isolation — **PASS** |
| 5 — owner-worker kill | bind + ×5, read owner from Redis, `kill -9` the owning gunicorn worker, hit stale sid, then fresh `initialize` | stale sid → **HTTP 404 / JSON-RPC `-32600 "Session not found"` in 30.0s** (not a hang/5xx); killed worker auto-respawns; fresh init `[1,2,3]` — **PASS** |

Test 5 trace:

```
[1] bound sid=fb8be982…  increments=[1, 2, 3, 4, 5]
[2] pool_owner -> 58f27b9c19e5:78        # owner pid 78 (not :1 -> per-worker WORKER_ID active)
[3] owner worker pid 78 in mcp-context-forge-gateway-1
[4] kill -9 78 -> worker dead (gunicorn respawns a replacement)
[5] stale-sid request -> HTTP 404 in 30.0s | {"error":{"code":-32600,"message":"Session not found"}}
[6] fresh initialize 88834714… increments=[1, 2, 3]
```

Per-session upstream state survives the cross-worker affinity forwarding (one upstream
session per downstream session, no scatter), isolation holds across sessions/tokens/upstreams,
and the owner-death failure mode returns a clean structured error rather than a hang.

</details>

## Notes

- Depends on #4981; review/merge that first.
- `httpx.ASGITransport` re-runs the middleware stack once per dispatch; a later
  optimization could call the RPC dispatcher directly to skip it, but profiling
  showed the dispatch is already cheap (~5-6 ms, dominated by the upstream call),
  so it is intentionally out of scope here.









