### PR TITLE
fixed the alpine.js sri hashes

### DIFF
--- a/.github/workflows/linting-full.yml
+++ b/.github/workflows/linting-full.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.4"
           cache-dependency-path: |
             a2a-agents/go/a2a-echo-agent/go.sum
             mcp-servers/go/benchmark-server/go.sum

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T14:00:51Z",
+  "generated_at": "2026-06-03T14:29:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T09:52:22Z",
+  "generated_at": "2026-06-03T14:00:51Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5125,18 +5125,10 @@
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": true,
-        "is_verified": false,
-        "line_number": 7210,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11229,
+        "line_number": 11185,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T12:42:17Z",
+  "generated_at": "2026-06-03T09:52:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5125,10 +5125,18 @@
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": true,
+        "is_verified": false,
+        "line_number": 7210,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11185,
+        "line_number": 11229,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -3832,7 +3832,7 @@ LINT_GO_ROOT ?= $(LINT_TMP_ROOT)/go
 LINT_HELM_ROOT ?= $(LINT_TMP_ROOT)/helm
 LINT_NODE_ROOT ?= $(LINT_TMP_ROOT)/node
 LINT_PY_VENV ?= $(LINT_TMP_ROOT)/py-venv
-LINT_GO_TOOLCHAIN ?= go1.26.3
+LINT_GO_TOOLCHAIN ?= go1.26.4
 
 # Tool target defaults
 LINT_ZIZMOR_TARGET ?= .github/workflows

--- a/a2a-agents/go/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/go/a2a-echo-agent/Dockerfile
@@ -4,7 +4,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=go1.26.3
+ENV GOTOOLCHAIN=go1.26.4
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/a2a-agents/go/a2a-echo-agent/go.mod
+++ b/a2a-agents/go/a2a-echo-agent/go.mod
@@ -1,3 +1,3 @@
 module github.com/ibm/mcp-context-forge/a2a-agents/go/a2a-echo-agent
 
