### PR TITLE
chore(ui): consolidate Alpine.js component setup

### DIFF
--- a/mcpgateway/admin_ui/alpine-setup.js
+++ b/mcpgateway/admin_ui/alpine-setup.js
@@ -1,90 +1,14 @@
 import Alpine from '@alpinejs/csp';
 import { buildTableUrl, syncCheckboxFromUrl } from './utils.js';
+import { appRoot } from './components/app-root.js';
+import { mainLayout } from './components/main-layout.js';
+import { overflowMenu } from './components/overflow-menu.js';
+import { teamSelector } from './components/team-selector.js';
 
-Alpine.data('appRoot', function () {
-  return {
-    darkMode: false,
-    init: function () {
-      try {
-        this.darkMode = JSON.parse(localStorage.getItem('darkMode') || 'false');
-      } catch (e) {
-        if (window.Admin) window.Admin.logRestrictedContext(e);
-      }
-      const self = this;
-      this.$watch('darkMode', function (val) {
-        try {
-          localStorage.setItem('darkMode', String(val));
-        } catch (e) {
-          if (window.Admin) window.Admin.logRestrictedContext(e);
-        }
-      });
-    },
-  };
-});
-
-Alpine.data('mainLayout', function () {
-  return {
-    sidebarOpen: true,
-    sidebarCollapsed: false,
-    isDesktop: window.innerWidth >= 1024,
-    init: function () {
-      const self = this;
-      window.addEventListener('resize', function () {
-        self.isDesktop = window.innerWidth >= 1024;
-        if (window.innerWidth >= 1024) self.sidebarOpen = true;
-      });
-    },
-  };
-});
-
-Alpine.data('teamSelector', function () {
-  return {
-    open: false,
-    selectedTeam: '',
-    selectedTeamName: 'All Teams',
-    init: function () {
-      const urlParams = new URLSearchParams(window.location.search);
-      const requestedTeamId = urlParams.get('team_id') || '';
-      this.selectedTeam = '';
-      this.selectedTeamName = 'All Teams';
-      if (requestedTeamId) {
-        const teams =
-          Array.isArray(window.USER_TEAMS_DATA) && window.USER_TEAMS_DATA.length > 0
-            ? window.USER_TEAMS_DATA
-            : Array.isArray(window.USER_TEAMS)
-              ? window.USER_TEAMS
-              : [];
-        const team = teams.find(function (t) {
-          return t.id === requestedTeamId;
-        });
-        if (team) {
-          this.selectedTeam = requestedTeamId;
-          this.selectedTeamName = (team.is_personal ? '👤 ' : '🏢 ') + team.name;
-        } else if (teams.length > 0) {
-          const cleanUrl = new URL(window.location.href);
-          cleanUrl.searchParams.delete('team_id');
-          if (window.Admin) window.Admin.safeReplaceState({}, '', cleanUrl);
-        }
-      }
-    },
-    toggleOpen: function () {
-      this.open = !this.open;
-      this.loadTeams();
-    },
-    selectAllTeams: function () {
-      this.selectedTeam = '';
-      this.selectedTeamName = 'All Teams';
-      this.open = false;
-      this.updateTeamContext('');
-    },
-    loadTeams: function () {
-      if (this.open && window.Admin) window.Admin.loadTeamSelectorDropdown();
-    },
-    updateTeamContext: function (teamId) {
-      if (typeof window.updateTeamContext === 'function') window.updateTeamContext(teamId);
-    },
-  };
-});
+Alpine.data('appRoot', appRoot);
+Alpine.data('mainLayout', mainLayout);
+Alpine.data('overflowMenu', overflowMenu);
+Alpine.data('teamSelector', teamSelector);
 
 Alpine.magic('syncCheckbox', function () {
   return syncCheckboxFromUrl;

--- a/mcpgateway/admin_ui/components/app-root.js
+++ b/mcpgateway/admin_ui/components/app-root.js
@@ -1,0 +1,20 @@
+export function appRoot() {
+  return {
+    darkMode: false,
+    init: function () {
+      try {
+        this.darkMode = JSON.parse(localStorage.getItem('darkMode') || 'false');
+      } catch (e) {
+        if (window.Admin) window.Admin.logRestrictedContext(e);
+      }
+      const self = this;
+      this.$watch('darkMode', function (val) {
+        try {
+          localStorage.setItem('darkMode', String(val));
+        } catch (e) {
+          if (window.Admin) window.Admin.logRestrictedContext(e);
+        }
+      });
+    },
+  };
+}

--- a/mcpgateway/admin_ui/components/main-layout.js
+++ b/mcpgateway/admin_ui/components/main-layout.js
@@ -1,0 +1,14 @@
+export function mainLayout() {
+  return {
+    sidebarOpen: true,
+    sidebarCollapsed: false,
+    isDesktop: window.innerWidth >= 1024,
+    init: function () {
+      const self = this;
+      window.addEventListener('resize', function () {
+        self.isDesktop = window.innerWidth >= 1024;
+        if (window.innerWidth >= 1024) self.sidebarOpen = true;
+      });
+    },
+  };
+}

--- a/mcpgateway/admin_ui/components/team-selector.js
+++ b/mcpgateway/admin_ui/components/team-selector.js
@@ -1,0 +1,48 @@
+export function teamSelector() {
+  return {
+    open: false,
+    selectedTeam: '',
+    selectedTeamName: 'All Teams',
+    init: function () {
+      const urlParams = new URLSearchParams(window.location.search);
+      const requestedTeamId = urlParams.get('team_id') || '';
+      this.selectedTeam = '';
+      this.selectedTeamName = 'All Teams';
+      if (requestedTeamId) {
+        const teams =
+          Array.isArray(window.USER_TEAMS_DATA) && window.USER_TEAMS_DATA.length > 0
+            ? window.USER_TEAMS_DATA
+            : Array.isArray(window.USER_TEAMS)
+              ? window.USER_TEAMS
+              : [];
+        const team = teams.find(function (t) {
+          return t.id === requestedTeamId;
+        });
+        if (team) {
+          this.selectedTeam = requestedTeamId;
+          this.selectedTeamName = (team.is_personal ? '👤 ' : '🏢 ') + team.name;
+        } else if (teams.length > 0) {
+          const cleanUrl = new URL(window.location.href);
+          cleanUrl.searchParams.delete('team_id');
+          if (window.Admin) window.Admin.safeReplaceState({}, '', cleanUrl);
+        }
+      }
+    },
+    toggleOpen: function () {
+      this.open = !this.open;
+      this.loadTeams();
+    },
+    selectAllTeams: function () {
+      this.selectedTeam = '';
+      this.selectedTeamName = 'All Teams';
+      this.open = false;
+      this.updateTeamContext('');
+    },
+    loadTeams: function () {
+      if (this.open && window.Admin) window.Admin.loadTeamSelectorDropdown();
+    },
+    updateTeamContext: function (teamId) {
+      if (typeof window.updateTeamContext === 'function') window.updateTeamContext(teamId);
+    },
+  };
+}

--- a/mcpgateway/admin_ui/events.js
+++ b/mcpgateway/admin_ui/events.js
@@ -1,6 +1,5 @@
 import { AppState } from "./appState.js";
 import { initializeCACertUpload } from "./caCertificate.js";
-import { overflowMenu } from "./components/overflow-menu.js";
 import { TABLE_TO_ENTITY_TYPE } from "./constants.js";
 import { initializeEventDelegation } from "./eventDelegation.js";
 import { toggleViewPublic, updateFilterStatus } from "./filters.js";
@@ -1005,7 +1004,6 @@ import {
   // Alpine Components
   // ===================================================================
   document.addEventListener("alpine:init", () => {
-    Alpine.data("overflowMenu", (wrapperId = null) => overflowMenu(wrapperId));
     Alpine.data("paginationData", () => Admin.paginationData());
     Alpine.data("overviewDashboard", () => Admin.overviewDashboard());
     Alpine.data("llmApiInfoApp", () => Admin.llmApiInfoApp());

--- a/tests/unit/js/app-root.test.js
+++ b/tests/unit/js/app-root.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for components/app-root.js
+ * Tests: appRoot factory, init lifecycle, darkMode persistence
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { appRoot } from "../../../mcpgateway/admin_ui/components/app-root.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeComponent() {
+  const component = appRoot();
+  const watchCallbacks = {};
+  component.$watch = vi.fn((prop, cb) => {
+    watchCallbacks[prop] = cb;
+  });
+  return { component, watchCallbacks };
+}
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.Admin;
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+describe("appRoot factory", () => {
+  test("returns darkMode as false initially", () => {
+    const { component } = makeComponent();
+    expect(component.darkMode).toBe(false);
+  });
+
+  test("exposes an init method", () => {
+    const { component } = makeComponent();
+    expect(typeof component.init).toBe("function");
+  });
+
+  test("does not throw on construction", () => {
+    expect(() => appRoot()).not.toThrow();
+  });
+});
+
+// ─── init ─────────────────────────────────────────────────────────────────────
+
+describe("init", () => {
+  test("sets darkMode to true when localStorage has 'true'", () => {
+    localStorage.setItem("darkMode", "true");
+    const { component } = makeComponent();
+    component.init();
+    expect(component.darkMode).toBe(true);
+  });
+
+  test("sets darkMode to false when localStorage has 'false'", () => {
+    localStorage.setItem("darkMode", "false");
+    const { component } = makeComponent();
+    component.init();
+    expect(component.darkMode).toBe(false);
+  });
+
+  test("defaults to false when localStorage has no darkMode entry", () => {
+    const { component } = makeComponent();
+    component.init();
+    expect(component.darkMode).toBe(false);
+  });
+
+  test("registers a $watch on darkMode", () => {
+    const { component } = makeComponent();
+    component.init();
+    expect(component.$watch).toHaveBeenCalledWith("darkMode", expect.any(Function));
+  });
+
+  test("calls Admin.logRestrictedContext when localStorage value is invalid JSON", () => {
+    localStorage.setItem("darkMode", "{not-valid-json");
+    const logRestrictedContext = vi.fn();
+    window.Admin = { logRestrictedContext };
+    const { component } = makeComponent();
+    component.init();
+    expect(logRestrictedContext).toHaveBeenCalledOnce();
+  });
+
+  test("does not throw on JSON parse error when Admin is absent", () => {
+    localStorage.setItem("darkMode", "not-json");
+    delete window.Admin;
+    const { component } = makeComponent();
+    expect(() => component.init()).not.toThrow();
+  });
+
+  test("does not call Admin.logRestrictedContext when value is valid JSON", () => {
+    localStorage.setItem("darkMode", "true");
+    const logRestrictedContext = vi.fn();
+    window.Admin = { logRestrictedContext };
+    const { component } = makeComponent();
+    component.init();
+    expect(logRestrictedContext).not.toHaveBeenCalled();
+  });
+});
+
+// ─── darkMode $watch callback ─────────────────────────────────────────────────
+
+describe("darkMode $watch callback", () => {
+  test("writes 'true' to localStorage when darkMode becomes true", () => {
+    const { component, watchCallbacks } = makeComponent();
+    component.init();
+    watchCallbacks.darkMode(true);
+    expect(localStorage.getItem("darkMode")).toBe("true");
+  });
+
+  test("writes 'false' to localStorage when darkMode becomes false", () => {
+    const { component, watchCallbacks } = makeComponent();
+    component.init();
+    watchCallbacks.darkMode(false);
+    expect(localStorage.getItem("darkMode")).toBe("false");
+  });
+
+  test("calls Admin.logRestrictedContext when localStorage.setItem throws", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const logRestrictedContext = vi.fn();
+    window.Admin = { logRestrictedContext };
+    const { component, watchCallbacks } = makeComponent();
+    component.init();
+    watchCallbacks.darkMode(true);
+    expect(logRestrictedContext).toHaveBeenCalledOnce();
+  });
+
+  test("does not throw on write error when Admin is absent", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    delete window.Admin;
+    const { component, watchCallbacks } = makeComponent();
+    component.init();
+    expect(() => watchCallbacks.darkMode(true)).not.toThrow();
+  });
+});

--- a/tests/unit/js/main-layout.test.js
+++ b/tests/unit/js/main-layout.test.js
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for components/main-layout.js
+ * Tests: mainLayout factory, init resize listener
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { mainLayout } from "../../../mcpgateway/admin_ui/components/main-layout.js";
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+let originalInnerWidth;
+
+beforeEach(() => {
+  originalInnerWidth = window.innerWidth;
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "innerWidth", {
+    value: originalInnerWidth,
+    writable: true,
+    configurable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+describe("mainLayout factory", () => {
+  test("returns sidebarOpen as true", () => {
+    const component = mainLayout();
+    expect(component.sidebarOpen).toBe(true);
+  });
+
+  test("returns sidebarCollapsed as false", () => {
+    const component = mainLayout();
+    expect(component.sidebarCollapsed).toBe(false);
+  });
+
+  test("returns isDesktop true when innerWidth is 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true, configurable: true });
+    const component = mainLayout();
+    expect(component.isDesktop).toBe(true);
+  });
+
+  test("returns isDesktop true when innerWidth is above 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 1440, writable: true, configurable: true });
+    const component = mainLayout();
+    expect(component.isDesktop).toBe(true);
+  });
+
+  test("returns isDesktop false when innerWidth is below 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 768, writable: true, configurable: true });
+    const component = mainLayout();
+    expect(component.isDesktop).toBe(false);
+  });
+
+  test("exposes an init method", () => {
+    const component = mainLayout();
+    expect(typeof component.init).toBe("function");
+  });
+
+  test("does not throw on construction", () => {
+    expect(() => mainLayout()).not.toThrow();
+  });
+});
+
+// ─── init — resize listener ───────────────────────────────────────────────────
+
+describe("init — resize listener", () => {
+  test("updates isDesktop to true when resized to >= 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 800, writable: true, configurable: true });
+    const component = mainLayout();
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 1280, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.isDesktop).toBe(true);
+  });
+
+  test("updates isDesktop to false when resized to < 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 1280, writable: true, configurable: true });
+    const component = mainLayout();
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 600, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.isDesktop).toBe(false);
+  });
+
+  test("sets sidebarOpen to true when resized to >= 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 800, writable: true, configurable: true });
+    const component = mainLayout();
+    component.sidebarOpen = false;
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.sidebarOpen).toBe(true);
+  });
+
+  test("does not change sidebarOpen when resized to < 1024", () => {
+    Object.defineProperty(window, "innerWidth", { value: 1280, writable: true, configurable: true });
+    const component = mainLayout();
+    component.sidebarOpen = false;
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 768, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.sidebarOpen).toBe(false);
+  });
+
+  test("updates isDesktop on exact 1024 boundary", () => {
+    Object.defineProperty(window, "innerWidth", { value: 800, writable: true, configurable: true });
+    const component = mainLayout();
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.isDesktop).toBe(true);
+  });
+
+  test("updates isDesktop on 1023 boundary (just below desktop)", () => {
+    Object.defineProperty(window, "innerWidth", { value: 1280, writable: true, configurable: true });
+    const component = mainLayout();
+    component.init();
+
+    Object.defineProperty(window, "innerWidth", { value: 1023, writable: true, configurable: true });
+    window.dispatchEvent(new Event("resize"));
+
+    expect(component.isDesktop).toBe(false);
+  });
+});

