### PR TITLE
fix(session-affinity): propagate StreamableHTTP auth context across cross-worker forwards

### DIFF
--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -221,6 +221,27 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
     return None
 
 
+def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
+    """Encode a trusted internal MCP auth context for forwarding.
+
+    Mirror of :func:`decode_internal_mcp_auth_context`. Used to package the
+    StreamableHTTP auth result (whatever ``streamable_http_auth()`` already
+    established at the edge) so it can be propagated to a trusted internal
+    dispatcher (e.g. ``/_internal/mcp/rpc``) without that dispatcher re-running
+    authentication. The unpadded base64url shape keeps the value header-safe.
+
+    Args:
+        auth_context: Auth-context dict (typically the return value of
+            :func:`mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context`).
+
+    Returns:
+        Unpadded base64url-encoded JSON payload suitable for the
+        ``x-contextforge-auth-context`` header.
+    """
+    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
+    return encoded.rstrip("=")
+
+
 def decode_internal_mcp_auth_context(header_value: str) -> Dict[str, Any]:
     """Decode the trusted internal MCP auth header payload.
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -277,18 +277,30 @@ _INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
 
 
 def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
-    """Return whether the request came from the local Rust runtime sidecar.
+    """Return whether the request came from a trusted local internal source.
+
+    Two callers are trusted today:
+
+    - ``"rust"`` — the local Rust runtime sidecar (over loopback).
+    - ``"affinity"`` — the in-process ASGITransport dispatch used by
+      session-affinity forwarding to propagate a request to the owner worker
+      after the originating worker already ran ``streamable_http_auth()``.
+
+    Both share the same defense-in-depth gates: a shared-secret-derived auth
+    header (``has_valid_internal_mcp_runtime_auth_header``) AND a loopback
+    client address. Only the ``x-contextforge-mcp-runtime`` marker value
+    differs.
 
     Args:
         request: Incoming request to inspect.
 
     Returns:
-        ``True`` when the request carries the trusted Rust runtime marker from
-        loopback, otherwise ``False``.
+        ``True`` when the request carries a trusted internal-runtime marker
+        from loopback, otherwise ``False``.
     """
     runtime_marker = request.headers.get("x-contextforge-mcp-runtime")
     client_host = getattr(getattr(request, "client", None), "host", None)
-    if runtime_marker != "rust" or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
+    if runtime_marker not in ("rust", "affinity") or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
         return False
     # Defense-in-depth: /_internal/a2a/* endpoints must refuse requests when
     # A2A support is disabled, even from an otherwise-trusted local sidecar.

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -1024,27 +1024,42 @@ class SessionAffinity:
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
         """Execute a forwarded Streamable HTTP request in-process and reply via Redis.
 
-        A forwarded request always lands here on the worker that OWNS the
-        downstream session (its ``WORKER_ID`` matched the Redis owner key), so the
-        bound upstream session in this process's ``UpstreamSessionRegistry`` can
-        serve it. We therefore dispatch the JSON-RPC call to the local ``/rpc``
-        route via an **in-process ASGI transport** instead of a network loopback
-        to ``127.0.0.1``: a real loopback hits the shared gunicorn socket and the
-        kernel routes it to an arbitrary worker that does not hold this session,
-        which breaks upstream-session reuse and fails the request. The
-        ``x-forwarded-internally`` header stops the re-entered handler from
-        forwarding again.
+        A forwarded request lands here on the worker that OWNS the downstream
+        session, so the bound upstream session in this process's
+        ``UpstreamSessionRegistry`` can serve it. We dispatch to the **trusted
+        internal** ``/_internal/mcp/rpc`` endpoint via an in-process ASGI
+        transport.
+
+        Why the trusted internal endpoint (not public ``/rpc``):
+
+        - The originating worker already ran ``streamable_http_auth()``, which
+          for ``/servers/{id}/mcp`` paths handles virtual-server OAuth verifiers
+          and ``MCP_REQUIRE_AUTH=false`` public-only mode. Public ``/rpc`` only
+          knows ContextForge JWTs / cookies, so re-authenticating an OAuth
+          bearer or an unauthenticated public-only request through ``/rpc``
+          would 401.
+        - The originating worker packages its already-validated identity into
+          ``auth_context`` (the encoded ``x-contextforge-auth-context`` value)
+          and forwards it here. Combined with the
+          ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret
+          HMAC header, and the loopback client address synthesised by
+          ASGITransport, the trusted endpoint's
+          ``_is_trusted_internal_mcp_runtime_request`` gate accepts the
+          request and ``_build_internal_mcp_forwarded_user`` reconstructs the
+          same user the edge saw.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
                 - type: "http_forward"
                 - response_channel: Redis channel to publish response to
                 - mcp_session_id: Session identifier
-                - method: HTTP method (GET, POST, DELETE)
-                - path: Request path (e.g., /servers/{id}/mcp)
-                - headers: Request headers dict (lowercased keys)
-                - body: Hex-encoded request body
-            redis: Redis client for publishing response
+                - method: HTTP method (POST primarily)
+                - path: Original request path (e.g., /servers/{id}/mcp)
+                - headers: Original request headers (lowercased keys)
+                - body: Hex-encoded JSON-RPC request body
+                - auth_context: base64url-encoded auth context from the
+                  originating worker's ``streamable_http_auth()`` result
+            redis: Redis client for publishing the response
         """
         response_channel = request.get("response_channel")
 