-go 1.26.3
+go 1.26.4

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -253,8 +253,8 @@ find . -path "./mcp-servers/templates" -prune -o -name "go.mod" -type f -print |
 done
 ```
 
-2. Update `LINT_GO_TOOLCHAIN ?= go1.26.3` appropriately in the _root_/Makefile
-3. Update Dockerfile e.g. `FROM golang:1.26.3`
+2. Update `LINT_GO_TOOLCHAIN ?= go1.26.4` appropriately in the _root_/Makefile
+3. Update Dockerfile e.g. `FROM golang:1.26.4`
 
 Verify Go code compiles and passes security checks:
 

--- a/mcp-servers/go/benchmark-server/Dockerfile
+++ b/mcp-servers/go/benchmark-server/Dockerfile
@@ -4,7 +4,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=go1.26.3
+ENV GOTOOLCHAIN=go1.26.4
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/mcp-servers/go/benchmark-server/go.mod
+++ b/mcp-servers/go/benchmark-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/ibm/mcp-context-forge/mcp-servers/go/benchmark-server
 
-go 1.26.3
+go 1.26.4
 
 require github.com/mark3labs/mcp-go v0.54.1
 

--- a/mcp-servers/go/fast-time-server/go.mod
+++ b/mcp-servers/go/fast-time-server/go.mod
@@ -2,7 +2,7 @@ module fast-time-server
 
 go 1.25.5
 
-toolchain go1.26.2
+toolchain go1.26.4
 
 require github.com/mark3labs/mcp-go v0.54.1 // MCP server/runtime
 

--- a/mcp-servers/go/slow-time-server/Dockerfile
+++ b/mcp-servers/go/slow-time-server/Dockerfile
@@ -17,7 +17,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 USER root
 RUN dnf install -y git tzdata ca-certificates && dnf clean all
-ENV GOTOOLCHAIN=go1.26.3
+ENV GOTOOLCHAIN=go1.26.4
 
 ARG TARGETARCH
 WORKDIR /src

--- a/mcp-servers/go/slow-time-server/go.mod
+++ b/mcp-servers/go/slow-time-server/go.mod
@@ -1,6 +1,6 @@
 module slow-time-server
 
-go 1.26.3
+go 1.26.4
 
 require github.com/mark3labs/mcp-go v0.54.1
 

--- a/mcpgateway/sri_hashes.json
+++ b/mcpgateway/sri_hashes.json
@@ -1,5 +1,4 @@
 {
-  "alpinejs": "sha384-pb6hrQvo4s23cEUFtj0CZkzGE3jyK3pj26RIupXXxhSrrcUA/Cn0lZgcCrGH0t6L",
   "chartjs": "sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ",
   "codemirror_addon_simple": "sha384-5+aYjV0V2W3IwhAYp/9WOrGMv1TaYkCjnkkW7Hv3yJQo28MergRCSRaUIUzDUs2J",
   "codemirror_css": "sha384-zaeBlB/vwYsDRSlFajnDd7OydJ0cWk+c2OWybl3eSUf6hW2EbhlCsQPqKr3gkznT",

--- a/mcpgateway/sri_hashes.json
+++ b/mcpgateway/sri_hashes.json
@@ -1,4 +1,5 @@
 {
+  "alpinejs": "sha384-pb6hrQvo4s23cEUFtj0CZkzGE3jyK3pj26RIupXXxhSrrcUA/Cn0lZgcCrGH0t6L",
   "chartjs": "sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ",
   "codemirror_addon_simple": "sha384-5+aYjV0V2W3IwhAYp/9WOrGMv1TaYkCjnkkW7Hv3yJQo28MergRCSRaUIUzDUs2J",
   "codemirror_css": "sha384-zaeBlB/vwYsDRSlFajnDd7OydJ0cWk+c2OWybl3eSUf6hW2EbhlCsQPqKr3gkznT",

--- a/scripts/cdn_resources.py
+++ b/scripts/cdn_resources.py
@@ -13,6 +13,7 @@ CDN_RESOURCES = {
     # Tailwind is intentionally excluded:
     # - Play CDN is a JIT compiler endpoint (non-static script semantics)
     # - It does not provide stable CORS/SRI guarantees for integrity enforcement
+    # AlpineJs and HTMX are excluded from CDN since they are integrated via Vite
     # Chart.js
     "chartjs": "https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js",
     # Marked (Markdown parser)

--- a/scripts/cdn_resources.py
+++ b/scripts/cdn_resources.py
@@ -13,8 +13,6 @@ CDN_RESOURCES = {
     # Tailwind is intentionally excluded:
     # - Play CDN is a JIT compiler endpoint (non-static script semantics)
     # - It does not provide stable CORS/SRI guarantees for integrity enforcement
-    # Alpine.js
-    "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js",
     # Chart.js
     "chartjs": "https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js",
     # Marked (Markdown parser)

--- a/scripts/download-cdn-assets.sh
+++ b/scripts/download-cdn-assets.sh
@@ -9,7 +9,6 @@ STATIC_DIR="${SCRIPT_DIR}/../app/mcpgateway/static/vendor"
 
 # Create vendor directory structure
 mkdir -p "${STATIC_DIR}/tailwindcss"
-mkdir -p "${STATIC_DIR}/htmx"
 mkdir -p "${STATIC_DIR}/codemirror/mode/javascript"
 mkdir -p "${STATIC_DIR}/codemirror/theme"
 mkdir -p "${STATIC_DIR}/chartjs"
@@ -22,11 +21,6 @@ echo "📦 Downloading CDN assets for airgapped deployment..."
 echo "  ⬇️  Tailwind CSS..."
 curl -fsSL "https://cdn.tailwindcss.com/3.4.17" \
   -o "${STATIC_DIR}/tailwindcss/tailwind.min.js"
-
-# Download HTMX
-echo "  ⬇️  HTMX 1.9.12..."
-curl -fsSL "https://unpkg.com/htmx.org@1.9.12/dist/htmx.min.js" \
-  -o "${STATIC_DIR}/htmx/htmx.min.js"
 
 # Download CodeMirror
 echo "  ⬇️  CodeMirror 5.65.20..."

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22419,7 +22419,6 @@ class TestLoadSriHashes:
         # Create a temporary sri_hashes.json file
         sri_file = tmp_path / "sri_hashes.json"
         test_hashes = {
-            "htmx.min.js": "sha384-test2",
             "chart.js": "sha384-test3",
         }
         sri_file.write_text(json.dumps(test_hashes))
@@ -22432,7 +22431,7 @@ class TestLoadSriHashes:
             result = admin_mod.load_sri_hashes()
 
             assert result == test_hashes
-            assert result["htmx.min.js"] == "sha384-test2"
+            assert result["chart.js"] == "sha384-test3"
 
     def test_load_sri_hashes_file_not_found(self, tmp_path):
         """Test load_sri_hashes returns empty dict when file doesn't exist."""
@@ -22540,7 +22539,7 @@ class TestLoadSriHashes:
         admin_mod.load_sri_hashes.cache_clear()
 
         # Mock load_sri_hashes to return test data
-        test_hashes = {"htmx.min.js": "sha384-test2"}
+        test_hashes = {"chart.js": "sha384-test2"}
         with patch.object(admin_mod, "load_sri_hashes", return_value=test_hashes):
             # We can't easily test the full admin_ui endpoint without extensive mocking,
             # but we can verify load_sri_hashes is called correctly

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22419,7 +22419,6 @@ class TestLoadSriHashes:
         # Create a temporary sri_hashes.json file
         sri_file = tmp_path / "sri_hashes.json"
         test_hashes = {
-            "alpine.js": "sha384-test1",
             "htmx.min.js": "sha384-test2",
             "chart.js": "sha384-test3",
         }
@@ -22433,7 +22432,6 @@ class TestLoadSriHashes:
             result = admin_mod.load_sri_hashes()
 
             assert result == test_hashes
-            assert "alpine.js" in result
             assert result["htmx.min.js"] == "sha384-test2"
 
     def test_load_sri_hashes_file_not_found(self, tmp_path):
@@ -22542,7 +22540,7 @@ class TestLoadSriHashes:
         admin_mod.load_sri_hashes.cache_clear()
 
         # Mock load_sri_hashes to return test data
-        test_hashes = {"alpine.js": "sha384-endpoint-test"}
+        test_hashes = {"htmx.min.js": "sha384-test2"}
         with patch.object(admin_mod, "load_sri_hashes", return_value=test_hashes):
             # We can't easily test the full admin_ui endpoint without extensive mocking,
             # but we can verify load_sri_hashes is called correctly


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - ≥ 80 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## 📌 Summary
Remove Alpine.js and HTMX remnants from SRI tracking and CDN asset download scripts. Update related test assertions.
This is a followup of failure in main after the merge during `make linting-full` https://github.com/IBM/mcp-context-forge/actions/runs/26837980662/job/79264976046

## 🔁 Reproduction Steps
Issue: some remnants of alpinejs existed in the code after https://github.com/IBM/mcp-context-forge/pull/4676, which our slack notifier failed to capture due to another issue and is fixed by https://github.com/IBM/mcp-context-forge/pull/5028
Further some remnants of htmx also existed after https://github.com/IBM/mcp-context-forge/pull/4203, we are clearing them here.

1. Compare branch against `origin/main`.
2. Inspect `scripts/cdn_resources.py`.
3. Observe `alpinejs` entry removed from CDN_RESOURCES dict.
4. Check `scripts/download-cdn-assets.sh` for HTMX download removal.
5. Check `tests/unit/mcpgateway/test_admin.py` for corresponding test updates.

## 🐞 Root Cause
Alpine.js and HTMX entries in `scripts/cdn_resources.py` and `scripts/download-cdn-assets.sh` were present but no longer needed since both libraries are now integrated via Vite bundling instead of CDN delivery.

## 💡 Fix Description

**CDN Resources Cleanup:**
- Removed `alpinejs` entry from `scripts/cdn_resources.py` CDN_RESOURCES dict
- Updated comment to clarify: "AlpineJs and HTMX are excluded from CDN since they are integrated via Vite"

**Asset Download Script Cleanup:**
- Removed HTMX download section from `scripts/download-cdn-assets.sh`
- Removed `mkdir -p "${STATIC_DIR}/htmx"` directory creation

**Test Updates:**
- Updated `tests/unit/mcpgateway/test_admin.py` to remove both Alpine.js and HTMX test assertions (3 locations):
  - Removed `"alpine.js": "sha384-test1"` from test data
  - Removed `"htmx.min.js": "sha384-test2"` from test data
  - Updated assertions to use `chart.js` instead

**Secrets Baseline:**
- Updated `.secrets.baseline` timestamp after regeneration

**Additional changes:**
- Bumped Go toolchain version from `1.26.3` to `1.26.4` across:
  - `.github/workflows/linting-full.yml`
  - `Makefile` (LINT_GO_TOOLCHAIN)
  - `docs/docs/development/release-management.md`
  - All Go module files (`go.mod`) in `a2a-agents/go/` and `mcp-servers/go/`
  - Dockerfiles for Go-based servers (ENV GOTOOLCHAIN and toolchain directives)

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | `make test`          | Not run |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | steps / screenshots  | Not run |

**Linting-Full report:** https://github.com/IBM/mcp-context-forge/actions/runs/26893460258/job/79325680429

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed