### PR TITLE
fix: Admin UI Teams panel stuck on loading

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -14742,7 +14742,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
         const relationship = activeFilterBtn ? activeFilterBtn.getAttribute('data-filter') : 'all';
 
         // Preserve current pagination state (use inline Admin.getPaginationParams)
-        const paginationState = getPaginationParams('teams');
+        const paginationState = Admin.getPaginationParams('teams');
         const params = new URLSearchParams();
         params.set('page', paginationState.page);
         params.set('per_page', paginationState.perPage);


### PR DESCRIPTION
## 📌 Summary

The Admin UI Teams panel was stuck on "Loading teams..." and team creation was failing with a 400 error. The inline script in `admin.html` called `getPaginationParams` as a bare global, but the function is only available as `Admin.getPaginationParams` via the JS bundle.

## 🔗 Related Issue

Closes: #5084 

## 🔁 Reproduction Steps

1. Start the gateway with `make dev` or `make serve`
2. Navigate to `/admin` and click the **Teams** tab
3. Panel is stuck on "Loading teams..." — browser console shows `ReferenceError: getPaginationParams is not defined`
4. Attempting to create a team returns `POST /admin/teams 400`

## 🐞 Root Cause

`initializeTeamManagement()` in `mcpgateway/templates/admin.html` called bare `getPaginationParams('teams')`. The function is exported onto the `Admin` global object by the JS bundle (`Admin.getPaginationParams`) and is never placed directly in the global scope.

## 💡 Fix Description

Changed the call from `getPaginationParams('teams')` to `Admin.getPaginationParams('teams')` — consistent with how all other inline scripts in `admin.html` access bundle-exported utilities.

## 🧪 Verification

| Check                             | Command              | Status |
|-----------------------------------|----------------------|--------|
| Lint suite                        | `make lint`          |    Passed    |
| Unit tests                        | `make test`          |    Passed    |
| Coverage ≥ 90 %                   | `make coverage`      |   Passed     |
| Manual regression no longer fails | steps / screenshots  |   Passed     |

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed