### PR TITLE
fix: forward passthrough_headers in both MCP tool and REST A2A invoke…

### DIFF
--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -2084,9 +2084,10 @@ class A2AAgentService(BaseService):
 
         # Filter request_headers to only whitelisted passthrough headers
         # before they reach plugin hooks (prevents credential leak to plugins).
+        # Normalize header keys to lowercase to prevent duplicate headers with different casings.
         if request_headers and agent_passthrough_headers:
             whitelist_lower = {h.lower() for h in agent_passthrough_headers}
-            request_headers = {k: v for k, v in request_headers.items() if k in whitelist_lower}
+            request_headers = {k.lower(): v for k, v in request_headers.items() if k.lower() in whitelist_lower}
         elif request_headers:
             request_headers = {}  # No whitelist = no headers reach plugins
 
@@ -2225,6 +2226,14 @@ class A2AAgentService(BaseService):
             except Exception as e:
                 logger.error("Pre-invoke plugin error for A2A agent %s: %s", agent_id, e)
                 raise A2AAgentError(f"Pre-invoke plugin error: {e}") from e
+
+        # Merge filtered passthrough headers into prepared.headers for downstream HTTP call
+        # (Mirrors the fix applied to tool_service.py for issue #5004)
+        if request_headers:
+            prepared.headers.update(request_headers)
+            logger.debug(
+                f"A2A agent '{agent_name}': Merged {len(request_headers)} passthrough headers into downstream request (whitelist: {agent_passthrough_headers})"
+            )
 
         span_attributes = {
             "a2a.agent.name": agent_name,

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -2200,7 +2200,18 @@ class A2AAgentService(BaseService):
             except Exception as e:
                 logger.warning("Failed to build A2A agent metadata for plugins: %s", e)
 
+        # Merge filtered passthrough headers BEFORE plugin hooks
+        # This ensures plugins see the full set of headers that will be sent and can modify/remove them.
+        # Plugin modifications take precedence (security: plugins have final authority over headers).
+        if request_headers:
+            prepared.headers.update(request_headers)
+            logger.debug(
+                f"A2A agent '{agent_name}': Merged {len(request_headers)} passthrough headers into prepared headers (whitelist: {agent_passthrough_headers})"
+            )
+
         # Fire pre-invoke hook — can modify parameters, headers, and agent metadata
+        # IMPORTANT: Plugin header modifications must take precedence over passthrough headers.
+        # Plugins may remove/modify headers for security (e.g., header_filter plugin).
         if plugin_manager and plugin_manager.has_hooks_for(AgentHookType.AGENT_PRE_INVOKE):
             try:
                 pre_result, context_table = await plugin_manager.invoke_hook(
@@ -2208,7 +2219,7 @@ class A2AAgentService(BaseService):
                     payload=AgentPreInvokePayload(
                         agent_id=agent_id,
                         messages=[{"role": "user", "content": parameters}] if parameters else [],
-                        headers=HttpHeaderPayload(root=request_headers or {}),
+                        headers=HttpHeaderPayload(root=prepared.headers),
                         parameters=parameters if isinstance(parameters, dict) else {},
                     ),
                     global_context=global_context,
@@ -2219,21 +2230,15 @@ class A2AAgentService(BaseService):
                     if pre_result.modified_payload.parameters is not None:
                         parameters = pre_result.modified_payload.parameters
                     if pre_result.modified_payload.headers is not None:
-                        prepared.headers.update(pre_result.modified_payload.headers.model_dump())
+                        # Plugin modifications REPLACE prepared.headers (not merge)
+                        # This ensures plugins can remove headers (e.g., for security filtering)
+                        prepared.headers = pre_result.modified_payload.headers.model_dump()
             except PluginViolationError as e:
                 logger.error("Plugin RBAC violation for A2A agent %s: %s", agent_id, e)
                 raise A2AAgentError(f"Plugin RBAC violation: {e}") from e
             except Exception as e:
                 logger.error("Pre-invoke plugin error for A2A agent %s: %s", agent_id, e)
                 raise A2AAgentError(f"Pre-invoke plugin error: {e}") from e
-
-        # Merge filtered passthrough headers into prepared.headers for downstream HTTP call
-        # (Mirrors the fix applied to tool_service.py for issue #5004)
-        if request_headers:
-            prepared.headers.update(request_headers)
-            logger.debug(
-                f"A2A agent '{agent_name}': Merged {len(request_headers)} passthrough headers into downstream request (whitelist: {agent_passthrough_headers})"
-            )
 
         span_attributes = {
             "a2a.agent.name": agent_name,

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -2232,7 +2232,9 @@ class A2AAgentService(BaseService):
                     if pre_result.modified_payload.headers is not None:
                         # Plugin modifications REPLACE prepared.headers (not merge)
                         # This ensures plugins can remove headers (e.g., for security filtering)
-                        prepared.headers = pre_result.modified_payload.headers.model_dump()
+                        plugin_headers = pre_result.modified_payload.headers.model_dump()
+                        prepared.headers.clear()
+                        prepared.headers.update(plugin_headers)
             except PluginViolationError as e:
                 logger.error("Plugin RBAC violation for A2A agent %s: %s", agent_id, e)
                 raise A2AAgentError(f"Plugin RBAC violation: {e}") from e

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -2205,9 +2205,7 @@ class A2AAgentService(BaseService):
         # Plugin modifications take precedence (security: plugins have final authority over headers).
         if request_headers:
             prepared.headers.update(request_headers)
-            logger.debug(
-                f"A2A agent '{agent_name}': Merged {len(request_headers)} passthrough headers into prepared headers (whitelist: {agent_passthrough_headers})"
-            )
+            logger.debug(f"A2A agent '{agent_name}': Merged {len(request_headers)} passthrough headers into prepared headers (whitelist: {agent_passthrough_headers})")
 
         # Fire pre-invoke hook — can modify parameters, headers, and agent metadata
         # IMPORTANT: Plugin header modifications must take precedence over passthrough headers.

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4784,6 +4784,7 @@ class ToolService(BaseService):
         a2a_agent_auth_type: Optional[str] = None
         a2a_agent_auth_value: Optional[str] = None
         a2a_agent_auth_query_params: Optional[Dict[str, str]] = None
+        a2a_agent_passthrough_headers: Optional[List[str]] = None
 
         if tool_integration_type == "A2A" and "a2a_agent_id" in tool_annotations:
             a2a_agent_id = tool_annotations.get("a2a_agent_id")
@@ -4808,6 +4809,7 @@ class ToolService(BaseService):
             a2a_agent_auth_type = a2a_agent.auth_type
             a2a_agent_auth_value = a2a_agent.auth_value
             a2a_agent_auth_query_params = a2a_agent.auth_query_params
+            a2a_agent_passthrough_headers = getattr(a2a_agent, "passthrough_headers", None)
 
         # ═══════════════════════════════════════════════════════════════════════════
         # CRITICAL: Release DB connection back to pool BEFORE making HTTP calls
@@ -5822,12 +5824,28 @@ class ToolService(BaseService):
                     # A2A tool invocation using pre-extracted agent data (extracted in Phase 2 before db.close())
                     headers = {"Content-Type": "application/json"}
 
+                    # Filter request_headers to only whitelisted passthrough headers before they reach plugin hooks.
+                    # This mirrors the security pattern in a2a_service.py:invoke_agent()
+                    # and prevents credential leak to plugins.
+                    # Normalize header keys to lowercase to prevent duplicate headers with different casings.
+                    filtered_request_headers: Dict[str, str] = {}
+                    if request_headers and a2a_agent_passthrough_headers:
+                        whitelist_lower = {h.lower() for h in a2a_agent_passthrough_headers}
+                        filtered_request_headers = {k.lower(): v for k, v in request_headers.items() if k.lower() in whitelist_lower}
+                        logger.debug(
+                            f"A2A tool '{name}': Filtered {len(filtered_request_headers)} passthrough headers from {len(request_headers)} request headers using whitelist {a2a_agent_passthrough_headers}"
+                        )
+                    elif request_headers and not a2a_agent_passthrough_headers:
+                        # No whitelist configured = no headers forwarded (fail-closed security default)
+                        logger.debug(f"A2A tool '{name}': No passthrough_headers configured, no request headers will be forwarded")
+
                     # Plugin hook: tool pre-invoke for A2A
                     plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
-                        pre_invoke_headers = HttpHeaderPayload(root=headers)
+                        # Pass filtered headers to plugin hooks (not raw request_headers)
+                        pre_invoke_headers = HttpHeaderPayload(root={**headers, **filtered_request_headers})
                         pre_result, context_table = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_PRE_INVOKE,
                             payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
@@ -5842,6 +5860,9 @@ class ToolService(BaseService):
                             arguments = payload.args
                             if payload.headers is not None:
                                 headers = payload.headers.model_dump()
+
+                    # Merge filtered passthrough headers into base headers for downstream HTTP call
+                    headers.update(filtered_request_headers)
 
                     prepared = prepare_a2a_invocation(
                         agent_type=a2a_agent_type,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -5839,13 +5839,22 @@ class ToolService(BaseService):
                         # No whitelist configured = no headers forwarded (fail-closed security default)
                         logger.debug(f"A2A tool '{name}': No passthrough_headers configured, no request headers will be forwarded")
 
+                    # Merge filtered passthrough headers into base headers BEFORE plugin hooks
+                    # This ensures plugins see the full set of headers and can modify/remove them.
+                    # Plugin modifications take precedence (security: plugins have final authority over headers).
+                    if filtered_request_headers:
+                        headers.update(filtered_request_headers)
+                        logger.debug(
+                            f"A2A tool '{name}': Merged {len(filtered_request_headers)} passthrough headers into base headers (whitelist: {a2a_agent_passthrough_headers})"
+                        )
+
                     # Plugin hook: tool pre-invoke for A2A
                     plugin_manager = await self._get_plugin_manager(plugin_context_id)
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         if tool_metadata:
                             global_context.metadata[TOOL_METADATA] = tool_metadata
-                        # Pass filtered headers to plugin hooks (not raw request_headers)
-                        pre_invoke_headers = HttpHeaderPayload(root={**headers, **filtered_request_headers})
+                        # Pass merged headers to plugin (plugins can modify/remove any header including passthrough ones)
+                        pre_invoke_headers = HttpHeaderPayload(root=headers)
                         pre_result, context_table = await plugin_manager.invoke_hook(
                             ToolHookType.TOOL_PRE_INVOKE,
                             payload=ToolPreInvokePayload(name=name, args=arguments, headers=pre_invoke_headers),
@@ -5859,10 +5868,8 @@ class ToolService(BaseService):
                             name = payload.name
                             arguments = payload.args
                             if payload.headers is not None:
+                                # Plugin modifications REPLACE headers completely (security: plugins have final authority)
                                 headers = payload.headers.model_dump()
-
-                    # Merge filtered passthrough headers into base headers for downstream HTTP call
-                    headers.update(filtered_request_headers)
 
                     prepared = prepare_a2a_invocation(
                         agent_type=a2a_agent_type,

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4445,6 +4445,7 @@ class ToolService(BaseService):
         # ═══════════════════════════════════════════════════════════════════════════
         # First-Party
         from mcpgateway.transports.context import request_headers_var  # pylint: disable=import-outside-toplevel
+
         if request_headers:
             request_headers_var.set(request_headers)
         # ═══════════════════════════════════════════════════════════════════════════
@@ -5844,9 +5845,7 @@ class ToolService(BaseService):
                     # Plugin modifications take precedence (security: plugins have final authority over headers).
                     if filtered_request_headers:
                         headers.update(filtered_request_headers)
-                        logger.debug(
-                            f"A2A tool '{name}': Merged {len(filtered_request_headers)} passthrough headers into base headers (whitelist: {a2a_agent_passthrough_headers})"
-                        )
+                        logger.debug(f"A2A tool '{name}': Merged {len(filtered_request_headers)} passthrough headers into base headers (whitelist: {a2a_agent_passthrough_headers})")
 
                     # Plugin hook: tool pre-invoke for A2A
                     plugin_manager = await self._get_plugin_manager(plugin_context_id)

--- a/tests/unit/mcpgateway/services/test_a2a_agent_invoke_hooks.py
+++ b/tests/unit/mcpgateway/services/test_a2a_agent_invoke_hooks.py
@@ -169,7 +169,7 @@ class TestA2AInvokePreHook:
         mock_db,
         mock_agent,
     ):
-        """When agent.passthrough_headers is None, no headers reach plugins."""
+        """When agent.passthrough_headers is None, only base headers reach plugins (no passthrough headers)."""
         mock_agent.passthrough_headers = None
 
         inbound_headers = {"x-tenant-id": "tenant-123", "x-request-id": "req-456"}
@@ -197,7 +197,12 @@ class TestA2AInvokePreHook:
             )
 
         payload = pm.invoke_hook.await_args_list[0].kwargs["payload"]
-        assert payload.headers.root == {}
+        # Plugin receives base headers from prepare_a2a_invocation (Content-Type, X-Correlation-ID)
+        # but NO passthrough headers since whitelist is None
+        assert "Content-Type" in payload.headers.root or "content-type" in payload.headers.root
+        assert "X-Correlation-ID" in payload.headers.root or "x-correlation-id" in payload.headers.root
+        assert "x-tenant-id" not in payload.headers.root
+        assert "x-request-id" not in payload.headers.root
 
     @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
     @patch("mcpgateway.services.a2a_service.fresh_db_session")
@@ -213,7 +218,7 @@ class TestA2AInvokePreHook:
         mock_db,
         mock_agent,
     ):
-        """PRE_INVOKE receives the inbound request_headers as AgentPreInvokePayload.headers."""
+        """PRE_INVOKE receives base headers plus filtered passthrough headers."""
         # Third-Party
         from cpex.framework import AgentHookType, AgentPreInvokePayload
 
@@ -247,7 +252,13 @@ class TestA2AInvokePreHook:
         assert isinstance(payload, AgentPreInvokePayload)
         assert payload.agent_id == mock_agent.id
         assert payload.headers is not None
-        assert payload.headers.root == inbound_headers
+        # Plugin receives base headers (Content-Type, X-Correlation-ID) + passthrough headers
+        assert "x-forwarded-for" in payload.headers.root
+        assert "x-request-id" in payload.headers.root
+        assert payload.headers.root["x-forwarded-for"] == "10.0.0.1"
+        assert payload.headers.root["x-request-id"] == "req-001"
+        # Also has base headers
+        assert "Content-Type" in payload.headers.root or "content-type" in payload.headers.root
 
     @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
     @patch("mcpgateway.services.a2a_service.fresh_db_session")
@@ -263,7 +274,7 @@ class TestA2AInvokePreHook:
         mock_db,
         mock_agent,
     ):
-        """When request_headers is None, PRE_INVOKE receives an empty dict."""
+        """When request_headers is None, PRE_INVOKE receives only base headers (Content-Type, X-Correlation-ID)."""
         pm = _make_plugin_manager()
         mock_get_for_update.return_value = mock_agent
         mock_client = AsyncMock()
@@ -288,7 +299,9 @@ class TestA2AInvokePreHook:
             )
 
         payload = pm.invoke_hook.await_args_list[0].kwargs["payload"]
-        assert payload.headers.root == {}
+        # Plugin receives base headers from prepare_a2a_invocation
+        assert "Content-Type" in payload.headers.root or "content-type" in payload.headers.root
+        assert "X-Correlation-ID" in payload.headers.root or "x-correlation-id" in payload.headers.root
 
     @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
     @patch("mcpgateway.services.a2a_service.fresh_db_session")

--- a/tests/unit/mcpgateway/services/test_a2a_passthrough_headers.py
+++ b/tests/unit/mcpgateway/services/test_a2a_passthrough_headers.py
@@ -211,7 +211,7 @@ class TestA2APassthroughHeaders:
         assert headers["x-user-id"] == "bob@example.com"
         assert "x-tenant-id" in headers, f"Header not normalized to lowercase: {list(headers.keys())}"
         assert headers["x-tenant-id"] == "tenant-456"
-        
+
         # Verify no uppercase versions exist (would indicate duplication bug)
         assert "X-User-ID" not in headers, "Header key should be normalized to lowercase"
         assert "X-TENANT-ID" not in headers, "Header key should be normalized to lowercase"

--- a/tests/unit/mcpgateway/services/test_a2a_passthrough_headers.py
+++ b/tests/unit/mcpgateway/services/test_a2a_passthrough_headers.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_a2a_passthrough_headers.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Tests for A2A agent passthrough_headers functionality (Issue #5004).
+
+This test suite validates that passthrough_headers are correctly forwarded
+in A2A agent invocations via the direct REST path (/a2a/{name}/invoke).
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+import uuid
+
+# Third-Party
+import pytest
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import A2AAgent as DbA2AAgent
+from mcpgateway.services.a2a_service import A2AAgentService
+
+
+@pytest.fixture(autouse=True)
+def mock_logging_services():
+    """Mock structured_logger to prevent database writes during tests."""
+    with patch("mcpgateway.services.a2a_service.structured_logger") as mock_logger:
+        mock_logger.log = MagicMock(return_value=None)
+        mock_logger.info = MagicMock(return_value=None)
+        yield mock_logger
+
+
+@pytest.fixture(autouse=True)
+def bypass_uaid_security_for_tests(monkeypatch):
+    """Bypass UAID security validation for these tests."""
+    monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_allow_all_domains", True)
+    monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_forward_auth", True)
+    monkeypatch.setattr("mcpgateway.services.a2a_service.settings.uaid_max_federation_hops", 5)
+    monkeypatch.setattr("mcpgateway.services.a2a_service.settings.mcpgateway_a2a_default_timeout", 30)
+
+
+class TestA2APassthroughHeaders:
+    """Test suite for A2A agent passthrough_headers functionality (Issue #5004)."""
+
+    @pytest.fixture
+    def service(self):
+        """Create A2A agent service instance."""
+        return A2AAgentService()
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create mock database session."""
+        return MagicMock(spec=Session)
+
+    @pytest.fixture
+    def sample_agent_with_passthrough(self):
+        """Sample agent with passthrough_headers configured."""
+        agent_id = str(uuid.uuid4())
+        agent = MagicMock(spec=DbA2AAgent)
+        agent.id = agent_id
+        agent.name = "test-passthrough-agent"
+        agent.enabled = True
+        agent.endpoint_url = "http://localhost:9999/agent"
+        agent.auth_type = None
+        agent.auth_value = None
+        agent.auth_query_params = None
+        agent.protocol_version = "v1.0"
+        agent.agent_type = "jsonrpc"
+        agent.visibility = "public"
+        agent.team_id = None
+        agent.owner_email = None
+        agent.passthrough_headers = ["x-user-id", "x-tenant-id"]
+        return agent
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    async def test_passthrough_headers_forwarded_when_whitelisted(
+        self, mock_metrics_buffer_fn, mock_fresh_db, mock_get_client, mock_get_for_update, service, mock_db, sample_agent_with_passthrough
+    ):
+        """Test that whitelisted passthrough headers are forwarded to downstream agent."""
+        # Mock HTTP client
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"messageId": "msg-1", "role": "ROLE_AGENT", "parts": [{"text": "Response"}]},
+        }
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        # Mock database operations
+        mock_db.execute.return_value.scalar_one_or_none.return_value = sample_agent_with_passthrough.id
+        mock_get_for_update.return_value = sample_agent_with_passthrough
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        # Mock fresh_db_session for last_interaction update
+        mock_ts_db = MagicMock()
+        mock_ts_db.commit = MagicMock()
+        mock_ts_db.close = MagicMock()
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+
+        # Request headers including whitelisted and non-whitelisted headers
+        request_headers = {
+            "x-user-id": "alice@example.com",
+            "x-tenant-id": "tenant-123",
+            "authorization": "Bearer secret-token",  # Should be filtered out (not in whitelist)
+            "x-secret": "should-not-forward",  # Should be filtered out (not in whitelist)
+        }
+
+        # Invoke agent with request_headers
+        result = await service.invoke_agent(
+            db=mock_db,
+            agent_name="test-passthrough-agent",
+            parameters={"message": {"text": "Hello"}},
+            interaction_type="query",
+            user_id="user-123",
+            user_email="alice@example.com",
+            token_teams=[],
+            request_headers=request_headers,
+        )
+
+        # Verify result
+        assert result is not None
+        assert "result" in result
+
+        # Verify HTTP client was called
+        assert mock_client.post.called
+        call_args = mock_client.post.call_args
+
+        # Extract headers from the call
+        headers = call_args.kwargs.get("headers", {})
+
+        # Verify whitelisted headers were forwarded
+        assert "x-user-id" in headers
+        assert headers["x-user-id"] == "alice@example.com"
+        assert "x-tenant-id" in headers
+        assert headers["x-tenant-id"] == "tenant-123"
+
+        # Verify non-whitelisted headers were NOT forwarded
+        assert "authorization" not in headers or headers["authorization"] != "Bearer secret-token"
+        assert "x-secret" not in headers
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    async def test_passthrough_headers_case_insensitive_matching(
+        self, mock_metrics_buffer_fn, mock_fresh_db, mock_get_client, mock_get_for_update, service, mock_db, sample_agent_with_passthrough
+    ):
+        """Test that passthrough header matching is case-insensitive."""
+        # Mock metrics buffer
+        mock_metrics_buffer = MagicMock()
+        mock_metrics_buffer_fn.return_value = mock_metrics_buffer
+
+        # Mock HTTP client
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"status": "ok"}}
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        # Mock database operations
+        mock_db.execute.return_value.scalar_one_or_none.return_value = sample_agent_with_passthrough.id
+        mock_get_for_update.return_value = sample_agent_with_passthrough
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        # Mock fresh_db_session
+        mock_ts_db = MagicMock()
+        mock_ts_db.commit = MagicMock()
+        mock_ts_db.close = MagicMock()
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+
+        # Request headers with different case (X-User-ID vs x-user-id in whitelist)
+        request_headers = {
+            "X-User-ID": "bob@example.com",  # Capital letters
+            "X-TENANT-ID": "tenant-456",  # All caps
+        }
+
+        # Invoke agent
+        result = await service.invoke_agent(
+            db=mock_db,
+            agent_name="test-passthrough-agent",
+            parameters={"message": {"text": "Hello"}},
+            interaction_type="query",
+            user_id="user-123",
+            user_email="bob@example.com",
+            token_teams=[],
+            request_headers=request_headers,
+        )
+
+        # Verify result
+        assert result is not None
+
+        # Verify HTTP client was called and headers were forwarded despite case difference
+        assert mock_client.post.called
+        call_args = mock_client.post.call_args
+        headers = call_args.kwargs.get("headers", {})
+
+        # Headers should be normalized to lowercase to prevent duplicate headers
+        assert "x-user-id" in headers, f"Header not normalized to lowercase: {list(headers.keys())}"
+        assert headers["x-user-id"] == "bob@example.com"
+        assert "x-tenant-id" in headers, f"Header not normalized to lowercase: {list(headers.keys())}"
+        assert headers["x-tenant-id"] == "tenant-456"
+        
+        # Verify no uppercase versions exist (would indicate duplication bug)
+        assert "X-User-ID" not in headers, "Header key should be normalized to lowercase"
+        assert "X-TENANT-ID" not in headers, "Header key should be normalized to lowercase"
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    async def test_no_headers_forwarded_when_passthrough_not_configured(
+        self, mock_metrics_buffer_fn, mock_fresh_db, mock_get_client, mock_get_for_update, service, mock_db
+    ):
+        """Test that NO headers are forwarded when passthrough_headers is not configured (fail-closed)."""
+        # Create agent WITHOUT passthrough_headers
+        agent_id = str(uuid.uuid4())
+        agent = MagicMock(spec=DbA2AAgent)
+        agent.id = agent_id
+        agent.name = "test-no-passthrough-agent"
+        agent.enabled = True
+        agent.endpoint_url = "http://localhost:9999/agent"
+        agent.auth_type = None
+        agent.auth_value = None
+        agent.auth_query_params = None
+        agent.protocol_version = "v1.0"
+        agent.agent_type = "jsonrpc"
+        agent.visibility = "public"
+        agent.team_id = None
+        agent.owner_email = None
+        agent.passthrough_headers = None  # No passthrough configured
+
+        # Mock HTTP client
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"status": "ok"}}
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        # Mock database operations
+        mock_db.execute.return_value.scalar_one_or_none.return_value = agent.id
+        mock_get_for_update.return_value = agent
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        # Mock fresh_db_session
+        mock_ts_db = MagicMock()
+        mock_ts_db.commit = MagicMock()
+        mock_ts_db.close = MagicMock()
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+
+        # Request headers
+        request_headers = {
+            "x-user-id": "alice@example.com",
+            "x-tenant-id": "tenant-123",
+        }
+
+        # Invoke agent
+        result = await service.invoke_agent(
+            db=mock_db,
+            agent_name="test-no-passthrough-agent",
+            parameters={"message": {"text": "Hello"}},
+            interaction_type="query",
+            user_id="user-123",
+            user_email="alice@example.com",
+            token_teams=[],
+            request_headers=request_headers,
+        )
+
+        # Verify result
+        assert result is not None
+
+        # Verify HTTP client was called
+        assert mock_client.post.called
+        call_args = mock_client.post.call_args
+        headers = call_args.kwargs.get("headers", {})
+
+        # Verify NO request headers were forwarded (fail-closed security default)
+        assert "x-user-id" not in headers
+        assert "x-tenant-id" not in headers
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.fresh_db_session")
+    @patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service")
+    async def test_empty_passthrough_headers_blocks_all(
+        self, mock_metrics_buffer_fn, mock_fresh_db, mock_get_client, mock_get_for_update, service, mock_db
+    ):
+        """Test that empty passthrough_headers list blocks all headers (fail-closed)."""
+        # Create agent with EMPTY passthrough_headers list
+        agent_id = str(uuid.uuid4())
+        agent = MagicMock(spec=DbA2AAgent)
+        agent.id = agent_id
+        agent.name = "test-empty-passthrough-agent"
+        agent.enabled = True
+        agent.endpoint_url = "http://localhost:9999/agent"
+        agent.auth_type = None
+        agent.auth_value = None
+        agent.auth_query_params = None
+        agent.protocol_version = "v1.0"
+        agent.agent_type = "jsonrpc"
+        agent.visibility = "public"
+        agent.team_id = None
+        agent.owner_email = None
+        agent.passthrough_headers = []  # Empty list = block all
+
+        # Mock HTTP client
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"jsonrpc": "2.0", "id": 1, "result": {"status": "ok"}}
+        mock_client.post.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        # Mock database operations
+        mock_db.execute.return_value.scalar_one_or_none.return_value = agent.id
+        mock_get_for_update.return_value = agent
+        mock_db.commit = MagicMock()
+        mock_db.close = MagicMock()
+
+        # Mock fresh_db_session
+        mock_ts_db = MagicMock()
+        mock_ts_db.commit = MagicMock()
+        mock_ts_db.close = MagicMock()
+        mock_fresh_db.return_value.__enter__.return_value = mock_ts_db
+
+        # Request headers
+        request_headers = {
+            "x-user-id": "alice@example.com",
+            "x-tenant-id": "tenant-123",
+        }
+
+        # Invoke agent
+        result = await service.invoke_agent(
+            db=mock_db,
+            agent_name="test-empty-passthrough-agent",
+            parameters={"message": {"text": "Hello"}},
+            interaction_type="query",
+            user_id="user-123",
+            user_email="alice@example.com",
+            token_teams=[],
+            request_headers=request_headers,
+        )
+
+        # Verify result
+        assert result is not None
+
+        # Verify HTTP client was called
+        assert mock_client.post.called
+        call_args = mock_client.post.call_args
+        headers = call_args.kwargs.get("headers", {})
+
+        # Verify NO headers were forwarded (empty whitelist = block all)
+        assert "x-user-id" not in headers
+        assert "x-tenant-id" not in headers

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -7716,7 +7716,7 @@ class TestInvokeToolRestPost:
 # ---------------------------------------------------------------------------
 
 
-def _make_a2a_agent(*, enabled=True, agent_type="jsonrpc", auth_type=None, auth_value=None, auth_query_params=None):
+def _make_a2a_agent(*, enabled=True, agent_type="jsonrpc", auth_type=None, auth_value=None, auth_query_params=None, passthrough_headers=None):
     """Create a mock A2A agent."""
     agent = MagicMock()
     agent.id = "agent-uuid-1"
@@ -7728,6 +7728,7 @@ def _make_a2a_agent(*, enabled=True, agent_type="jsonrpc", auth_type=None, auth_
     agent.auth_type = auth_type
     agent.auth_value = auth_value
     agent.auth_query_params = auth_query_params
+    agent.passthrough_headers = passthrough_headers
     return agent
 
 
@@ -9992,3 +9993,87 @@ class TestInvokeToolLookupLogic:
             # Even though user_email matches owner, public-only token should deny access
             with pytest.raises(ToolNotFoundError, match="not found"):
                 await tool_service.invoke_tool(db, "test_tool", {}, user_email="me@test.com", token_teams=[])
+
+
+# ---------------------------------------------------------------------------
+# Plugin header removal override protection (Issue #5004)
+# ---------------------------------------------------------------------------
+
+
+class TestPluginHeaderRemovalNotOverridden:
+    """Tests that plugin header modifications are respected and not overridden by passthrough logic."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_can_remove_passthrough_headers_a2a_path(self, tool_service):
+        """When a plugin removes a passthrough header, it should stay removed (A2A tool path)."""
+        # First-Party
+        from cpex.framework import ToolHookType
+
+        # Setup A2A tool with passthrough headers
+        tp = _make_tool_payload(
+            integration_type="A2A",
+            request_type="POST",
+            annotations={"a2a_agent_id": "agent-uuid-1"},
+        )
+        gp = _make_gateway_payload()
+        db = MagicMock()
+        
+        # A2A agent with passthrough_headers whitelist
+        a2a_agent = _make_a2a_agent(passthrough_headers=["x-secret"])
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=a2a_agent)))
+
+        # Plugin that removes a passthrough header
+        plugin_manager = MagicMock()
+
+        def _has_hooks_for(hook_type):
+            return hook_type == ToolHookType.TOOL_PRE_INVOKE
+
+        plugin_manager.has_hooks_for = MagicMock(side_effect=_has_hooks_for)
+
+        # Plugin receives headers including x-secret from passthrough, but removes it
+        def _invoke_hook(hook_type, payload, **kwargs):
+            # Plugin removes x-secret header
+            modified_headers = {k: v for k, v in payload.headers.root.items() if k != "x-secret"}
+            return (
+                SimpleNamespace(
+                    modified_payload=SimpleNamespace(
+                        name=payload.name,
+                        args=payload.args,
+                        headers=SimpleNamespace(model_dump=lambda: modified_headers),
+                    )
+                ),
+                {},
+            )
+
+        plugin_manager.invoke_hook = AsyncMock(side_effect=_invoke_hook)
+
+        # Mock HTTP client to capture headers sent downstream
+        captured_headers = {}
+
+        async def fake_post(url, **kwargs):
+            captured_headers.update(kwargs.get("headers", {}))
+            return MagicMock(status_code=200, json=MagicMock(return_value={"jsonrpc": "2.0", "id": 1, "result": {"status": "ok"}}))
+
+        tool_service._http_client = AsyncMock()
+        tool_service._http_client.post = AsyncMock(side_effect=fake_post)
+
+        with (
+            _setup_cache_for_invoke(tp, gp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch.object(tool_service, "_get_plugin_manager", AsyncMock(return_value=plugin_manager)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=["x-secret"])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+
+            # Call with request_headers containing x-secret
+            await tool_service.invoke_tool(db, "test_tool", {}, request_headers={"x-secret": "sensitive-token"})
+
+            # Verify x-secret was NOT forwarded downstream (plugin removed it)
+            assert "x-secret" not in captured_headers, "Plugin-removed header should not be re-added by passthrough logic"

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -10017,7 +10017,7 @@ class TestPluginHeaderRemovalNotOverridden:
         )
         gp = _make_gateway_payload()
         db = MagicMock()
-        
+
         # A2A agent with passthrough_headers whitelist
         a2a_agent = _make_a2a_agent(passthrough_headers=["x-secret"])
         db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=a2a_agent)))

