### PR TITLE
feat: add title field to MCP tool serialization paths

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-22T11:49:09Z",
+  "generated_at": "2026-06-23T17:15:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1485,
+        "line_number": 1590,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1573,
+        "line_number": 1678,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1923,
+        "line_number": 2028,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3289,
+        "line_number": 3394,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3380,
+        "line_number": 3485,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3423,
+        "line_number": 3528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3428,
+        "line_number": 3533,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3433,
+        "line_number": 3538,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6382,
+        "line_number": 6051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6879,
+        "line_number": 6548,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6891,
+        "line_number": 6560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6963,
+        "line_number": 6632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8045,
+        "line_number": 7714,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1378,7 +1378,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 416,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 515,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 580,
+        "line_number": 581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 597,
+        "line_number": 598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 619,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 621,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 623,
+        "line_number": 624,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 669,
+        "line_number": 670,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 680,
+        "line_number": 681,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 682,
+        "line_number": 683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 714,
+        "line_number": 715,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2896,7 +2896,7 @@
         "hashed_secret": "c58994eefb19ae2d0bfc26a106de438359e53fb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 314,
+        "line_number": 325,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2904,7 +2904,7 @@
         "hashed_secret": "8c9fdbd88e905d33102d0be537adeab8595fe0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2912,7 +2912,7 @@
         "hashed_secret": "6ea1c94703f93074853165df24e0ded6917472af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2920,7 +2920,7 @@
         "hashed_secret": "b05b46675e3b6cecdb5ed7d0c24a8a183abd4de8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 751,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3896,7 +3896,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 200,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T06:34:32Z",
+  "generated_at": "2026-06-22T11:49:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 690,
+        "line_number": 708,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 918,
+        "line_number": 936,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1248,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1239,
+        "line_number": 1256,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1318,
+        "line_number": 1335,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1345,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1351,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1363,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1364,
+        "line_number": 1381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1425,
+        "line_number": 1442,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1336,
+        "line_number": 1485,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1424,
+        "line_number": 1573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1774,
+        "line_number": 1923,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3140,
+        "line_number": 3289,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3231,
+        "line_number": 3380,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3274,
+        "line_number": 3423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3279,
+        "line_number": 3428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3284,
+        "line_number": 3433,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6381,
+        "line_number": 6382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6878,
+        "line_number": 6879,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6890,
+        "line_number": 6891,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6962,
+        "line_number": 6963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8043,
+        "line_number": 8045,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -432,7 +432,7 @@
         "hashed_secret": "b7991211e1e73c924ee8febee2d1e80f0173c762",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 132,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -440,7 +440,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 239,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -448,7 +448,7 @@
         "hashed_secret": "5d4e7584ece9047cd53ae0e4b40726328968ce68",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 326,
+        "line_number": 327,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -456,7 +456,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 444,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -464,7 +464,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 443,
+        "line_number": 444,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -472,7 +472,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 532,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -480,7 +480,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 627,
+        "line_number": 628,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -488,7 +488,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 698,
+        "line_number": 699,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -496,7 +496,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 704,
+        "line_number": 705,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -986,7 +986,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 269,
+        "line_number": 270,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +994,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 364,
+        "line_number": 365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 412,
+        "line_number": 413,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 420,
+        "line_number": 421,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 468,
+        "line_number": 469,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1004,
+        "line_number": 1005,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1107,
+        "line_number": 1108,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1113,
+        "line_number": 1114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1223,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1257,
+        "line_number": 1258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1796,
+        "line_number": 1797,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1873,
+        "line_number": 1874,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2189,
+        "line_number": 2190,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2650,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2650,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2659,
+        "line_number": 2663,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2811,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2828,
+        "line_number": 2832,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2836,
+        "line_number": 2840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2841,
+        "line_number": 2845,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1375,122 +1375,10 @@
     ],
     "docs/docs/architecture/roadmap.md": [
       {
-        "hashed_secret": "e62854369199d65b6a66cd90fe8203ac4d5be26c",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 190,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "35722442567571107241e7e6ca2b554515e485da",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 338,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0608c4054662dd902e1314f7e450e3eaa81c1143",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 340,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 347,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "564289a5f34546401bbc727c20a14069761f9143",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 420,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "37745ed7a0f005fb14522c5cc7c1ba3d9e0df579",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 424,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "0c8207b92779c0a42507a293a23106814cc381e1",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 427,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "ce5070ef8a0cf3e595ae4cf3f73f6a0eca87e346",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 429,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "46a808cfd5beafa5e60aefee867bf92025dc2849",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 434,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "e4ae36d7ffd9dd805a909ac5a20de165a2629ba4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 435,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "9f08d40159a4b035fc7998b398bd16b38f91e806",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 440,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "61a135089eac561a2ff7cedeefb03975bed000f8",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 633,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5bdcd3c0d4d24ae3e71b3b452a024c6324c7e4bb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 645,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "a4b3ee46e1384e5b0be8cfdb2169977d8a160136",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 650,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 745,
+        "line_number": 104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 746,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 754,
+        "line_number": 113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 783,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1036,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1037,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1038,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1056,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 514,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1190,
+        "line_number": 549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1191,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 564,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1586,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1212,
+        "line_number": 571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1594,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1221,
+        "line_number": 580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1602,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1226,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1610,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1238,
+        "line_number": 597,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1618,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1259,
+        "line_number": 618,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1626,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1261,
+        "line_number": 620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1634,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1264,
+        "line_number": 623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1642,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1271,
+        "line_number": 630,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1650,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1658,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1310,
+        "line_number": 669,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1666,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1321,
+        "line_number": 680,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1674,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1682,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1355,
+        "line_number": 714,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1690,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1358,
+        "line_number": 717,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2292,7 +2180,7 @@
         "hashed_secret": "998ab9e14841d778dcafdf72ceaac0cacbb5ea2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 467,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2300,7 +2188,7 @@
         "hashed_secret": "d20047e4dff166045c7f61066c62955ec33c1657",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 599,
+        "line_number": 670,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2308,7 +2196,7 @@
         "hashed_secret": "fc19bda36b0af2d6a957034199a79c6583c707a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 760,
+        "line_number": 831,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2316,7 +2204,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 928,
+        "line_number": 999,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2324,7 +2212,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1276,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2332,7 +2220,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1326,
+        "line_number": 1397,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2388,7 +2276,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2396,7 +2284,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2404,7 +2292,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 793,
+        "line_number": 798,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2412,7 +2300,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1280,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2420,7 +2308,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2660,7 +2548,15 @@
         "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 104,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 127,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2668,7 +2564,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2676,7 +2572,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 136,
+        "line_number": 164,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4318,7 +4214,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 740,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4328,7 +4224,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4317,
+        "line_number": 4419,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4348,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14971,
+        "line_number": 15016,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4998,15 +4894,17 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 18,
         "type": "Secret Keyword",
         "verified_result": null
-      },
+      }
+    ],
+    "tests/migration/utils/container_manager.py": [
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 409,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5103,12 +5001,58 @@
         "verified_result": null
       }
     ],
