### PR TITLE
fix: exchange OAuth tokens for internal JWTs before forwarding to /rpc with session affinity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-29T16:11:04Z",
+  "generated_at": "2026-06-30T07:26:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1324,7 +1324,7 @@
         "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 154,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -144,6 +144,7 @@ This OAuth flow is **separate** from user authentication to ContextForge itself:
 
 For user authentication details, see [RBAC Configuration](../manage/rbac.md).
 
+<<<<<<< HEAD
 ## Inbound External-Token Validation (M2M API Auth)
 
 The flows above describe ContextForge as an OAuth **client** delegating to upstream MCP servers. ContextForge can also act as a **resource server** for its own API/MCP endpoints, accepting access tokens minted by a trusted external SSO provider directly as `Bearer` credentials — see [SSO: Machine-to-machine API auth with external IdP tokens](../manage/sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for operator-facing setup.
@@ -158,6 +159,25 @@ This path is gated by `SSO_API_TOKEN_AUTH_ENABLED` (global) and `SSOProvider.tru
 
 !!! note "Revocation and role-sync caveats"
     ContextForge cannot revoke an externally-issued token before its own expiry — only local user-deactivation/team-membership changes take effect immediately. If role-sync is enabled for the provider, teams/admin status are re-derived from token claims into the local DB on each provisioning pass. See the [SSO documentation](../manage/sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for details.
+=======
+### Session Affinity with OAuth
+
+When `MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`, session-bound MCP POSTs are
+routed to the internal `/rpc` endpoint for optimal worker locality.
+
+The `/rpc` endpoint authenticates via `verify_jwt_token()`, which only accepts
+internal ContextForge JWTs. OAuth tokens issued by an external IdP fail
+signature verification there. To bridge this gap, the streamable HTTP transport
+layer automatically exchanges an external IdP OAuth token for a short-lived
+(1-minute) internal JWT before forwarding the request to `/rpc`. This exchange
+is transparent to clients.
+
+!!! note "Security: is_admin is not included in the exchanged JWT"
+    The minted internal JWT intentionally omits `is_admin` from its claims.
+    The `/rpc` endpoint determines admin status by querying the database, not
+    from JWT claims. This prevents JWT-based privilege escalation if token
+    verification were ever bypassed.
+>>>>>>> 1d61f3d6a (docs(oauth): add session affinity with OAuth section to oauth-design.md)
 
 ## Future Enhancements
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4157,18 +4157,7 @@ class SessionManagerWrapper:
                         "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
                         "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
                     }
-                    # If the request was authenticated via an external IdP OAuth
-                    # token, exchange it for a short-lived internal JWT that
-                    # /rpc's verify_jwt_token() accepts.  Minting is cheap and
-                    # the 1-minute TTL limits blast radius if the token leaks.
-                    # The raw IdP token would fail at /rpc because it is signed
-                    # with the IdP's key, not the gateway's jwt_secret_key.
-                    internal_jwt = await _mint_internal_jwt_for_rpc()
-                    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                    if internal_jwt:
-                        rpc_headers[_gw_auth_lower] = f"Bearer {internal_jwt}"
-                    elif _gw_auth_lower in headers:
-                        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                    await _set_rpc_auth_header(rpc_headers, headers)
                     # Forward passthrough headers for upstream MCP servers (see #3640).
                     # First-Party
                     from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
@@ -4333,12 +4322,7 @@ class SessionManagerWrapper:
                                 "x-mcp-session-id": mcp_session_id,
                                 "x-forwarded-internally": "true",
                             }
-                            internal_jwt = await _mint_internal_jwt_for_rpc()
-                            _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                            if internal_jwt:
-                                rpc_headers[_gw_auth_lower] = f"Bearer {internal_jwt}"
-                            elif _gw_auth_lower in headers:
-                                rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                            await _set_rpc_auth_header(rpc_headers, headers)
                             # Forward passthrough headers for upstream MCP servers (see #3640).
                             # First-Party
                             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
@@ -4836,12 +4820,27 @@ async def _mint_internal_jwt_for_rpc() -> str | None:
         "email": email,
         "auth_provider": "oauth_delegated",
     }
-    return await create_jwt_token(
-        payload,
-        expires_in_minutes=1,
-        teams=ctx.get("teams"),
-        user_data=user_data,
-    )
+    try:
+        return await create_jwt_token(
+            payload,
+            expires_in_minutes=1,
+            teams=ctx.get("teams"),
+            user_data=user_data,
+        )
+    except Exception as e:
+        logger.error("Failed to mint internal JWT for /rpc forwarding: %s", e)
+        return None
+
+
+async def _set_rpc_auth_header(rpc_headers: dict[str, str], headers: Headers) -> None:
+    """Set the auth header on RPC-forwarded requests, exchanging OAuth tokens
+    for internal JWTs when applicable."""
+    internal_jwt = await _mint_internal_jwt_for_rpc()
+    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+    if internal_jwt:
+        rpc_headers[_gw_auth_lower] = f"Bearer {internal_jwt}"
+    elif _gw_auth_lower in headers:
+        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
 
 
 class _StreamableHttpAuthHandler:

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -89,6 +89,7 @@ from mcpgateway.services.resource_service import ResourceService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
+from mcpgateway.utils.create_jwt_token import create_jwt_token
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers, GATEWAY_ID_HEADER
 from mcpgateway.utils.identity_propagation import build_identity_headers
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
@@ -4156,12 +4157,17 @@ class SessionManagerWrapper:
                         "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
                         "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
                     }
-                    # Forward the inbound gateway auth header (default: Authorization,
-                    # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
-                    # the same caller. Hardcoding "authorization" here would silently
-                    # drop auth on deployments using a custom AUTH_HEADER_NAME.
+                    # If the request was authenticated via an external IdP OAuth
+                    # token, exchange it for a short-lived internal JWT that
+                    # /rpc's verify_jwt_token() accepts.  Minting is cheap and
+                    # the 1-minute TTL limits blast radius if the token leaks.
+                    # The raw IdP token would fail at /rpc because it is signed
+                    # with the IdP's key, not the gateway's jwt_secret_key.
+                    internal_jwt = await _mint_internal_jwt_for_rpc()
                     _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                    if _gw_auth_lower in headers:
+                    if internal_jwt:
+                        rpc_headers[_gw_auth_lower] = f"Bearer {internal_jwt}"
+                    elif _gw_auth_lower in headers:
                         rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
                     # Forward passthrough headers for upstream MCP servers (see #3640).
                     # First-Party
@@ -4327,8 +4333,11 @@ class SessionManagerWrapper:
                                 "x-mcp-session-id": mcp_session_id,
                                 "x-forwarded-internally": "true",
                             }
+                            internal_jwt = await _mint_internal_jwt_for_rpc()
                             _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                            if _gw_auth_lower in headers:
+                            if internal_jwt:
+                                rpc_headers[_gw_auth_lower] = f"Bearer {internal_jwt}"
+                            elif _gw_auth_lower in headers:
                                 rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
                             # Forward passthrough headers for upstream MCP servers (see #3640).
                             # First-Party
@@ -4785,6 +4794,54 @@ def get_streamable_http_auth_context() -> dict[str, Any]:
         else:
             forwarded[key] = value
     return forwarded
+
+
+async def _mint_internal_jwt_for_rpc() -> str | None:
+    """If the current request was authenticated via an external IdP OAuth
+    token, mint a short-lived internal ContextForge JWT to forward to /rpc.
+
+    Session-affinity forwarding routes session-bound MCP POSTs to the
+    internal /rpc endpoint.  /rpc authenticates via verify_jwt_token(),
+    which only accepts internal JWTs signed with the gateway's own key.
+    The raw IdP OAuth token fails signature/issuer validation there.
+
+    Non-OAuth paths (internal JWTs, proxy auth, anonymous) pass through
+    unchanged — this helper returns None and the caller forwards whatever
+    auth header it already has.
+
+    Security note:
+        The minted JWT intentionally omits ``is_admin`` from its claims.
+        ``/rpc`` determines admin status by querying the database, not from
+        JWT claims. Including ``is_admin`` here would be redundant (the DB
+        query happens anyway) and would introduce a JWT-based privilege
+        escalation vector if token verification were ever bypassed.
+
+    Returns:
+        A signed internal JWT string (1-minute TTL), or None if the
+        auth context is missing or the request was not OAuth-authenticated.
+    """
+    ctx = get_streamable_http_auth_context()
+    if not ctx.get("is_authenticated") or ctx.get("auth_method") != "oauth_access_token":
+        return None
+
+    email = ctx.get("email")
+    if not email:
+        return None
+
+    payload: dict[str, Any] = {
+        "sub": email,
+        "token_use": "session",  # nosec B105 — claim type marker, not secret
+    }
+    user_data = {
+        "email": email,
+        "auth_provider": "oauth_delegated",
+    }
+    return await create_jwt_token(
+        payload,
+        expires_in_minutes=1,
+        teams=ctx.get("teams"),
+        user_data=user_data,
+    )
 
 
 class _StreamableHttpAuthHandler:

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -604,6 +604,27 @@ async def test_mint_internal_jwt_for_rpc_ttl():
         tr.user_context_var.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_create_jwt_failure_returns_none():
+    """Should return None when create_jwt_token raises an exception."""
+    token = tr.user_context_var.set(
+        {
+            "email": "user@example.com",
+            "teams": ["team-a"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        with patch("mcpgateway.transports.streamablehttp_transport.create_jwt_token", side_effect=RuntimeError("JWT signing failed")):
+            result = await tr._mint_internal_jwt_for_rpc()
+            assert result is None
+    finally:
+        tr.user_context_var.reset(token)
+
+
 def test_record_mcp_auth_cache_event_swallows_metrics_errors(monkeypatch):
     """Metrics failures must not break MCP auth cache instrumentation."""
 

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -427,6 +427,109 @@ def test_get_streamable_http_auth_context_copies_supported_keys_and_lists():
     assert forwarded["scoped_permissions"] is not original["scoped_permissions"]
 
 
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_returns_none_for_non_oauth():
+    """Should return None when auth_method is not oauth_access_token."""
+    token = tr.user_context_var.set(
+        {
+            "email": "user@example.com",
+            "teams": ["team-a"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "jwt",
+            "token_use": "session",
+        }
+    )
+    try:
+        result = await tr._mint_internal_jwt_for_rpc()
+        assert result is None
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_returns_none_for_unauthenticated():
+    """Should return None when is_authenticated is False."""
+    token = tr.user_context_var.set(
+        {
+            "email": "user@example.com",
+            "is_authenticated": False,
+            "auth_method": "oauth_access_token",
+        }
+    )
+    try:
+        result = await tr._mint_internal_jwt_for_rpc()
+        assert result is None
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_returns_none_for_empty_email():
+    """Should return None when email is missing from the auth context."""
+    token = tr.user_context_var.set(
+        {
+            "is_authenticated": True,
+            "auth_method": "oauth_access_token",
+        }
+    )
+    try:
+        result = await tr._mint_internal_jwt_for_rpc()
+        assert result is None
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_empty_teams():
+    """Should mint an internal JWT with empty teams list."""
+    token = tr.user_context_var.set(
+        {
+            "email": "viewer@example.com",
+            "teams": [],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        jwt_str = await tr._mint_internal_jwt_for_rpc()
+        import jwt as pyjwt
+
+        claims = pyjwt.decode(jwt_str, options={"verify_signature": False})
+        assert claims["sub"] == "viewer@example.com"
+        assert claims["teams"] == []
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_round_trip():
+    """Should mint a JWT that passes verify_credentials (round-trip)."""
+    token = tr.user_context_var.set(
+        {
+            "email": "bob@example.com",
+            "teams": ["team-x"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        # First-Party
+        from mcpgateway.utils.verify_credentials import verify_credentials
+
+        jwt_str = await tr._mint_internal_jwt_for_rpc()
+        payload = await verify_credentials(jwt_str)
+        assert payload["sub"] == "bob@example.com"
+        assert payload["token_use"] == "session"
+        assert payload["teams"] == ["team-x"]
+    finally:
+        tr.user_context_var.reset(token)
+
+
 def test_record_mcp_auth_cache_event_swallows_metrics_errors(monkeypatch):
     """Metrics failures must not break MCP auth cache instrumentation."""
 
@@ -17009,6 +17112,7 @@ async def test_normalize_jwt_payload_non_admin_without_db_record():
 
 
 def test_get_scoped_visibility_from_user_context_admin_missing_teams_key():
+    # First-Party
     from mcpgateway.auth_context import get_scoped_visibility_from_user_context
 
     user_email, token_teams = get_scoped_visibility_from_user_context({"email": "admin@x.com", "is_admin": True})
@@ -17018,6 +17122,7 @@ def test_get_scoped_visibility_from_user_context_admin_missing_teams_key():
 
 
 def test_get_scoped_visibility_from_user_context_admin_with_empty_teams():
+    # First-Party
     from mcpgateway.auth_context import get_scoped_visibility_from_user_context
 
     user_email, token_teams = get_scoped_visibility_from_user_context({"email": "admin@x.com", "is_admin": True, "teams": []})
@@ -17027,6 +17132,7 @@ def test_get_scoped_visibility_from_user_context_admin_with_empty_teams():
 
 
 def test_get_scoped_visibility_from_user_context_admin_with_team_scope():
+    # First-Party
     from mcpgateway.auth_context import get_scoped_visibility_from_user_context
 
     user_email, token_teams = get_scoped_visibility_from_user_context({"email": "admin@x.com", "is_admin": True, "teams": ["team1"]})

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8450,6 +8450,80 @@ async def test_forwarded_post_routes_to_rpc_multipart_body_and_auth_header(monke
 
 
 @pytest.mark.asyncio
+async def test_forwarded_post_with_oauth_exchanges_token(monkeypatch):
+    """When forwarded request is OAuth-authenticated, the IdP token is exchanged for an internal JWT."""
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[
+            (b"x-forwarded-internally", b"true"),
+            (b"authorization", b"Bearer idp-token-abc"),
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    receive = _make_receive_sequence(
+        [
+            {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"tools/list","id":1}', "more_body": False},
+        ]
+    )
+
+    token = user_context_var.set(
+        {
+            "email": "user@example.com",
+            "teams": ["team-a"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        with patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            await wrapper.handle_streamable_http(scope, receive, send)
+    finally:
+        user_context_var.reset(token)
+
+    await wrapper.shutdown()
+    assert messages[0]["status"] == 200
+
+    forwarded_auth = mock_client.post.call_args.kwargs["headers"]["authorization"]
+    # Must be an exchanged JWT, not the raw IdP token
+    assert forwarded_auth.startswith("Bearer ")
+    assert forwarded_auth != "Bearer idp-token-abc"
+    # Verify it decodes to the expected internal claims
+    import jwt as pyjwt
+
+    claims = pyjwt.decode(forwarded_auth.removeprefix("Bearer "), options={"verify_signature": False})
+    assert claims["sub"] == "user@example.com"
+    assert claims["token_use"] == "session"
+    assert claims["teams"] == ["team-a"]
+
+
+@pytest.mark.asyncio
 async def test_forwarded_post_empty_body_returns_202(monkeypatch):
     """Test forwarded POST with empty body returns 202 (line 1406-1410)."""
 
@@ -9408,6 +9482,96 @@ async def test_local_affinity_post_routes_to_rpc_multipart_and_auth_header(monke
     await wrapper.shutdown()
     assert messages[0]["status"] == 200
     assert mock_client.post.call_args.kwargs["headers"]["authorization"] == "Bearer abc"
+
+
+@pytest.mark.asyncio
+async def test_local_affinity_post_with_oauth_exchanges_token(monkeypatch):
+    """When local-affinity request is OAuth-authenticated, exchange IdP token for internal JWT."""
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, messages = _make_send_collector()
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[
+            (b"mcp-session-id", b"sess-abc"),
+            (b"authorization", b"Bearer idp-token-xyz"),
+        ],
+    )
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{}}'
+
+    receive = _make_receive_sequence(
+        [
+            {"type": "http.request", "body": b'{"jsonrpc":"2.0","method":"tools/list","id":1}', "more_body": False},
+        ]
+    )
+
+    mock_session_registry = AsyncMock()
+    mock_session_registry.get_session_owner = AsyncMock(return_value="user@example.com")
+
+    token = user_context_var.set(
+        {
+            "email": "user@example.com",
+            "teams": ["team-a"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        with (
+            patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+            patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+            patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+            patch("mcpgateway.transports.streamablehttp_transport._get_shared_session_registry", return_value=mock_session_registry),
+            patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            await wrapper.handle_streamable_http(scope, receive, send)
+    finally:
+        user_context_var.reset(token)
+
+    await wrapper.shutdown()
+    assert messages[0]["status"] == 200
+
+    forwarded_auth = mock_client.post.call_args.kwargs["headers"]["authorization"]
+    assert forwarded_auth.startswith("Bearer ")
+    assert forwarded_auth != "Bearer idp-token-xyz"
+    import jwt as pyjwt
+
+    claims = pyjwt.decode(forwarded_auth.removeprefix("Bearer "), options={"verify_signature": False})
+    assert claims["sub"] == "user@example.com"
+    assert claims["token_use"] == "session"
+    assert claims["teams"] == ["team-a"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -530,6 +530,80 @@ async def test_mint_internal_jwt_for_rpc_round_trip():
         tr.user_context_var.reset(token)
 
 
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_omits_is_admin_claim():
+    """Minted JWT must not include is_admin claim (security invariant)."""
+    token = tr.user_context_var.set(
+        {
+            "email": "admin@example.com",
+            "teams": None,
+            "is_authenticated": True,
+            "is_admin": True,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        jwt_str = await tr._mint_internal_jwt_for_rpc()
+        import jwt as pyjwt
+
+        claims = pyjwt.decode(jwt_str, options={"verify_signature": False})
+        assert "is_admin" not in claims
+        assert claims["sub"] == "admin@example.com"
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_admin_bypass_teams_none():
+    """Admin users with teams=None should get JWT with teams=None (admin bypass)."""
+    token = tr.user_context_var.set(
+        {
+            "email": "admin@example.com",
+            "teams": None,
+            "is_authenticated": True,
+            "is_admin": True,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        jwt_str = await tr._mint_internal_jwt_for_rpc()
+        import jwt as pyjwt
+
+        claims = pyjwt.decode(jwt_str, options={"verify_signature": False})
+        assert claims["teams"] is None
+        assert claims["sub"] == "admin@example.com"
+    finally:
+        tr.user_context_var.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_mint_internal_jwt_for_rpc_ttl():
+    """Minted JWT should have 1-minute TTL."""
+    import time
+
+    token = tr.user_context_var.set(
+        {
+            "email": "user@example.com",
+            "teams": ["team-a"],
+            "is_authenticated": True,
+            "is_admin": False,
+            "auth_method": "oauth_access_token",
+            "token_use": "session",
+        }
+    )
+    try:
+        before = time.time()
+        jwt_str = await tr._mint_internal_jwt_for_rpc()
+        import jwt as pyjwt
+
+        claims = pyjwt.decode(jwt_str, options={"verify_signature": False})
+        assert 55 <= (claims["exp"] - before) <= 65
+    finally:
+        tr.user_context_var.reset(token)
+
+
 def test_record_mcp_auth_cache_event_swallows_metrics_errors(monkeypatch):
     """Metrics failures must not break MCP auth cache instrumentation."""
 


### PR DESCRIPTION
## 📌 Summary

When `MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`, session-bound MCP POSTs are forwarded to the internal `/rpc` endpoint. If the request was authenticated via an external IdP OAuth token (e.g., Keycloak, Entra ID), `/rpc` rejects it with **401** because it uses `verify_jwt_token()` which only accepts internal ContextForge JWTs signed with the gateways own `JWT_SECRET_KEY`.

## 🔁 Reproduction

1. Configure an OAuth-protected MCP server with `oauth_enabled=True` and an external IdP (e.g., Keycloak, Entra ID).
2. Enable session affinity: `MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`
3. Authenticate via the IdP and send an MCP `tools/list` POST with a valid Bearer token from the IdP.
4. The response is **401 Unauthorized** — the IdP token reaches `/rpc`, which fails signature validation.

Closes #4923

## 🐞 Root Cause

The streamable HTTP transport performs two distinct authentications:

| Layer | Where | What it accepts |
|-------|-------|-----------------|
| **Transport middleware** (`_route_idp_issued_token`) | `_StreamableHttpAuthHandler` | External IdP OAuth tokens (validated via `verify_oauth_access_token`) |
| **RPC handler** (`get_current_user_with_permissions`) | `/rpc` endpoint | Internal ContextForge JWTs only (validated via `verify_jwt_token`) |

Session affinity forwards session-bound POSTs from the transport layer directly to `/rpc` as an internal HTTP or loopback call, carrying the original `Authorization` header. When that header contains an IdP-issued token, `/rpc` has no path to validate it — no JWKS fetching, no OAuth introspection — so it returns 401.

## 💡 Fix Description

### Approach: Token Exchange (Internal JWT Minting)

Single-file change in `streamablehttp_transport.py`. No modifications to `/rpc`, RBAC middleware, or `verify_jwt_token()`.

**Before:**
```
┌──────────────┐     IdP OAuth Bearer     ┌──────────────┐
│  Transport   │ ──────────────────────►  │     /rpc     │
│  Middleware  │   (raw IdP token)        │  verify_jwt  │
│  (validates  │                          │ (only knows  │
│   OAuth)     │                          │internal JWTs)│
└──────────────┘                          └──────┬───────┘
                                                 │
                                              ❌ 401
```

**After:**
```
┌──────────────┐     IdP OAuth Bearer     ┌──────────────────┐
│  Transport   │ ──────────────────────►  │  _mint_internal_ │
│  Middleware  │                          │  jwt_for_rpc()   │
│  (validates  │                          │  ┌────────────┐  │
│   OAuth)     │                          │  │ 1-min TTL  │  │
└──────────────┘                          │  │ internal   │  │
                                          │  │ JWT        │  │
                                          │  └─────┬──────┘  │
                                          └────────┼─────────┘
                                                   │
                                                   ▼
                                          ┌──────────────────┐
                                          │      /rpc        │
                                          │  verify_jwt()    │
                                          │  (accepts it)    │
                                          └────────┬─────────┘
                                                   │
                                                ✅ 200
```

### Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| **Token exchange vs adding JWKS to /rpc** | More surgical — /rpcs auth dependency remains unchanged, no new security surface |
| **1-minute TTL** | Token consumed within milliseconds; limits blast radius if leaked |
| **`auth_provider: "oauth_delegated"`** | Audit trail marker matching `session_registry.py` pattern |
| **No `is_admin` in claims** | `/rpc` resolves admin status from DB, not JWT — prevents JWT-based privilege escalation |
| **Both `HTTP_AFFINITY_FORWARDED` and `HTTP_AFFINITY_LOCAL` paths** | Covers local-owner and cross-worker forwarding |
| **SSE/WebSocket excluded** | These transports cannot receive IdP tokens by design |

### Security Invariants Preserved

| Layer | Mechanism | Status |
|-------|-----------|--------|
| Token scoping | Minted JWT carries same `teams` as original OAuth context | ✅ |
| Admin bypass | `teams=None` passes through for admin users | ✅ |
| RBAC | `/rpc` queries DB for permissions — no auth-claim-based decisions | ✅ |
| Fail-closed | Non-OAuth paths return `None` (skip exchange) | ✅ |

## 🧪 Verification

| Check | Status |
|-------|--------|
| Lint suite (`make ruff bandit interrogate pylint`) | ✅ |
| Unit tests (`make test`) | **18900 passed, 599 skipped, 2 xfailed, 343 warnings** |
| 5 new unit tests for `_mint_internal_jwt_for_rpc()` | ✅ Coverage: non-OAuth, unauthenticated, missing email, empty teams, round-trip via `verify_credentials` |

### Test Cases Added

| Test | What it guards |
|------|----------------|
| `test_mint_internal_jwt_for_rpc_returns_none_for_non_oauth` | Skips exchange for internal JWT / proxy auth |
| `test_mint_internal_jwt_for_rpc_returns_none_for_unauthenticated` | Returns None for anonymous requests |
| `test_mint_internal_jwt_for_rpc_returns_none_for_empty_email` | Fail-closed when email is missing |
| `test_mint_internal_jwt_for_rpc_empty_teams` | Public-only scope (`teams=[]`) preserved |
| `test_mint_internal_jwt_for_rpc_round_trip` | Minted JWT passes `verify_credentials()` exactly as /rpc would |

## 📓 Notes

- **Orthogonal to PRs #4981/#4987**: Those fix the dispatch mechanism (loopback vs in-process); this fix addresses the auth token problem. Trivial rebase if they merge first.
- **Unrelated formatting**: The diff includes `# First-Party` comments added by `isort` pre-commit in neighboring test functions — these are formatting-only and semantically neutral.