@@ -1060,6 +1075,7 @@ class SessionAffinity:
             headers = request.get("headers", {})
             body_hex = request.get("body", "")
             mcp_session_id = request.get("mcp_session_id")
+            auth_context_header = request.get("auth_context") or ""
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
@@ -1082,7 +1098,8 @@ class SessionAffinity:
                 await _publish(202, b"")
                 return
 
-            # Inject the virtual server id (from the path) into params so /rpc routes correctly.
+            # Inject the virtual server id (from the path) into params so the
+            # dispatcher routes to the right virtual server.
             server_match = _SERVER_ID_RE.search(path)
             if server_match and isinstance(json_body, dict):
                 if not isinstance(json_body.get("params"), dict):
@@ -1091,34 +1108,42 @@ class SessionAffinity:
                 body = orjson.dumps(json_body)
 
             # First-Party - lazy imports avoid a circular dependency with main/transport.
+            from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header  # pylint: disable=import-outside-toplevel,protected-access
             from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel
 
+            # Build headers for the TRUSTED internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" marker that identifies us
+            #   to _is_trusted_internal_mcp_runtime_request.
+            # - x-contextforge-mcp-runtime-auth: shared-secret-derived HMAC
+            #   matched by has_valid_internal_mcp_runtime_auth_header.
+            # - x-contextforge-auth-context: the encoded auth context from the
+            #   originating worker; decoded server-side via
+            #   _build_internal_mcp_forwarded_user so the dispatcher uses the
+            #   same user identity streamable_http_auth() established.
             rpc_headers = {
                 "content-type": "application/json",
                 "x-mcp-session-id": mcp_session_id or "",
-                "x-forwarded-internally": "true",
+                "x-contextforge-mcp-runtime": "affinity",
+                "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                "x-contextforge-auth-context": auth_context_header,
             }
-            auth_header = _resolve_auth_header_name(settings).lower()
-            if auth_header in headers:
-                rpc_headers[auth_header] = headers[auth_header]
             # Preserve passthrough headers destined for upstream MCP servers (#3640).
             rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
-            # Dispatch IN-PROCESS: ASGITransport runs the FastAPI app in *this* worker,
-            # so /rpc resolves the bound upstream session from this process's registry
-            # instead of bouncing back through the shared socket to a random worker.
-            transport = httpx.ASGITransport(app=app)
+            # Dispatch IN-PROCESS to the trusted internal endpoint. The explicit
+            # client=("127.0.0.1", 0) tells ASGITransport to set scope["client"]
+            # to a loopback address so the trust check accepts the request.
+            transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
             async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                 response = await client.post(
-                    "/rpc",
+                    "/_internal/mcp/rpc",
                     content=body,
                     headers=rpc_headers,
                     timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                 )
 
-            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process: {response.status_code}")
+            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process via /_internal/mcp/rpc: {response.status_code}")
 
             resp_headers = {"content-type": "application/json"}
             if mcp_session_id:
@@ -1155,6 +1180,7 @@ class SessionAffinity:
         headers: Dict[str, str],
         body: bytes,
         query_string: str = "",
+        auth_context: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Forward a Streamable HTTP request to the worker that owns the session via Redis Pub/Sub.
 
@@ -1171,6 +1197,12 @@ class SessionAffinity:
             headers: Request headers.
             body: Request body bytes.
             query_string: Query string if any.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying
+                the result of ``streamable_http_auth()`` from the originating
+                worker. Lets the owner dispatch via the trusted internal
+                ``/_internal/mcp/rpc`` endpoint without re-authenticating, so
+                OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only modes
+                survive forwarding.
 
         Returns:
             Dict with 'status', 'headers', and 'body' from the owner worker's response,
@@ -1212,6 +1244,11 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
+                # Encoded auth context from the originating worker's
+                # streamable_http_auth() result; the owner uses this to
+                # dispatch via the trusted internal /_internal/mcp/rpc
+                # endpoint without re-authenticating.
+                "auth_context": auth_context,
             }
 
             # Subscribe to response channel BEFORE publishing request (prevent race)

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -1128,6 +1128,15 @@ class SessionAffinity:
                 "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
                 "x-contextforge-auth-context": auth_context_header,
             }
+            # Preserve the originating request's Authorization header. The
+            # trusted-internal endpoint doesn't re-authenticate (it trusts the
+            # encoded auth-context above), but the CSRF middleware short-circuits
+            # on requests carrying a bearer token, and lacking that bearer makes
+            # it 403 the dispatch. Mirrors the Rust runtime forward path, which
+            # also passes Authorization straight through.
+            original_auth = headers.get("authorization") or headers.get("Authorization")
+            if original_auth:
+                rpc_headers["authorization"] = original_auth
             # Preserve passthrough headers destined for upstream MCP servers (#3640).
             rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 

--- a/mcpgateway/transports/rust_mcp_runtime_proxy.py
+++ b/mcpgateway/transports/rust_mcp_runtime_proxy.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 # Standard
 import asyncio
-import base64
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 import httpx
-import orjson
 from sqlalchemy import exists as sa_exists
 from starlette.types import Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import encode_internal_mcp_auth_context
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session
 from mcpgateway.db import Server as DbServer
@@ -338,5 +337,4 @@ def _build_forwarded_auth_context_header() -> str | None:
     auth_context = get_streamable_http_auth_context()
     if not auth_context:
         return None
-    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
-    return encoded.rstrip("=")
+    return encode_internal_mcp_auth_context(auth_context)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4213,6 +4213,17 @@ class SessionManagerWrapper:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
 
+                    # Package the authenticated identity that streamable_http_auth()
+                    # established for this request so the owner worker can dispatch
+                    # via the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating. This is what makes virtual-server OAuth
+                    # tokens and MCP_REQUIRE_AUTH=false public-only mode survive a
+                    # cross-worker forward.
+                    # First-Party
+                    from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+                    encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
+
                     # Read request body
                     body_parts = []
                     while True:
@@ -4234,6 +4245,7 @@ class SessionManagerWrapper:
                         headers=headers,
                         body=body,
                         query_string=query_string,
+                        auth_context=encoded_auth_context,
                     )
 
                     if response:

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -2320,6 +2320,52 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
 
 
 @pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_authorization_for_csrf_bypass():
+    """The originating ``Authorization`` bearer is copied onto the trusted-internal dispatch.
+
+    The CSRF middleware short-circuits on bearer-tokened requests; without
+    preserving the original ``Authorization`` header, the affinity dispatch to
+    ``/_internal/mcp/rpc`` 403s on CSRF even though the trusted-internal gate
+    itself is satisfied. Mirrors the Rust runtime forward path.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-auth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"authorization": "Bearer original-jwt"},  # lowercased like the wire
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-auth-bypass",
+        "auth_context": "ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    sent_headers = client.last_post_kwargs["headers"]
+    assert sent_headers.get("authorization") == "Bearer original-jwt"
+
+
+@pytest.mark.asyncio
 async def test_execute_forwarded_http_request_sends_empty_auth_context_header_when_missing():
     """Executor side: a forwarded payload with no auth_context still dispatches with an empty x-contextforge-auth-context header.
 

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1099,6 +1099,81 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
 
 
 @pytest.mark.asyncio
