### PR TITLE
fix(oauth): use dict list value for multi-resource RFC 8707 token requests

### DIFF
--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -1595,12 +1595,14 @@ class OAuthManager:
         scopes = runtime_credentials.get("scopes", [])
         if self._should_include_resource_parameter(credentials, scopes):
             if isinstance(resource, list):
-                # RFC 8707 allows multiple resource parameters - use list of tuples
-                form_data: list[tuple[str, str]] = list(token_data.items())
-                for r in resource:
-                    if r:
-                        form_data.append(("resource", r))
-                token_data = form_data  # type: ignore[assignment]
+                # RFC 8707 allows multiple resource parameters.
+                # Keep token_data as a dict with a list value — httpx's encode_urlencoded_data
+                # expands list values into repeated key=value pairs automatically.
+                # Converting to a list of tuples instead causes httpx to treat the payload as
+                # a raw sync iterable (IteratorByteStream) rather than form data, which
+                # raises RuntimeError on AsyncClient ("Attempted to send an sync request
+                # with an AsyncClient instance").
+                token_data["resource"] = [r for r in resource if r]  # type: ignore[assignment]
             else:
                 token_data["resource"] = resource
 
@@ -1706,12 +1708,14 @@ class OAuthManager:
         scopes = runtime_credentials.get("scopes", [])
         if self._should_include_resource_parameter(credentials, scopes):
             if isinstance(resource, list):
-                # RFC 8707 allows multiple resource parameters - use list of tuples
-                form_data: list[tuple[str, str]] = list(token_data.items())
-                for r in resource:
-                    if r:
-                        form_data.append(("resource", r))
-                token_data = form_data  # type: ignore[assignment]
+                # RFC 8707 allows multiple resource parameters.
+                # Keep token_data as a dict with a list value — httpx's encode_urlencoded_data
+                # expands list values into repeated key=value pairs automatically.
+                # Converting to a list of tuples instead causes httpx to treat the payload as
+                # a raw sync iterable (IteratorByteStream) rather than form data, which
+                # raises RuntimeError on AsyncClient ("Attempted to send an sync request
+                # with an AsyncClient instance").
+                token_data["resource"] = [r for r in resource if r]  # type: ignore[assignment]
             else:
                 token_data["resource"] = resource
 


### PR DESCRIPTION
When oauth_config["resource"] is a list (e.g. learned from a JWT aud claim with multiple audiences), the token exchange and refresh code converted token_data from a dict into a list[tuple[str, str]] to carry multiple resource= parameters.

httpx only invokes encode_urlencoded_data() — which produces a ByteStream compatible with AsyncClient — when data= is a Mapping.  A list of tuples is not a Mapping, so httpx falls through to encode_content(), which wraps the list in an IteratorByteStream (SyncByteStream only).  AsyncClient then raises:

  RuntimeError: Attempted to send an sync request with an AsyncClient instance.

This error surfaces as "Unexpected Error" on the OAuth callback page and affects every authorization attempt after the first one succeeds (because _persist_learned_audience() stores the JWT aud list into oauth_config).

Fix: keep token_data as a dict and store the resource list directly as its value.  httpx's encode_urlencoded_data() already expands list values into repeated key=value pairs, producing the correct
resource=r1&resource=r2 encoding with a ByteStream that AsyncClient accepts.

Affects _exchange_code_for_tokens() and refresh_token() in OAuthManager.

Closes #XXXX

<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

## 🔗 Related Issue
Closes #

---

## 📝 Summary
_What does this PR do and why?_

---

## 🏷️ Type of Change
- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)
_Screenshots, design decisions, or additional context._
