### PR TITLE
Fix node installation on paywright worflow

### DIFF
--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -69,11 +69,22 @@ jobs:
           version: "0.9.2"
           python-version: "3.12"
 
-      - name: 🟢 Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
+      - name: 🟢 Install Node.js 22
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl gnupg
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+            | sudo tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y nodejs
+          node --version
+          npm --version
+
+      - name: 🔧 Upgrade npm to minimum required version
+        run: sudo npm install -g npm@^11.10.0
 
       - name: 📦 Install gateway dependencies
         run: |

--- a/mcpgateway/admin_ui/a2aAgents.js
+++ b/mcpgateway/admin_ui/a2aAgents.js
@@ -18,7 +18,7 @@ import {
 // ===================================================================
 
 /**
- * Toggle UAID fields visibility based on checkbox state
+ * Toggle UAID fields visibility based on checkbox state.
  * @param {string} formSuffix - Form identifier suffix ('a2a' or 'a2a-edit')
  * @param {boolean} enabled - Whether UAID generation is enabled
  */


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #https://github.com/IBM/mcp-context-forge/issues/5062

---

## 📝 Summary
_What does this PR do and why?_

Security policy requires all GitHub Actions to be from IBM-owned repositories, GitHub-created actions, verified in the Marketplace, or match specific allowed patterns. While actions/setup-node is GitHub-created, it was blocked by the policy configuration.

The fix manually installs Node.js 20 via NodeSource's apt repository instead of using the GitHub Action, ensuring CI compliance without functionality loss.



---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
