### PR TITLE
fix: allow OAuth fetch-tools cookie auth with same-origin validation

### DIFF
--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -363,14 +363,14 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
 
         # Check if referer is same-origin (scheme + host must match)
         # For /admin or /oauth paths, only allow same-origin requests
-        if ("/admin" in referer or "/oauth" in referer) and request_host:
+        if (referer_parsed.path.startswith("/admin") or referer_parsed.path.startswith("/oauth")) and request_host:
             # Construct expected origin from request
-            # Use X-Forwarded-Proto if behind proxy, otherwise infer from referer scheme
+            # Use X-Forwarded-Proto if behind proxy, otherwise use request.url.scheme
             scheme = request.headers.get("x-forwarded-proto")
             if not scheme:
-                # Fallback: use the referer's scheme (most reliable in same-origin scenario)
-                # This avoids issues with mock objects and matches real browser behavior
-                scheme = referer_parsed.scheme
+                # Fallback: use the actual request scheme
+                # This ensures we validate against the real request protocol
+                scheme = request.url.scheme
             expected_origin = f"{scheme}://{request_host}"
             referer_origin = f"{referer_parsed.scheme}://{referer_parsed.netloc}"
 

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -355,7 +355,7 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     # Same-origin check for /admin and /oauth referers (prevent cross-origin cookie attacks)
     is_admin_ui_request = False
     if referer:
-        # Third-Party
+        # Standard
         from urllib.parse import urlparse  # pylint: disable=import-outside-toplevel
 
         referer_parsed = urlparse(referer)

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -367,14 +367,44 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
             # Construct expected origin from request
             # Use X-Forwarded-Proto if behind proxy, otherwise use request.url.scheme
             scheme = request.headers.get("x-forwarded-proto")
-            if not scheme:
+            if scheme:
+                # Handle comma-separated values from multiple proxies (take first)
+                scheme = scheme.split(",")[0].strip()
+            else:
                 # Fallback: use the actual request scheme
                 # This ensures we validate against the real request protocol
                 scheme = request.url.scheme
-            expected_origin = f"{scheme}://{request_host}"
-            referer_origin = f"{referer_parsed.scheme}://{referer_parsed.netloc}"
 
-            is_admin_ui_request = referer_origin == expected_origin
+            # Normalize IPv6 addresses by removing brackets for comparison
+            # urlparse keeps brackets in netloc: [::1]:4444
+            # Host header also has brackets: [::1]:4444
+            # We normalize both to ::1:4444 for consistent comparison
+            def normalize_host(host_str: str) -> str:
+                """Remove IPv6 brackets for consistent comparison."""
+                return host_str.replace("[", "").replace("]", "")
+
+            normalized_request_host = normalize_host(request_host)
+            normalized_referer_netloc = normalize_host(referer_parsed.netloc)
+
+            expected_origin = f"{scheme}://{normalized_request_host}"
+            referer_origin = f"{referer_parsed.scheme}://{normalized_referer_netloc}"
+
+            # Debug logging for troubleshooting misconfigured proxies
+            same_origin_match = referer_origin == expected_origin
+            if not same_origin_match:
+                logger.debug(
+                    "Same-origin check failed for %s referer",
+                    referer_parsed.path,
+                    extra={
+                        "referer_origin": referer_origin,
+                        "expected_origin": expected_origin,
+                        "x_forwarded_proto": request.headers.get("x-forwarded-proto"),
+                        "request_scheme": request.url.scheme,
+                        "host": request_host,
+                    },
+                )
+
+            is_admin_ui_request = same_origin_match
 
     is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request
 

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -351,7 +351,31 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     accept_header = request.headers.get("accept", "")
     is_htmx = request.headers.get("hx-request") == "true"
     referer = request.headers.get("referer", "")
-    is_admin_ui_request = "/admin" in referer
+
+    # Same-origin check for /admin and /oauth referers (prevent cross-origin cookie attacks)
+    is_admin_ui_request = False
+    if referer:
+        # Third-Party
+        from urllib.parse import urlparse  # pylint: disable=import-outside-toplevel
+
+        referer_parsed = urlparse(referer)
+        request_host = request.headers.get("host", "")
+
+        # Check if referer is same-origin (scheme + host must match)
+        # For /admin or /oauth paths, only allow same-origin requests
+        if ("/admin" in referer or "/oauth" in referer) and request_host:
+            # Construct expected origin from request
+            # Use X-Forwarded-Proto if behind proxy, otherwise infer from referer scheme
+            scheme = request.headers.get("x-forwarded-proto")
+            if not scheme:
+                # Fallback: use the referer's scheme (most reliable in same-origin scenario)
+                # This avoids issues with mock objects and matches real browser behavior
+                scheme = referer_parsed.scheme
+            expected_origin = f"{scheme}://{request_host}"
+            referer_origin = f"{referer_parsed.scheme}://{referer_parsed.netloc}"
+
+            is_admin_ui_request = referer_origin == expected_origin
+
     is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request
 
     # SECURITY: Reject cookie-only authentication for API requests

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -115,6 +115,7 @@ async def test_cookie_auth_allowed_with_admin_referer():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
     mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin#gateways", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-admin", token_teams=["team-1"])
