### PR TITLE
fix(admin): prevent false-positive pattern error on Add Gateway form

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-17T07:41:32Z",
+  "generated_at": "2026-06-17T15:31:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5060,7 +5060,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11389,
+        "line_number": 11419,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5068,7 +5068,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17785,
+        "line_number": 17815,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -979,6 +979,16 @@ async def _parse_gateway_data_from_request(request: Request) -> dict[str, Any]:
         if oauth_config:
             data["oauth_config"] = oauth_config
 
+        # Hidden auth-section inputs are always submitted by browsers (even when the
+        # containing div is display:none), arriving as empty strings rather than None.
+        # auth_query_param_key has a pattern constraint that rejects "", causing a
+        # false-positive ValidationError whenever any non-query-param auth type is used.
+        # Convert empty strings to None here for defense in depth; mirrors what the
+        # gateway update handler already does manually. See: #5064
+        for _field in ("auth_query_param_key", "auth_query_param_value"):
+            if data.get(_field) == "":
+                data[_field] = None
+
         return data
 
     else:

--- a/mcpgateway/admin_ui/auth.js
+++ b/mcpgateway/admin_ui/auth.js
@@ -543,45 +543,44 @@ export function handleAuthTypeChange() {
   const oauthFields = safeGetElement(`auth-oauth-fields-${prefix}`);
   const queryParamFields = safeGetElement(`auth-query_param-fields-${prefix}`);
 
+  // Disable inputs in hidden sections so browsers don't submit them.
+  // Without this, e.g. auth_query_param_key arrives as "" and fails its
+  // pattern validator even when query_param auth was never selected. (#5064)
+  const hideSection = (section) => {
+    if (!section) return;
+    section.style.display = "none";
+    section.querySelectorAll("input, select, textarea").forEach((el) => {
+      el.disabled = true;
+    });
+  };
+
+  const showSection = (section) => {
+    if (!section) return;
+    section.style.display = "block";
+    section.querySelectorAll("input, select, textarea").forEach((el) => {
+      el.disabled = false;
+    });
+  };
+
   // Hide all auth sections first
-  [
-    basicFields,
-    bearerFields,
-    headersFields,
-    oauthFields,
-    queryParamFields,
-  ].forEach((section) => {
-    if (section) {
-      section.style.display = "none";
-    }
-  });
+  [basicFields, bearerFields, headersFields, oauthFields, queryParamFields].forEach(hideSection);
 
   // Show the appropriate section
   switch (authType) {
     case "basic":
-      if (basicFields) {
-        basicFields.style.display = "block";
-      }
+      showSection(basicFields);
       break;
     case "bearer":
-      if (bearerFields) {
-        bearerFields.style.display = "block";
-      }
+      showSection(bearerFields);
       break;
     case "authheaders":
-      if (headersFields) {
-        headersFields.style.display = "block";
-      }
+      showSection(headersFields);
       break;
     case "oauth":
-      if (oauthFields) {
-        oauthFields.style.display = "block";
-      }
+      showSection(oauthFields);
       break;
     case "query_param":
-      if (queryParamFields) {
-        queryParamFields.style.display = "block";
-      }
+      showSection(queryParamFields);
       break;
     default:
       // "none" or unknown type — keep everything hidden

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3309,6 +3309,36 @@ class TestAdminGatewayRoutes:
             assert result.status_code == 200
 
     @patch.object(GatewayService, "register_gateway")
+    async def test_admin_add_gateway_empty_query_param_fields_converted_to_none(self, mock_register_gateway, mock_request, mock_db):
+        """Browser always submits hidden auth_query_param_key/value inputs as empty strings.
+
+        When a non-query-param auth type is selected, those empty strings must be
+        converted to None before schema validation, otherwise the pattern constraint
+        on auth_query_param_key raises a false-positive ValidationError. See: #5064
+        """
+        form_data = FakeForm(
+            {
+                "name": "Bearer_Gateway",
+                "url": "http://example.com",
+                "auth_type": "bearer",
+                "auth_token": "tok123",
+                "auth_query_param_key": "",
+                "auth_query_param_value": "",
+            }
+        )
+        mock_request.form = AsyncMock(return_value=form_data)
+        mock_request.headers = {"content-type": "multipart/form-data"}
+
+        result = await admin_add_gateway(mock_request, mock_db, user={"email": "test-user", "db": mock_db})
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 200
+        call_data = mock_register_gateway.call_args[1] if mock_register_gateway.call_args[1] else mock_register_gateway.call_args[0][0]
+        # Confirm the empty strings were normalised to None, not passed as ""
+        if isinstance(call_data, dict):
+            assert call_data.get("auth_query_param_key") is None
+            assert call_data.get("auth_query_param_value") is None
+
+    @patch.object(GatewayService, "register_gateway")
     async def test_admin_add_gateway_without_auth(self, mock_register_gateway, mock_request, mock_db):
         """Test adding gateway without authentication."""
         # Test gateway without auth_type (should default to empty string which is valid)


### PR DESCRIPTION
Fixes #5064.

## What and why

Clicking **Add Gateway** with any authentication type other than "Query Parameter (INSECURE)" produced:

> String should match pattern '^[a-zA-Z_][a-zA-Z0-9_\-]*$'

with no indication of which field was wrong, blocking all gateway creation that required authentication.

**Root cause:** The Add Gateway form contains a hidden `<div>` with `<input name="auth_query_param_key">`. Browsers submit every enabled input regardless of `display:none`, so `auth_query_param_key=""` was always included in the POST. An empty string fails the field's Pydantic pattern constraint, and the error surfaced as if the gateway name or URL was invalid.

## Changes

**`admin_ui/auth.js` — `handleAuthTypeChange`**

Introduce `hideSection` / `showSection` helpers that toggle both `style.display` and `disabled` on all child inputs when switching auth type. Disabled inputs are not submitted by browsers, eliminating the spurious empty-string field at the source.

**`mcpgateway/admin.py` — `_parse_gateway_data_from_request`**

After form parsing, convert `""` to `None` for `auth_query_param_key` and `auth_query_param_value` before the data reaches Pydantic. This mirrors what the gateway **update** handler already did manually and provides server-side defense in depth in case other form paths or API clients send empty strings.