### PR TITLE
fix: Disable CA Cert validation on authless MCPs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-08T14:11:13Z",
+  "generated_at": "2026-06-09T13:17:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4336,7 +4336,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4397,
+        "line_number": 4403,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4336,7 +4336,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4323,
+        "line_number": 4397,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2846,7 +2846,7 @@ class GatewayCreate(BaseModelWithConfigDict):
     auth_token: Optional[str] = Field(None, description="Token for bearer authentication")
     auth_header_key: Optional[str] = Field(None, description="Key for custom headers authentication")
     auth_header_value: Optional[str] = Field(None, description="Value for custom headers authentication")
-    auth_headers: Optional[List[Dict[str, str]]] = Field(None, description="List of custom headers for authentication")
+    auth_headers: Optional[List[Union[Dict[str, str], str, None]]] = Field(None, description="List of custom headers for authentication")
 
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(
@@ -2857,18 +2857,51 @@ class GatewayCreate(BaseModelWithConfigDict):
     auth_query_param_key: Optional[str] = Field(
         None,
         description="Query parameter name for authentication (e.g., 'api_key', 'tavilyApiKey')",
-        pattern=r"^[a-zA-Z_][a-zA-Z0-9_\-]*$",
     )
     auth_query_param_value: Optional[SecretStr] = Field(
         None,
         description="Query parameter value (API key). Stored encrypted.",
     )
 
+    @field_validator("auth_query_param_key")
+    @classmethod
+    def validate_auth_query_param_key(cls, v: Optional[str]) -> Optional[str]:
+        """Validate query param key format only if provided and non-empty.
+
+        Args:
+            v: Query parameter key to validate
+
+        Returns:
+            The validated query parameter key
+
+        Raises:
+            ValueError: If the key format is invalid
+        """
+        if v is not None and v != "":
+            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_\-]*$", v):
+                raise ValueError("Query parameter key must start with a letter or underscore, " "followed by letters, numbers, underscores, or hyphens")
+        return v
+
     # Adding `auth_value` as an alias for better access post-validation
     auth_value: Optional[str] = Field(None, validate_default=True)
 
     # One time auth - do not store the auth in gateway flag
     one_time_auth: Optional[bool] = Field(default=False, description="The authentication should be used only once and not stored in the gateway")
+
+    @field_validator("auth_type", mode="before")
+    @classmethod
+    def normalize_auth_type(cls, v: Any) -> Optional[str]:
+        """Normalize auth_type: convert string 'none' or 'None' to None.
+
+        Args:
+            v: The auth_type value (may be string "none" or "None")
+
+        Returns:
+            None if v is "none" or "None", otherwise returns v unchanged
+        """
+        if isinstance(v, str) and v.lower() == "none":
+            return None
+        return v
 
     tags: Optional[List[Union[str, Dict[str, str]]]] = Field(default_factory=list, description="Tags for categorizing the gateway")
 
@@ -3085,7 +3118,7 @@ class GatewayCreate(BaseModelWithConfigDict):
         if auth_type == "authheaders":
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
-            if auth_headers and isinstance(auth_headers, list):
+            if auth_headers is not None and isinstance(auth_headers, list):
                 # New multi-headers format with enhanced validation
                 header_dict = {}
                 duplicate_keys = set()
@@ -3143,7 +3176,11 @@ class GatewayCreate(BaseModelWithConfigDict):
             # Validation is handled by model_validator
             return None
 
-        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.")
+        # Handle no authentication (None or already normalized from "none")
+        if auth_type is None:
+            return None
+
+        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
 
     @model_validator(mode="after")
     def validate_query_param_auth(self) -> "GatewayCreate":
@@ -3207,6 +3244,21 @@ class GatewayUpdate(BaseModelWithConfigDict):
     # Adding `auth_value` as an alias for better access post-validation
     auth_value: Optional[str] = Field(None, validate_default=True)
 
+    @field_validator("auth_type", mode="before")
+    @classmethod
+    def normalize_auth_type(cls, v: Any) -> Optional[str]:
+        """Normalize auth_type: convert string 'none' or 'None' to None.
+
+        Args:
+            v: The auth_type value (may be string "none" or "None")
+
+        Returns:
+            None if v is "none" or "None", otherwise returns v unchanged
+        """
+        if isinstance(v, str) and v.lower() == "none":
+            return None
+        return v
+
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(
         None, description="OAuth 2.0 configuration including grant_type, client_id, encrypted client_secret, URLs, scopes, audience (for Atlassian/Auth0), and resource (RFC 8707)"
@@ -3216,12 +3268,30 @@ class GatewayUpdate(BaseModelWithConfigDict):
     auth_query_param_key: Optional[str] = Field(
         None,
         description="Query parameter name for authentication",
-        pattern=r"^[a-zA-Z_][a-zA-Z0-9_\-]*$",
     )
     auth_query_param_value: Optional[SecretStr] = Field(
         None,
         description="Query parameter value (API key)",
     )
+
+    @field_validator("auth_query_param_key")
+    @classmethod
+    def validate_auth_query_param_key(cls, v: Optional[str]) -> Optional[str]:
+        """Validate query param key format only if provided and non-empty.
+
+        Args:
+            v: Query parameter key to validate
+
+        Returns:
+            The validated query parameter key
+
+        Raises:
+            ValueError: If the key format is invalid
+        """
+        if v is not None and v != "":
+            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_\-]*$", v):
+                raise ValueError("Query parameter key must start with a letter or underscore, " "followed by letters, numbers, underscores, or hyphens")
+        return v
 
     # One time auth - do not store the auth in gateway flag
     one_time_auth: Optional[bool] = Field(default=False, description="The authentication should be used only once and not stored in the gateway")
@@ -3460,7 +3530,11 @@ class GatewayUpdate(BaseModelWithConfigDict):
             # Validation is handled by model_validator
             return None
 
-        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.")
+        # Handle no authentication (None or already normalized from "none")
+        if auth_type is None:
+            return None
+
+        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
 
     @model_validator(mode="after")
     def validate_query_param_auth(self) -> "GatewayUpdate":
@@ -4661,6 +4735,22 @@ class A2AAgentCreate(BaseModel):
 
     # Adding `auth_value` as an alias for better access post-validation
     auth_value: Optional[str] = Field(None, validate_default=True)
+
+    @field_validator("auth_type", mode="before")
+    @classmethod
+    def normalize_auth_type(cls, v: Any) -> Optional[str]:
+        """Normalize auth_type: convert string 'none' or 'None' to None.
+
+        Args:
+            v: The auth_type value (may be string "none" or "None")
+
+        Returns:
+            None if v is "none" or "None", otherwise returns v unchanged
+        """
+        if isinstance(v, str) and v.lower() == "none":
+            return None
+        return v
+
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the agent")
 
     # Team scoping fields
@@ -4909,7 +4999,11 @@ class A2AAgentCreate(BaseModel):
             # Validation is handled by model_validator
             return None
 
-        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.")
+        # Handle no authentication (None or already normalized from "none")
+        if auth_type is None:
+            return None
+
+        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
 
     @model_validator(mode="after")
     def validate_query_param_auth(self) -> "A2AAgentCreate":
@@ -5001,6 +5095,24 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
     uaid_protocol: Optional[str] = Field(default=None, description="Protocol for UAID (a2a, mcp, rest, grpc)")
     version: Optional[str] = Field(default=None, description="Agent version for UAID generation")
     uaid_native_id_override: Optional[str] = Field(None, description="Override nativeId in UAID for cross-gateway routing (defaults to endpoint_url if not provided)")
+
+    @field_validator("auth_type")
+    @classmethod
+    def normalize_auth_type(cls, v: Any) -> Optional[str]:
+        """Normalize auth_type by converting string 'none' or 'None' to Python None.
+
+        This allows the UI to send "none" as a string value which gets converted
+        to Python None for proper handling throughout the system.
+
+        Args:
+            v: The auth_type value (can be str or None)
+
+        Returns:
+            The normalized auth_type (None if input was "none"/"None", otherwise unchanged)
+        """
+        if isinstance(v, str) and v.lower() == "none":
+            return None
+        return v
 
     @field_validator("tags")
     @classmethod
@@ -5239,7 +5351,11 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
             # Validation is handled by model_validator
             return None
 
-        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.")
+        # Handle no authentication (None or already normalized from "none")
+        if auth_type is None:
+            return None
+
+        raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
 
     @model_validator(mode="after")
     def validate_query_param_auth(self) -> "A2AAgentUpdate":

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2891,16 +2891,19 @@ class GatewayCreate(BaseModelWithConfigDict):
     @field_validator("auth_type", mode="before")
     @classmethod
     def normalize_auth_type(cls, v: Any) -> Optional[str]:
-        """Normalize auth_type: convert string 'none' or 'None' to None.
+        """Normalize auth_type: convert string 'none' or 'None' to empty string.
+
+        The service layer treats empty string as the clear-auth sentinel.
+        Converting "none" to None would cause the update to be ignored.
 
         Args:
             v: The auth_type value (may be string "none" or "None")
 
         Returns:
-            None if v is "none" or "None", otherwise returns v unchanged
+            Empty string if v is "none" or "None", otherwise returns v unchanged
         """
         if isinstance(v, str) and v.lower() == "none":
-            return None
+            return ""
         return v
 
     tags: Optional[List[Union[str, Dict[str, str]]]] = Field(default_factory=list, description="Tags for categorizing the gateway")
@@ -3247,16 +3250,19 @@ class GatewayUpdate(BaseModelWithConfigDict):
     @field_validator("auth_type", mode="before")
     @classmethod
     def normalize_auth_type(cls, v: Any) -> Optional[str]:
-        """Normalize auth_type: convert string 'none' or 'None' to None.
+        """Normalize auth_type: convert string 'none' or 'None' to empty string.
+
+        The service layer treats empty string as the clear-auth sentinel.
+        Converting "none" to None would cause the update to be ignored.
 
         Args:
             v: The auth_type value (may be string "none" or "None")
 
         Returns:
-            None if v is "none" or "None", otherwise returns v unchanged
+            Empty string if v is "none" or "None", otherwise returns v unchanged
         """
         if isinstance(v, str) and v.lower() == "none":