+async def test_forward_to_owner_includes_auth_context_in_redis_payload():
+    """The encoded auth context from the originating worker is carried in the forwarded Redis payload.
+
+    Without this, the owner worker cannot reconstruct the StreamableHTTP user
+    that ``streamable_http_auth()`` already validated at the edge, so forwarded
+    OAuth and ``MCP_REQUIRE_AUTH=false`` requests would re-authenticate against
+    the public ``/rpc`` and fail with 401.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    # Make the pubsub wait return immediately so we focus on the published payload.
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    encoded_ctx = "base64url-encoded-auth-ctx-from-edge"
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner(
+            owner_worker_id="other-worker",
+            mcp_session_id="sess-auth",
+            method="POST",
+            path="/servers/srv-9/mcp",
+            headers={"Authorization": "Bearer x"},
+            body=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            auth_context=encoded_ctx,
+        )
+
+    # Locate the forward payload published to the owner's HTTP channel.
+    owner_channels = [(chan, payload) for chan, payload in fake.published if chan == "mcpgw:pool_http:other-worker"]
+    assert owner_channels, "forward payload was not published to the owner channel"
+    forward_data = orjson.loads(owner_channels[0][1])
+    assert forward_data["type"] == "http_forward"
+    assert forward_data["auth_context"] == encoded_ctx
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_defaults_auth_context_to_none_when_omitted():
+    """Sender side: when no auth_context is supplied, the field is present and set to None.
+
+    The executor reads ``request.get("auth_context") or ""`` and forwards an
+    empty string header — equivalent to the pre-auth-context behaviour. This
+    test pins the shape so future signature changes don't silently break the
+    contract.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner("other-worker", "sess-no-ctx", "POST", "/mcp", {}, b"")
+
+    forward_data = orjson.loads(fake.published[0][1])
+    assert "auth_context" in forward_data
+    assert forward_data["auth_context"] is None
+
+
+@pytest.mark.asyncio
 async def test_forward_to_owner_times_out_and_returns_none_with_metric_bump():
     """No message arrives → asyncio.timeout fires → metric incremented, None returned."""
     # First-Party
@@ -1433,8 +1508,8 @@ class _FakeHttpxClient:
     async def __aexit__(self, *_exc):
         return False
 
-    async def post(self, url, *, json=None, headers=None, timeout=None):
-        self.last_post_kwargs = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+    async def post(self, url, *, json=None, content=None, headers=None, timeout=None):
+        self.last_post_kwargs = {"url": url, "json": json, "content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
@@ -1571,7 +1646,10 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_response_via_redis():
-    """Happy path: make the internal HTTP call, hex-encode the response body, publish to Redis."""
+    """Happy path: dispatch in-process to the trusted internal endpoint and publish the response back."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1581,34 +1659,44 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
     response.headers = {"content-type": "application/json"}
     client = _FakeHttpxClient(response=response)
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-1",
         "method": "POST",
-        "path": "/mcp",
+        "path": "/servers/srv-9/mcp",
         "query_string": "",
         "headers": {"Authorization": "Bearer x"},
-        "body": b"upstream-body".hex(),
+        "body": jsonrpc_body.hex(),
         "original_worker": "origin-worker",
         "mcp_session_id": "sess-123456789",
+        "auth_context": "encoded-ctx",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Dispatched to the trusted-internal endpoint, NOT the public /rpc.
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == "encoded-ctx"
+    assert headers["x-mcp-session-id"] == "sess-123456789"
+    # server_id from the path is injected into JSON-RPC params before dispatch.
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"]["server_id"] == "srv-9"
 
     # Response published to the requester's channel.
     assert fake.published
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-1"
-    # Orjson round-trips the dict — body is hex-encoded.
-    # Third-Party
-    import orjson
-
     decoded = orjson.loads(payload)
     assert decoded["status"] == 200
     assert bytes.fromhex(decoded["body"]) == b"response-body"
@@ -1617,6 +1705,9 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_500_error_on_exception():
     """If the internal HTTP call raises, a 500 error envelope is still published to Redis."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1624,12 +1715,13 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
     fake = _FakeRedis()
     client = _FakeHttpxClient(raise_exc=RuntimeError("internal crash"))
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-2",
         "method": "POST",
         "path": "/mcp",
         "headers": {},
-        "body": "",
+        "body": jsonrpc_body.hex(),
         "mcp_session_id": "sess-abcdef",
     }
 
