### PR TITLE
fix: demote SSE RPC response-content log to debug (emits >64KB per tool call)

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -2369,7 +2369,7 @@ class SessionRegistry(SessionBackend):
                     )
                     logger.info(f"SSE RPC: Got response status {rpc_response.status_code}")
                     result = rpc_response.json()
-                    logger.info(f"SSE RPC: Response content: {result}")
+                    logger.debug(f"SSE RPC: Response content: {result}")
                     result = result.get("result", {})
 
                 response = {"jsonrpc": "2.0", "result": result, "id": req_id}


### PR DESCRIPTION
## Problem

`SSE RPC: Response content` log line at `mcpgateway/cache/session_registry.py:2372` emits the entire JSON-RPC response body at `logger.info` on every tool call. Real-world responses (search/list operations) routinely exceed 64KB per emission; dominates gateway logs without diagnostic gain at INFO severity.

## Root cause

High-cardinality content (full response payload) at INFO severity. Appropriate for DEBUG (opt-in for active troubleshooting), not INFO (normal-operation skim).

## Solution

Single-line `logger.info` → `logger.debug` demotion on L2372. Adjacent INFO lines (status code, request URL) preserved so request existence still observable.

## Testing

Patch running in downstream 0.9.0 deployment for ~3 weeks via bind-mount override. `grep -c "SSE RPC: Response content"` over 24h = 0 matches at default INFO filter. No regression. DEBUG-level still emits when enabled.

## Files changed

`mcpgateway/cache/session_registry.py`, 1 line.

## Consider for follow-up

Lines 2361 / 2364 / 2370 in same SSE RPC lifecycle are also at INFO; smaller per-emission but fire every RPC call. Scope decision left to maintainers.

## Reference

PR #2616 (translate.py stdio buffer limit, merged 2026-01-31) addressed the related 64KB-shape issue on the bridge-side; this PR addresses the log-volume side at session_registry.