--- a/tests/unit/js/team-selector.test.js
+++ b/tests/unit/js/team-selector.test.js
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for components/team-selector.js
+ * Tests: teamSelector factory, init URL parsing, toggleOpen, selectAllTeams,
+ *        loadTeams, updateTeamContext
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { teamSelector } from "../../../mcpgateway/admin_ui/components/team-selector.js";
+
+// ─── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  delete window.USER_TEAMS;
+  delete window.USER_TEAMS_DATA;
+  delete window.Admin;
+  delete window.updateTeamContext;
+
+  delete window.location;
+  window.location = {
+    href: "http://localhost/admin",
+    search: "",
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+describe("teamSelector factory", () => {
+  test("returns open as false", () => {
+    expect(teamSelector().open).toBe(false);
+  });
+
+  test("returns selectedTeam as empty string", () => {
+    expect(teamSelector().selectedTeam).toBe("");
+  });
+
+  test("returns selectedTeamName as 'All Teams'", () => {
+    expect(teamSelector().selectedTeamName).toBe("All Teams");
+  });
+
+  test("exposes init, toggleOpen, selectAllTeams, loadTeams, updateTeamContext", () => {
+    const component = teamSelector();
+    expect(typeof component.init).toBe("function");
+    expect(typeof component.toggleOpen).toBe("function");
+    expect(typeof component.selectAllTeams).toBe("function");
+    expect(typeof component.loadTeams).toBe("function");
+    expect(typeof component.updateTeamContext).toBe("function");
+  });
+
+  test("does not throw on construction", () => {
+    expect(() => teamSelector()).not.toThrow();
+  });
+});
+
+// ─── init ─────────────────────────────────────────────────────────────────────
+
+describe("init — no team_id in URL", () => {
+  test("keeps selectedTeam as empty string", () => {
+    const component = teamSelector();
+    component.init();
+    expect(component.selectedTeam).toBe("");
+  });
+
+  test("keeps selectedTeamName as 'All Teams'", () => {
+    const component = teamSelector();
+    component.init();
+    expect(component.selectedTeamName).toBe("All Teams");
+  });
+});
+
+describe("init — team_id present in URL", () => {
+  test("selects team from USER_TEAMS_DATA when matching id found", () => {
+    window.location.search = "?team_id=t1";
+    window.USER_TEAMS_DATA = [{ id: "t1", name: "Alpha", is_personal: false }];
+
+    const component = teamSelector();
+    component.init();
+
+    expect(component.selectedTeam).toBe("t1");
+    expect(component.selectedTeamName).toBe("🏢 Alpha");
+  });
+
+  test("prefixes personal team name with person emoji", () => {
+    window.location.search = "?team_id=t2";
+    window.USER_TEAMS_DATA = [{ id: "t2", name: "My Team", is_personal: true }];
+
+    const component = teamSelector();
+    component.init();
+
+    expect(component.selectedTeamName).toBe("👤 My Team");
+  });
+
+  test("prefixes non-personal team name with building emoji", () => {
+    window.location.search = "?team_id=t3";
+    window.USER_TEAMS_DATA = [{ id: "t3", name: "Corp", is_personal: false }];
+
+    const component = teamSelector();
+    component.init();
+
+    expect(component.selectedTeamName).toBe("🏢 Corp");
+  });
+
+  test("falls back to USER_TEAMS when USER_TEAMS_DATA is empty", () => {
+    window.location.search = "?team_id=t3";
+    window.USER_TEAMS_DATA = [];
+    window.USER_TEAMS = [{ id: "t3", name: "Beta", is_personal: false }];
+
+    const component = teamSelector();
+    component.init();
+
+    expect(component.selectedTeam).toBe("t3");
+    expect(component.selectedTeamName).toBe("🏢 Beta");
+  });
+
+  test("falls back to USER_TEAMS when USER_TEAMS_DATA is not an array", () => {
+    window.location.search = "?team_id=t4";
+    window.USER_TEAMS_DATA = null;
+    window.USER_TEAMS = [{ id: "t4", name: "Gamma", is_personal: false }];
+
+    const component = teamSelector();
+    component.init();
+
+    expect(component.selectedTeam).toBe("t4");
+  });
+
+  test("calls Admin.safeReplaceState removing team_id when id not found in non-empty teams", () => {
+    window.location = {
+      href: "http://localhost/admin?team_id=unknown",
+      search: "?team_id=unknown",
+    };
+    window.USER_TEAMS_DATA = [{ id: "t1", name: "Alpha", is_personal: false }];
+    const safeReplaceState = vi.fn();
+    window.Admin = { safeReplaceState };
+
+    const component = teamSelector();
+    component.init();
+
+    expect(safeReplaceState).toHaveBeenCalledOnce();
+    const cleanUrl = safeReplaceState.mock.calls[0][2];
+    expect(cleanUrl.searchParams.has("team_id")).toBe(false);
+  });
+
+  test("does not call safeReplaceState when teams array is empty", () => {
+    window.location.search = "?team_id=t1";
+    window.USER_TEAMS_DATA = [];
+    window.USER_TEAMS = [];
+    const safeReplaceState = vi.fn();
+    window.Admin = { safeReplaceState };
+
+    const component = teamSelector();
+    component.init();
+
+    expect(safeReplaceState).not.toHaveBeenCalled();
+    expect(component.selectedTeam).toBe("");
+  });
+
+  test("does not throw when team not found and Admin is absent", () => {
+    window.location = {
+      href: "http://localhost/admin?team_id=missing",
+      search: "?team_id=missing",
+    };
+    window.USER_TEAMS_DATA = [{ id: "t1", name: "Alpha", is_personal: false }];
+    delete window.Admin;
+
+    const component = teamSelector();
+    expect(() => component.init()).not.toThrow();
+  });
+});
+
+// ─── toggleOpen ───────────────────────────────────────────────────────────────
+
+describe("toggleOpen", () => {
+  test("sets open to true when currently false", () => {
+    const component = teamSelector();
+    component.toggleOpen();
+    expect(component.open).toBe(true);
+  });
+
+  test("sets open to false when currently true", () => {
+    const component = teamSelector();
+    component.open = true;
+    component.toggleOpen();
+    expect(component.open).toBe(false);
+  });
+
+  test("calls loadTeams after toggling", () => {
+    const component = teamSelector();
+    const loadSpy = vi.spyOn(component, "loadTeams");
+    component.toggleOpen();
+    expect(loadSpy).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── selectAllTeams ───────────────────────────────────────────────────────────
+
+describe("selectAllTeams", () => {
+  test("resets selectedTeam to empty string", () => {
+    const component = teamSelector();
+    component.selectedTeam = "t1";
+    component.selectAllTeams();
+    expect(component.selectedTeam).toBe("");
+  });
+
+  test("resets selectedTeamName to 'All Teams'", () => {
+    const component = teamSelector();
+    component.selectedTeamName = "🏢 Alpha";
+    component.selectAllTeams();
+    expect(component.selectedTeamName).toBe("All Teams");
+  });
+
+  test("closes the dropdown", () => {
+    const component = teamSelector();
+    component.open = true;
+    component.selectAllTeams();
+    expect(component.open).toBe(false);
+  });
+
+  test("calls updateTeamContext with empty string", () => {
+    window.updateTeamContext = vi.fn();
+    const component = teamSelector();
+    component.selectAllTeams();
+    expect(window.updateTeamContext).toHaveBeenCalledWith("");
+  });
+});
+
+// ─── loadTeams ────────────────────────────────────────────────────────────────
+
+describe("loadTeams", () => {
+  test("calls Admin.loadTeamSelectorDropdown when open is true", () => {
+    const loadTeamSelectorDropdown = vi.fn();
+    window.Admin = { loadTeamSelectorDropdown };
+    const component = teamSelector();
+    component.open = true;
+    component.loadTeams();
+    expect(loadTeamSelectorDropdown).toHaveBeenCalledOnce();
+  });
+
+  test("does not call loadTeamSelectorDropdown when open is false", () => {
+    const loadTeamSelectorDropdown = vi.fn();
+    window.Admin = { loadTeamSelectorDropdown };
+    const component = teamSelector();
+    component.open = false;
+    component.loadTeams();
+    expect(loadTeamSelectorDropdown).not.toHaveBeenCalled();
+  });
+
+  test("does not throw when Admin is absent and open is true", () => {
+    const component = teamSelector();
+    component.open = true;
+    expect(() => component.loadTeams()).not.toThrow();
+  });
+});
+
+// ─── updateTeamContext ────────────────────────────────────────────────────────
+
+describe("updateTeamContext", () => {
+  test("calls window.updateTeamContext with the given teamId", () => {
+    window.updateTeamContext = vi.fn();
+    const component = teamSelector();
+    component.updateTeamContext("t1");
+    expect(window.updateTeamContext).toHaveBeenCalledWith("t1");
+  });
+
+  test("calls window.updateTeamContext with empty string", () => {
+    window.updateTeamContext = vi.fn();
+    const component = teamSelector();
+    component.updateTeamContext("");
+    expect(window.updateTeamContext).toHaveBeenCalledWith("");
+  });
+
+  test("does not throw when window.updateTeamContext is not defined", () => {
+    delete window.updateTeamContext;
+    const component = teamSelector();
+    expect(() => component.updateTeamContext("t1")).not.toThrow();
+  });
+
+  test("does not throw when window.updateTeamContext is not a function", () => {
+    window.updateTeamContext = "not-a-function";
+    const component = teamSelector();
+    expect(() => component.updateTeamContext("t1")).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #4882

Structural refactor only — no behaviour change.

### What changed

**Extracted three inline component definitions into self-contained files**, following the existing `components/overflow-menu.js` pattern:

  - `components/app-root.js` — `appRoot` factory
  - `components/main-layout.js` — `mainLayout` factory
  - `components/team-selector.js` — `teamSelector` factory

  **`alpine-setup.js` is now the single registration point** for all Alpine components. It imports the four factories and calls `Alpine.data()` for each:

  ```js
  Alpine.data('appRoot', appRoot);
  Alpine.data('mainLayout', mainLayout);
  Alpine.data('overflowMenu', overflowMenu);
  Alpine.data('teamSelector', teamSelector);
```

 `events.js` had its overflowMenu import and `Alpine.data("overflowMenu", ...)` registration removed — it no longer scatters Alpine registrations outside alpine-setup.js.

  Also simplified the overflowMenu registration from the redundant wrapper `(wrapperId = null) => overflowMenu(wrapperId)` to a direct reference, consistent with the other three registrations.

**Tests**

Unit tests added for the three new component files:

  - tests/unit/js/app-root.test.js
  - tests/unit/js/main-layout.test.js
  - tests/unit/js/team-selector.test.js