### PR TITLE
DUMMY DO NOT MERGE: Pre-commit Checks baseline CI validation

### DIFF
--- a/.github/scripts/secret_baseline_ci_decision.py
+++ b/.github/scripts/secret_baseline_ci_decision.py
@@ -1,0 +1,101 @@
+"""Decide whether a secrets-baseline-only commit can skip full CI."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+ALLOWED_FILE = ".secrets.baseline"
+
+
+def append(path: str | None, line: str) -> None:
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(f"{line}\n")
+
+
+def api_json(path: str, query: dict[str, str] | None = None) -> dict:
+    url = f"{os.environ['GITHUB_API_URL']}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def finish(run_full_ci: bool, reason: str) -> None:
+    append(os.environ["GITHUB_OUTPUT"], f"run-full-ci={str(run_full_ci).lower()}")
+    append(os.environ["GITHUB_OUTPUT"], f"reason={reason}")
+    append(os.environ.get("GITHUB_STEP_SUMMARY"), "### Full CI decision")
+    append(os.environ.get("GITHUB_STEP_SUMMARY"), reason)
+    print(reason)
+    sys.exit(0)
+
+
+def is_baseline_only(files: list[dict]) -> bool:
+    return len(files) == 1 and files[0].get("filename") == ALLOWED_FILE and files[0].get("status") == "modified"
+
+
+def previous_success(repo: str, workflow_file: str, sha: str, event_name: str, default_branch: str) -> bool:
+    query = {"event": event_name, "head_sha": sha, "status": "success", "per_page": "10"}
+    if event_name == "push":
+        query["branch"] = default_branch
+        query["exclude_pull_requests"] = "true"
+    data = api_json(f"/repos/{repo}/actions/workflows/{workflow_file}/runs", query)
+    return any(run.get("event") == event_name and run.get("head_sha") == sha and (event_name != "push" or run.get("head_branch") == default_branch) for run in data.get("workflow_runs", []))
+
+
+def main() -> None:
+    event = json.loads(os.environ["EVENT_JSON"])
+    event_name = os.environ["EVENT_NAME"]
+    default_branch = event.get("repository", {}).get("default_branch") or "main"
+
+    if event_name not in {"pull_request", "push"}:
+        finish(True, f"event {event_name} is not eligible for secrets-baseline-only skipping")
+    if event_name == "push" and os.environ["GITHUB_REF_TYPE_VALUE"] == "tag":
+        finish(True, "tag refs are not eligible for secrets-baseline-only skipping")
+
+    if event_name == "pull_request":
+        target_sha = event.get("pull_request", {}).get("head", {}).get("sha") or os.environ["GITHUB_SHA_VALUE"]
+        commit_repo = event.get("pull_request", {}).get("head", {}).get("repo", {}).get("full_name") or os.environ["GITHUB_REPOSITORY_NAME"]
+    else:
+        target_sha = event.get("after") or os.environ["GITHUB_SHA_VALUE"]
+        commit_repo = os.environ["GITHUB_REPOSITORY_NAME"]
+
+    try:
+        commit = api_json(f"/repos/{commit_repo}/commits/{target_sha}")
+        changed_files = commit.get("files", [])
+        parents = commit.get("parents", [])
+        previous_sha = parents[0]["sha"] if parents else ""
+    except Exception as exc:
+        finish(True, f"could not inspect latest commit; run full CI: {exc}")
+
+    if not changed_files:
+        finish(True, "latest commit changed no files; run full CI")
+    if not is_baseline_only(changed_files):
+        finish(True, "latest commit is not secrets-baseline-only; run full CI")
+    if not previous_sha:
+        finish(True, "could not resolve previous commit; run full CI")
+
+    workflow_file = os.environ["WORKFLOW_FILE"]
+    try:
+        if previous_success(os.environ["GITHUB_REPOSITORY_NAME"], workflow_file, previous_sha, event_name, default_branch):
+            finish(False, f"latest commit changes only {ALLOWED_FILE}; previous {workflow_file} {event_name} run passed on {previous_sha}; skip full CI")
+    except Exception as exc:
+        finish(True, f"could not verify previous workflow success; run full CI: {exc}")
+
+    finish(True, f"latest commit changes only {ALLOWED_FILE}, but no successful previous {workflow_file} {event_name} run was found for {previous_sha}; run full CI")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,9 @@
 name: Pre-commit Checks
 
 on:
+  push:
+    branches: ["main"]
+    tags: ["*"]
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
@@ -10,11 +13,39 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
+  ci-decision:
+    name: Full CI decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-full-ci: ${{ steps.decision.outputs.run-full-ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Decide full CI scope
+        id: decision
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: pre-commit.yml
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJson(github.event) }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: python3 .github/scripts/secret_baseline_ci_decision.py
+
   pre-commit:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -24,7 +55,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -32,6 +63,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Go
+        if: needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false'
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.x"
@@ -40,4 +72,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run pre-commit
+        if: needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false'
         run: make --no-print-directory pre-commit
+
+      - name: Run detect-secrets validation
+        if: needs.ci-decision.result == 'success' && needs.ci-decision.outputs.run-full-ci == 'false'
+        run: make --no-print-directory detect-secrets-hook

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,11 +31,38 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
+  ci-decision:
+    name: Full CI decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-full-ci: ${{ steps.decision.outputs.run-full-ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Decide full CI scope
+        id: decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: pytest.yml
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJson(github.event) }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: python3 .github/scripts/secret_baseline_ci_decision.py
+
   test:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: pytest (py${{ matrix.python }})
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,11 +19,38 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
+  ci-decision:
+    name: Full CI decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-full-ci: ${{ steps.decision.outputs.run-full-ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Decide full CI scope
+        id: decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: python-package.yml
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJson(github.event) }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: python3 .github/scripts/secret_baseline_ci_decision.py
+
   build-package:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     runs-on: ubuntu-slim
     timeout-minutes: 20
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,38 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
+  ci-decision:
+    name: Full CI decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-full-ci: ${{ steps.decision.outputs.run-full-ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Decide full CI scope
+        id: decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: rust.yml
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJson(github.event) }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: python3 .github/scripts/secret_baseline_ci_decision.py
+
   rust-build:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Rust build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -79,7 +106,8 @@ jobs:
         run: make rust-verify-stubs
 
   rust-fmt:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Rust fmt
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -108,7 +136,8 @@ jobs:
         run: make rust-fmt-check
 
   rust-clippy:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Rust clippy
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -137,7 +166,8 @@ jobs:
         run: make rust-lint
 
   rust-test:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Rust test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -167,7 +197,8 @@ jobs:
         run: make rust-test
 
   rust-test-redis:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Rust test (Redis-backed paths)
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -207,7 +238,8 @@ jobs:
         run: cargo test -p contextforge_mcp_runtime --test runtime
 
   build-wheels:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Build wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -256,7 +288,8 @@ jobs:
           path: crates/**/target/wheels/*.whl
 
   security-audit:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Dependency policy
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -273,7 +306,8 @@ jobs:
         run: make rust-deny
 
   supply-chain-vet:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Supply-chain vet
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -293,7 +327,8 @@ jobs:
         run: make rust-vet
 
   license-check:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: License check (workspace)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -310,7 +345,8 @@ jobs:
         run: make rust-licenses
 
   benchmark-build-check:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Benchmarks (build check only)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -336,7 +372,8 @@ jobs:
         run: make rust-bench-check
 
   coverage:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -376,7 +413,8 @@ jobs:
           path: coverage/cobertura.xml
 
   documentation:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -25,11 +25,38 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
+  ci-decision:
+    name: Full CI decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run-full-ci: ${{ steps.decision.outputs.run-full-ci }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Decide full CI scope
+        id: decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: vitest.yml
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_JSON: ${{ toJson(github.event) }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
+        run: python3 .github/scripts/secret_baseline_ci_decision.py
+
   vitest:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: ci-decision
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false')
     name: vitest
     runs-on: ubuntu-slim
     timeout-minutes: 15

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-03T14:29:13Z",
+  "generated_at": "2026-06-04T08:38:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8043,
+        "line_number": 8044,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-04T09:00:00Z",
+  "generated_at": "2026-06-04T10:00:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-04T08:38:37Z",
+  "generated_at": "2026-06-04T09:00:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/Makefile
+++ b/Makefile
@@ -7897,10 +7897,11 @@ detect-secrets-audit: uv                     ## 🔎  detect-secrets audit for r
 .PHONY: detect-secrets-hook
 detect-secrets-hook: uv                      ## 🔎  detect-secrets pre-commit hook equivalent
 	@echo "🔎 Running detect-secrets-hook pre-commit hook equivalent..."
-	@$(UV_BIN) tool run --from '$(DETECT_SECRETS_SPEC)' detect-secrets-hook \
+	@git ls-files -z | xargs -0 $(UV_BIN) tool run --from '$(DETECT_SECRETS_SPEC)' detect-secrets-hook \
 		--baseline .secrets.baseline \
 		--use-all-plugins \
-		--fail-on-unaudited
+		--fail-on-unaudited \
+		--
 
 ## --------------------------------------------------------------------------- ##
 ##  DevSkim (.NET-based security patterns scanner)

--- a/tests/unit/test_secret_baseline_ci_decision_workflow.py
+++ b/tests/unit/test_secret_baseline_ci_decision_workflow.py
@@ -1,0 +1,318 @@
+"""Regression tests for the secrets-baseline-only CI decision workflow."""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import runpy
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+PRE_COMMIT_WORKFLOW = Path(".github/workflows/pre-commit.yml")
+DECISION_SCRIPT = Path(".github/scripts/secret_baseline_ci_decision.py")
+MAKEFILE = Path("Makefile")
+
+
+class _JsonResponse(io.BytesIO):
+    def __enter__(self) -> "_JsonResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def _step_if_expression(step_name: str) -> str:
+    lines = PRE_COMMIT_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    marker = f"      - name: {step_name}"
+    start = lines.index(marker) + 1
+    for line in lines[start:]:
+        if line.startswith("      - name: "):
+            break
+        if line.startswith("        if: "):
+            return line.removeprefix("        if: ")
+    raise AssertionError(f"missing if expression for step {step_name}")
+
+
+def _run_decision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    event_name: str = "push",
+    event: dict[str, Any] | None = None,
+    commit_files: list[str | dict[str, Any]] | None = None,
+    parent_sha: str = "previous",
+    successful_head_sha: str | None = None,
+    successful_run_branch: str = "main",
+    successful_run_event: str = "push",
+    fail_commit_api: bool = False,
+    fail_workflow_runs_api: bool = False,
+    ref_type: str = "branch",
+    forbid_api_calls: bool = False,
+) -> str:
+    output = tmp_path / "github-output"
+    summary = tmp_path / "github-summary"
+    event_payload = event or {"after": "latest", "before": "stale-before", "repository": {"default_branch": "main"}}
+
+    env = {
+        "GH_TOKEN": "token",
+        "WORKFLOW_FILE": "pytest.yml",
+        "EVENT_NAME": event_name,
+        "EVENT_JSON": json.dumps(event_payload),
+        "GITHUB_API_URL": "https://api.github.test",
+        "GITHUB_REPOSITORY_NAME": "owner/repo",
+        "GITHUB_REF_TYPE_VALUE": ref_type,
+        "GITHUB_SHA_VALUE": "latest",
+        "GITHUB_OUTPUT": str(output),
+        "GITHUB_STEP_SUMMARY": str(summary),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int = 20) -> _JsonResponse:
+        if forbid_api_calls:
+            raise AssertionError(f"unexpected API request: {request.full_url}")
+        assert timeout == 20
+        url = urllib.parse.urlparse(request.full_url)
+        query = urllib.parse.parse_qs(url.query)
+
+        if url.path == "/repos/owner/repo/commits/latest":
+            if fail_commit_api:
+                raise OSError("api unavailable")
+            files = [item if isinstance(item, dict) else {"filename": item, "status": "modified"} for item in (commit_files or [])]
+            payload = {
+                "files": files,
+                "parents": [{"sha": parent_sha}] if parent_sha else [],
+            }
+            return _JsonResponse(json.dumps(payload).encode("utf-8"))
+
+        if url.path == "/repos/owner/repo/actions/workflows/pytest.yml/runs":
+            if fail_workflow_runs_api:
+                raise OSError("workflow runs unavailable")
+            assert query.get("event") == [event_name]
+            if event_name == "push":
+                assert query.get("branch") == ["main"]
+                assert query.get("exclude_pull_requests") == ["true"]
+            else:
+                assert "branch" not in query
+                assert "exclude_pull_requests" not in query
+            assert query.get("status") == ["success"]
+            workflow_runs = []
+            if query.get("head_sha") == [successful_head_sha]:
+                workflow_runs.append({"event": successful_run_event, "head_branch": successful_run_branch, "head_sha": successful_head_sha})
+            return _JsonResponse(json.dumps({"total_count": len(workflow_runs), "workflow_runs": workflow_runs}).encode("utf-8"))
+
+        raise AssertionError(f"unexpected API request: {request.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path(str(DECISION_SCRIPT), run_name="__main__")
+    assert exc.value.code == 0
+
+    return output.read_text(encoding="utf-8")
+
+
+def test_pull_request_baseline_only_without_previous_success_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        event_name="pull_request",
+        event={"pull_request": {"head": {"sha": "latest", "repo": {"full_name": "owner/repo"}}}},
+        commit_files=[".secrets.baseline"],
+        parent_sha="actual-parent",
+        successful_head_sha="different-sha",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+def test_mixed_push_commit_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline", "mcpgateway/main.py"],
+        successful_head_sha="previous",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+@pytest.mark.parametrize("status", ["added", "removed", "renamed"])
+def test_non_modified_secrets_baseline_status_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, status: str) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[{"filename": ".secrets.baseline", "previous_filename": "other.txt", "status": status}],
+        successful_head_sha="previous",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+def test_baseline_only_push_uses_parent_commit_for_previous_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        parent_sha="actual-parent",
+        successful_head_sha="actual-parent",
+    )
+
+    assert "run-full-ci=false" in output
+
+
+def test_baseline_only_pull_request_uses_parent_commit_for_previous_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        event_name="pull_request",
+        event={"pull_request": {"head": {"sha": "latest", "repo": {"full_name": "owner/repo"}}}},
+        commit_files=[".secrets.baseline"],
+        parent_sha="actual-parent",
+        successful_head_sha="actual-parent",
+        successful_run_event="pull_request",
+    )
+
+    assert "run-full-ci=false" in output
+
+
+def test_baseline_only_push_without_previous_success_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        parent_sha="actual-parent",
+        successful_head_sha="different-sha",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+@pytest.mark.parametrize(
+    ("run_branch", "run_event"),
+    [
+        ("feature", "push"),
+        ("main", "pull_request"),
+    ],
+)
+def test_only_default_branch_push_success_allows_skip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, run_branch: str, run_event: str) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        parent_sha="actual-parent",
+        successful_head_sha="actual-parent",
+        successful_run_branch=run_branch,
+        successful_run_event=run_event,
+    )
+
+    assert "run-full-ci=true" in output
+
+
+def test_commit_api_failure_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(monkeypatch, tmp_path, fail_commit_api=True)
+
+    assert "run-full-ci=true" in output
+
+
+def test_tag_push_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        successful_head_sha="previous",
+        ref_type="tag",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+def test_baseline_only_push_without_parent_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        parent_sha="",
+        successful_head_sha="previous",
+    )
+
+    assert "run-full-ci=true" in output
+
+
+def test_previous_workflow_api_failure_runs_full_ci(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = _run_decision(
+        monkeypatch,
+        tmp_path,
+        commit_files=[".secrets.baseline"],
+        fail_workflow_runs_api=True,
+    )
+
+    assert "run-full-ci=true" in output
+
+
+@pytest.mark.parametrize(
+    ("event_name", "decision_result", "run_full_ci", "expected"),
+    [
+        ("pull_request", "skipped", "", True),
+        ("push", "failure", "", True),
+        ("push", "success", "", True),
+        ("push", "success", "tru", True),
+        ("push", "success", "true", True),
+        ("push", "success", "false", False),
+        ("pull_request", "success", "false", False),
+    ],
+)
+def test_full_ci_gate_only_skips_on_explicit_false(event_name: str, decision_result: str, run_full_ci: str, expected: bool) -> None:
+    full_ci_if = _step_if_expression("Run pre-commit")
+    assert full_ci_if == "needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false'"
+
+    should_run_full_ci = decision_result != "success" or run_full_ci != "false"
+
+    assert should_run_full_ci is expected
+
+
+def test_pre_commit_uses_shared_decision_for_fast_path() -> None:
+    text = PRE_COMMIT_WORKFLOW.read_text(encoding="utf-8")
+    full_ci_if = "needs.ci-decision.result != 'success' || needs.ci-decision.outputs.run-full-ci != 'false'"
+    secrets_only_if = "needs.ci-decision.result == 'success' && needs.ci-decision.outputs.run-full-ci == 'false'"
+
+    assert "git diff-tree" not in text
+    assert "github.event.pull_request.head.sha" not in text
+    assert "github.event.pull_request.head.repo.full_name" not in text
+    assert "uses: ./.github/workflows/secret-baseline-ci-decision.yml" not in text
+    assert "python3 <<'PY'" not in text
+    assert "python3 .github/scripts/secret_baseline_ci_decision.py" in text
+    assert Path(".github/workflows/secret-baseline-ci-decision.yml").exists() is False
+    assert DECISION_SCRIPT.exists()
+    assert re.search(r"ci-decision:\n\s+name: Full CI decision", text)
+    assert _step_if_expression("Set up Go") == full_ci_if
+    assert _step_if_expression("Run pre-commit") == full_ci_if
+    assert _step_if_expression("Run detect-secrets validation") == secrets_only_if
+
+
+def test_pr_workflows_gate_heavy_jobs_on_ci_decision() -> None:
+    workflows = [
+        Path(".github/workflows/pytest.yml"),
+        Path(".github/workflows/python-package.yml"),
+        Path(".github/workflows/vitest.yml"),
+        Path(".github/workflows/rust.yml"),
+    ]
+    expected_gate = "needs.ci-decision.outputs.run-full-ci != 'false'"
+
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        assert "WORKFLOW_FILE:" in text
+        assert "python3 .github/scripts/secret_baseline_ci_decision.py" in text
+        assert expected_gate in text
+
+
+def test_detect_secrets_hook_target_scans_tracked_files() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+
+    assert "git ls-files -z | xargs -0 $(UV_BIN) tool run --from '$(DETECT_SECRETS_SPEC)' detect-secrets-hook" in text
+    assert "--fail-on-unaudited \\\n\t\t--" in text


### PR DESCRIPTION
## Dummy PR

This is a dummy PR for validating the secrets-baseline CI skip behavior for **Pre-commit Checks**.

Do not merge this PR. It exists only to exercise CI behavior for PR #5012.

## Validation Shape

- The current head is a `.secrets.baseline`-only commit.
- Its parent is an intentionally empty dummy commit with no completed CI.
- Expected first result: full CI runs because the parent commit has not completed this PR workflow.
- After that completes, another `.secrets.baseline`-only commit will be pushed.
- Expected second result: decision jobs pass, heavy jobs skip, and Pre-commit runs detect-secrets only.

## Checklist

- [x] Dummy validation PR
- [x] Labeled `do-not-merge`
- [x] Not intended for merge