-            return None
+            return ""
         return v
 
     # OAuth 2.0 configuration
@@ -4739,16 +4745,19 @@ class A2AAgentCreate(BaseModel):
     @field_validator("auth_type", mode="before")
     @classmethod
     def normalize_auth_type(cls, v: Any) -> Optional[str]:
-        """Normalize auth_type: convert string 'none' or 'None' to None.
+        """Normalize auth_type: convert string 'none' or 'None' to empty string.
+
+        The service layer treats empty string as the clear-auth sentinel.
+        Converting "none" to None would cause auth to not be cleared properly.
 
         Args:
             v: The auth_type value (may be string "none" or "None")
 
         Returns:
-            None if v is "none" or "None", otherwise returns v unchanged
+            Empty string if v is "none" or "None", otherwise returns v unchanged
         """
         if isinstance(v, str) and v.lower() == "none":
-            return None
+            return ""
         return v
 
     tags: List[str] = Field(default_factory=list, description="Tags for categorizing the agent")
@@ -5099,19 +5108,19 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
     @field_validator("auth_type")
     @classmethod
     def normalize_auth_type(cls, v: Any) -> Optional[str]:
-        """Normalize auth_type by converting string 'none' or 'None' to Python None.
+        """Normalize auth_type: convert string 'none' or 'None' to empty string.
 
-        This allows the UI to send "none" as a string value which gets converted
-        to Python None for proper handling throughout the system.
+        The service layer treats empty string as the clear-auth sentinel.
+        Converting "none" to None would cause the update to be ignored.
 
         Args:
             v: The auth_type value (can be str or None)
 
         Returns:
-            The normalized auth_type (None if input was "none"/"None", otherwise unchanged)
+            Empty string if v is "none" or "None", otherwise returns v unchanged
         """
         if isinstance(v, str) and v.lower() == "none":
-            return None
+            return ""
         return v
 
     @field_validator("tags")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -3121,7 +3121,7 @@ class GatewayCreate(BaseModelWithConfigDict):
         if auth_type == "authheaders":
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
-            if auth_headers is not None and isinstance(auth_headers, list):
+            if auth_headers and isinstance(auth_headers, list):
                 # New multi-headers format with enhanced validation
                 header_dict = {}
                 duplicate_keys = set()
@@ -3180,7 +3180,7 @@ class GatewayCreate(BaseModelWithConfigDict):
             return None
 
         # Handle no authentication (None or already normalized from "none")
-        if auth_type is None:
+        if auth_type is None or auth_type == "":
             return None
 
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
@@ -3537,7 +3537,7 @@ class GatewayUpdate(BaseModelWithConfigDict):
             return None
 
         # Handle no authentication (None or already normalized from "none")
-        if auth_type is None:
+        if auth_type is None or auth_type == "":
             return None
 
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
@@ -5009,7 +5009,7 @@ class A2AAgentCreate(BaseModel):
             return None
 
         # Handle no authentication (None or already normalized from "none")
-        if auth_type is None:
+        if auth_type is None or auth_type == "":
             return None
 
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")
@@ -5361,7 +5361,7 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
             return None
 
         # Handle no authentication (None or already normalized from "none")
-        if auth_type is None:
+        if auth_type is None or auth_type == "":
             return None
 
         raise ValueError("Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, query_param, or none.")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2846,7 +2846,7 @@ class GatewayCreate(BaseModelWithConfigDict):
     auth_token: Optional[str] = Field(None, description="Token for bearer authentication")
     auth_header_key: Optional[str] = Field(None, description="Key for custom headers authentication")
     auth_header_value: Optional[str] = Field(None, description="Value for custom headers authentication")
-    auth_headers: Optional[List[Union[Dict[str, str], str, None]]] = Field(None, description="List of custom headers for authentication")
+    auth_headers: Optional[List[Dict[str, str]]] = Field(None, description="List of custom headers for authentication")
 
     # OAuth 2.0 configuration
     oauth_config: Optional[Dict[str, Any]] = Field(

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -1538,6 +1538,10 @@ class A2AAgentService(BaseService):
                 if hasattr(agent, field):
                     setattr(agent, field, value)
 
+            # Clear auth_value when auth_type is explicitly set to empty string
+            if agent_data.auth_type is not None and agent_data.auth_type == "":
+                agent.auth_value = ""
+
             # Handle query_param auth updates
             # Clear auth_query_params when switching away from query_param auth
             if original_auth_type == "query_param" and agent_data.auth_type is not None and agent_data.auth_type != "query_param":

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3906,7 +3906,7 @@
                   id="auth-type"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 >
-                  <option value="">None</option>
+                  <option value="none">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -5454,7 +5454,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   id="auth-type-gw"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 >
-                  <option value="">None</option>
+                  <option value="none">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -6896,7 +6896,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   name="auth_type"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                 >
-                  <option value="">None</option>
+                  <option value="none">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -8805,7 +8805,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         id="edit-auth-type"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
-                        <option value="">None</option>
+                        <option value="none">None</option>
                         <option value="basic">Basic</option>
                         <option value="bearer">Bearer Token</option>
                         <option value="authheaders">Custom Headers</option>
@@ -9990,7 +9990,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         id="auth-type-gw-edit"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
-                        <option value="">None</option>
+                        <option value="none">None</option>
                         <option value="basic">Basic</option>
                         <option value="bearer">Bearer Token</option>
                         <option value="authheaders">Custom Headers</option>
@@ -10497,7 +10497,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
                                 focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                         >
-                          <option value="">None</option>
+                          <option value="none">None</option>
                           <option value="basic">Basic</option>
                           <option value="bearer">Bearer Token</option>
                           <option value="authheaders">Custom Headers</option>

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1816,7 +1816,7 @@ class TestAuthValidationErrors:
                 auth_headers=[],
             )
 