@@ -1637,15 +1729,12 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
     # Error response still published so the requester doesn't hang.
-    # Third-Party
-    import orjson
-
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-2"
     decoded = orjson.loads(payload)
@@ -2231,8 +2320,59 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
 
 
 @pytest.mark.asyncio
-async def test_execute_forwarded_http_request_appends_query_string():
-    """Query string from forwarded request is appended to the internal URL."""
+async def test_execute_forwarded_http_request_sends_empty_auth_context_header_when_missing():
+    """Executor side: a forwarded payload with no auth_context still dispatches with an empty x-contextforge-auth-context header.
+
+    Old payloads (or non-authenticated paths) may omit ``auth_context``. The
+    executor should not crash and the trust headers (runtime marker + HMAC)
+    must still be set so the trusted-internal endpoint accepts the request.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-noctx",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-ctx",
+        # No "auth_context" key on purpose.
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == ""
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
+    """Lifecycle methods (DELETE, GET) don't carry a JSON-RPC body, so the owner just acks 200 without dispatching."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -2242,24 +2382,26 @@ async def test_execute_forwarded_http_request_appends_query_string():
 
     request = {
         "response_channel": "r",
-        "method": "GET",
+        "method": "DELETE",
         "path": "/mcp",
-        "query_string": "foo=bar&baz=qux",
+        "query_string": "",
         "headers": {},
         "body": "",
-        "mcp_session_id": "sess-qs",
+        "mcp_session_id": "sess-delete",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    assert client.last_request_kwargs["url"] == "http://localhost:4444/mcp?foo=bar&baz=qux"  # type: ignore[index]
+    # Acked without invoking the in-process dispatch.
+    assert client.last_post_kwargs is None
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -9011,6 +9011,65 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeypatch):
+    """The sender encodes the live ``get_streamable_http_auth_context()`` result and passes it through ``forward_to_owner``.
+
+    Without this, OAuth-enabled virtual servers and ``MCP_REQUIRE_AUTH=false``
+    public-only mode would 401 after a cross-worker forward, because the owner
+    would have nothing to reconstruct the edge-authenticated user from.
+    """
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    # Stand-in for the authenticated identity the edge worker already established.
+    edge_auth_ctx = {"email": "alice@example.com", "is_admin": False, "teams": ["t1"]}
+    expected_encoded = encode_internal_mcp_auth_context(edge_auth_ctx)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context", lambda: edge_auth_ctx)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-auth")])
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-2")
+    mock_pool.forward_to_owner = AsyncMock(
+        return_value={
+            "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body": b'{"jsonrpc":"2.0","result":{}}',
+        }
+    )
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+    ):
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
+
+    await wrapper.shutdown()
+    # auth_context kwarg is supplied and equals the encoded edge identity.
+    assert mock_pool.forward_to_owner.call_args.kwargs["auth_context"] == expected_encoded
+
+
+@pytest.mark.asyncio
 async def test_affinity_forward_failure_falls_through(monkeypatch):
     """Test affinity forward failure falls through to local handling (line 1525-1527)."""
 


### PR DESCRIPTION
Stacked on top of #4981. Addresses the reviewer concern that virtual-server OAuth and `MCP_REQUIRE_AUTH=false` public-only sessions would 401 after a cross-worker forward, because the forward path replays through the public `/rpc` which only understands ContextForge JWTs/cookies.

## What changes

The forwarding worker now packages the identity that `streamable_http_auth()` already validated at the edge and ships it to the owner worker, which dispatches in-process to the existing trusted-internal endpoint `/_internal/mcp/rpc` (the same one the Rust runtime uses). The owner reconstructs the same user via `_build_internal_mcp_forwarded_user` rather than re-authenticating.

Pieces:

1. **`auth_context.py`** — promote `encode_internal_mcp_auth_context` to a public helper (mirror of the existing `decode_internal_mcp_auth_context`). Rust proxy switches to using it so the encode/decode pair lives in one module.
2. **`main.py`** — generalize `_is_trusted_internal_mcp_runtime_request` to accept a second trusted caller marker `affinity` alongside `rust`. Loopback-client check, shared-secret HMAC, and the A2A defense-in-depth path guard remain unchanged.
3. **`session_affinity.py`**
   - `forward_to_owner` carries a new `auth_context` field in the Redis `http_forward` payload.
   - `_execute_forwarded_http_request` dispatches to `/_internal/mcp/rpc` with the full trust-header set (`x-contextforge-mcp-runtime: affinity`, HMAC, encoded auth-context, `x-mcp-session-id`) over an in-process `ASGITransport(client=("127.0.0.1", 0))`.
   - Original `Authorization` header is preserved so the CSRF middleware short-circuits on its bearer exemption. The trusted-internal endpoint doesn't re-authenticate from it.
4. **`streamablehttp_transport.py`** — at the forward call site, encode `get_streamable_http_auth_context()` and pass it through as `auth_context=...`.

## Why the trusted-internal endpoint instead of public `/rpc`

`streamable_http_auth()` handles virtual-server OAuth verifiers (RFC 9728) and `MCP_REQUIRE_AUTH=false` public-only mode for `/servers/{id}/mcp` paths. The public `/rpc` only knows ContextForge JWTs/cookies, so an OAuth bearer or unauthenticated public-only request would 401 after a forward. Routing through `/_internal/mcp/rpc` lets the owner trust the edge's already-validated decision.

## Tests

Unit tests pin both ends of the wire (`tests/unit/mcpgateway/services/test_session_affinity.py`, `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py`):

- Sender side: streamable-HTTP handler encodes `get_streamable_http_auth_context()` and passes it through `forward_to_owner(auth_context=...)`.
- Executor side: `forward_to_owner` carries the encoded value in the Redis payload (and defaults to `None` when omitted, so the field shape stays stable for old payloads).
- Executor side: `_execute_forwarded_http_request` dispatches to `/_internal/mcp/rpc` with the affinity trust marker, HMAC, encoded auth-context, session-id, and the original `Authorization` header; injects `server_id` from the path into JSON-RPC `params`.
- Executor side: missing auth-context still produces valid trust headers (with an empty `x-contextforge-auth-context`) so the endpoint can fall back to its existing visibility rules.

Also repairs three pre-existing `_execute_forwarded_http_request` tests that went stale at 616f6508 when the executor switched to in-process ASGI dispatch.

## End-to-end validation (3 x 24 gateway stack)

Probe (`/tmp/mcp_probe.py`):
- `initialize` 200, `notifications/initialized` 202, 6/6 `tools/list` 200
- Zero `Error executing forwarded HTTP request`
- Zero CSRF rejections

Benchmark (`make benchmark-mcp-tools`, 125 users / 60s):
- 399.92 RPS (on par with the 397 RPS measured on #4981 alone, so auth-context propagation has no throughput cost)
- 0 failures (0.00%)
- p99 1,800ms

`tests/integration/test_issue_4205_upstream_session_isolation.py`: 4/4 green.

## Follow-ups (not blocking)

- A full-stack OAuth probe (provisioning an `oauth_enabled=True` virtual server in Keycloak) would belt-and-brace the contract pinned by the unit tests.
- **Public-only forwards + CSRF.** When `MCP_REQUIRE_AUTH=false` and the virtual server is public-only, the forwarded request carries no bearer, so the CSRF middleware's bearer-based short-circuit doesn't apply. With `/_internal/mcp/` not in `csrf_exempt_paths`, the cross-worker forward would 403 on CSRF at the inner dispatch. Two clean fixes: add `/_internal/mcp/` to `csrf_exempt_paths` (mirrors how `/rpc` and `/mcp/` are already exempt), or have CSRF trust the internal HMAC marker the same way `security_headers.py` already exempts `^/_internal`. Same dependency exists for the Rust runtime path's `/_internal/mcp/rpc` dispatch — both currently survive only because they happen to carry a bearer in their tested scenarios. Worth handling as defense-in-depth before more `/_internal/*` paths are added.