+    "tests/unit/mcpgateway/services/test_gateway_service.py": [
+      {
+        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8137,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
         "line_number": 1412,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_audience.py": [
+      {
+        "hashed_secret": "e360adbe2fa9bb945b9afc993ea1306cb976e947",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "50e8361b5726f72eed9dffaec824570b635147b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 246,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 319,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 592,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5125,28 +5069,18 @@
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 7210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11229,
+        "line_number": 11421,
         "type": "Hex High Entropy String",
         "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/test_auth.py": [
+      },
       {
-        "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
+        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2745,
+        "line_number": 17838,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5156,7 +5090,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 228,
+        "line_number": 235,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-23T15:57:56Z",
+  "generated_at": "2026-06-03T06:34:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 72,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 708,
+        "line_number": 690,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 918,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1222,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1248,
+        "line_number": 1231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1256,
+        "line_number": 1239,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1335,
+        "line_number": 1318,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1340,
+        "line_number": 1323,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1345,
+        "line_number": 1328,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1351,
+        "line_number": 1334,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1363,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1381,
+        "line_number": 1364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1442,
+        "line_number": 1425,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1590,
+        "line_number": 1336,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1678,
+        "line_number": 1424,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2028,
+        "line_number": 1774,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3394,
+        "line_number": 3140,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3485,
+        "line_number": 3231,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3528,
+        "line_number": 3274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3533,
+        "line_number": 3279,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3538,
+        "line_number": 3284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6051,
+        "line_number": 6381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6548,
+        "line_number": 6878,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6560,
+        "line_number": 6890,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6632,
+        "line_number": 6962,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7714,
+        "line_number": 8043,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -432,7 +432,7 @@
         "hashed_secret": "b7991211e1e73c924ee8febee2d1e80f0173c762",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 131,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -440,7 +440,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 239,
+        "line_number": 238,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -448,7 +448,7 @@
         "hashed_secret": "5d4e7584ece9047cd53ae0e4b40726328968ce68",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 327,
+        "line_number": 326,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -456,7 +456,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 444,
+        "line_number": 443,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -464,7 +464,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 444,
+        "line_number": 443,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -472,7 +472,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 532,
+        "line_number": 531,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -480,7 +480,7 @@
         "hashed_secret": "5546721ffdfc2e5b0e4c0da38f10774f9ad50b09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 628,
+        "line_number": 627,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -488,7 +488,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 699,
+        "line_number": 698,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -496,7 +496,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 705,
+        "line_number": 704,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -986,7 +986,7 @@
         "hashed_secret": "b6f3674b78a02881de33177e6f6fb8b851e0101c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 270,
+        "line_number": 269,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -994,7 +994,7 @@
         "hashed_secret": "108b310facc1a193833fc2971fd83081f775ea0c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 365,
+        "line_number": 364,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1002,7 +1002,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 413,
+        "line_number": 412,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 421,
+        "line_number": 420,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 468,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1005,
+        "line_number": 1004,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1108,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1114,
+        "line_number": 1113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1223,
+        "line_number": 1222,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1258,
+        "line_number": 1257,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1797,
+        "line_number": 1796,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1874,
+        "line_number": 1873,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
+        "line_number": 2189,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2646,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2646,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2811,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2832,
+        "line_number": 2828,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2840,
+        "line_number": 2836,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2845,
+        "line_number": 2841,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1375,10 +1375,122 @@
     ],
     "docs/docs/architecture/roadmap.md": [
       {
+        "hashed_secret": "e62854369199d65b6a66cd90fe8203ac4d5be26c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 190,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "35722442567571107241e7e6ca2b554515e485da",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 338,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0608c4054662dd902e1314f7e450e3eaa81c1143",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 340,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "176939638191d5a13935ccb90c0c8a70a5e30773",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 347,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "564289a5f34546401bbc727c20a14069761f9143",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 420,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37745ed7a0f005fb14522c5cc7c1ba3d9e0df579",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 424,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0c8207b92779c0a42507a293a23106814cc381e1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 427,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ce5070ef8a0cf3e595ae4cf3f73f6a0eca87e346",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 429,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "46a808cfd5beafa5e60aefee867bf92025dc2849",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 434,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e4ae36d7ffd9dd805a909ac5a20de165a2629ba4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 435,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f08d40159a4b035fc7998b398bd16b38f91e806",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 440,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "61a135089eac561a2ff7cedeefb03975bed000f8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 633,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5bdcd3c0d4d24ae3e71b3b452a024c6324c7e4bb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 645,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a4b3ee46e1384e5b0be8cfdb2169977d8a160136",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 650,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 745,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1498,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1506,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 754,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1514,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 783,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1522,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 1036,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1530,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 1037,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1538,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 1038,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1546,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 1056,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1554,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 1155,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1562,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 1190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1570,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 1191,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1578,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 1205,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1586,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 1212,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1594,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 1221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1602,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 586,
+        "line_number": 1226,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1610,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 1238,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1618,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 619,
+        "line_number": 1259,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1626,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 621,
+        "line_number": 1261,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1634,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 1264,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1642,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 1271,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1650,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 1272,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1658,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 1310,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1666,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 1321,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1674,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 683,
+        "line_number": 1323,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1682,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 715,
+        "line_number": 1355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1690,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2180,7 +2292,7 @@
         "hashed_secret": "998ab9e14841d778dcafdf72ceaac0cacbb5ea2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 396,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2188,7 +2300,7 @@
         "hashed_secret": "d20047e4dff166045c7f61066c62955ec33c1657",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 599,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2196,7 +2308,7 @@
         "hashed_secret": "fc19bda36b0af2d6a957034199a79c6583c707a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 760,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2204,7 +2316,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 999,
+        "line_number": 928,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2212,7 +2324,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1205,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2220,7 +2332,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1326,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2276,7 +2388,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2284,7 +2396,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 432,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2292,7 +2404,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2300,7 +2412,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1275,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2308,7 +2420,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2548,15 +2660,7 @@
         "hashed_secret": "cfac92b56e517a2186d60c9f812878a82a8c210c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "c92ae7357b37d02896900f57e76d315173fbf715",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 127,
+        "line_number": 103,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2564,7 +2668,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 162,
+        "line_number": 134,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2572,7 +2676,7 @@
         "hashed_secret": "9b466094ec991a03cb95c489c19c4d75635f0ae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 164,
+        "line_number": 136,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2896,7 +3000,7 @@
         "hashed_secret": "c58994eefb19ae2d0bfc26a106de438359e53fb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 325,
+        "line_number": 314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2904,7 +3008,7 @@
         "hashed_secret": "8c9fdbd88e905d33102d0be537adeab8595fe0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2912,7 +3016,7 @@
         "hashed_secret": "6ea1c94703f93074853165df24e0ded6917472af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 381,
+        "line_number": 370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2920,7 +3024,7 @@
         "hashed_secret": "b05b46675e3b6cecdb5ed7d0c24a8a183abd4de8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 740,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3896,7 +4000,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4214,7 +4318,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4224,7 +4328,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4419,
+        "line_number": 4317,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4244,7 +4348,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15016,
+        "line_number": 14971,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4894,17 +4998,15 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
-      }
-    ],
-    "tests/migration/utils/container_manager.py": [
+      },
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 34,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5001,58 +5103,12 @@
         "verified_result": null
       }
     ],
-    "tests/unit/mcpgateway/services/test_gateway_service.py": [
-      {
-        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8137,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
         "line_number": 1412,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_audience.py": [
-      {
-        "hashed_secret": "e360adbe2fa9bb945b9afc993ea1306cb976e947",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 213,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "50e8361b5726f72eed9dffaec824570b635147b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 246,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 319,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 592,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5069,18 +5125,28 @@
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11421,
-        "type": "Hex High Entropy String",
+        "line_number": 7210,
+        "type": "Secret Keyword",
         "verified_result": null
       },
       {
-        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
+        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17838,
+        "line_number": 11229,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/test_auth.py": [
+      {
+        "hashed_secret": "5038e18712161fca54e52805726d3c70b296eff6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2745,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5090,7 +5156,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 228,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5100,7 +5166,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2770,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -758,12 +758,15 @@ def _serialize_mcp_tool_definition(tool: Any) -> Dict[str, Any]:
         data = {}
 
     name = data.get("name", getattr(tool, "name", None))
+    title = data.get("title", getattr(tool, "title", None))
     description = data.get("description", getattr(tool, "description", None))
     input_schema = data.get("inputSchema", getattr(tool, "input_schema", None))
 
     payload: Dict[str, Any] = {}
     if name is not None:
         payload["name"] = name
+    if title is not None:
+        payload["title"] = title
     if description is not None or name is not None or input_schema is not None:
         payload["description"] = description or ""
     if input_schema is not None:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -3008,6 +3008,7 @@ class ToolService(BaseService):
             query = (
                 select(
                     name_column.label("name"),
+                    DbTool.title.label("title"),
                     DbTool.description.label("description"),
                     DbTool.input_schema.label("input_schema"),
                     DbTool.output_schema.label("output_schema"),
@@ -3045,6 +3046,8 @@ class ToolService(BaseService):
                     "inputSchema": row["input_schema"] or {"type": "object", "properties": {}},
                     "annotations": row["annotations"] or {},
                 }
+                if row["title"] is not None:
+                    payload["title"] = row["title"]
                 if row["output_schema"] is not None:
                     payload["outputSchema"] = row["output_schema"]
                 result.append(payload)

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -8921,6 +8921,7 @@ class TestRustMcpExecutionPlan:
         rows = [
             {
                 "name": "tool-public",
+                "title": None,
                 "description": "desc",
                 "input_schema": {"type": "object"},
                 "output_schema": None,
@@ -8931,6 +8932,7 @@ class TestRustMcpExecutionPlan:
             },
             {
                 "name": "tool-team",
+                "title": "Team Tool",
                 "description": "team-desc",
                 "input_schema": None,
                 "output_schema": {"type": "object"},
@@ -8960,6 +8962,7 @@ class TestRustMcpExecutionPlan:
             },
             {
                 "name": "tool-team",
+                "title": "Team Tool",
                 "description": "team-desc",
                 "inputSchema": {"type": "object", "properties": {}},
                 "annotations": {"title": "Team"},
@@ -10550,6 +10553,7 @@ async def test_list_server_mcp_tool_definitions_creates_span(tool_service):
     db.execute.return_value.mappings.return_value.all.return_value = [
         {
             "name": "tool-one",
+            "title": None,
             "description": "Tool One",
             "input_schema": {"type": "object"},
             "output_schema": None,

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -1163,6 +1163,7 @@ class TestMcpSerialization:
         payload = _serialize_mcp_tool_definition(
             {
                 "name": "a2a-test-agent",
+                "title": "A2A Test Agent",
                 "description": "A2A tool",
                 "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
                 "outputSchema": {"type": "object"},
@@ -1174,6 +1175,7 @@ class TestMcpSerialization:
 
         assert payload == {
             "name": "a2a-test-agent",
+            "title": "A2A Test Agent",
             "description": "A2A tool",
             "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
             "outputSchema": {"type": "object"},
@@ -1185,6 +1187,41 @@ class TestMcpSerialization:
     def test_serialize_mcp_tool_definition_handles_unknown_objects(self):
         """Unknown objects should serialize to an empty MCP payload."""
         assert _serialize_mcp_tool_definition(object()) == {}
+
+    def test_serialize_mcp_tool_definition_omits_title_when_null(self):
+        """title should be omitted from payload when None/absent."""
+        payload = _serialize_mcp_tool_definition(
+            {
+                "name": "test-no-title",
+                "title": None,
+                "description": "No title tool",
+                "inputSchema": {"type": "object"},
+            }
+        )
+
+        assert payload == {
+            "name": "test-no-title",
+            "description": "No title tool",
+            "inputSchema": {"type": "object"},
+        }
+        assert "title" not in payload
+
+    def test_serialize_mcp_tool_definition_gets_title_from_object_attr(self):
+        """title should be extractable via getattr for non-dict objects."""
+        class FakeTool:
+            name = "fake-tool"
+            title = "Fake Tool Title"
+            description = "A fake tool"
+            input_schema = {"type": "object"}
+
+        payload = _serialize_mcp_tool_definition(FakeTool())
+
+        assert payload == {
+            "name": "fake-tool",
+            "title": "Fake Tool Title",
+            "description": "A fake tool",
+            "inputSchema": {"type": "object"},
+        }
 
     def test_serialize_mcp_tool_definition_normalizes_null_description(self):
         """MCP tool payloads should always expose a string description."""


### PR DESCRIPTION
## Summary
Closes #4949

Adds the optional `title` field (MCP BaseMetadata, 2025-03-26 spec) to the two MCP serialization paths that were missing it, making ContextForge fully MCP spec-compliant for tool metadata.

## Problem
The MCP 2025-03-26 spec defines a `title` field on tool definitions as a human-readable display name, separate from the programmatic `name`. While the database model, Pydantic schemas, Admin UI, and Streamable HTTP transport already supported `title`, it was silently dropped in two serialization paths:
1. **JSON-RPC / stdio handler** (`_serialize_mcp_tool_definition()`)
2. **Rust bridge hot-path** (`list_server_mcp_tool_definitions()`)

This meant MCP clients using these transport paths (like Claude Desktop via stdio) never received the `title` field in `tools/list` responses.

## What was already in place (existing infrastructure)
- **ORM model** (`db.py`): `Tool.title` column
- **Pydantic schemas** (`schemas.py`): `ToolCreate.title`, `ToolUpdate.title`, `ToolRead.title`
- **Service layer**: `create_tool`, `update_tool`, `upsert_tool`, `_build_tool_db_object` all handle `title`
- **Streamable HTTP transport** (`streamablehttp_transport.py`): Already passes `title=_safe_str_attr(tool, "title")` to `types.Tool()`
- **Admin UI template** (`tools_partial.html`): Renders `title` below `name` when present
- **Gateway sync** (`gateway_service.py`): `_resolve_tool_title()` implements `annotations.title > title > name` precedence

## Changes

### Production code (2 files, +6 lines)
| File | Change |
|---|---|
| `mcpgateway/main.py:755,763-764` | Extract `title` in `_serialize_mcp_tool_definition()` and include in payload if not None |
| `mcpgateway/services/tool_service.py:3012,3046-3047` | Select `DbTool.title` in query and include in MCP response dict |

### Test improvements (2 files, +41 lines)
| Test | What it covers |
|---|---|
| `test_serialize_mcp_tool_definition_omits_title_when_null` | Verifies `title=None` is omitted from output |
| `test_serialize_mcp_tool_definition_gets_title_from_object_attr` | Verifies `getattr` fallback for non-dict objects |
| `test_serialize_mcp_tool_definition_strips_api_only_fields` | Updated with `title` in input/expected output |
| `test_list_server_mcp_tool_definitions_*` | Both updated to include `title` in mock rows |

### Baseline
- `.secrets.baseline` updated to resolve stale detection audit state

## Verification
- `make doctest` ✅ (1175 passed)
- `make pre-commit` ✅ (all hooks passed)
- `make ruff` ✅
- `make interrogate` ✅ (100%)
- `make pylint` ✅ (10.00/10)
- All affected tests pass

## Risk
Very low — additive change, fully backwards compatible. The `title` field is always optional and falls back to existing behavior when absent.