### PR TITLE
fix(ui-rewrite): carry visibility and team_id through from MCP server form to virtual server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ CSRF_SECRET_KEY=
 CSRF_TOKEN_NAME=X-CSRF-Token
 
 # Cookie name for CSRF token
-CSRF_COOKIE_NAME=csrf_token
+CSRF_COOKIE_NAME=mcpgateway_csrf_token
 
 # CSRF token expiration time in seconds (default: 3600 = 1 hour)
 CSRF_TOKEN_EXPIRY=3600
@@ -64,7 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8000","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/app/auth/login","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ CSRF_SECRET_KEY=
 CSRF_TOKEN_NAME=X-CSRF-Token
 
 # Cookie name for CSRF token
-CSRF_COOKIE_NAME=mcpgateway_csrf_token
+CSRF_COOKIE_NAME=csrf_token
 
 # CSRF token expiration time in seconds (default: 3600 = 1 hour)
 CSRF_TOKEN_EXPIRY=3600
@@ -64,8 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8000","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/app/auth/login","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc"]
-
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values
 PLATFORM_ADMIN_EMAIL=admin@example.com

--- a/client/src/api/virtualServers.test.ts
+++ b/client/src/api/virtualServers.test.ts
@@ -177,4 +177,40 @@ describe("virtualServers API", () => {
     expect(payload.server.description).toBeUndefined();
     expect(payload.server.oauth_config).toBeUndefined();
   });
+
+  it("sets team_id when visibility is team and teamId is provided", () => {
+    const payload = buildCreateVirtualServerPayload({
+      name: "Team server",
+      visibility: "team",
+      teamId: "team-abc-123",
+      oauthEnabled: false,
+    });
+
+    expect(payload.server.team_id).toBe("team-abc-123");
+    expect(payload.team_id).toBe("team-abc-123");
+    expect(payload.visibility).toBe("team");
+  });
+
+  it("keeps team_id null when visibility is team but teamId is absent", () => {
+    const payload = buildCreateVirtualServerPayload({
+      name: "Team server no id",
+      visibility: "team",
+      oauthEnabled: false,
+    });
+
+    expect(payload.server.team_id).toBeNull();
+    expect(payload.team_id).toBeNull();
+  });
+
+  it("keeps team_id null when teamId is provided but visibility is not team", () => {
+    const payload = buildCreateVirtualServerPayload({
+      name: "Private server",
+      visibility: "private",
+      teamId: "team-abc-123",
+      oauthEnabled: false,
+    });
+
+    expect(payload.server.team_id).toBeNull();
+    expect(payload.team_id).toBeNull();
+  });
 });

--- a/client/src/api/virtualServers.ts
+++ b/client/src/api/virtualServers.ts
@@ -25,6 +25,8 @@ export interface CreateVirtualServerPayload {
 export function buildCreateVirtualServerPayload(
   details: CreateServerDetails,
 ): CreateVirtualServerPayload {
+  const teamId = details.visibility === "team" && details.teamId ? details.teamId : null;
+
   return {
     server: {
       name: details.name,
@@ -35,12 +37,12 @@ export function buildCreateVirtualServerPayload(
       associated_resources: details.associatedResources ?? [],
       associated_prompts: details.associatedPrompts ?? [],
       associated_a2a_agents: [],
-      team_id: null,
+      team_id: teamId,
       visibility: details.visibility,
       oauth_enabled: details.oauthEnabled,
       oauth_config: details.oauthEnabled ? {} : undefined,
     },
-    team_id: null,
+    team_id: teamId,
     visibility: details.visibility,
   };
 }

--- a/client/src/auth/AuthContext.tsx
+++ b/client/src/auth/AuthContext.tsx
@@ -25,11 +25,13 @@ interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  selectedTeamId: string | null;
 }
 
 interface AuthContextValue extends AuthState {
   login: (email: string, password: string) => Promise<void>; // pragma: allowlist secret
   logout: () => Promise<void>;
+  setSelectedTeamId: (teamId: string | null) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,7 +46,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     user: null,
     isAuthenticated: false,
     isLoading: true,
+    selectedTeamId: null,
   });