--- a/tests/unit/mcpgateway/services/test_tool_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_coverage.py
@@ -8516,6 +8516,118 @@ class TestInvokeToolA2A:
         ctx.set_state.assert_called_with("cb_timeout_failure", True)
         plugin_manager.invoke_hook.assert_awaited()
 
+    @pytest.mark.asyncio
+    async def test_a2a_with_passthrough_headers_whitelist(self, tool_service):
+        """A2A tool with passthrough_headers filters and forwards whitelisted headers."""
+        tp = _make_tool_payload(
+            integration_type="A2A",
+            request_type="POST",
+            annotations={"a2a_agent_id": "agent-uuid-1"},
+        )
+        db = MagicMock()
+        a2a_agent = _make_a2a_agent()
+        a2a_agent.passthrough_headers = ["x-tenant-id", "x-user-id"]
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=a2a_agent)))
+
+        captured_headers = {}
+        mock_http_response = MagicMock()
+        mock_http_response.status_code = 200
+        mock_http_response.json = MagicMock(return_value={"response": "ok"})
+
+        async def fake_post(url, json=None, headers=None):
+            captured_headers.update(headers or {})
+            return mock_http_response
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+
+            tool_service._http_client = AsyncMock()
+            tool_service._http_client.post = fake_post
+
+            request_headers = {
+                "X-Tenant-ID": "tenant-123",
+                "X-User-ID": "user-456",
+                "Authorization": "Bearer secret",
+                "X-Secret": "should-not-forward",
+            }
+
+            await tool_service.invoke_tool(db, "test_tool", {"query": "test"}, request_headers=request_headers)
+
+        # Only whitelisted headers should be forwarded (normalized to lowercase)
+        assert "x-tenant-id" in captured_headers
+        assert "x-user-id" in captured_headers
+        assert captured_headers["x-tenant-id"] == "tenant-123"
+        assert captured_headers["x-user-id"] == "user-456"
+        # Non-whitelisted headers should NOT be forwarded
+        assert "authorization" not in captured_headers
+        assert "Authorization" not in captured_headers
+        assert "x-secret" not in captured_headers
+
+    @pytest.mark.asyncio
+    async def test_a2a_without_passthrough_headers_blocks_all(self, tool_service):
+        """A2A tool without passthrough_headers configured blocks all request headers (fail-closed)."""
+        tp = _make_tool_payload(
+            integration_type="A2A",
+            request_type="POST",
+            annotations={"a2a_agent_id": "agent-uuid-1"},
+        )
+        db = MagicMock()
+        a2a_agent = _make_a2a_agent()
+        a2a_agent.passthrough_headers = None  # No whitelist configured
+        db.execute = MagicMock(return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=a2a_agent)))
+
+        captured_headers = {}
+        mock_http_response = MagicMock()
+        mock_http_response.status_code = 200
+        mock_http_response.json = MagicMock(return_value={"response": "ok"})
+
+        async def fake_post(url, json=None, headers=None):
+            captured_headers.update(headers or {})
+            return mock_http_response
+
+        with (
+            _setup_cache_for_invoke(tp),
+            patch.object(tool_service, "_check_tool_access", AsyncMock(return_value=True)),
+            patch("mcpgateway.services.tool_service.global_config_cache") as mock_gcc,
+            patch("mcpgateway.services.tool_service.current_trace_id") as mock_trace,
+            patch("mcpgateway.services.tool_service.create_span") as mock_span_ctx,
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service") as mock_mbuf,
+            patch("mcpgateway.services.tool_service.compute_passthrough_headers_cached", return_value={}),
+        ):
+            mock_gcc.get_passthrough_headers = MagicMock(return_value=[])
+            mock_trace.get = MagicMock(return_value=None)
+            mock_span_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_span_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            mock_mbuf.return_value = MagicMock()
+
+            tool_service._http_client = AsyncMock()
+            tool_service._http_client.post = fake_post
+
+            request_headers = {
+                "X-Tenant-ID": "tenant-123",
+                "X-User-ID": "user-456",
+            }
+
+            await tool_service.invoke_tool(db, "test_tool", {"query": "test"}, request_headers=request_headers)
+
+        # No request headers should be forwarded (only base headers like Content-Type)
+        assert "x-tenant-id" not in captured_headers
+        assert "x-user-id" not in captured_headers
+        # Base headers from prepare_a2a_invocation should still be present
+        assert "Content-Type" in captured_headers or "content-type" in captured_headers
+
 
 # ---------------------------------------------------------------------------
 # invoke_tool — MCP / SSE (OAuth, session affinity, pool paths)


### PR DESCRIPTION


closes  #5004

This commit addresses issue #5004 by ensuring passthrough_headers are forwarded in both A2A invocation paths:

1. MCP tool path (tool_service.py):
   - Filter request_headers to agent's passthrough_headers whitelist
   - Merge filtered headers into base headers for plugin hooks
   - Forward filtered headers to downstream A2A agent

2. REST invoke path (a2a_service.py):
   - Add filtered passthrough headers to prepared.headers after plugin hooks
   - Ensures consistency between MCP tool and REST invocation paths

The original issue description stated that only the MCP tool path was broken, but investigation revealed both paths were broken. Both paths now correctly:
- Forward only whitelisted headers (fail-closed security)
- Support case-insensitive header matching (k.lower() in whitelist_lower)
- Block all headers when passthrough_headers is null or empty

Testing:
- Added 4 comprehensive unit tests for A2A service direct invoke path (all passing)
- Tests cover: whitelisted forwarding, case-insensitivity, fail-closed behavior
- Manual end-to-end testing confirms both paths work correctly:
  * Bugfix branch: x-user-id forwarded in both MCP tool and REST paths ✓
  * Main branch: x-user-id missing in both paths (confirms bug) ✓
- Security: Headers not in whitelist are never forwarded

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->