-        assert "at least one valid header with a key must be provided" in str(exc_info.value)
+        assert "either 'auth_headers' list or both" in str(exc_info.value).lower()
 
     def test_gateway_create_authheaders_no_valid_keys(self):
         """Test GatewayCreate validation when auth_headers has no valid keys."""
@@ -1874,7 +1874,7 @@ class TestAuthValidationErrors:
         from mcpgateway.schemas import GatewayCreate
         import logging
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.schemas"):
             gw = GatewayCreate(
                 name="test-gateway",
                 url="http://example.com",
@@ -1906,22 +1906,21 @@ class TestAuthValidationErrors:
 
         assert gw.auth_type == "authheaders"
 
-    def test_gateway_create_authheaders_non_dict_items_skipped(self):
-        """Test GatewayCreate skips non-dict items in auth_headers."""
+    def test_gateway_create_authheaders_non_dict_items_rejected(self):
+        """Test GatewayCreate rejects non-dict items in auth_headers."""
         from mcpgateway.schemas import GatewayCreate
 
-        gw = GatewayCreate(
-            name="test-gateway",
-            url="http://example.com",
-            auth_type="authheaders",
-            auth_headers=[
-                "invalid-string",  # Skipped
-                {"key": "Valid-Header", "value": "test"},
-                None,  # Skipped
-            ],
-        )
-
-        assert gw.auth_type == "authheaders"
+        with pytest.raises(ValidationError):
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=[
+                    "invalid-string",
+                    {"key": "Valid-Header", "value": "test"},
+                    None,
+                ],
+            )
 
     def test_gateway_create_authheaders_legacy_missing_key(self):
         """Test GatewayCreate validation for legacy format missing key."""

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1675,3 +1675,280 @@ class TestTitleSchemas:
             ),
         )
         assert prompt_read.title == "Read Prompt Title"
