### PR TITLE
fix(security): enforce JWT signature verification in auth router

### DIFF
--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -234,8 +234,8 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
                 # First-Party
                 from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
 
-                # Decode JWT to get jti (don't verify since we just created it)
-                payload = jwt.decode(access_token, options={"verify_signature": False})
+                # Decode JWT to get jti (verify signature for defense-in-depth)
+                payload = jwt.decode(access_token, settings.jwt_secret_key.get_secret_value(), algorithms=[settings.jwt_algorithm])
                 session_id = payload.get("jti", "")
 
                 # Generate CSRF token
@@ -322,7 +322,7 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
             if hasattr(secret_key, "get_secret_value"):
                 secret_key = secret_key.get_secret_value()
 
-            payload = jwt.decode(token, secret_key, algorithms=[settings.jwt_algorithm], options={"verify_signature": False})  # Already verified by get_current_user
+            payload = jwt.decode(token, secret_key, algorithms=[settings.jwt_algorithm])  # Verify signature for defense-in-depth
 
             jti = payload.get("jti")
             exp = payload.get("exp")


### PR DESCRIPTION
## Problem

Two `jwt.decode()` calls in `mcpgateway/routers/auth.py` use `verify_signature=False`:

1. **Line 238**: After login, the newly-created JWT is decoded without signature verification to extract the `jti` for CSRF token generation. While the token was just created by the server, this pattern is fragile — any refactoring that moves this decode to handle external tokens creates a direct auth bypass.

2. **Line 325**: A token is decoded with `verify_signature=False` with the comment "Already verified by get_current_user". However, the decoded payload is trusted for security decisions without re-verification. If `get_current_user`'s verification is bypassed (e.g. via default secret), the payload is trusted unconditionally.

**CWE-345** (Insufficient Verification of Data Authenticity) | **CVSS 7.5** (chained with FIND-001)

## Fix

- Line 238: Pass `settings.jwt_secret_key` and `algorithms` to `jwt.decode()` for full verification
- Line 325: Remove `verify_signature=False` option, letting the full verification proceed

Defense-in-depth: even if upstream verification is bypassed, the signature is re-verified at point of use.

## Test Plan
- [ ] Existing test suite passes
- [ ] Login flow still generates valid CSRF tokens
- [ ] Token revocation still works correctly
- [ ] Forged tokens are rejected at both decode sites

## Security Note

High severity when chained with FIND-001 (hardcoded default secrets). Standalone, this is a defense-in-depth improvement that prevents a class of future vulnerabilities.