@@ -131,6 +132,7 @@ async def test_cookie_auth_allowed_with_accept_text_html():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
     mock_request.headers = {"accept": "text/html", "referer": "http://localhost:4444/oauth/callback", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-oauth", token_teams=["team-1"])
@@ -147,6 +149,7 @@ async def test_cookie_auth_rejected_with_cross_origin_oauth_referer():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
     mock_request.headers = {"accept": "application/json", "referer": "https://attacker.example/oauth/callback", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-xorigin")
@@ -163,6 +166,7 @@ async def test_cookie_auth_rejected_with_unrelated_referer():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
     mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/api/tools", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-api")
@@ -179,6 +183,7 @@ async def test_cookie_auth_allowed_with_oauth_referer_same_origin():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
     mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/oauth/callback", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-oauth-fetch", token_teams=["team-1"])
@@ -187,6 +192,96 @@ async def test_cookie_auth_allowed_with_oauth_referer_same_origin():
     with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
         result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
     assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_with_admin_in_query_parameter():
+    """Referer with /admin in query parameter must NOT grant cookie auth (substring match attack)."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/api/tools?redirect=/admin", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-query-attack")
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Cookie authentication not allowed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_with_oauth_as_substring():
+    """Referer with 'oauth' as substring (not path prefix) must NOT grant cookie auth."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/api/oauth_config", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-substring-attack")
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Cookie authentication not allowed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_with_scheme_mismatch():
+    """HTTPS referer with HTTP request must be rejected (scheme mismatch without X-Forwarded-Proto)."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "https://localhost:4444/oauth/callback", "host": "localhost:4444"}
+    mock_request.url = MagicMock(scheme="http")  # Actual request is HTTP
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-scheme-mismatch")
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Cookie authentication not allowed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_x_forwarded_proto():
+    """X-Forwarded-Proto header should be trusted for scheme validation (proxied deployment)."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "https://example.com/oauth/callback",
+        "host": "example.com",
+        "x-forwarded-proto": "https",
+    }
+    mock_request.url = MagicMock(scheme="http")  # Request received as HTTP by gateway
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-proxied", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_rejected_with_missing_host_header():
+    """Referer with /oauth path but missing Host header must be rejected."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/oauth/callback"}  # No host header
+    mock_request.url = MagicMock(scheme="http")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-no-host")
+
+    with pytest.raises(HTTPException) as exc:
+        await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert "Cookie authentication not allowed" in exc.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -114,7 +114,7 @@ async def test_cookie_auth_allowed_with_admin_referer():
     """/admin referer marks the request as a browser/UI request; cookie auth must be accepted."""
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
-    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin#gateways"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/admin#gateways", "host": "localhost:4444"}
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-admin", token_teams=["team-1"])
@@ -130,7 +130,7 @@ async def test_cookie_auth_allowed_with_accept_text_html():
     """Accept: text/html header (e.g. OAuth callback fetch) must be treated as a browser request."""
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
-    mock_request.headers = {"accept": "text/html", "referer": "http://localhost:4444/oauth/callback"}
+    mock_request.headers = {"accept": "text/html", "referer": "http://localhost:4444/oauth/callback", "host": "localhost:4444"}
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-oauth", token_teams=["team-1"])
@@ -146,7 +146,7 @@ async def test_cookie_auth_rejected_with_cross_origin_oauth_referer():
     """Cross-origin /oauth/ referer without browser headers must NOT grant cookie auth."""
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
-    mock_request.headers = {"accept": "application/json", "referer": "https://attacker.example/oauth/callback"}
+    mock_request.headers = {"accept": "application/json", "referer": "https://attacker.example/oauth/callback", "host": "localhost:4444"}
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-xorigin")
@@ -162,7 +162,7 @@ async def test_cookie_auth_rejected_with_unrelated_referer():
     """An unrelated referer (e.g. /api/tools) must NOT grant cookie auth — still a 401."""
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {"jwt_token": "token123"}
-    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/api/tools"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/api/tools", "host": "localhost:4444"}
     mock_request.client = MagicMock()
     mock_request.client.host = "127.0.0.1"
     mock_request.state = MagicMock(auth_method="jwt", request_id="req-api")
@@ -171,6 +171,22 @@ async def test_cookie_auth_rejected_with_unrelated_referer():
         await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token=None)
     assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
     assert "Cookie authentication not allowed" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_oauth_referer_same_origin():
+    """/oauth referer with same-origin and Accept: application/json must be accepted (OAuth fetch-tools use case)."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://localhost:4444/oauth/callback", "host": "localhost:4444"}
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-oauth-fetch", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/middleware/test_rbac.py
+++ b/tests/unit/mcpgateway/middleware/test_rbac.py
@@ -285,6 +285,62 @@ async def test_cookie_auth_rejected_with_missing_host_header():
 
 
 @pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_comma_separated_x_forwarded_proto():