+
+
+class TestAuthValidationErrors:
+    """Test error handling in auth validation for GatewayCreate, GatewayUpdate, A2AAgentCreate, A2AAgentUpdate."""
+
+    def test_gateway_create_invalid_query_param_key(self):
+        """Test GatewayCreate field validator rejects invalid query_param_key format."""
+        from mcpgateway.schemas import GatewayCreate
+
+        # Test the field validator directly by calling it
+        with pytest.raises(ValueError, match="Query parameter key must start with a letter or underscore"):
+            GatewayCreate.validate_auth_query_param_key("123invalid")
+
+    def test_gateway_update_invalid_query_param_key(self):
+        """Test GatewayUpdate field validator rejects invalid query_param_key format."""
+        from mcpgateway.schemas import GatewayUpdate
+
+        # Test the field validator directly by calling it
+        with pytest.raises(ValueError, match="Query parameter key must start with a letter or underscore"):
+            GatewayUpdate.validate_auth_query_param_key("@invalid")
+
+    def test_gateway_create_invalid_auth_type(self):
+        """Test GatewayCreate rejects invalid auth_type."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(url="http://example.com", name="test", auth_type="invalid_type")
+        assert "Invalid 'auth_type'" in str(exc_info.value)
+
+    def test_gateway_update_invalid_auth_type(self):
+        """Test GatewayUpdate rejects invalid auth_type."""
+        from mcpgateway.schemas import GatewayUpdate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayUpdate(auth_type="invalid_type")
+        assert "Invalid 'auth_type'" in str(exc_info.value)
+
+    def test_a2a_agent_create_invalid_auth_type(self):
+        """Test A2AAgentCreate rejects invalid auth_type."""
+        from mcpgateway.schemas import A2AAgentCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            A2AAgentCreate(name="test", uaid="test@example.com", auth_type="invalid_type")
+        assert "Invalid 'auth_type'" in str(exc_info.value)
+
+    def test_a2a_agent_update_invalid_auth_type(self):
+        """Test A2AAgentUpdate rejects invalid auth_type."""
+        from mcpgateway.schemas import A2AAgentUpdate
+
+        with pytest.raises(ValidationError) as exc_info:
+            A2AAgentUpdate(auth_type="invalid_type")
+        assert "Invalid 'auth_type'" in str(exc_info.value)
+
+    def test_gateway_create_query_param_missing_key(self):
+        """Test GatewayCreate validation when query param key is missing."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.insecure_allow_queryparam_auth = True
+
+            with pytest.raises(ValidationError) as exc_info:
+                GatewayCreate(
+                    name="test-gateway",
+                    url="http://example.com",
+                    auth_type="query_param",
+                    auth_query_param_value="secret123",
+                    # Missing: auth_query_param_key
+                )
+
+            assert "auth_query_param_key is required" in str(exc_info.value)
+
+    def test_gateway_create_query_param_missing_value(self):
+        """Test GatewayCreate validation when query param value is missing."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.insecure_allow_queryparam_auth = True
+
+            with pytest.raises(ValidationError) as exc_info:
+                GatewayCreate(
+                    name="test-gateway",
+                    url="http://example.com",
+                    auth_type="query_param",
+                    auth_query_param_key="api_key",
+                    # Missing: auth_query_param_value
+                )
+
+            assert "auth_query_param_value is required" in str(exc_info.value)
+
+    def test_gateway_create_query_param_disabled(self):
+        """Test GatewayCreate validation when query param auth is disabled."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.insecure_allow_queryparam_auth = False
+
+            with pytest.raises(ValidationError) as exc_info:
+                GatewayCreate(
+                    name="test-gateway",
+                    url="http://example.com",
+                    auth_type="query_param",
+                    auth_query_param_key="api_key",
+                    auth_query_param_value="secret123",
+                )
+
+            assert "Query parameter authentication is disabled" in str(exc_info.value)
+            assert "INSECURE_ALLOW_QUERYPARAM_AUTH=true" in str(exc_info.value)
+
+    def test_gateway_create_query_param_host_not_allowed(self):
+        """Test GatewayCreate validation when host is not in allowlist."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with patch("mcpgateway.schemas.settings") as mock_settings:
+            mock_settings.insecure_allow_queryparam_auth = True
+            mock_settings.insecure_queryparam_auth_allowed_hosts = ["allowed.com", "trusted.org"]
+
+            with pytest.raises(ValidationError) as exc_info:
+                GatewayCreate(
+                    name="test-gateway",
+                    url="http://forbidden.com/api",
+                    auth_type="query_param",
+                    auth_query_param_key="api_key",
+                    auth_query_param_value="secret123",
+                )
+
+            assert "not in the allowed hosts" in str(exc_info.value)
+            assert "forbidden.com" in str(exc_info.value)
+            assert "allowed.com" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_empty_list(self):
+        """Test GatewayCreate validation when auth_headers list is empty."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=[],
+            )
+
+        assert "at least one valid header with a key must be provided" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_no_valid_keys(self):
+        """Test GatewayCreate validation when auth_headers has no valid keys."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=[
+                    {"value": "only-value"},  # Missing key
+                    {"key": "", "value": "empty-key"},  # Empty key
+                ],
+            )
+
+        assert "at least one valid header with a key must be provided" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_invalid_key_format(self):
+        """Test GatewayCreate validation when auth_headers has invalid key format."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=[
+                    {"key": "Invalid@Key!", "value": "test"},
+                ],
+            )
+
+        assert "Invalid header key format" in str(exc_info.value)
+        assert "Invalid@Key!" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_excessive_headers(self):
+        """Test GatewayCreate validation when auth_headers exceeds limit."""
+        from mcpgateway.schemas import GatewayCreate
+
+        # Create 101 headers (exceeds 100 limit)
+        headers = [{"key": f"Header-{i}", "value": f"value-{i}"} for i in range(101)]
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=headers,
+            )
+
+        assert "Maximum of 100 headers allowed" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_duplicate_keys_warning(self, caplog):
+        """Test GatewayCreate logs warning for duplicate header keys."""
+        from mcpgateway.schemas import GatewayCreate
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            gw = GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_headers=[
+                    {"key": "X-API-Key", "value": "first"},
+                    {"key": "X-API-Key", "value": "second"},  # Duplicate
+                    {"key": "Authorization", "value": "Bearer token"},
+                ],
+            )
+
+        assert gw.auth_type == "authheaders"
+        assert "Duplicate header keys detected" in caplog.text
+        assert "X-API-Key" in caplog.text
+
+    def test_gateway_create_authheaders_empty_value_allowed(self):
+        """Test GatewayCreate allows empty header values."""
+        from mcpgateway.schemas import GatewayCreate
+
+        gw = GatewayCreate(
+            name="test-gateway",
+            url="http://example.com",
+            auth_type="authheaders",
+            auth_headers=[
+                {"key": "X-Empty-Header", "value": ""},
+                {"key": "X-Valid-Header", "value": "test"},
+            ],
+        )
+
+        assert gw.auth_type == "authheaders"
+
+    def test_gateway_create_authheaders_non_dict_items_skipped(self):
+        """Test GatewayCreate skips non-dict items in auth_headers."""
+        from mcpgateway.schemas import GatewayCreate
+
+        gw = GatewayCreate(
+            name="test-gateway",
+            url="http://example.com",
+            auth_type="authheaders",
+            auth_headers=[
+                "invalid-string",  # Skipped
+                {"key": "Valid-Header", "value": "test"},
+                None,  # Skipped
+            ],
+        )
+
+        assert gw.auth_type == "authheaders"
+
+    def test_gateway_create_authheaders_legacy_missing_key(self):
+        """Test GatewayCreate validation for legacy format missing key."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_header_value="test-value",
+                # Missing: auth_header_key
+            )
+
+        assert "either 'auth_headers' list or both 'auth_header_key' and 'auth_header_value' must be provided" in str(exc_info.value)
+
+    def test_gateway_create_authheaders_legacy_missing_value(self):
+        """Test GatewayCreate validation for legacy format missing value."""
+        from mcpgateway.schemas import GatewayCreate
+
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://example.com",
+                auth_type="authheaders",
+                auth_header_key="X-API-Key",
+                # Missing: auth_header_value
+            )
+
+        assert "either 'auth_headers' list or both 'auth_header_key' and 'auth_header_value' must be provided" in str(exc_info.value)

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -407,55 +407,55 @@ def test_email_registration_request_deprecated_alias():
 
 
 def test_gateway_create_auth_type_none_lowercase():
-    """Test GatewayCreate converts auth_type='none' to None."""
+    """Test GatewayCreate converts auth_type='none' to empty string."""
     gateway = GatewayCreate(name="gw", url="https://example.com", auth_type="none")
-    assert gateway.auth_type is None
+    assert gateway.auth_type == ""
     assert gateway.auth_value is None
 
 
 def test_gateway_create_auth_type_none_capitalized():
-    """Test GatewayCreate converts auth_type='None' to None."""
+    """Test GatewayCreate converts auth_type='None' to empty string."""
     gateway = GatewayCreate(name="gw", url="https://example.com", auth_type="None")
-    assert gateway.auth_type is None
+    assert gateway.auth_type == ""
     assert gateway.auth_value is None
 
 
 def test_gateway_update_auth_type_none_lowercase():
-    """Test GatewayUpdate converts auth_type='none' to None."""
+    """Test GatewayUpdate converts auth_type='none' to empty string."""
     gateway = GatewayUpdate(auth_type="none")
-    assert gateway.auth_type is None
+    assert gateway.auth_type == ""
 
 
 def test_gateway_update_auth_type_none_capitalized():
-    """Test GatewayUpdate converts auth_type='None' to None."""
+    """Test GatewayUpdate converts auth_type='None' to empty string."""
     gateway = GatewayUpdate(auth_type="None")
-    assert gateway.auth_type is None
+    assert gateway.auth_type == ""
 
 
 def test_a2a_agent_create_auth_type_none_lowercase():
-    """Test A2AAgentCreate converts auth_type='none' to None."""
+    """Test A2AAgentCreate converts auth_type='none' to empty string."""
     agent = A2AAgentCreate(name="agent", endpoint_url="https://example.com", auth_type="none")
-    assert agent.auth_type is None
+    assert agent.auth_type == ""
     assert agent.auth_value is None
 
 
 def test_a2a_agent_create_auth_type_none_capitalized():
-    """Test A2AAgentCreate converts auth_type='None' to None."""
+    """Test A2AAgentCreate converts auth_type='None' to empty string."""
     agent = A2AAgentCreate(name="agent", endpoint_url="https://example.com", auth_type="None")
-    assert agent.auth_type is None
+    assert agent.auth_type == ""
     assert agent.auth_value is None
 
 
 def test_a2a_agent_update_auth_type_none_lowercase():
-    """Test A2AAgentUpdate converts auth_type='none' to None."""
+    """Test A2AAgentUpdate converts auth_type='none' to empty string."""
     agent = A2AAgentUpdate(auth_type="none")
-    assert agent.auth_type is None
+    assert agent.auth_type == ""
 
 
 def test_a2a_agent_update_auth_type_none_capitalized():
-    """Test A2AAgentUpdate converts auth_type='None' to None."""
+    """Test A2AAgentUpdate converts auth_type='None' to empty string."""
     agent = A2AAgentUpdate(auth_type="None")
-    assert agent.auth_type is None
+    assert agent.auth_type == ""
 
 
 # =========================================================================
@@ -496,28 +496,44 @@ def test_gateway_update_query_param_empty_key(monkeypatch):
 
 
 def test_gateway_create_process_auth_fields_none_auth_type():
-    """GatewayCreate._process_auth_fields returns None when auth_type is None."""
+    """GatewayCreate._process_auth_fields returns None when auth_type is None or empty string."""
     info = Mock()
     info.data = {"auth_type": None}
     assert GatewayCreate._process_auth_fields(info) is None
 
+    # Empty string should also return None (clear auth sentinel)
+    info.data = {"auth_type": ""}
+    assert GatewayCreate._process_auth_fields(info) is None
+
 
 def test_gateway_update_process_auth_fields_none_auth_type():
-    """GatewayUpdate._process_auth_fields returns None when auth_type is None."""
+    """GatewayUpdate._process_auth_fields returns None when auth_type is None or empty string."""
     info = Mock()
     info.data = {"auth_type": None}
     assert GatewayUpdate._process_auth_fields(info) is None
 
+    # Empty string should also return None (clear auth sentinel)
+    info.data = {"auth_type": ""}
+    assert GatewayUpdate._process_auth_fields(info) is None
+
 
 def test_a2a_agent_create_process_auth_fields_none_auth_type():
-    """A2AAgentCreate._process_auth_fields returns None when auth_type is None."""
+    """A2AAgentCreate._process_auth_fields returns None when auth_type is None or empty string."""
     info = Mock()
     info.data = {"auth_type": None}
     assert A2AAgentCreate._process_auth_fields(info) is None
 
+    # Empty string should also return None (clear auth sentinel)
+    info.data = {"auth_type": ""}
+    assert A2AAgentCreate._process_auth_fields(info) is None
+
 
 def test_a2a_agent_update_process_auth_fields_none_auth_type():
-    """A2AAgentUpdate._process_auth_fields returns None when auth_type is None."""
+    """A2AAgentUpdate._process_auth_fields returns None when auth_type is None or empty string."""
     info = Mock()
     info.data = {"auth_type": None}
+    assert A2AAgentUpdate._process_auth_fields(info) is None
+
+    # Empty string should also return None (clear auth sentinel)
+    info.data = {"auth_type": ""}
     assert A2AAgentUpdate._process_auth_fields(info) is None

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -7,6 +7,9 @@ Authors: Mihai Criveti
 Schema auth validation tests to improve coverage.
 """
 
