### PR TITLE
ci: add Docker Build Complete gate for merge queue

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -313,3 +313,22 @@ jobs:
           done
 
           echo "Images signed and attested successfully"
+
+  # ---------------------------------------------------------------
+  # Fan-in gate: single required status check for merge queue/PRs
+  # ---------------------------------------------------------------
+  build-complete:
+    name: Docker Build Complete
+    needs: build
+    runs-on: ubuntu-24.04
+    if: always()
+    steps:
+      - name: Check all platform builds passed
+        run: |
+          result="${{ needs.build.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "Docker builds passed (result: $result)"
+          else
+            echo "Docker builds failed (result: $result)"
+            exit 1
+          fi

--- a/.github/workflows/docker-required.yml
+++ b/.github/workflows/docker-required.yml
@@ -1,0 +1,39 @@
+# ===============================================================
+# Docker Build Required — Skip Reporter
+# ===============================================================
+#
+# This workflow is the complement of docker-multiplatform.yml.
+# It runs ONLY when Docker-related files did NOT change, and
+# immediately reports success for the "Docker Build Complete"
+# required status check so that PRs are not blocked waiting.
+#
+# Together with the build-complete job in docker-multiplatform.yml,
+# the "Docker Build Complete" check always reports a result:
+#   - Files changed  → docker-multiplatform.yml reports the real result
+#   - Files unchanged → this workflow reports success (skipped)
+#
+# ===============================================================
+
+name: Docker Build Skip Reporter
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths-ignore:
+      - 'Containerfile.lite'
+      - 'mcpgateway/**'
+      - 'plugins/**'
+      - 'pyproject.toml'
+      - '.github/workflows/docker-multiplatform.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-complete:
+    name: Docker Build Complete
+    runs-on: ubuntu-24.04
+    steps:
+      - name: No Docker-related files changed
+        run: echo "Docker build skipped — no relevant files changed in this PR"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary
Adds a `Docker Build Complete` fan-in gate job to docker-multiplatform.yml that aggregates all 4 platform build results into a single status check. Also adds a new `docker-required.yml` skip-reporter workflow that immediately reports success for `Docker Build Complete` on PRs that don't touch Docker-related files.

This enables using a single required status check (`Docker Build Complete`) in the branch protection rule instead of 4 individual job names, and prevents non-Docker PRs from being blocked indefinitely waiting for checks that will never run due to `paths:` filtering.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | N/A — workflow config only |
| Unit tests                | `make test`     | N/A — workflow config only |
| Coverage ≥ 80%            | `make coverage` | N/A — workflow config only |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (N/A)
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Why a separate `docker-required.yml`?**
GitHub's `paths:` filter on `pull_request` skips the workflow entirely when non-Docker files change. When a workflow is skipped, its jobs never report a result, causing required status checks to stay "Waiting for status to be reported" indefinitely and blocking those PRs from merging.

`docker-required.yml` uses `paths-ignore` (the inverse of docker-multiplatform.yml's `paths:`) to cover the gap — exactly one of the two workflows always runs on every PR and reports `Docker Build Complete`.

**Follow-up action for repo admin:**
1. Remove `Build amd64`, `Build arm64`, `Build s390x`, `Build ppc64le` from required status checks in the `main` branch protection rule
2. Add `Docker Build Complete` as the single required status check
3. Do this **after** this PR merges — otherwise the check will be pending on all open PRs