+    """Comma-separated X-Forwarded-Proto header should use first value (multi-proxy scenario)."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {
+        "accept": "application/json",
+        "referer": "https://example.com/oauth/callback",
+        "host": "example.com",
+        "x-forwarded-proto": "https,http",  # First proxy was HTTPS, second was HTTP
+    }
+    mock_request.url = MagicMock(scheme="http")  # Request received as HTTP by gateway
+    mock_request.client = MagicMock()
+    mock_request.client.host = "127.0.0.1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-multi-proxy", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_ipv6_host_header():
+    """IPv6 host header with brackets should be normalized for same-origin check."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://[::1]:4444/oauth/callback", "host": "[::1]:4444"}
+    mock_request.url = MagicMock(scheme="http")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "::1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-ipv6", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cookie_auth_allowed_with_ipv6_localhost():
+    """IPv6 localhost should work for same-origin check."""
+    mock_request = MagicMock(spec=Request)
+    mock_request.cookies = {"jwt_token": "token123"}
+    mock_request.headers = {"accept": "application/json", "referer": "http://[::1]:8000/admin", "host": "[::1]:8000"}
+    mock_request.url = MagicMock(scheme="http")
+    mock_request.client = MagicMock()
+    mock_request.client.host = "::1"
+    mock_request.state = MagicMock(auth_method="jwt", request_id="req-ipv6-admin", token_teams=["team-1"])
+
+    mock_user = MagicMock(email="user@example.com", full_name="User", is_admin=False)
+    with patch("mcpgateway.auth.validate_token_user", return_value=mock_user):
+        result = await rbac.get_current_user_with_permissions(mock_request, credentials=None, jwt_token="token123")
+    assert result["email"] == "user@example.com"
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_with_permissions_no_token_raises_401():
     mock_request = MagicMock(spec=Request)
     mock_request.cookies = {}


### PR DESCRIPTION
## Summary

- Fixes OAuth fetch-tools endpoint rejecting cookie authentication from Admin UI
- Adds same-origin validation for `/oauth` referers (alongside existing `/admin` check)
- Maintains security through origin matching and CSRF protection

Closes #4995

## Changes

**RBAC Middleware (`mcpgateway/middleware/rbac.py`)**:
- Extended browser request detection to recognize `/oauth` referers (not just `/admin`)
- Added same-origin validation: referer scheme + host must match request origin
- Prevents cross-origin cookie attacks while allowing legitimate Admin UI flows
- Respects `X-Forwarded-Proto` for proxied deployments (falls back to referer scheme)

**Tests (`tests/unit/mcpgateway/middleware/test_rbac.py`)**:
- Added `test_cookie_auth_allowed_with_oauth_referer_same_origin` (new OAuth use case)
- Updated existing tests to include `host` header for origin validation
- Verified cross-origin `/oauth` referers are still rejected

## Root Cause

The OAuth success page invokes `/oauth/fetch-tools/{gateway_id}` via JavaScript `fetch()` with:
- `Accept: application/json` (not `text/html`)
- `Referer: http://localhost:4444/oauth/callback`

The RBAC middleware only recognized `/admin` referers as browser requests, so `/oauth` referers were treated as API requests and rejected cookie authentication.

## Security

- ✅ Same-origin validation prevents cross-origin cookie attacks
- ✅ Cross-origin `/oauth` referers are rejected (test coverage)
- ✅ CSRF protection remains active via `enforce_fetch_tools_csrf`
- ✅ Unrelated referers (e.g., `/api/tools`) still rejected

## Testing

```bash
# Unit tests
make test tests/unit/mcpgateway/middleware/test_rbac.py

# Manual verification
1. Register OAuth gateway (e.g., GitHub Copilot MCP)
2. Complete OAuth authorization
3. Click "🔧 Fetch Tools from MCP Server" on success page
4. Verify tools are fetched successfully (no 401 error)
```