+
+  const setSelectedTeamId = useCallback((teamId: string | null) => {
+    setState((prev) => ({ ...prev, selectedTeamId: teamId }));
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -54,16 +61,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .get<User>("/app/auth/me")
       .then((user) => {
         if (!cancelled && version === authVersion.current) {
-          setState({ user, isAuthenticated: true, isLoading: false });
+          setState({ user, isAuthenticated: true, isLoading: false, selectedTeamId: null });
         }
       })
       .catch((err) => {
         if (!cancelled && version === authVersion.current) {
           if (err instanceof ApiError && err.status === 401) {
-            setState({ user: null, isAuthenticated: false, isLoading: false });
+            setState({
+              user: null,
+              isAuthenticated: false,
+              isLoading: false,
+              selectedTeamId: null,
+            });
             return;
           }
-          setState({ user: null, isAuthenticated: false, isLoading: false });
+          setState({ user: null, isAuthenticated: false, isLoading: false, selectedTeamId: null });
         }
       });
 
@@ -84,7 +96,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       );
 
       authVersion.current += 1;
-      setState({ user: data.user, isAuthenticated: true, isLoading: false });
+      setState({ user: data.user, isAuthenticated: true, isLoading: false, selectedTeamId: null });
     },
     [],
   );
@@ -97,13 +109,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // or the CSRF cookie has expired.
     } finally {
       authVersion.current += 1;
-      setState({ user: null, isAuthenticated: false, isLoading: false });
+      setState({ user: null, isAuthenticated: false, isLoading: false, selectedTeamId: null });
       window.location.href = "/app/login";
     }
   }, []);
 
   return (
-    <AuthContext.Provider value={{ ...state, login, logout }}>{children}</AuthContext.Provider>
+    <AuthContext.Provider value={{ ...state, login, logout, setSelectedTeamId }}>
+      {children}
+    </AuthContext.Provider>
   );
 }
 

--- a/client/src/components/gateways/CreateServerForm.tsx
+++ b/client/src/components/gateways/CreateServerForm.tsx
@@ -9,10 +9,11 @@ import {
   useCreateServerForm,
   type CreateServerFormInitialValues,
 } from "@/hooks/useCreateServerForm";
