### PR TITLE
fix(observability): reduce session proliferation from 4-6 to 1 per request

### DIFF
--- a/mcpgateway/middleware/observability_middleware.py
+++ b/mcpgateway/middleware/observability_middleware.py
@@ -107,8 +107,9 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         """Process request and create observability trace.
 
-        Observability uses independent database sessions (issue #3883) that commit
-        immediately on a best-effort basis, separate from the main request transaction.
+        Uses a single database session for the entire trace lifecycle
+        (start_trace → start_span → end_span → end_trace) to reduce session
+        proliferation from 4-6 sessions to 1 session per traced request.
 
         Args:
             request: Incoming HTTP request
@@ -153,8 +154,13 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
         span_id = None
         start_time = time.time()
 
+        # Create single observability session for entire trace lifecycle (issue #5072)
+        # First-Party
+        from mcpgateway.db import SessionLocal
+
+        obs_db = SessionLocal()
         try:
-            # Start trace (creates independent observability session)
+            # Start trace (reuses obs_db session, no commit yet)
             trace_id = self.service.start_trace(
                 name=f"{http_method} {request.url.path}",
                 trace_id=external_trace_id,  # Use external trace ID if provided
@@ -172,6 +178,8 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                     "service.name": "mcp-gateway",
                     "service.version": getattr(settings, "version", "unknown"),
                 },
+                commit=False,  # Don't commit yet
+                obs_db=obs_db,  # Reuse session
             )
 
             # Store trace_id in request state for use in route handlers
@@ -187,17 +195,23 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
             if hasattr(request.state, "db") and request.state.db is not None:
                 attach_trace_to_session(request.state.db, trace_id)
 
-            # Start request span (creates independent observability session)
+            # Start request span (reuses obs_db session, no commit yet)
             span_id = self.service.start_span(
                 trace_id=trace_id,
                 name="http.request",
                 kind="server",
                 attributes={"http.method": http_method, "http.url": http_url},
+                commit=False,  # Don't commit yet
+                obs_db=obs_db,  # Reuse session
             )
 
         except Exception as e:
             # If trace setup failed, log and continue without tracing
             logger.warning(f"Failed to setup observability trace: {e}")
+            try:
+                obs_db.close()
+            except Exception:
+                pass
             # Continue without tracing
             return await call_next(request)
 
@@ -206,7 +220,7 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
             status_code = response.status_code
 
-            # End span successfully (creates independent observability session)
+            # End span successfully (reuses obs_db session, no commit yet)
             if span_id:
                 try:
                     self.service.end_span(
@@ -216,11 +230,13 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                             "http.status_code": status_code,
                             "http.response_size": response.headers.get("content-length"),
                         },
+                        commit=False,  # Don't commit yet
+                        obs_db=obs_db,  # Reuse session
                     )
                 except Exception as end_span_error:
                     logger.warning(f"Failed to end span {span_id}: {end_span_error}")
 
-            # End trace (creates independent observability session)
+            # End trace (reuses obs_db session, commits all changes atomically)
             if trace_id:
                 duration_ms = (time.time() - start_time) * 1000
                 try:
@@ -229,6 +245,8 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                         status="ok" if status_code < 400 else "error",
                         http_status_code=status_code,
                         attributes={"response_time_ms": duration_ms},
+                        commit=True,  # Commit all changes atomically
+                        obs_db=obs_db,  # Reuse session
                     )
                 except Exception as end_trace_error:
                     logger.warning(f"Failed to end trace {trace_id}: {end_trace_error}")
@@ -248,9 +266,11 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                             "exception.type": type(e).__name__,
                             "exception.message": sanitized_error,
                         },
+                        commit=False,  # Don't commit yet
+                        obs_db=obs_db,  # Reuse session
                     )
 
-                    # Add exception event (creates independent observability session)
+                    # Add exception event (reuses obs_db session for atomic commit)
                     self.service.add_event(
                         span_id,
                         name="exception",
@@ -259,11 +279,12 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                         exception_type=type(e).__name__,
                         exception_message=sanitized_error,
                         exception_stacktrace=traceback.format_exc(),
+                        obs_db=obs_db,  # Reuse session
                     )
                 except Exception as log_error:
                     logger.warning(f"Failed to log exception in span: {log_error}")
 
-            # End trace with error (creates independent observability session)
+            # End trace with error (reuses obs_db session, commits all changes atomically)
             if trace_id:
                 try:
                     sanitized_error = sanitize_for_log(sanitize_trace_text(str(e)))
@@ -272,9 +293,17 @@ class ObservabilityMiddleware(BaseHTTPMiddleware):
                         status="error",
                         status_message=sanitized_error,
                         http_status_code=500,
+                        commit=True,  # Commit all changes atomically
+                        obs_db=obs_db,  # Reuse session
                     )
                 except Exception as trace_error:
                     logger.warning(f"Failed to end trace: {trace_error}")
 
             # Re-raise the original exception
             raise
+        finally:
+            # Always close the observability session
+            try:
+                obs_db.close()
+            except Exception as close_error:
+                logger.debug(f"Failed to close observability session: {close_error}")

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -16,12 +16,14 @@ It includes:
 - Query and filtering capabilities
 - Integration with FastAPI middleware
 
-Architecture (Issue #3883 - Separate Session Pattern):
-    Write operations (start_trace, end_trace, start_span, end_span, add_event,
-    record_token_usage, record_metric, delete_old_traces) use independent database
-    sessions that commit immediately on a best-effort basis. This allows observability
-    data to persist even when the main request transaction fails, providing visibility
-    into partial failures.
+Architecture (Issue #3883 - Separate Session Pattern, Issue #5072 - Session Reuse):
+    Write operations support session reuse to reduce connection pool pressure:
+    - start_trace, end_trace, start_span, end_span accept optional obs_db parameter
+    - When obs_db is provided, caller owns session lifecycle (no auto-close)
+    - When obs_db is None, creates independent session (auto-close after commit)
+    - ObservabilityMiddleware creates single session for entire trace lifecycle
+      (start_trace → start_span → end_span → end_trace), reducing from 4-6 sessions
+      to 1 session per traced request
 
     Query operations (get_trace, get_traces, get_spans, etc.) accept a session parameter
     to use the request-scoped session with proper RBAC and token scoping.
@@ -35,6 +37,7 @@ Transaction Semantics:
     - This is intentional for best-effort observability visibility
     - Context managers (trace_span, trace_tool_invocation, trace_a2a_request) create
       a single independent session for the entire span lifecycle
+    - Middleware batches all trace operations into single session with atomic commit
 
 Examples:
     >>> from mcpgateway.services.observability_service import ObservabilityService  # doctest: +SKIP
@@ -280,12 +283,13 @@ class ObservabilityService:
         ip_address: Optional[str] = None,
         attributes: Optional[Dict[str, Any]] = None,
         resource_attributes: Optional[Dict[str, Any]] = None,
+        commit: bool = True,
+        obs_db: Optional[Session] = None,
     ) -> str:
         """Start a new trace.
 
