### PR TITLE
fix: use valid JSON string in Slack notify payload instead of YAML >-…

### DIFF
--- a/.github/workflows/notify-slack-failure.yml
+++ b/.github/workflows/notify-slack-failure.yml
@@ -68,12 +68,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": >-
-                      :x: *${{ github.event.workflow_run.name || 'Manual test dispatch' }}* failed on `main`
-                      • *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}|`${{ github.event.workflow_run.head_sha || github.sha }}`>
-                      • *Author:* `${{ github.event.workflow_run.head_commit.author.name || github.actor }}`
-                      • *Merged by:* `${{ github.event.workflow_run.actor.login || github.actor }}`
-                      • *Run:* <${{ github.event.workflow_run.html_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}|View run>
+                    "text": ":x: *${{ github.event.workflow_run.name || 'Manual test dispatch' }}* failed on `main`\n• *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha || github.sha }}|`${{ github.event.workflow_run.head_sha || github.sha }}`>\n• *Author:* `${{ github.event.workflow_run.head_commit.author.name || github.actor }}`\n• *Merged by:* `${{ github.event.workflow_run.actor.login || github.actor }}`\n• *Run:* <${{ github.event.workflow_run.html_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}|View run>"
                   }
                 }
               ]


### PR DESCRIPTION
## 🔗 Related Issue
Closes # (no issue — regression introduced by #4788)

---

## 📝 Summary
PR #4788 changed the notify-slack-failure.yml payload to use a YAML block scalar (`>-`) for the multi-line `mrkdwn` text field. The `payload: |` block makes the entire value an opaque string that the `slackapi/slack-github-action` re-parses at runtime as JSON (and falls back to YAML). A YAML block scalar inside a JSON flow collection (`{}`) is invalid in both parsers, causing the action to throw `SyntaxError: Unexpected token '>', ..."text": >-` and `YAMLException: missed comma between flow collection entries`.

This PR replaces the `>-` block with a single valid JSON string, using `\n` for line breaks, which both parsers accept correctly.

---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | N/A — YAML-only change |
| Unit tests | `make test` | N/A — YAML-only change |
| Coverage ≥ 80% | `make coverage` | N/A — YAML-only change |

Verified by manually triggering the `Notify Slack on Build Failure` workflow via `workflow_dispatch` — Slack message delivered successfully.

---

## ✅ Checklist
- [x] No secrets or credentials committed

---

## 📓 Notes