-import type { CreateServerDetails, CreateServerVisibility } from "@/components/gateways/types";
+import type { CreateServerDetails } from "@/components/gateways/types";
+import type { Visibility } from "@/types/server";
 
 const visibilityOptions: Array<{
-  value: CreateServerVisibility;
+  value: Visibility;
   labelId: string;
 }> = [
   {
@@ -113,7 +114,7 @@ export function CreateServerForm({
                     value={option.value}
                     checked={selected}
                     onChange={(event) => {
-                      const nextVisibility = event.target.value as CreateServerVisibility;
+                      const nextVisibility = event.target.value as Visibility;
                       setVisibility(nextVisibility);
                       validateField("visibility", nextVisibility);
                     }}

--- a/client/src/components/gateways/ExposeComponentsForm.test.tsx
+++ b/client/src/components/gateways/ExposeComponentsForm.test.tsx
@@ -6,6 +6,7 @@ import { setupServer } from "msw/node";
 import { ExposeComponentsForm } from "./ExposeComponentsForm";
 import { RouterProvider } from "@/router";
 import { I18nProvider } from "@/i18n";
+import * as virtualServersApi from "@/api/virtualServers";
 
 // Mock data - must match the API response format with id fields
 const mockTools = [
@@ -247,6 +248,48 @@ describe("ExposeComponentsForm", () => {
   });
 
   describe("Form Submission", () => {
+    it("should use provided visibility when creating virtual server", async () => {
+      const spy = vi
+        .spyOn(virtualServersApi, "createVirtualServer")
+        .mockResolvedValue({ id: "virtual-server-456" } as never);
+
+      const user = userEvent.setup();
+      renderWithProviders(<ExposeComponentsForm {...defaultProps} visibility="private" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /expose components/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /expose components/i }));
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ visibility: "private" }));
+      });
+
+      spy.mockRestore();
+    });
+
+    it("should default to public visibility when none is provided", async () => {
+      const spy = vi
+        .spyOn(virtualServersApi, "createVirtualServer")
+        .mockResolvedValue({ id: "virtual-server-456" } as never);
+
+      const user = userEvent.setup();
+      renderWithProviders(<ExposeComponentsForm {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /expose components/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /expose components/i }));
+
+      await waitFor(() => {
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ visibility: "public" }));
+      });
+
+      spy.mockRestore();
+    });
+
     it("should create virtual server with selected components", async () => {
       const user = userEvent.setup();
       renderWithProviders(<ExposeComponentsForm {...defaultProps} />);

--- a/client/src/components/gateways/ExposeComponentsForm.tsx
+++ b/client/src/components/gateways/ExposeComponentsForm.tsx
@@ -25,10 +25,13 @@ import { Loading } from "@/components/ui/loading";
 import { createVirtualServer } from "@/api/virtualServers";
 import { useRouter } from "@/router";
 import type { CreateServerDetails } from "@/components/gateways/types";
+import type { Visibility } from "@/types/server";
 
 interface ExposeComponentsFormProps {
   gatewayId: string;
   gatewayName: string;
+  visibility?: Visibility;
+  teamId?: string;
   oauthNotification?: {
     type: "success" | "error";
     message: string;
@@ -128,6 +131,8 @@ function MCPObjectsTable({
 export function ExposeComponentsForm({
   gatewayId,
   gatewayName,
+  visibility = "public",
+  teamId,
   oauthNotification,
   clearOAuthNotification,
 }: ExposeComponentsFormProps) {
@@ -227,7 +232,8 @@ export function ExposeComponentsForm({
     try {
       const serverDetails: CreateServerDetails = {
         name: gatewayName,
-        visibility: "public",
+        visibility,
+        teamId,
         oauthEnabled: requireOAuth,
         tags: [],
         description: undefined,

--- a/client/src/components/gateways/types.ts
+++ b/client/src/components/gateways/types.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import type { Visibility } from "@/types/server";
 
 export interface ActionCard {
   icon: ComponentType<{ className?: string }>;
@@ -12,11 +13,10 @@ export interface ActionCard {
 
 export type ComponentFilter = "all" | "tools" | "resources" | "prompts";
 
-export type CreateServerVisibility = "public" | "team" | "private";
-
 export interface CreateServerDetails {
   name: string;
-  visibility: CreateServerVisibility;
+  visibility: Visibility;
+  teamId?: string;
   oauthEnabled: boolean;
   tags?: string[];
   description?: string;

--- a/client/src/components/layout/TeamSwitcher.test.tsx
+++ b/client/src/components/layout/TeamSwitcher.test.tsx
@@ -3,15 +3,18 @@ import { screen, waitFor, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { I18nProvider } from "@/i18n";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { AuthProvider } from "@/auth/AuthContext";
 import { TeamSwitcher } from "./TeamSwitcher";
 
 function renderTeamSwitcher() {
   return render(
-    <I18nProvider>
-      <SidebarProvider>
-        <TeamSwitcher />
-      </SidebarProvider>
-    </I18nProvider>,
+    <AuthProvider>
+      <I18nProvider>
+        <SidebarProvider>
+          <TeamSwitcher />
+        </SidebarProvider>
+      </I18nProvider>
+    </AuthProvider>,
   );
 }
 

--- a/client/src/components/layout/TeamSwitcher.tsx
+++ b/client/src/components/layout/TeamSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import { ChevronsUpDown, Globe } from "lucide-react";
 import {
   DropdownMenu,
@@ -8,6 +8,7 @@ import {
 } from "../ui/dropdown-menu";
 import { SidebarMenuButton } from "../ui/sidebar";
 import { useQuery } from "../../hooks/useQuery";
+import { useAuthContext } from "../../auth/AuthContext";
 
 interface Team {
   id: string;
@@ -20,19 +21,22 @@ interface TeamsResponse {
 }
 
 export function TeamSwitcher() {
-  const [selectedTeam, setSelectedTeam] = useState<string | null>(null);
+  const { selectedTeamId, setSelectedTeamId } = useAuthContext();
   const { data, isLoading, error } = useQuery<TeamsResponse>("/teams");
 
   const teams = useMemo(() => data?.teams ?? [], [data?.teams]);
   const currentTeam = useMemo(
-    () => (selectedTeam ? teams.find((t) => t.id === selectedTeam) : null),
-    [selectedTeam, teams],
+    () => (selectedTeamId ? teams.find((t) => t.id === selectedTeamId) : null),
+    [selectedTeamId, teams],
   );
   const displayName = currentTeam?.name ?? "All teams";
 
-  const handleSelectTeam = useCallback((teamId: string | null) => {
-    setSelectedTeam(teamId);
-  }, []);
+  const handleSelectTeam = useCallback(
+    (teamId: string | null) => {
+      setSelectedTeamId(teamId);
+    },
+    [setSelectedTeamId],
+  );
 
   return (
     <DropdownMenu>
@@ -75,7 +79,7 @@ export function TeamSwitcher() {
           className="gap-2 p-2"
           onClick={() => handleSelectTeam(null)}
           aria-label="Select all teams"
-          aria-current={selectedTeam === null ? "true" : "false"}
+          aria-current={selectedTeamId === null ? "true" : "false"}
         >
           <div
             className="flex size-6 items-center justify-center rounded-sm border bg-background"
@@ -91,7 +95,7 @@ export function TeamSwitcher() {
             className="gap-2 p-2"
             onClick={() => handleSelectTeam(team.id)}
             aria-label={`Select ${team.name} team${team.description ? `: ${team.description}` : ""}`}
-            aria-current={selectedTeam === team.id ? "true" : "false"}
+            aria-current={selectedTeamId === team.id ? "true" : "false"}
           >
             <div
               className="flex size-6 items-center justify-center rounded-sm border bg-background"

--- a/client/src/components/mcp-servers/AdvancedSettings.tsx
+++ b/client/src/components/mcp-servers/AdvancedSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Info, TriangleAlert } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
@@ -15,6 +16,7 @@ import { BearerTokenAuth } from "@/components/mcp-servers/BearerTokenAuth";
 import { CustomHeadersAuth, type CustomHeader } from "@/components/mcp-servers/CustomHeadersAuth";
 import { OAuth2Auth } from "@/components/mcp-servers/OAuth2Auth";
 import { QueryParameterAuth } from "@/components/mcp-servers/QueryParameterAuth";
+import { useAuthContext } from "@/auth/AuthContext";
 
 export type { CustomHeader };
 
@@ -23,6 +25,8 @@ type AuthType = "none" | "basic" | "bearer" | "custom" | "oauth" | "query";
 interface AdvancedSettingsProps {
   visibility: string;
   onVisibilityChange: (value: string) => void;
+  teamId: string;
+  onTeamIdChange: (value: string) => void;
   authType: AuthType;
   onAuthTypeChange: (value: AuthType) => void;
   basicAuthUsername: string;
@@ -72,6 +76,8 @@ interface AdvancedSettingsProps {
 export function AdvancedSettings({
   visibility,
   onVisibilityChange,
+  teamId,
+  onTeamIdChange,
   authType,
   onAuthTypeChange,
   basicAuthUsername,
@@ -117,6 +123,18 @@ export function AdvancedSettings({
   onCACertificateFilesSelected,
   oauthErrors,
 }: AdvancedSettingsProps) {
+  const { selectedTeamId } = useAuthContext();
+
+  useEffect(() => {
+    if (visibility === "team") {
+      if (selectedTeamId && !teamId) {
+        onTeamIdChange(selectedTeamId);
+      }
+    } else if (teamId) {
+      onTeamIdChange("");
+    }
+  }, [visibility, selectedTeamId, teamId, onTeamIdChange]);
+
   const renderAuthContent = () => {
     switch (authType) {
       case "none":
@@ -200,6 +218,13 @@ export function AdvancedSettings({
             <SelectItem value="team">Team</SelectItem>
           </SelectContent>
         </Select>
+        {visibility === "team" && (
+          <p className="text-sm text-neutral-600 dark:text-neutral-400">
+            {selectedTeamId
+              ? "This server will be scoped to your currently selected team"
+              : "Please select a team using the team switcher in the sidebar"}
+          </p>
+        )}
       </div>
 
       {/* Authentication type */}

--- a/client/src/components/mcp-servers/MCPServerForm.test.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.test.tsx
@@ -6,9 +6,13 @@ import { setupServer } from "msw/node";
 import { MCPServerForm } from "./MCPServerForm";
 import { RouterProvider } from "@/router";
 import { I18nProvider } from "@/i18n";
+import { AuthProvider } from "@/auth/AuthContext";
 
 // Mock API responses for ExposeComponentsForm and gateway creation
 const server = setupServer(
+  http.get("/app/auth/me", () => {
+    return HttpResponse.json({ detail: "Unauthorized" }, { status: 401 });
+  }),
   // Mock gateway creation
   http.post("/gateways", () => {
     return HttpResponse.json({ id: "test-gateway-123", name: "Test Server" });
@@ -35,12 +39,14 @@ describe("MCPServerForm", () => {
     onToggle: vi.fn(),
   };
 
-  // Helper to render with router and i18n
+  // Helper to render with router, i18n, and auth context
   const renderWithRouter = (ui: React.ReactElement) => {
     return render(
-      <I18nProvider>
-        <RouterProvider>{ui}</RouterProvider>
-      </I18nProvider>,
+      <AuthProvider>
+        <I18nProvider>
+          <RouterProvider>{ui}</RouterProvider>
+        </I18nProvider>
+      </AuthProvider>,
     );
   };
 
@@ -931,8 +937,7 @@ describe("MCPServerForm", () => {
       }
     });
 
-    it("should log selected files to console", async () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    it("should handle CA certificate file selection without errors", async () => {
       const user = userEvent.setup();
       renderWithRouter(<MCPServerForm {...defaultProps} />);
 
@@ -949,17 +954,9 @@ describe("MCPServerForm", () => {
           writable: false,
         });
 
-        fireEvent.change(fileInput);
-
-        await waitFor(() => {
-          expect(consoleSpy).toHaveBeenCalledWith(
-            "Selected CA certificate files:",
-            expect.arrayContaining([expect.any(File)]),
-          );
-        });
+        // File selection should not throw
+        expect(() => fireEvent.change(fileInput)).not.toThrow();
       }
-
-      consoleSpy.mockRestore();
     });
 
     describe("OAuth Notifications", () => {

--- a/client/src/components/mcp-servers/MCPServerForm.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.tsx
@@ -32,6 +32,7 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
     transport,
     advancedOpen,
     visibility,
+    teamId,
     authType,
     oneTimeAuth,
     passthroughHeaders,
@@ -49,6 +50,7 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
     setTransport,
     setAdvancedOpen,
     setVisibility,
+    setTeamId,
     setAuthType,
     setOneTimeAuth,
     setPassthroughHeaders,
@@ -129,6 +131,8 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
       <ExposeComponentsForm
         gatewayId={createdGateway.id}
         gatewayName={createdGateway.name}
+        visibility={visibility}
+        teamId={teamId}
         oauthNotification={oauthNotification}
         clearOAuthNotification={clearOAuthNotification}
       />
@@ -294,6 +298,8 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
                 <AdvancedSettings
                   visibility={visibility}
                   onVisibilityChange={setVisibility}
+                  teamId={teamId}
+                  onTeamIdChange={setTeamId}
                   authType={authType}
                   onAuthTypeChange={setAuthType}
                   basicAuthUsername={authUsername}
@@ -336,8 +342,8 @@ export function MCPServerForm({ isOpen, onToggle, serverId, onSuccess }: MCPServ
                   onOneTimeAuthChange={setOneTimeAuth}
                   passthroughHeaders={passthroughHeaders}
                   onPassthroughHeadersChange={setPassthroughHeaders}
-                  onCACertificateFilesSelected={(files) => {
-                    console.log("Selected CA certificate files:", files);
+                  onCACertificateFilesSelected={() => {
+                    // CA certificate file selection handled by AdvancedSettings
                   }}
                   oauthErrors={{
                     username: errors.oauthUsername,

--- a/client/src/hooks/useCreateServerForm.ts
+++ b/client/src/hooks/useCreateServerForm.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo, useState, type FormEvent } from "react";
 import { useIntl } from "react-intl";
 import { z } from "zod";
-import type { CreateServerDetails, CreateServerVisibility } from "@/components/gateways/types";
+import type { CreateServerDetails } from "@/components/gateways/types";
+import type { Visibility } from "@/types/server";
 import { sanitizeString } from "@/lib/sanitize";
 
 function createServerFormSchema(messages: {
@@ -37,7 +38,7 @@ export type CreateServerFormData = z.infer<ReturnType<typeof createServerFormSch
 
 interface CreateServerFormValues {
   name: string;
-  visibility: CreateServerVisibility;
+  visibility: Visibility;
   oauthEnabled: boolean;
   tags: string;
   description: string;
@@ -45,7 +46,7 @@ interface CreateServerFormValues {
 
 export interface CreateServerFormInitialValues {
   name?: string;
-  visibility?: CreateServerVisibility;
+  visibility?: Visibility;
   oauthEnabled?: boolean;
   tags?: string[];
   description?: string;
@@ -62,14 +63,14 @@ export interface CreateServerFormErrors {
 
 export interface UseCreateServerFormReturn {
   name: string;
-  visibility: CreateServerVisibility;
+  visibility: Visibility;
   oauthEnabled: boolean;
   tags: string;
   description: string;
   errors: CreateServerFormErrors;
   isValid: boolean;
   setName: (value: string) => void;
-  setVisibility: (value: CreateServerVisibility) => void;
+  setVisibility: (value: Visibility) => void;
   setOAuthEnabled: (value: boolean) => void;
   setTags: (value: string) => void;
   setDescription: (value: string) => void;
@@ -133,9 +134,7 @@ export function useCreateServerForm(
   );
   const resolvedInitialState = useMemo(() => getInitialState(initialValues), [initialValues]);
   const [name, setName] = useState(resolvedInitialState.name);
-  const [visibility, setVisibility] = useState<CreateServerVisibility>(
-    resolvedInitialState.visibility,
-  );
+  const [visibility, setVisibility] = useState<Visibility>(resolvedInitialState.visibility);
   const [oauthEnabled, setOAuthEnabled] = useState(resolvedInitialState.oauthEnabled);
   const [tags, setTags] = useState(resolvedInitialState.tags);
   const [description, setDescription] = useState(resolvedInitialState.description);

--- a/client/src/hooks/useMCPServerForm.test.ts
+++ b/client/src/hooks/useMCPServerForm.test.ts
@@ -16,6 +16,7 @@ describe("useMCPServerForm", () => {
       expect(result.current.transport).toBe("STREAMABLEHTTP");
       expect(result.current.advancedOpen).toBe(false);
       expect(result.current.visibility).toBe("public");
+      expect(result.current.teamId).toBe("");
       expect(result.current.authType).toBe("none");
       expect(result.current.oneTimeAuth).toBe(false);
       expect(result.current.passthroughHeaders).toBe("");
@@ -67,6 +68,16 @@ describe("useMCPServerForm", () => {
       expect(result.current.description).toBe("Test description");
     });
 
+    it("should update teamId", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setTeamId("team-xyz-456");
+      });
+
+      expect(result.current.teamId).toBe("team-xyz-456");
+    });
+
     it("should toggle advanced settings", () => {
       const { result } = renderHook(() => useMCPServerForm());
 
@@ -111,6 +122,41 @@ describe("useMCPServerForm", () => {
       });
 
       expect(result.current.errors.url).toBe("URL must start with http:// or https://");
+    });
+
+    it("should add teamId error when visibility is team and teamId is empty", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("team");
+      });
+
+      act(() => {
+        result.current.validateForm();
+      });
+
+      expect(result.current.errors.teamId).toBeDefined();
+    });
+
+    it("should pass validation when visibility is team and teamId is set", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("team");
+        result.current.setTeamId("team-abc");
+      });
+
+      let isValid: boolean;
+      act(() => {
+        isValid = result.current.validateForm();
+      });
+
+      expect(isValid!).toBe(true);
+      expect(result.current.errors.teamId).toBeUndefined();
     });
 
     it("should pass validation with valid data", () => {
@@ -197,8 +243,10 @@ describe("useMCPServerForm", () => {
         result.current.setUrl("http://localhost:3000");
       });
 
-      result.current.handleSubmit(mockEvent, () => {
-        callbackCalled = true;
+      await act(async () => {
+        await result.current.handleSubmit(mockEvent, () => {
+          callbackCalled = true;
+        });
       });
 
       await waitFor(() => {
@@ -220,7 +268,9 @@ describe("useMCPServerForm", () => {
         result.current.setDescription("Test description");
       });
 
-      result.current.handleSubmit(mockEvent);
+      await act(async () => {
+        await result.current.handleSubmit(mockEvent);
+      });
 
       await waitFor(() => {
         expect(result.current.name).toBe("");
@@ -255,6 +305,7 @@ describe("useMCPServerForm", () => {
       expect(result.current.description).toBe("");
       expect(result.current.advancedOpen).toBe(false);
       expect(result.current.visibility).toBe("public");
+      expect(result.current.teamId).toBe("");
       expect(result.current.authType).toBe("none");
       expect(result.current.errors).toEqual({});
     });
@@ -291,6 +342,31 @@ describe("useMCPServerForm", () => {
 
       expect(result.current.isValid).toBe(true);
     });
+
+    it("should be false when visibility is team but teamId is empty", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("team");
+      });
+
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("should be true when visibility is team and teamId is provided", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("team");
+        result.current.setTeamId("team-abc");
+      });
+
+      expect(result.current.isValid).toBe(true);
+    });
   });
 
   describe("getFormData", () => {
@@ -310,6 +386,34 @@ describe("useMCPServerForm", () => {
       expect(formData.description).toBe("Test description");
       expect(formData.transport).toBe("STREAMABLEHTTP");
       expect(formData.visibility).toBe("public");
+    });
+
+    it("includes teamId when visibility is team", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("team");
+        result.current.setTeamId("team-abc-123");
+      });
+
+      const formData = result.current.getFormData();
+      expect(formData.teamId).toBe("team-abc-123");
+    });
+
+    it("omits teamId when visibility is not team", () => {
+      const { result } = renderHook(() => useMCPServerForm());
+
+      act(() => {
+        result.current.setName("Test Server");
+        result.current.setUrl("http://localhost:3000");
+        result.current.setVisibility("private");
+        result.current.setTeamId("team-abc-123");
+      });
+
+      const formData = result.current.getFormData();
+      expect(formData.teamId).toBeUndefined();
     });
   });
 

--- a/client/src/hooks/useMCPServerForm.ts
+++ b/client/src/hooks/useMCPServerForm.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useEffect, useRef, type FormEvent } fro
 import { z } from "zod";
 import { useQuery } from "@/hooks/useQuery";
 import { serversApi } from "@/api/servers";
+import type { Visibility } from "@/types/server";
 import {
   sanitizeString,
   sanitizeUrl,
@@ -112,7 +113,8 @@ const mcpServerFormObjectSchema = z.object({
     .transform((val) => sanitizeQueryParam(val, 500))
     .optional(),
   oneTimeAuth: z.boolean().optional(),
-  visibility: z.enum(["public", "private"]).optional(),
+  visibility: z.enum(["public", "private", "team"]).optional(),
+  teamId: z.string().optional(),
   caCertificate: z
     .string()
     .transform((val) => sanitizeCertificate(val, 10000))
@@ -138,6 +140,14 @@ const mcpServerFormSchema = mcpServerFormObjectSchema.superRefine((data, ctx) =>
       });
     }
   }
+  // Require teamId when visibility is "team"
+  if (data.visibility === "team" && !data.teamId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Team selection is required when visibility is set to team",
+      path: ["teamId"],
+    });
+  }
 });
 
 export type MCPServerFormData = z.infer<typeof mcpServerFormSchema>;
@@ -154,6 +164,7 @@ export interface FormErrors {
   authToken?: string;
   oneTimeAuth?: string;
   visibility?: string;
+  teamId?: string;
   caCertificate?: string;
   oauthUsername?: string;
   oauthPassword?: string;
@@ -168,7 +179,8 @@ export interface UseMCPServerFormReturn {
   description: string;
   transport: TransportType;
   advancedOpen: boolean;
-  visibility: string;
+  visibility: Visibility;
+  teamId: string;
   authType: AuthType;
   oneTimeAuth: boolean; // pragma: allowlist secret
   passthroughHeaders: string;
@@ -206,7 +218,8 @@ export interface UseMCPServerFormReturn {
   setDescription: (value: string) => void;
   setTransport: (value: TransportType) => void;
   setAdvancedOpen: (value: boolean | ((prev: boolean) => boolean)) => void;
-  setVisibility: (value: string) => void;
+  setVisibility: (value: Visibility) => void;
+  setTeamId: (value: string) => void;
   setAuthType: (value: AuthType) => void;
   setOneTimeAuth: (value: boolean) => void; // pragma: allowlist secret
   setPassthroughHeaders: (value: string) => void;
@@ -251,7 +264,8 @@ const initialState = {
   description: "",
   transport: "STREAMABLEHTTP" as TransportType,
   advancedOpen: false,
-  visibility: "public",
+  visibility: "public" as Visibility,
+  teamId: "",
   authType: "none" as AuthType,
   oneTimeAuth: false,
   passthroughHeaders: "",
@@ -284,6 +298,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
   const [transport, setTransport] = useState<TransportType>(initialState.transport);
   const [advancedOpen, setAdvancedOpen] = useState(initialState.advancedOpen);
   const [visibility, setVisibility] = useState(initialState.visibility);
+  const [teamId, setTeamId] = useState(initialState.teamId);
   const [authType, setAuthType] = useState<AuthType>(initialState.authType);
   const [oneTimeAuth, setOneTimeAuth] = useState(initialState.oneTimeAuth);
   const [passthroughHeaders, setPassthroughHeaders] = useState(initialState.passthroughHeaders);
@@ -330,6 +345,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     description?: string;
     transport?: string;
     visibility?: string;
+    teamId?: string;
     authType?: string;
     authUsername?: string;
     authPassword?: string;
@@ -369,6 +385,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
       setDescription(serverData.description || "");
       setTransport((serverData.transport as TransportType) || "STREAMABLEHTTP");
       setVisibility(serverData.visibility || "public");
+      if (serverData.teamId) setTeamId(serverData.teamId);
 
       // Auth fields — open advanced panel when any auth is configured
       if (serverData.authType) {
@@ -516,7 +533,8 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
       auth_query_param_key: authType === "query" ? queryParamName || undefined : undefined,
       auth_query_param_value: authType === "query" ? queryParamApiKey || undefined : undefined,
       oneTimeAuth: oneTimeAuth || undefined, // pragma: allowlist secret
-      visibility: (visibility as "public" | "private") || undefined,
+      visibility: visibility || undefined,
+      teamId: visibility === "team" ? teamId || undefined : undefined,
       caCertificate: caCertificate || undefined,
       oauth_config: oauthConfig,
     };
@@ -535,6 +553,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     queryParamApiKey,
     oneTimeAuth,
     visibility,
+    teamId,
     caCertificate,
     oauthGrantType,
     oauthClientId,
@@ -613,6 +632,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     setTransport(initialState.transport);
     setAdvancedOpen(initialState.advancedOpen);
     setVisibility(initialState.visibility);
+    setTeamId(initialState.teamId);
     setAuthType(initialState.authType);
     setOneTimeAuth(initialState.oneTimeAuth);
     setPassthroughHeaders(initialState.passthroughHeaders);
@@ -644,9 +664,10 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     async (event: FormEvent<HTMLFormElement>, onSuccess?: (response?: unknown) => void) => {
       event.preventDefault();
 
-      if (validateForm()) {
+      const formValid = validateForm();
+
+      if (formValid) {
         try {
-          // Form is valid, proceed with submission
           const formData = getFormData();
 
           // Call the appropriate API based on mode (create or update)
@@ -774,8 +795,12 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
       if (!oauthUsername.trim()) return false;
       if (!oauthPassword.trim()) return false;
     }
+    // Require teamId when visibility is "team"
+    if (visibility === "team" && (!teamId || !teamId.trim())) {
+      return false;
+    }
     return true;
-  }, [name, url, authType, oauthGrantType, oauthUsername, oauthPassword]);
+  }, [name, url, authType, oauthGrantType, oauthUsername, oauthPassword, visibility, teamId]);
 
   return {
     // State
@@ -786,6 +811,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     transport,
     advancedOpen,
     visibility,
+    teamId,
     authType,
     oneTimeAuth,
     passthroughHeaders,
@@ -823,6 +849,7 @@ export function useMCPServerForm(gatewayId?: string): UseMCPServerFormReturn {
     setTransport,
     setAdvancedOpen,
     setVisibility,
+    setTeamId,
     setAuthType,
     setOneTimeAuth,
     setPassthroughHeaders,

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -66,6 +66,9 @@ window.HTMLElement.prototype.releasePointerCapture = vi.fn();
 // Mock scrollIntoView required by Radix UI Select dropdown item focus
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
+// Mock window.open — jsdom does not implement it and OAuth flows call it
+window.open = vi.fn();
+
 // Start MSW server before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 

--- a/client/src/types/server.ts
+++ b/client/src/types/server.ts
@@ -1,3 +1,5 @@
+export type Visibility = "private" | "team" | "public";
+
 /**
  * Base server interface with common fields
  */
@@ -6,7 +8,7 @@ export interface BaseServer {
   name: string;
   description?: string;
   enabled: boolean;
-  visibility: "private" | "team" | "public";
+  visibility: Visibility;
   team_id?: string;
   team?: string;
   owner_email?: string;


### PR DESCRIPTION
Closes #4951

## Summary

  - Fix `ExposeComponentsForm` hardcoding `visibility: "public"` instead of using the value
    selected in the MCP server form; passes `visibility` and `teamId` as props
  - Fix `buildCreateVirtualServerPayload` hardcoding `team_id: null`; now resolves the correct
    team ID when visibility is `"team"`
  - Lift `selectedTeamId` from `TeamSwitcher` local state into `AuthContext` so it is accessible
    across the form flow
  - Add `teamId` / `onTeamIdChange` props to `AdvancedSettings`; auto-populates from the selected
    team on context, and clears when switching away from `"team"` visibility
  - Extend `useMCPServerForm` schema and validation to include `"team"` as a valid visibility
    value and require `teamId` when it is selected
  - Extract `Visibility` as a named type from `@/types/server` and remove the duplicate
    `CreateServerVisibility` type from `@/components/gateways/types`

  ## Tests

  - Fix 57 `MCPServerForm` tests broken by `AdvancedSettings` now requiring `AuthProvider`
  - Fix all `TeamSwitcher` tests broken by the component now reading from `AuthContext`
  - Replace MSW body-reading handlers with `vi.spyOn` for the two new visibility tests to avoid
    a "Body is unusable" error caused by two concurrent MSW server instances
  - Add `window.open = vi.fn()` globally in test setup to silence jsdom warnings from OAuth flows
  - Fix two pre-existing `act()` warnings in `useMCPServerForm` submission tests
  - Add unit tests: `team_id` payload for team/non-team visibility (`virtualServers.test`),
    `teamId` state, `isValid` gate, validation error, `getFormData` scoping, and reset
    (`useMCPServerForm.test`)
