### PR TITLE
fix: adapt Azure reasoning chat parameters

### DIFF
--- a/mcpgateway/routers/llm_admin_router.py
+++ b/mcpgateway/routers/llm_admin_router.py
@@ -528,7 +528,7 @@ async def admin_test_api(
     test_type = body.get("test_type", "models")
     model_id = body.get("model_id")
     message = body.get("message", "Hello! Please respond with a short greeting.")
-    max_tokens = body.get("max_tokens", 100)
+    max_tokens = body.get("max_tokens")
 
     start_time = time.time()
 

--- a/mcpgateway/services/llm_proxy_service.py
+++ b/mcpgateway/services/llm_proxy_service.py
@@ -48,6 +48,30 @@ logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
 
+_REASONING_MODEL_NAMES = {"gpt-chat-latest"}
+_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def _is_reasoning_model_name(*model_names: Optional[str]) -> bool:
+    """Return whether any model/deployment name looks like an OpenAI reasoning model.
+
+    Args:
+        model_names: Candidate request, model, or deployment names.
+
+    Returns:
+        ``True`` when a candidate matches known reasoning-class naming patterns.
+    """
+    for model_name in model_names:
+        if not model_name:
+            continue
+        normalized = str(model_name).strip().lower()
+        candidates = {normalized, normalized.rsplit("/", 1)[-1]}
+        for candidate in candidates:
+            if candidate in _REASONING_MODEL_NAMES or candidate.startswith(_REASONING_MODEL_PREFIXES):
+                return True
+    return False
+
+
 def _provider_trace_system(provider: LLMProvider) -> str:
     """Map provider type to a stable ``gen_ai.system`` label.
 
@@ -300,20 +324,23 @@ class LLMProxyService:
             "api-key": api_key or "",
         }
 
+        is_reasoning_model = _is_reasoning_model_name(request.model, model.model_id, deployment_name)
+
         # Build request body (similar to OpenAI)
         body: Dict[str, Any] = {
             "messages": [msg.model_dump(exclude_none=True) for msg in request.messages],
         }
 
-        if request.temperature is not None:
-            body["temperature"] = request.temperature
-        elif provider.default_temperature:
-            body["temperature"] = provider.default_temperature
+        temperature = request.temperature if request.temperature is not None else provider.default_temperature
+        if temperature is not None and (not is_reasoning_model or temperature == 1):
+            body["temperature"] = temperature
 
-        if request.max_tokens is not None:
-            body["max_tokens"] = request.max_tokens
-        elif provider.default_max_tokens:
-            body["max_tokens"] = provider.default_max_tokens
+        max_tokens = request.max_tokens if request.max_tokens is not None else provider.default_max_tokens
+        if max_tokens is not None:
+            if is_reasoning_model:
+                body["max_completion_tokens"] = max_tokens
+            else:
+                body["max_tokens"] = max_tokens
 
         if request.stream:
             body["stream"] = True

--- a/tests/unit/mcpgateway/routers/test_llm_admin_router.py
+++ b/tests/unit/mcpgateway/routers/test_llm_admin_router.py
@@ -199,7 +199,7 @@ async def test_admin_test_api_chat_success(monkeypatch: pytest.MonkeyPatch):
 
     import mcpgateway.services.llm_proxy_service as proxy_module
 
-    monkeypatch.setattr(proxy_module, "LLMProxyService", lambda: DummyProxy())
+    monkeypatch.setattr(proxy_module, "LLMProxyService", DummyProxy)
 
     request = MagicMock()
     request.body = AsyncMock(return_value=orjson.dumps({"test_type": "chat", "model_id": "m1", "message": "hi"}))
@@ -209,6 +209,36 @@ async def test_admin_test_api_chat_success(monkeypatch: pytest.MonkeyPatch):
     payload = orjson.loads(response.body)
     assert payload["success"] is True
     assert payload["assistant_message"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_admin_test_api_chat_omits_default_max_tokens(monkeypatch: pytest.MonkeyPatch):
+    captured = {}
+    response_obj = ChatCompletionResponse(
+        id="resp1",
+        created=1,
+        model="m1",
+        choices=[ChatChoice(index=0, message=ChatMessage(role="assistant", content="ok"), finish_reason="stop")],
+        usage=UsageStats(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+    class DummyProxy:
+        async def chat_completion(self, _db, chat_request):
+            captured["request"] = chat_request
+            return response_obj
+
+    import mcpgateway.services.llm_proxy_service as proxy_module
+
+    monkeypatch.setattr(proxy_module, "LLMProxyService", DummyProxy)
+
+    request = MagicMock()
+    request.body = AsyncMock(return_value=orjson.dumps({"test_type": "chat", "model_id": "m1", "message": "hi"}))
+
+    response = await llm_admin_router.admin_test_api(request, db=MagicMock(), current_user_ctx={"db": MagicMock(), "email": "user@example.com"})
+
+    payload = orjson.loads(response.body)
+    assert payload["success"] is True
+    assert captured["request"].max_tokens is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/services/test_llm_proxy_service.py
+++ b/tests/unit/mcpgateway/services/test_llm_proxy_service.py
@@ -550,6 +550,52 @@ def test_build_azure_request_defaults(service):
     assert body["stream"] is True
 
 
+def test_build_azure_request_reasoning_model_uses_completion_tokens(service):
+    """Azure reasoning deployments use max_completion_tokens and omit non-default temperature."""
+    request = ChatCompletionRequest(
+        model="gpt-5.4-mini",
+        messages=[ChatMessage(role="user", content="hi")],
+        temperature=0.7,
+        max_tokens=123,
+    )
+    provider = _make_provider(
+        provider_type=LLMProviderType.AZURE_OPENAI,
+        api_base="https://res.openai.azure.com",
+        config={"deployment_name": "gpt-5.4-mini"},
+        default_temperature=0.3,
+        default_max_tokens=50,
+    )
+    model = _make_model(model_id="gpt-5.4-mini")
+
+    _url, _headers, body = service._build_azure_request(request, provider, model)
+
+    assert body["max_completion_tokens"] == 123
+    assert "max_tokens" not in body
+    assert "temperature" not in body
+
+
+def test_build_azure_request_reasoning_model_allows_temperature_one(service):
+    """Azure reasoning deployments may still send default temperature=1."""
+    request = ChatCompletionRequest(
+        model="chat-alias",
+        messages=[ChatMessage(role="user", content="hi")],
+    )
+    provider = _make_provider(
+        provider_type=LLMProviderType.AZURE_OPENAI,
+        api_base="https://res.openai.azure.com",
+        config={"deployment_name": "o3-mini"},
+        default_temperature=1,
+        default_max_tokens=50,
+    )
+    model = _make_model(model_id="internal-alias")
+
+    _url, _headers, body = service._build_azure_request(request, provider, model)
+
+    assert body["temperature"] == 1
+    assert body["max_completion_tokens"] == 50
+    assert "max_tokens" not in body
+
+
 def test_build_anthropic_request_temperature_default(service):
     """Anthropic request uses provider default temperature (lines 330-332)."""
     request = ChatCompletionRequest(


### PR DESCRIPTION
## Summary

Fixes #5021.

This updates the Azure OpenAI chat request builder so reasoning-class deployments (for example `gpt-5.x`, `o1`/`o3`/`o4`, and `gpt-chat-latest`) do not receive parameters that Azure rejects:

- map requested/default `max_tokens` to `max_completion_tokens` for detected reasoning deployments;
- omit non-default `temperature` values for reasoning deployments, while still allowing `temperature=1`;
- stop the Admin UI chat test endpoint from forcing `max_tokens=100` when the test request omitted max tokens.

The detection checks the requested model, configured model id, and Azure deployment name so alias/deployment-based configurations are covered without adding a new DB field.

## Verification

```text
uv run pytest tests/unit/mcpgateway/services/test_llm_proxy_service.py::test_build_azure_request_defaults \
  tests/unit/mcpgateway/services/test_llm_proxy_service.py::test_build_azure_request_reasoning_model_uses_completion_tokens \
  tests/unit/mcpgateway/services/test_llm_proxy_service.py::test_build_azure_request_reasoning_model_allows_temperature_one \
  tests/unit/mcpgateway/routers/test_llm_admin_router.py::test_admin_test_api_chat_success \
  tests/unit/mcpgateway/routers/test_llm_admin_router.py::test_admin_test_api_chat_omits_default_max_tokens -q
# ..... [100%]

uv run pytest tests/unit/mcpgateway/services/test_llm_proxy_service.py tests/unit/mcpgateway/routers/test_llm_admin_router.py -q
# 112 passed

uv run ruff check mcpgateway/services/llm_proxy_service.py mcpgateway/routers/llm_admin_router.py tests/unit/mcpgateway/services/test_llm_proxy_service.py tests/unit/mcpgateway/routers/test_llm_admin_router.py
# All checks passed!

git diff --check
# no output
```
