### PR TITLE
fix: expose OAuth metadata for non-public servers

### DIFF
--- a/mcpgateway/services/server_service.py
+++ b/mcpgateway/services/server_service.py
@@ -1970,19 +1970,23 @@ class ServerService(BaseService):
         """
         server = db.get(DbServer, server_id)
 
-        # Return not found for non-existent, disabled, or non-public servers
-        # (avoids leaking information about private/team servers)
+        # Return not found for non-existent or disabled servers.
         if not server:
             raise ServerNotFoundError(f"Server not found: {server_id}")
 
         if not server.enabled:
             raise ServerNotFoundError(f"Server not found: {server_id}")
 
-        if getattr(server, "visibility", "public") != "public":
+        # RFC 9728 metadata is intentionally unauthenticated discovery material.
+        # OAuth-enabled private/team servers advertise this URL from /servers/{id}/mcp;
+        # let those clients fetch only the non-secret authorization metadata while
+        # keeping non-OAuth private/team servers hidden.
+        oauth_enabled = getattr(server, "oauth_enabled", False)
+        if getattr(server, "visibility", "public") != "public" and not oauth_enabled:
             raise ServerNotFoundError(f"Server not found: {server_id}")
 
         # Check OAuth configuration
-        if not getattr(server, "oauth_enabled", False):
+        if not oauth_enabled:
             raise ServerError(f"OAuth not enabled for server: {server_id}")
 
         oauth_config = getattr(server, "oauth_config", None)

--- a/tests/e2e/test_oauth_protected_resource.py
+++ b/tests/e2e/test_oauth_protected_resource.py
@@ -306,8 +306,8 @@ class TestOAuthProtectedResourceMetadata:
         assert response.status_code == 404
         assert "OAuth not enabled" in response.json()["detail"]
 
-    async def test_private_server_returns_404(self, client: AsyncClient):
-        """Scenario 4: Server with visibility="private" (non-public) returns 404."""
+    async def test_private_server_with_oauth_enabled_returns_metadata(self, client: AsyncClient):
+        """Scenario 4: OAuth-enabled private servers expose only RFC 9728 metadata."""
         server_id = await self._create_server(
             client,
             {
@@ -318,6 +318,8 @@ class TestOAuthProtectedResourceMetadata:
                     "oauth_enabled": True,
                     "oauth_config": {
                         "authorization_server": "https://idp.example.com",
+                        "token_endpoint": "https://idp.example.com/oauth/token",
+                        "client_secret": "must-not-be-exposed",
                     },
                 },
                 "team_id": None,
@@ -325,8 +327,32 @@ class TestOAuthProtectedResourceMetadata:
         )
 
         response = await client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["resource"] == f"http://test/servers/{server_id}/mcp"
+        assert data["authorization_servers"] == ["https://idp.example.com"]
+        assert data["bearer_methods_supported"] == ["header"]
+        # Only discovery metadata should be public; OAuth credentials/endpoints are not exposed.
+        assert "client_secret" not in data
+        assert "token_endpoint" not in data
+
+    async def test_private_server_without_oauth_still_returns_404(self, client: AsyncClient):
+        """Non-public servers without OAuth metadata remain hidden."""
+        server_id = await self._create_server(
+            client,
+            {
+                "server": {
+                    "name": "server_private_no_oauth",
+                    "description": "Private server without OAuth",
+                    "visibility": "private",
+                },
+                "team_id": None,
+            },
+        )
+
+        response = await client.get(f"/.well-known/oauth-protected-resource/servers/{server_id}/mcp")
         assert response.status_code == 404
-        # Should not leak that the server exists (just "not found")
         assert "not found" in response.json()["detail"].lower()
 
     async def test_disabled_server_returns_404(self, client: AsyncClient):


### PR DESCRIPTION
## Summary

Fixes the OAuth protected resource metadata discovery path for OAuth-enabled non-public virtual servers.

Today `/servers/{server_id}/mcp` can advertise:

```http
WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/servers/{server_id}/mcp"
```

but the advertised RFC 9728 metadata URL returns `404 Server not found` when the server is `visibility="private"` (and similarly for non-public visibility), because `ServerService.get_oauth_protected_resource_metadata()` rejects non-public rows before checking OAuth metadata.

This PR lets the unauthenticated RFC 9728 metadata endpoint return only the non-secret OAuth discovery fields for non-public servers **when `oauth_enabled=True`**.

## Safety / non-secret invariant

The response remains limited to the existing RFC 9728 fields:

- `resource`
- `authorization_servers`
- `bearer_methods_supported`
- optional `scopes_supported`

The regression test includes `client_secret` and `token_endpoint` in `oauth_config` and asserts they are not returned.

Non-public servers without OAuth remain hidden (`404 Server not found`), and disabled/non-existent servers still return 404.

## Tests

```text
uv run pytest tests/e2e/test_oauth_protected_resource.py::TestOAuthProtectedResourceMetadata::test_private_server_with_oauth_enabled_returns_metadata tests/e2e/test_oauth_protected_resource.py::TestOAuthProtectedResourceMetadata::test_private_server_without_oauth_still_returns_404 tests/e2e/test_oauth_protected_resource.py::TestOAuthProtectedResourceMetadata::test_server_with_oauth_enabled_returns_metadata tests/e2e/test_oauth_protected_resource.py::TestVirtualServerWellKnownFiles::test_private_server_well_known_returns_404 -q
.... [100%]
```

```text
uv run pytest tests/e2e/test_oauth_protected_resource.py -q
.................. [100%]
```

```text
uv run ruff check mcpgateway/services/server_service.py tests/e2e/test_oauth_protected_resource.py
All checks passed!
```

Closes #5074
