### PR TITLE
docs: Fix Kubernetes PostgreSQL ConfigMap formatting

### DIFF
--- a/docs/docs/deployment/kubernetes.md
+++ b/docs/docs/deployment/kubernetes.md
@@ -161,7 +161,7 @@ You can load your `.env` as a ConfigMap:
     EOF
 
     kubectl create configmap mcpgateway-env --from-env-file=.env
-```
+    ```
 
 > Make sure it includes `JWT_SECRET_KEY`, `PLATFORM_ADMIN_EMAIL`, etc.
 


### PR DESCRIPTION
# 📚 Documentation PR

> Run `make markdownlint spellcheck` and fix any issues.
> Preview locally with `cd docs && make serve`.
> Do **not** commit secrets or internal URLs.

---

## 🔗 Related Issue / Epic
Closes #5067

---

## 📝 Summary (1-2 sentences)
Fixes the Kubernetes deployment guide PostgreSQL ConfigMap example so the fenced bash block stays inside the MkDocs Material tab content.

---

## ✏️ Type of Change
- [x] Typo / formatting
- [ ] Outdated or incorrect info
- [ ] Missing explanation / example
- [ ] Unclear instructions
- [ ] New page or major rewrite
- [ ] Other (describe)

---