### PR TITLE
fix(ui-rewrite): update .env.example for csrf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ CSRF_SECRET_KEY=
 CSRF_TOKEN_NAME=X-CSRF-Token
 
 # Cookie name for CSRF token
-CSRF_COOKIE_NAME=csrf_token
+CSRF_COOKIE_NAME=mcpgateway_csrf_token
 
 # CSRF token expiration time in seconds (default: 3600 = 1 hour)
 CSRF_TOKEN_EXPIRY=3600
@@ -64,7 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8000","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/app/auth/login","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values


### PR DESCRIPTION
Update `.env.example`: align `CSRF_COOKIE_NAME` with the `mcpgateway_csrf_token` value used in code; add missing CSRF-exempt paths (`/app/auth/login`, `/admin/login`, `/admin/forgot-password`, `/admin/reset-password`)

Related #4898 