### PR TITLE
fix(security): replace hardcoded default secrets with __REPLACE_ME__ placeholders

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -391,9 +391,9 @@ class Settings(BaseSettings):
         return cleaned
 
     basic_auth_user: str = "admin"
-    basic_auth_password: SecretStr = Field(default=SecretStr("changeme"))
+    basic_auth_password: SecretStr = Field(default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"))
     jwt_algorithm: str = "HS256"
-    jwt_secret_key: SecretStr = Field(default=SecretStr("changeme"))
+    jwt_secret_key: SecretStr = Field(default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"))
     jwt_public_key_path: str = ""
     jwt_private_key_path: str = ""
     jwt_audience: str = "mcpgateway-api"
@@ -628,7 +628,7 @@ class Settings(BaseSettings):
     proxy_user_header: str = Field(default="X-Authenticated-User", description="Header containing authenticated username from proxy")
 
     #  Encryption key phrase for auth storage
-    auth_encryption_secret: SecretStr = Field(default=SecretStr("changeme"))
+    auth_encryption_secret: SecretStr = Field(default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"))
 
     # Query Parameter Authentication (INSECURE - disabled by default)
     insecure_allow_queryparam_auth: bool = Field(
@@ -971,8 +971,8 @@ class Settings(BaseSettings):
         description="When true (default), prevent any admin from being demoted, deactivated, or locked out via API/UI. When false, only the last active admin is protected.",
     )
     platform_admin_email: str = Field(default="admin@example.com", description="Platform administrator email address")
-    platform_admin_password: SecretStr = Field(default=SecretStr("changeme"), description="Platform administrator password")
-    default_user_password: SecretStr = Field(default=SecretStr("changeme"), description="Default password for new users")  # nosec B105
+    platform_admin_password: SecretStr = Field(default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"), description="Platform administrator password")
+    default_user_password: SecretStr = Field(default=SecretStr("__REPLACE_ME__run_init-secrets_before_starting"), description="Default password for new users")  # nosec B105
     platform_admin_full_name: str = Field(default="Platform Administrator", description="Platform administrator full name")
 
     # Argon2id Password Hashing Configuration


### PR DESCRIPTION
## Problem

Five security-critical configuration fields in `mcpgateway/config.py` default to `"changeme"`:
- `jwt_secret_key` (line 396)
- `auth_encryption_secret` (line 631)
- `basic_auth_password` (line 394)
- `platform_admin_password` (line 974)
- `default_user_password` (line 975)

While `validate_secrets()` logs warnings for weak values, it only raises `SecurityConfigurationError` in non-development environments. The default `environment` is `"development"`, so the gateway starts with known secrets and only logs a warning.

An attacker who knows the default JWT secret can forge arbitrary tokens, impersonate any user including admins, and decrypt auth-encrypted data. With the default basic auth password, they can authenticate as `admin:changeme`.

**CWE-798** (Use of Hard-coded Credentials) | **CVSS 9.8**

## Fix

Replace all five `"changeme"` defaults with `"__REPLACE_ME__run_init-secrets_before_starting"` placeholders. These already trigger `SecurityConfigurationError` in all environments (the existing validator at line 1471 checks for `__replace_me__` prefix). This makes the gateway fail-safe: it refuses to start with unset secrets, forcing operators to run `init_secrets.py` or set environment variables.

## Test Plan
- [ ] Existing test suite passes
- [ ] Gateway refuses to start with default config (no .env) — `SecurityConfigurationError` raised
- [ ] Gateway starts correctly after running `init_secrets.py`
- [ ] Development mode still works with explicitly-set secrets

## Security Note

Critical severity. This enables full authentication bypass in default-config deployments. Related to open epic #2595 but provides a concrete, minimal fix that can be merged immediately.