### PR TITLE
fix: extend FedRAMP FIPS compliance block with missing STIG controls

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -125,17 +125,24 @@ RUN chown -R 1001:0 /app && \
 
 # hadolint ignore=DL3041
 # FedRAMP compliance block — only active when ENABLE_FIPS=true
-# Resolves findings: 1 (FIPS policy), 2+3 (SSH ciphers/MACs via FIPS), 7 (init perms), 8 (rootfiles), 9 (SSH RekeyLimit)
+# Resolves: FIPS crypto policy, SSH ciphers/MACs, gnutls-utils, nss-tools,
+#           subscription-manager, pam_wheel, init file perms, home dir perms,
+#           rootfiles tmpfile.d, SSH RekeyLimit
 RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         if ! grep -q "release 9" /etc/redhat-release 2>/dev/null; then \
             echo "ERROR: ENABLE_FIPS=true requires UBI 9 base images (UBI_MINIMAL must be ubi9/ubi-minimal)" >&2; \
             exit 1; \
         fi; \
         microdnf install -y crypto-policies crypto-policies-scripts rootfiles \
+            gnutls-utils nss-tools subscription-manager \
         && microdnf clean all \
         && update-crypto-policies --set FIPS \
         && mkdir -p /etc/ssh/ssh_config.d /etc/tmpfiles.d \
         && echo "RekeyLimit 512M 1h" > /etc/ssh/ssh_config.d/02-rekey-limit.conf \
+        && if [ -f /etc/pam.d/su ]; then \
+               grep -q 'pam_wheel\.so' /etc/pam.d/su \
+               || echo 'auth required pam_wheel.so use_uid' >> /etc/pam.d/su; \
+           fi \
         && printf '%s\n' \
             'C /root/.bash_logout  0740 root root - /usr/share/rootfiles/.bash_logout' \
             'C /root/.bash_profile 0740 root root - /usr/share/rootfiles/.bash_profile' \
@@ -145,7 +152,10 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
             > /etc/tmpfiles.d/rootfiles.conf \
         && install -m 0740 /dev/null /root/.bash_profile \
         && install -m 0740 /dev/null /root/.bashrc \
-        && install -m 0740 /dev/null /root/.bash_logout; \
+        && install -m 0740 /dev/null /root/.bash_logout \
+        && chmod 0750 /root \
+        && find /home -maxdepth 1 -mindepth 1 -type d -exec chmod 0750 {} \; \
+        && find /home -maxdepth 2 -name '.*' -type f -exec chmod 0740 {} \;; \
     else \
         echo "ENABLE_FIPS=false — skipping FedRAMP compliance block"; \
     fi

--- a/Containerfile
+++ b/Containerfile
@@ -140,7 +140,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         && mkdir -p /etc/ssh/ssh_config.d /etc/tmpfiles.d \
         && echo "RekeyLimit 512M 1h" > /etc/ssh/ssh_config.d/02-rekey-limit.conf \
         && if [ -f /etc/pam.d/su ]; then \
-               grep -q 'pam_wheel\.so' /etc/pam.d/su \
+               grep -Eq '^[[:space:]]*auth[[:space:]]+required[[:space:]]+pam_wheel\.so([[:space:]]|$)' /etc/pam.d/su \
                || echo 'auth required pam_wheel.so use_uid' >> /etc/pam.d/su; \
            fi \
         && printf '%s\n' \

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -435,17 +435,24 @@ EXPOSE 4444
 
 # hadolint ignore=DL3041
 # FedRAMP compliance block — only active when ENABLE_FIPS=true
-# Resolves findings: 1 (FIPS policy), 2+3 (SSH ciphers/MACs via FIPS), 7 (init perms), 8 (rootfiles), 9 (SSH RekeyLimit)
+# Resolves: FIPS crypto policy, SSH ciphers/MACs, gnutls-utils, nss-tools,
+#           subscription-manager, pam_wheel, init file perms, home dir perms,
+#           rootfiles tmpfile.d, SSH RekeyLimit
 RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         if ! grep -q "release 9" /etc/redhat-release 2>/dev/null; then \
             echo "ERROR: ENABLE_FIPS=true requires UBI 9 base images (UBI_MINIMAL must be ubi9/ubi-minimal)" >&2; \
             exit 1; \
         fi; \
         microdnf install -y crypto-policies crypto-policies-scripts rootfiles \
+            gnutls-utils nss-tools subscription-manager \
         && microdnf clean all \
         && update-crypto-policies --set FIPS \
         && mkdir -p /etc/ssh/ssh_config.d /etc/tmpfiles.d \
         && echo "RekeyLimit 512M 1h" > /etc/ssh/ssh_config.d/02-rekey-limit.conf \
+        && if [ -f /etc/pam.d/su ]; then \
+               grep -q 'pam_wheel\.so' /etc/pam.d/su \
+               || echo 'auth required pam_wheel.so use_uid' >> /etc/pam.d/su; \
+           fi \
         && printf '%s\n' \
             'C /root/.bash_logout  0740 root root - /usr/share/rootfiles/.bash_logout' \
             'C /root/.bash_profile 0740 root root - /usr/share/rootfiles/.bash_profile' \
@@ -455,7 +462,10 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
             > /etc/tmpfiles.d/rootfiles.conf \
         && install -m 0740 /dev/null /root/.bash_profile \
         && install -m 0740 /dev/null /root/.bashrc \
-        && install -m 0740 /dev/null /root/.bash_logout; \
+        && install -m 0740 /dev/null /root/.bash_logout \
+        && chmod 0750 /root \
+        && find /home -maxdepth 1 -mindepth 1 -type d -exec chmod 0750 {} \; \
+        && find /home -maxdepth 2 -name '.*' -type f -exec chmod 0740 {} \;; \
     else \
         echo "ENABLE_FIPS=false — skipping FedRAMP compliance block"; \
     fi

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -450,7 +450,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         && mkdir -p /etc/ssh/ssh_config.d /etc/tmpfiles.d \
         && echo "RekeyLimit 512M 1h" > /etc/ssh/ssh_config.d/02-rekey-limit.conf \
         && if [ -f /etc/pam.d/su ]; then \
-               grep -q 'pam_wheel\.so' /etc/pam.d/su \
+               grep -Eq '^[[:space:]]*auth[[:space:]]+required[[:space:]]+pam_wheel\.so([[:space:]]|$)' /etc/pam.d/su \
                || echo 'auth required pam_wheel.so use_uid' >> /etc/pam.d/su; \
            fi \
         && printf '%s\n' \


### PR DESCRIPTION
## Summary

Extends the `ENABLE_FIPS=true` compliance block in `Containerfile` and `Containerfile.lite` to satisfy additional RHEL 9 STIG rules that were not covered by the initial implementation.

- Install `gnutls-utils`, `nss-tools`, and `subscription-manager` before running `update-crypto-policies --set FIPS`, which enables the crypto policy tool to fully configure all backend libraries
- Enforce `pam_wheel` for `su` authentication by appending the required PAM line to `/etc/pam.d/su`
- Set correct permissions on interactive user home directories (`0750`) and initialization files (`0740`)

All changes are conditional on `--build-arg ENABLE_FIPS=true`. Default builds are unaffected.

## Related

Follows up on #4810 which introduced the opt-in FIPS compliance mode.