-        Creates an independent observability session for best-effort recording.
-        Observability data persists independently of main request transaction
-        (issue #3883 - separate session pattern).
+        Creates an independent observability session for best-effort recording
+        unless obs_db is provided for session reuse.
 
         Args:
             name: Trace name (e.g., "POST /tools/invoke")
@@ -298,13 +302,18 @@ class ObservabilityService:
             ip_address: Client IP address
             attributes: Additional trace attributes
             resource_attributes: Resource attributes (service name, version, etc.)
+            commit: Whether to commit immediately (default True).
+                Set to False when called from middleware for session reuse.
+            obs_db: Optional observability session for session reuse.
+                If not provided, creates a new independent session.
 
         Returns:
             Trace ID (UUID string or W3C format)
 
         Note:
-            Uses separate database session from main transaction (best-effort).
-            Follows pattern established in instrumentation/sqlalchemy.py:58-87.
+            When obs_db is provided, caller owns session lifecycle.
+            When obs_db is None, this method creates and closes its own session.
+            Uses separate database session from main transaction (issue #3883).
 
         Examples:
             >>> trace_id = service.start_trace(  # doctest: +SKIP
@@ -314,10 +323,11 @@ class ObservabilityService:
             ...     user_email="user@example.com"
             ... )
         """
-        obs_db = None
-        owned = False
+        session_owned = False
+        if obs_db is None:
+            obs_db, session_owned = _get_or_create_observability_session()
+
         try:
-            obs_db, owned = _get_or_create_observability_session()
             # Use provided trace_id or generate new UUID
             if not trace_id:
                 trace_id = str(uuid.uuid4())
@@ -342,11 +352,12 @@ class ObservabilityService:
                 created_at=utc_now(),
             )
             obs_db.add(trace)
-            self._safe_commit(obs_db, "start_trace")
-            logger.debug("Started trace %s: %s", trace_id, name)
+            if commit:
+                self._safe_commit(obs_db, "start_trace")
+            logger.debug(f"Started trace {trace_id}: {name}")
             return trace_id
         finally:
-            if owned and obs_db is not None:
+            if session_owned and obs_db is not None:
                 try:
                     obs_db.close()
                 except Exception as close_error:
@@ -359,12 +370,13 @@ class ObservabilityService:
         status_message: Optional[str] = None,
         http_status_code: Optional[int] = None,
         attributes: Optional[Dict[str, Any]] = None,
+        commit: bool = True,
+        obs_db: Optional[Session] = None,
     ) -> None:
         """End a trace.
 
-        Creates an independent observability session for best-effort recording.
-        Observability data persists independently of main request transaction
-        (issue #3883 - separate session pattern).
+        Creates an independent observability session for best-effort recording
+        unless obs_db is provided for session reuse.
 
         Args:
             trace_id: Trace ID to end
@@ -372,10 +384,15 @@ class ObservabilityService:
             status_message: Optional status message
             http_status_code: HTTP response status code
             attributes: Additional attributes to merge
+            commit: Whether to commit immediately (default True).
+                Set to False when called from middleware for session reuse.
+            obs_db: Optional observability session for session reuse.
+                If not provided, creates a new independent session.
 
         Note:
-            Uses separate database session from main transaction (best-effort).
-            Follows pattern established in instrumentation/sqlalchemy.py:58-87.
+            When obs_db is provided, caller owns session lifecycle.
+            When obs_db is None, this method creates and closes its own session.
+            Uses separate database session from main transaction (issue #3883).
 
         Examples:
             >>> service.end_trace(  # doctest: +SKIP
@@ -384,10 +401,11 @@ class ObservabilityService:
             ...     http_status_code=200
             ... )
         """
-        obs_db = None
-        owned = False
+        session_owned = False
+        if obs_db is None:
+            obs_db, session_owned = _get_or_create_observability_session()
+
         try:
-            obs_db, owned = _get_or_create_observability_session()
             trace = obs_db.query(ObservabilityTrace).filter_by(trace_id=trace_id).first()
             if not trace:
                 logger.warning("Trace %s not found", trace_id)
@@ -405,10 +423,11 @@ class ObservabilityService:
             if attributes:
                 trace.attributes = {**(trace.attributes or {}), **attributes}
 
-            self._safe_commit(obs_db, "end_trace")
-            logger.debug("Ended trace %s: %s (%.2fms)", trace_id, status, duration_ms)
+            if commit:
+                self._safe_commit(obs_db, "end_trace")
+            logger.debug(f"Ended trace {trace_id}: {status} ({duration_ms:.2f}ms)")
         finally:
-            if owned and obs_db is not None:
+            if session_owned and obs_db is not None:
                 try:
                     obs_db.close()
                 except Exception as close_error:

--- a/mcpgateway/services/observability_service.py
+++ b/mcpgateway/services/observability_service.py
@@ -271,7 +271,7 @@ class ObservabilityService:
     # Trace Management
     # ==============================
 
-    def start_trace(  # pylint: disable=too-many-locals
+    def start_trace(  # pylint: disable=too-many-locals,too-many-arguments
         self,
         name: str,
         trace_id: Optional[str] = None,

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -140,6 +140,30 @@ async def test_dispatch_end_span_failure_logs_warning(mock_request, mock_call_ne
 
 
 @pytest.mark.asyncio
+async def test_dispatch_session_close_failure_logs_debug(mock_request, mock_call_next):
+    """Test that session close failures in finally block are logged at debug level."""
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+
+    mock_session = MagicMock()
+    mock_session.close.side_effect = Exception("close failed")
+
+    with (
+        patch("mcpgateway.db.SessionLocal", return_value=mock_session),
+        patch.object(middleware.service, "start_trace", return_value="trace123"),
+        patch.object(middleware.service, "start_span", return_value="span123"),
+        patch.object(middleware.service, "end_span"),
+        patch.object(middleware.service, "end_trace"),
+        patch("mcpgateway.middleware.observability_middleware.logger.debug") as mock_debug,
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        response = await middleware.dispatch(mock_request, mock_call_next)
+        assert response.status_code == 200
+        # Verify debug log was called for close failure
+        debug_calls = [str(call) for call in mock_debug.call_args_list]
+        assert any("Failed to close observability session" in str(call) for call in debug_calls)
+
+
+@pytest.mark.asyncio
 async def test_dispatch_end_trace_failure_logs_warning(mock_request, mock_call_next):
     middleware = ObservabilityMiddleware(app=None, enabled=True)
 
@@ -212,11 +236,6 @@ def mock_observability_service():
     return service
 
 
-# Test removed - obsolete after #3883
-# Middleware no longer creates or manages request sessions.
-# Each observability operation creates its own independent session.
-
-
 @pytest.mark.asyncio
 async def test_get_db_reuses_middleware_session():
     """Test that get_db() reuses the session from ObservabilityMiddleware."""
@@ -240,10 +259,6 @@ async def test_get_db_reuses_middleware_session():
         next(db_generator)
     except StopIteration:
         pass
-
-    # Verify get_db() commits the middleware session (Issue #3731 fix)
-    # Transaction control is now delegated to get_db(), not middleware
-    # Verify the session is NOT closed (middleware will handle that)
 
 
 @pytest.mark.asyncio
@@ -272,14 +287,3 @@ async def test_get_db_creates_own_session_when_no_middleware_session():
             next(db_generator)
         except StopIteration:
             pass
-
-        # Verify the session was committed and closed
-
-
-# Test removed - obsolete after #3883
-# Middleware no longer creates request sessions. Each observability operation
-# creates its own independent session. See test_middleware_no_session_management() in
-# test_observability_middleware_transactions.py for the updated behavior.
-
-# Tests removed - obsolete after #3883
-# Middleware no longer creates or manages database sessions, so no rollback/invalidate operations.

--- a/tests/unit/mcpgateway/middleware/test_observability_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_observability_middleware.py
@@ -177,6 +177,35 @@ async def test_dispatch_end_trace_failure_logs_warning(mock_request, mock_call_n
     ):
         response = await middleware.dispatch(mock_request, mock_call_next)
         assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_dispatch_trace_setup_failure_with_session_close_failure(mock_request, mock_call_next):
+    """Test that trace setup failure with session close failure is handled gracefully.
+
+    This test covers lines 213-214 in observability_middleware.py where the session
+    close operation in the exception handler also fails.
+    """
+    middleware = ObservabilityMiddleware(app=None, enabled=True)
+
+    mock_session = MagicMock()
+    # Make session close fail
+    mock_session.close.side_effect = Exception("close failed")
+
+    with (
+        patch("mcpgateway.db.SessionLocal", return_value=mock_session),
+        patch.object(middleware.service, "start_trace", side_effect=Exception("trace setup failed")),
+        patch("mcpgateway.middleware.observability_middleware.logger.warning") as mock_warning,
+        patch("mcpgateway.middleware.observability_middleware.should_skip_observability", return_value=False),
+    ):
+        # Should continue without tracing despite both failures
+        response = await middleware.dispatch(mock_request, mock_call_next)
+        assert response.status_code == 200
+        # Verify warning was logged for trace setup failure
+        mock_warning.assert_called_once()
+        assert "Failed to setup observability trace" in str(mock_warning.call_args)
+        # Session close failure should be silently caught (lines 213-214)
+        mock_session.close.assert_called_once()
         mock_warning.assert_called()
 
 

--- a/tests/unit/mcpgateway/services/test_observability_session_reuse.py
+++ b/tests/unit/mcpgateway/services/test_observability_session_reuse.py
@@ -1,0 +1,242 @@
+
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_observability_session_reuse.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for observability session reuse optimization (Issue #5072).
+
+Tests verify that ObservabilityService methods accept and reuse database sessions
+to reduce connection pool pressure from 4-6 sessions per traced request to 1 session.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.observability_service import ObservabilityService
+
+
+class TestObservabilitySessionReuse:
+    """Test session reuse optimization for observability operations."""
+
+    @pytest.fixture
+    def service(self):
+        """Create ObservabilityService instance."""
+        return ObservabilityService()
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create mock database session."""
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+        return session
+
+    def test_start_trace_with_session_reuse(self, service, mock_session):
+        """Test start_trace accepts obs_db parameter for session reuse."""
+        # When obs_db is provided, should not create new session
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            trace_id = service.start_trace(
+                name="test_trace",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # Should not create new session when obs_db provided
+            mock_get.assert_not_called()
+            # Should use provided session
+            mock_session.add.assert_called_once()
+            # Should not commit when commit=False
+            mock_session.commit.assert_not_called()
+            # Should not close session (caller owns it)
+            mock_session.close.assert_not_called()
+            assert trace_id is not None
+
+    def test_start_trace_without_session_creates_own(self, service):
+        """Test start_trace creates own session when obs_db not provided."""
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            mock_session = MagicMock()
+            mock_get.return_value = (mock_session, True)
+
+            trace_id = service.start_trace(name="test_trace")
+
+            # Should create new session when obs_db not provided
+            mock_get.assert_called_once()
+            # Should commit by default
+            mock_session.commit.assert_called_once()
+            # Should close session (owns it)
+            mock_session.close.assert_called_once()
+            assert trace_id is not None
+
+    def test_end_trace_with_session_reuse(self, service, mock_session):
+        """Test end_trace accepts obs_db parameter for session reuse."""
+        # Setup mock trace with proper datetime
+        from datetime import datetime, timezone
+        mock_trace = MagicMock()
+        mock_trace.start_time = datetime.now(timezone.utc)
+        mock_session.query.return_value.filter_by.return_value.first.return_value = mock_trace
+
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            service.end_trace(
+                trace_id="test-trace-id",
+                status="ok",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # Should not create new session when obs_db provided
+            mock_get.assert_not_called()
+            # Should not commit when commit=False
+            mock_session.commit.assert_not_called()
+            # Should not close session (caller owns it)
+            mock_session.close.assert_not_called()
+
+    def test_end_trace_without_session_creates_own(self, service):
+        """Test end_trace creates own session when obs_db not provided."""
+        from datetime import datetime, timezone
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            mock_session = MagicMock()
+            mock_trace = MagicMock()
+            mock_trace.start_time = datetime.now(timezone.utc)
+            mock_session.query.return_value.filter_by.return_value.first.return_value = mock_trace
+            mock_get.return_value = (mock_session, True)
+
+            service.end_trace(trace_id="test-trace-id", status="ok")
+
+            # Should create new session when obs_db not provided
+            mock_get.assert_called_once()
+            # Should commit by default
+            mock_session.commit.assert_called_once()
+            # Should close session (owns it)
+            mock_session.close.assert_called_once()
+
+    def test_start_span_with_session_reuse(self, service, mock_session):
+        """Test start_span accepts obs_db parameter for session reuse."""
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            span_id = service.start_span(
+                trace_id="test-trace-id",
+                name="test_span",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # Should not create new session when obs_db provided
+            mock_get.assert_not_called()
+            # Should use provided session
+            mock_session.add.assert_called_once()
+            # Should not commit when commit=False
+            mock_session.commit.assert_not_called()
+            # Should not close session (caller owns it)
+            mock_session.close.assert_not_called()
+            assert span_id is not None
+
+    def test_end_span_with_session_reuse(self, service, mock_session):
+        """Test end_span accepts obs_db parameter for session reuse."""
+        # Setup mock span with proper datetime
+        from datetime import datetime, timezone
+        mock_span = MagicMock()
+        mock_span.start_time = datetime.now(timezone.utc)
+        mock_session.query.return_value.filter_by.return_value.first.return_value = mock_span
+
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            service.end_span(
+                span_id="test-span-id",
+                status="ok",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # Should not create new session when obs_db provided
+            mock_get.assert_not_called()
+            # Should not commit when commit=False
+            mock_session.commit.assert_not_called()
+            # Should not close session (caller owns it)
+            mock_session.close.assert_not_called()
+
+    def test_full_trace_lifecycle_with_single_session(self, service, mock_session):
+        """Test complete trace lifecycle reuses single session."""
+        # Setup mocks with proper datetime
+        from datetime import datetime, timezone
+        mock_trace = MagicMock()
+        mock_trace.start_time = datetime.now(timezone.utc)
+        mock_span = MagicMock()
+        mock_span.start_time = datetime.now(timezone.utc)
+
+        def query_side_effect(*args):
+            mock_query = MagicMock()
+            if "ObservabilityTrace" in str(args):
+                mock_query.filter_by.return_value.first.return_value = mock_trace
+            else:
+                mock_query.filter_by.return_value.first.return_value = mock_span
+            return mock_query
+
+        mock_session.query.side_effect = query_side_effect
+
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            # Simulate middleware pattern: create session once
+            # Start trace (no commit)
+            trace_id = service.start_trace(
+                name="test_trace",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # Start span (no commit)
+            span_id = service.start_span(
+                trace_id=trace_id,
+                name="test_span",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # End span (no commit)
+            service.end_span(
+                span_id=span_id,
+                status="ok",
+                commit=False,
+                obs_db=mock_session,
+            )
+
+            # End trace (final commit)
+            service.end_trace(
+                trace_id=trace_id,
+                status="ok",
+                commit=True,
+                obs_db=mock_session,
+            )
+
+            # Verify no new sessions created (all operations reused provided session)
+            mock_get.assert_not_called()
+
+            # Verify session was used for all operations
+            assert mock_session.add.call_count == 2  # trace + span
+            # Only final commit should happen
+            assert mock_session.commit.call_count == 1
+            # Session should not be closed (caller owns it)
+            mock_session.close.assert_not_called()
+
+    def test_add_event_with_session_reuse(self, service, mock_session):
+        """Test add_event accepts obs_db parameter for session reuse."""
+        # Mock commit to return False (simulating failure)
+        mock_session.commit.return_value = None
+
+        with patch("mcpgateway.services.observability_service._get_or_create_observability_session") as mock_get:
+            with patch.object(service, '_safe_commit', return_value=False):
+                event_id = service.add_event(
+                    span_id="test-span-id",
+                    name="test_event",
+                    severity="info",
+                    message="Test message",
+                    obs_db=mock_session,
+                )
+
+                # Should not create new session when obs_db provided
+                mock_get.assert_not_called()
+                # Should use provided session
+                mock_session.add.assert_called_once()
+                # Should not close session (caller owns it)
+                mock_session.close.assert_not_called()
+                assert event_id == 0  # Returns 0 when commit fails


### PR DESCRIPTION
## 🔗 Related Issue
Closes #5072

---

## 📝 Summary

This PR fixes the observability session proliferation bug where each traced request was creating 4-6 independent database sessions, causing connection pool saturation under moderate load.

**Problem**: After PR #4696 optimized SQL instrumentation, the main observability lifecycle (start_trace → start_span → end_span → end_trace) still created 4-6 sessions per request by calling `_get_or_create_observability_session()` independently for each operation.

**Solution**: Implemented session reuse pattern where `ObservabilityMiddleware` creates a single database session at trace start and passes it through the entire lifecycle. All operations use `commit=False` for batching, with a final atomic `commit=True` in `end_trace()`.

**Impact**:
- **Before**: 4-6 database sessions per traced request
- **After**: 1 database session per traced request
- **Reduction**: 75-83% fewer sessions
- **Result**: Prevents connection pool saturation, improves transaction consistency through atomic batching

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ 102 observability tests pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Covered |

**Test Results**:
```bash
# Session reuse tests
uv run pytest tests/unit/mcpgateway/services/test_observability_session_reuse.py -v
# Result: 8 passed

# All observability tests
uv run pytest tests/unit/mcpgateway/services/test_observability_service.py tests/unit/mcpgateway/middleware/test_observability_middleware.py -v
# Result: 102 passed
```

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Changes Made

**1. Service Layer** (`mcpgateway/services/observability_service.py`):
- Modified `start_trace()` (lines 271-362): Added `commit` and `obs_db` parameters
- Modified `end_trace()` (lines 364-432): Added `commit` and `obs_db` parameters
- `start_span()` and `end_span()` already had session reuse from PR #4696

**2. Middleware Layer** (`mcpgateway/middleware/observability_middleware.py`):
- Rewrote `dispatch()` method (lines 107-309)
- Creates single `SessionLocal()` session at line 161
- Passes session through entire lifecycle:
  - `start_trace(commit=False, obs_db=obs_db)` - lines 164-175
  - `start_span(commit=False, obs_db=obs_db)` - lines 191-196
  - `end_span(commit=False, obs_db=obs_db)` - lines 227-234
  - `end_trace(commit=True, obs_db=obs_db)` - lines 240-249 (atomic commit)
- Proper error handling with session cleanup in finally block (lines 304-309)

**3. Test Coverage**

**Session Reuse Tests** (`tests/unit/mcpgateway/services/test_observability_session_reuse.py`):
- `test_start_trace_with_session_reuse` - Verifies start_trace accepts obs_db parameter and doesn't create new session
- `test_start_trace_without_session_creates_own` - Verifies backward compatibility when obs_db=None
- `test_end_trace_with_session_reuse` - Verifies end_trace accepts obs_db parameter and doesn't create new session
- `test_end_trace_without_session_creates_own` - Verifies backward compatibility when obs_db=None
- `test_start_span_with_session_reuse` - Verifies start_span session reuse (from PR #4696)
- `test_end_span_with_session_reuse` - Verifies end_span session reuse (from PR #4696)
- `test_full_trace_lifecycle_with_single_session` - **Critical test**: Verifies complete lifecycle (start_trace → start_span → end_span → end_trace) uses only 1 session with single atomic commit
- `test_add_event_with_session_reuse` - Verifies event handling with session reuse

**Middleware Tests** (`tests/unit/mcpgateway/middleware/test_observability_middleware.py`):
- `test_dispatch_disabled` - Verifies middleware skips when disabled
- `test_dispatch_health_check_skipped` - Verifies health check paths are skipped
- `test_dispatch_trace_setup_success` - Verifies successful trace lifecycle
- `test_dispatch_trace_setup_failure` - Verifies graceful handling of trace setup failures
- `test_dispatch_exception_during_request` - Verifies trace completion even when request fails
- `test_dispatch_trace_setup_cleanup_close_failure_logs_debug` - Verifies debug logging for cleanup failures
- `test_dispatch_end_span_failure_logs_warning` - Verifies warning logging for end_span failures
- `test_dispatch_session_close_failure_logs_debug` - Verifies debug logging for session close failures in finally block
- `test_dispatch_end_trace_failure_logs_warning` - Verifies warning logging for end_trace failures
- `test_dispatch_trace_setup_failure_with_session_close_failure` - **New**: Verifies graceful handling when both trace setup AND session close fail (covers lines 213-214)
- `test_dispatch_with_user_context` - Verifies user context extraction
- `test_dispatch_with_traceparent_header` - Verifies W3C trace context propagation
- `test_dispatch_response_headers` - Verifies trace ID in response headers
- `test_dispatch_status_code_handling` - Verifies status code tracking

**Test Results**:
```bash
# Session reuse tests
uv run pytest tests/unit/mcpgateway/services/test_observability_session_reuse.py -v
# Result: 8 passed

# Middleware tests
uv run pytest tests/unit/mcpgateway/middleware/test_observability_middleware.py -v
# Result: 14 passed (including new test)

# All observability tests
uv run pytest tests/unit/mcpgateway/services/test_observability_service.py tests/unit/mcpgateway/middleware/test_observability_middleware.py -v
# Result: 102 passed
```

**Coverage**: The test suite now provides comprehensive coverage including:
- Session reuse for all lifecycle methods
- Backward compatibility when `obs_db=None`
- Full trace lifecycle with single session
- Atomic commit behavior (commit=False for batching, commit=True for final)
- Session ownership (caller-owned sessions not closed by service)
- Event handling with session reuse
- Error handling edge cases (trace setup failure, session close failure, both failing simultaneously)
- W3C trace context propagation
- User context extraction
- Response header injection

### Backward Compatibility

The fix maintains full backward compatibility:
- When `obs_db=None` (default), methods create their own independent sessions (original behavior)
- When `obs_db` is provided, methods reuse the provided session (new optimized behavior)
- Existing code continues to work without modifications

### Design Decision: Atomic Batching

All observability operations within a trace lifecycle are batched into a single transaction with a final atomic commit. This provides:
- **Consistency**: All trace data commits together or rolls back together
- **Performance**: Single commit reduces database round-trips
- **Observability**: Even if main request fails, trace data persists (best-effort pattern from #3883)

### Connection Pool Sizing Guidance

With this fix, the observability lifecycle uses 1 session per traced request (down from 4-6). Default pool configuration (`DB_POOL_SIZE=200`, `DB_MAX_OVERFLOW=10`) now supports ~200 concurrent traced requests instead of ~35-50, a 4-5x improvement in capacity.