+# Standard
+from unittest.mock import Mock
+
 # Third-Party
 from pydantic import SecretStr, ValidationError
 import pytest
@@ -395,3 +398,126 @@ def test_admin_create_user_request_with_pcr_true():
 def test_email_registration_request_deprecated_alias():
     """Test EmailRegistrationRequest is a deprecated alias for AdminCreateUserRequest."""
     assert EmailRegistrationRequest is AdminCreateUserRequest
+
+
+# =========================================================================
+# normalize_auth_type validator tests
+# Verify that "none" and "None" strings are converted to Python None
+# =========================================================================
+
+
+def test_gateway_create_auth_type_none_lowercase():
+    """Test GatewayCreate converts auth_type='none' to None."""
+    gateway = GatewayCreate(name="gw", url="https://example.com", auth_type="none")
+    assert gateway.auth_type is None
+    assert gateway.auth_value is None
+
+
+def test_gateway_create_auth_type_none_capitalized():
+    """Test GatewayCreate converts auth_type='None' to None."""
+    gateway = GatewayCreate(name="gw", url="https://example.com", auth_type="None")
+    assert gateway.auth_type is None
+    assert gateway.auth_value is None
+
+
+def test_gateway_update_auth_type_none_lowercase():
+    """Test GatewayUpdate converts auth_type='none' to None."""
+    gateway = GatewayUpdate(auth_type="none")
+    assert gateway.auth_type is None
+
+
+def test_gateway_update_auth_type_none_capitalized():
+    """Test GatewayUpdate converts auth_type='None' to None."""
+    gateway = GatewayUpdate(auth_type="None")
+    assert gateway.auth_type is None
+
+
+def test_a2a_agent_create_auth_type_none_lowercase():
+    """Test A2AAgentCreate converts auth_type='none' to None."""
+    agent = A2AAgentCreate(name="agent", endpoint_url="https://example.com", auth_type="none")
+    assert agent.auth_type is None
+    assert agent.auth_value is None
+
+
+def test_a2a_agent_create_auth_type_none_capitalized():
+    """Test A2AAgentCreate converts auth_type='None' to None."""
+    agent = A2AAgentCreate(name="agent", endpoint_url="https://example.com", auth_type="None")
+    assert agent.auth_type is None
+    assert agent.auth_value is None
+
+
+def test_a2a_agent_update_auth_type_none_lowercase():
+    """Test A2AAgentUpdate converts auth_type='none' to None."""
+    agent = A2AAgentUpdate(auth_type="none")
+    assert agent.auth_type is None
+
+
+def test_a2a_agent_update_auth_type_none_capitalized():
+    """Test A2AAgentUpdate converts auth_type='None' to None."""
+    agent = A2AAgentUpdate(auth_type="None")
+    assert agent.auth_type is None
+
+
+# =========================================================================
+# validate_auth_query_param_key validator tests
+# Verify that empty string for auth_query_param_key raises validation error
+# =========================================================================
+
+
+def test_gateway_create_query_param_empty_key(monkeypatch):
+    """Test GatewayCreate rejects empty auth_query_param_key."""
+    monkeypatch.setattr(settings, "insecure_allow_queryparam_auth", True)
+    with pytest.raises(ValidationError, match="auth_query_param_key is required"):
+        GatewayCreate(
+            name="gw",
+            url="https://example.com",
+            auth_type="query_param",
+            auth_query_param_key="",
+            auth_query_param_value=SecretStr("secret"),
+        )
+
+
+def test_gateway_update_query_param_empty_key(monkeypatch):
+    """Test GatewayUpdate rejects empty auth_query_param_key."""
+    monkeypatch.setattr(settings, "insecure_allow_queryparam_auth", True)
+    with pytest.raises(ValidationError, match="auth_query_param_key is required"):
+        GatewayUpdate(
+            auth_type="query_param",
+            auth_query_param_key="",
+            auth_query_param_value=SecretStr("secret"),
+        )
+
+
+# =========================================================================
+# _process_auth_fields: auth_type is None branch (lines 3181, 3535, 5004, 5356)
+# The auth_value field_validator returns early before calling _process_auth_fields
+# when auth_type is None, so these branches are only reachable via direct call.
+# =========================================================================
+
+
+def test_gateway_create_process_auth_fields_none_auth_type():
+    """GatewayCreate._process_auth_fields returns None when auth_type is None."""
+    info = Mock()
+    info.data = {"auth_type": None}
+    assert GatewayCreate._process_auth_fields(info) is None
+
+
+def test_gateway_update_process_auth_fields_none_auth_type():
+    """GatewayUpdate._process_auth_fields returns None when auth_type is None."""
+    info = Mock()
+    info.data = {"auth_type": None}
+    assert GatewayUpdate._process_auth_fields(info) is None
+
+
+def test_a2a_agent_create_process_auth_fields_none_auth_type():
+    """A2AAgentCreate._process_auth_fields returns None when auth_type is None."""
+    info = Mock()
+    info.data = {"auth_type": None}
+    assert A2AAgentCreate._process_auth_fields(info) is None
+
+
+def test_a2a_agent_update_process_auth_fields_none_auth_type():
+    """A2AAgentUpdate._process_auth_fields returns None when auth_type is None."""
+    info = Mock()
+    info.data = {"auth_type": None}
+    assert A2AAgentUpdate._process_auth_fields(info) is None


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Closes #5070 

## 🔁 Reproduction Steps

### UI Reproduction Steps

1. Access the admin UI
2. Navigate to the Gateways tab
3. Fill the MCP form with a valid MCP server, with authentication type=none and no CA certificate
4. Submit the form
5. Verify the form validation errors

### API Reproduction Steps

 1. Generate a valid JWT token for authentication:
 `export TOKEN=$(python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 10080 --secret your-secret-key)`

 2. Attempt to register an authless MCP server via POST /gateways:
 ```bash
curl -X POST http://localhost:4444/gateways \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{
    "name": "test-authless-server",
    "url": "http://localhost:9000",
    "auth_type": "none"
  }'
```

 3. Observe the validation error response:
`{"detail":[{"type":"value_error","loc":["body","auth_value"],"msg":"Value error, Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.","input":null,"ctx":{"error":{}}}]}% `

 4. Confirm the same error occurs with explicit null:
```bash
# With explicit null
curl -X POST http://localhost:8000/gateways \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{
    "name": "test-authless-server",
    "url": "http://localhost:9000",
    "auth_type": "none",
    "auth_query_param_key": null
  }'
```

 5. Observe the validation error response:

`{"detail":[{"type":"value_error","loc":["body","auth_value"],"msg":"Value error, Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.","input":null,"ctx":{"error":{}}}]}% `

 6. Confirm the validation error occurs with an empty string:
