### PR TITLE
fix: use auth cache in stateful JWT normalization

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -2125,11 +2125,35 @@ async def _normalize_jwt_payload(payload: dict[str, Any]) -> dict[str, Any]:
     # stateful-session path, matching the primary _auth_jwt path behavior (issue #4070).
     db_user_is_admin = False
     if email:
-        # First-Party
-        from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+        platform_admin_email = getattr(settings, "platform_admin_email", "")
+        if email == platform_admin_email:
+            db_user_is_admin = True
+        else:
+            auth_cache_resolved = False
+            if settings.auth_cache_enabled:
+                try:
+                    # First-Party
+                    from mcpgateway.cache.auth_cache import get_auth_cache  # pylint: disable=import-outside-toplevel
 
-        with SessionLocal() as db:
-            db_user_is_admin = is_user_admin(db, email)
+                    cached_ctx = await get_auth_cache().get_auth_context(email, payload.get("jti"))
+                    if cached_ctx is not None:
+                        _record_mcp_auth_cache_event("auth_context_hit")
+                        auth_cache_resolved = True
+                        if cached_ctx.user:
+                            db_user_is_admin = bool(cached_ctx.user.get("is_admin", False))
+                    else:
+                        _record_mcp_auth_cache_event("auth_context_miss")
+                except Exception as cache_error:  # pylint: disable=broad-except
+                    _record_mcp_auth_cache_event("auth_context_cache_error")
+                    logger.debug("Stateful MCP auth cache lookup failed for %s: %s", email, cache_error)
+
+            if not auth_cache_resolved:
+                _record_mcp_auth_cache_event("auth_context_fallback")
+                # First-Party
+                from mcpgateway.utils.admin_check import is_user_admin  # pylint: disable=import-outside-toplevel
+
+                with SessionLocal() as db:
+                    db_user_is_admin = is_user_admin(db, email)
 
     effective_is_admin = db_user_is_admin or jwt_is_admin
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -16930,6 +16930,8 @@ async def test_normalize_jwt_payload_sso_platform_admin_gets_effective_admin(mon
         "token_use": "session",
     }
 
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+
     with patch("mcpgateway.utils.admin_check.is_user_admin", mock_is_user_admin):
         with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = ["team1"]
@@ -16943,7 +16945,7 @@ async def test_normalize_jwt_payload_sso_platform_admin_gets_effective_admin(mon
 
 
 @pytest.mark.asyncio
-async def test_normalize_jwt_payload_non_admin_without_db_record():
+async def test_normalize_jwt_payload_non_admin_without_db_record(monkeypatch):
     """_normalize_jwt_payload: non-admin without DB record gets is_admin=False."""
     # Standard
     from unittest.mock import patch
@@ -16960,6 +16962,8 @@ async def test_normalize_jwt_payload_non_admin_without_db_record():
         "token_use": "session",
     }
 
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", False)
+
     with patch("mcpgateway.utils.admin_check.is_user_admin", mock_is_user_admin):
         with patch("mcpgateway.auth.resolve_session_teams", new_callable=AsyncMock) as mock_resolve:
             mock_resolve.return_value = ["team1"]
@@ -16969,6 +16973,84 @@ async def test_normalize_jwt_payload_non_admin_without_db_record():
     # Verify non-admin status
     assert result["is_admin"] is False
     assert result["email"] == "regular_user@example.com"