```bash
# With empty string
curl -X POST http://localhost:8000/gateways \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{
    "name": "test-authless-server",
    "url": "http://localhost:9000",
    "auth_type": "none",
    "auth_query_param_key": ""
  }'
```

 7. Observe the validation error response:
```bash
{"detail":[{"type":"string_pattern_mismatch","loc":["body","auth_query_param_key"],"msg":"String should match pattern '^[a-zA-Z_][a-zA-Z0-9_\\-]*$'","input":"","ctx":{"pattern":"^[a-zA-Z_][a-zA-Z0-9_\\-]*$"}},{"type":"value_error","loc":["body","auth_value"],"msg":"Value error, Invalid 'auth_type'. Must be one of: basic, bearer, oauth, authheaders, or query_param.","input":null,"ctx":{"error":{}}}]}%
```

## 🐞 Root Cause
There is a mismatch between the UI form and backend validation: the admin UI's `auth_type` dropdown sent an empty string `value=""` for the `"None"` option, but the Pydantic schemas expected either a valid auth type string or Python `None`. The schemas lacked a validator to normalize the string `"none"` to Python None, causing validation failures when users selected "No authentication" in the UI.

## 💡 Fix Description
This PR solves the issue by adding a Pydantic @field_validator to both `GatewayCreate` and `GatewayUpdate` schemas that normalizes empty strings and the literal string `"none"` (case-insensitive) to Python `None`, ensuring the backend correctly interprets the UI's `"No authentication" `selection. The fix includes comprehensive test coverage for all auth_type variations (valid types, None, empty string, "none" string) across both create and update operations.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |

## 📐 MCP Compliance (if relevant)
- [ ] Matches current MCP spec
- [ ] No breaking change to MCP clients

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] No secrets/credentials committed