+    assert result["teams"] == ["team1"]
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_uses_auth_cache_without_db_session(monkeypatch):
+    """Cached auth context should avoid opening a DB session in the stateful fallback."""
+    # First-Party
+    from mcpgateway.cache.auth_cache import CachedAuthContext
+
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(
+        return_value=CachedAuthContext(
+            user={
+                "email": "cached_admin@example.com",
+                "is_admin": True,
+                "is_active": True,
+            },
+            personal_team_id=None,
+            is_token_revoked=False,
+        )
+    )
+    session_local = MagicMock(side_effect=AssertionError("SessionLocal should not be called"))
+
+    payload = {
+        "sub": "cached_admin@example.com",
+        "jti": "cached-jti",
+        "teams": ["team1"],
+        "user": {"is_admin": False},
+        "token_use": "session",
+    }
+
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr, "SessionLocal", session_local)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", AsyncMock(return_value=["team1"]))
+
+    result = await tr._normalize_jwt_payload(payload)
+
+    auth_cache.get_auth_context.assert_awaited_once_with("cached_admin@example.com", "cached-jti")
+    session_local.assert_not_called()
+    assert result["is_admin"] is True
+    assert result["email"] == "cached_admin@example.com"
+    assert result["teams"] == ["team1"]
+
+
+@pytest.mark.asyncio
+async def test_normalize_jwt_payload_cache_miss_falls_back_to_db_session(monkeypatch):
+    """Cache misses should keep the existing DB fallback behavior."""
+    auth_cache = MagicMock()
+    auth_cache.get_auth_context = AsyncMock(return_value=None)
+    db = object()
+    session_context = MagicMock()
+    session_context.__enter__.return_value = db
+    session_context.__exit__.return_value = None
+    session_local = MagicMock(return_value=session_context)
+    is_user_admin = MagicMock(return_value=True)
+
+    payload = {
+        "sub": "db_admin@example.com",
+        "jti": "miss-jti",
+        "teams": ["team1"],
+        "user": {"is_admin": False},
+        "token_use": "session",
+    }
+
+    monkeypatch.setattr(tr.settings, "auth_cache_enabled", True)
+    monkeypatch.setattr(tr, "SessionLocal", session_local)
+    monkeypatch.setattr("mcpgateway.cache.auth_cache.get_auth_cache", lambda: auth_cache)
+    monkeypatch.setattr("mcpgateway.utils.admin_check.is_user_admin", is_user_admin)
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", AsyncMock(return_value=["team1"]))
+
+    result = await tr._normalize_jwt_payload(payload)
+
+    auth_cache.get_auth_context.assert_awaited_once_with("db_admin@example.com", "miss-jti")
+    session_local.assert_called_once_with()
+    is_user_admin.assert_called_once_with(db, "db_admin@example.com")
+    assert result["is_admin"] is True
+    assert result["email"] == "db_admin@example.com"
     assert result["teams"] == ["team1"]
 
 


### PR DESCRIPTION
## Summary

Fixes #4988.

What:
- Reuse the MCP auth cache in `_normalize_jwt_payload` before opening a `SessionLocal` DB session.
- Short-circuit the configured platform admin email without creating a DB session.
- Preserve the existing DB fallback when the auth cache is disabled, misses, or errors.
- Add unit coverage for both the cache-hit/no-DB path and the cache-miss DB fallback.

Why:
- The stateful-session fallback path calls `_normalize_jwt_payload` on MCP requests. It previously opened a fresh DB session for every authenticated request even when the primary `_auth_jwt` path had already made auth context cache support available, causing the latency regression described in the issue.

## Repro Steps

The issue is covered by the new regression test `test_normalize_jwt_payload_uses_auth_cache_without_db_session`, which patches `SessionLocal` to raise if a cached auth context is available.

## Root Cause

`_normalize_jwt_payload` always called `SessionLocal()` and `is_user_admin()` for any payload with an email. That bypassed the auth cache used by `_auth_jwt`, so the stateful fallback path still performed a per-request DB round trip.

## Fix Description

The normalizer now:
- Resolves the configured platform admin email without DB access.
- Looks up `get_auth_cache().get_auth_context(email, jti)` when auth caching is enabled.
- Uses cached `user["is_admin"]` on cache hit.
- Falls back to the previous `SessionLocal()` + `is_user_admin()` behavior on cache miss, cache error, or disabled cache.

## Verification

| Check | Result |
| --- | --- |
| `uv run --frozen --python /Users/dogxi/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 --extra plugins pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -k normalize_jwt_payload -q` | Passed: 12 passed, 1 existing Pydantic deprecation warning |
| `uv tool run ruff==0.15.1 check mcpgateway/transports/streamablehttp_transport.py` | Passed |
| `uv tool run ruff==0.15.1 check --ignore PLC2801 tests/unit/mcpgateway/transports/test_streamablehttp_transport.py` | Passed |

## MCP Compliance

No MCP protocol behavior changes. The normalized user context shape is unchanged; the change only avoids unnecessary DB work when equivalent cached auth context is already available.

## Checklist

- [x] Added focused regression tests
- [x] Preserved existing cache-miss fallback behavior
- [x] DCO sign-off included in commit
