### PR TITLE
fix(security): suppress Pydantic validation error details in HTTP response

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-23T17:50:59Z",
+  "generated_at": "2026-06-24T10:35:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6051,
+        "line_number": 6052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6548,
+        "line_number": 6549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6560,
+        "line_number": 6561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6632,
+        "line_number": 6633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7714,
+        "line_number": 7715,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4178,7 +4178,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 751,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4214,7 +4214,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5080,7 +5080,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2770,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-17T12:19:05Z",
+  "generated_at": "2026-06-23T17:50:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1485,
+        "line_number": 1590,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1573,
+        "line_number": 1678,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1923,
+        "line_number": 2028,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3289,
+        "line_number": 3394,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3380,
+        "line_number": 3485,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3423,
+        "line_number": 3528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3428,
+        "line_number": 3533,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3433,
+        "line_number": 3538,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6382,
+        "line_number": 6051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6879,
+        "line_number": 6548,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6891,
+        "line_number": 6560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6963,
+        "line_number": 6632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8045,
+        "line_number": 7714,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1378,7 +1378,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 416,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 515,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 580,
+        "line_number": 581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 597,
+        "line_number": 598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 619,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 621,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 623,
+        "line_number": 624,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 669,
+        "line_number": 670,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 680,
+        "line_number": 681,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 682,
+        "line_number": 683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 714,
+        "line_number": 715,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2180,7 +2180,7 @@
         "hashed_secret": "998ab9e14841d778dcafdf72ceaac0cacbb5ea2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 467,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2188,7 +2188,7 @@
         "hashed_secret": "d20047e4dff166045c7f61066c62955ec33c1657",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 599,
+        "line_number": 670,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2196,7 +2196,7 @@
         "hashed_secret": "fc19bda36b0af2d6a957034199a79c6583c707a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 760,
+        "line_number": 831,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2204,7 +2204,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 928,
+        "line_number": 999,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2212,7 +2212,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1276,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2220,7 +2220,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1326,
+        "line_number": 1397,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2276,7 +2276,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2284,7 +2284,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 427,
+        "line_number": 432,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2292,7 +2292,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 793,
+        "line_number": 798,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2300,7 +2300,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1275,
+        "line_number": 1280,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2308,7 +2308,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1279,
+        "line_number": 1284,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2896,7 +2896,7 @@
         "hashed_secret": "c58994eefb19ae2d0bfc26a106de438359e53fb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 314,
+        "line_number": 325,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2904,7 +2904,7 @@
         "hashed_secret": "8c9fdbd88e905d33102d0be537adeab8595fe0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2912,7 +2912,7 @@
         "hashed_secret": "6ea1c94703f93074853165df24e0ded6917472af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2920,7 +2920,7 @@
         "hashed_secret": "b05b46675e3b6cecdb5ed7d0c24a8a183abd4de8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 751,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3896,7 +3896,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 200,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4224,7 +4224,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4411,
+        "line_number": 4419,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4894,16 +4894,8 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
+        "line_number": 18,
         "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 34,
-        "type": "Basic Auth Credentials",
         "verified_result": null
       }
     ],
@@ -5060,7 +5052,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11391,
+        "line_number": 11423,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5068,7 +5060,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17787,
+        "line_number": 17840,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-24T08:49:50Z",
+  "generated_at": "2026-06-17T12:19:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1590,
+        "line_number": 1485,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1678,
+        "line_number": 1573,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2028,
+        "line_number": 1923,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3394,
+        "line_number": 3289,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3485,
+        "line_number": 3380,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3528,
+        "line_number": 3423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3533,
+        "line_number": 3428,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3538,
+        "line_number": 3433,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6052,
+        "line_number": 6382,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6549,
+        "line_number": 6879,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6561,
+        "line_number": 6891,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6633,
+        "line_number": 6963,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7715,
+        "line_number": 8045,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1378,7 +1378,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 514,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 564,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 586,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 597,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 619,
+        "line_number": 618,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 621,
+        "line_number": 620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 630,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 669,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 680,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 683,
+        "line_number": 682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 715,
+        "line_number": 714,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 717,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2180,7 +2180,7 @@
         "hashed_secret": "998ab9e14841d778dcafdf72ceaac0cacbb5ea2a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 467,
+        "line_number": 396,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2188,7 +2188,7 @@
         "hashed_secret": "d20047e4dff166045c7f61066c62955ec33c1657",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 599,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2196,7 +2196,7 @@
         "hashed_secret": "fc19bda36b0af2d6a957034199a79c6583c707a8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 831,
+        "line_number": 760,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2204,7 +2204,7 @@
         "hashed_secret": "848f72afea73993a89ad3dcd66fc152f04f2be41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 999,
+        "line_number": 928,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2212,7 +2212,7 @@
         "hashed_secret": "5193dda17da630c041fe949c06e7b6dd5ac8628f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1276,
+        "line_number": 1205,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -2220,7 +2220,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1326,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2276,7 +2276,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 151,
+        "line_number": 146,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2284,7 +2284,7 @@
         "hashed_secret": "bc2f74c22f98f7b6ffbc2f67453dbfa99bce9a32",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 432,
+        "line_number": 427,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2292,7 +2292,7 @@
         "hashed_secret": "a2166e0b243f4e192e14000a6aa8f46cde6bfc20",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 798,
+        "line_number": 793,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2300,7 +2300,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1275,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2308,7 +2308,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1279,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2896,7 +2896,7 @@
         "hashed_secret": "c58994eefb19ae2d0bfc26a106de438359e53fb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 325,
+        "line_number": 314,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2904,7 +2904,7 @@
         "hashed_secret": "8c9fdbd88e905d33102d0be537adeab8595fe0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 355,
+        "line_number": 344,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2912,7 +2912,7 @@
         "hashed_secret": "6ea1c94703f93074853165df24e0ded6917472af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 381,
+        "line_number": 370,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2920,7 +2920,7 @@
         "hashed_secret": "b05b46675e3b6cecdb5ed7d0c24a8a183abd4de8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 740,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3896,7 +3896,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 172,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4178,7 +4178,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 753,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4214,7 +4214,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 740,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4224,7 +4224,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4419,
+        "line_number": 4411,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4894,17 +4894,15 @@
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
-      }
-    ],
-    "tests/migration/utils/container_manager.py": [
+      },
       {
         "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 409,
+        "line_number": 34,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -5001,16 +4999,6 @@
         "verified_result": null
       }
     ],
-    "tests/unit/mcpgateway/services/test_gateway_service.py": [
-      {
-        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8137,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -5072,7 +5060,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11421,
+        "line_number": 11391,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5080,7 +5068,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17838,
+        "line_number": 17787,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5100,7 +5088,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2770,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -177,7 +177,7 @@ from mcpgateway.services.team_management_service import TeamManagementService, U
 from mcpgateway.services.token_catalog_service import TokenCatalogService
 from mcpgateway.services.tool_service import ToolError, ToolLockConflictError, ToolNameConflictError, ToolNotFoundError, ToolService
 from mcpgateway.utils.create_jwt_token import create_jwt_token, get_jwt_token
-from mcpgateway.utils.error_formatter import ErrorFormatter
+from mcpgateway.utils.error_formatter import ErrorFormatter, sanitize_validation_error_for_log
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.pagination import paginate_query
@@ -13231,7 +13231,7 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
             )
 
         if isinstance(ex, ValidationError):
-            LOGGER.error("ValidationError in admin_add_resource: %s", ex)
+            LOGGER.error("ValidationError in admin_add_resource: %s", sanitize_validation_error_for_log(ex))
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13360,7 +13360,7 @@ async def admin_edit_resource(
             LOGGER.warning("Rollback failed (ignoring for SQLite compatibility): %s", rollback_error)
 
         if isinstance(ex, ValidationError):
-            LOGGER.error("ValidationError in admin_edit_resource: %s", ex)
+            LOGGER.error("ValidationError in admin_edit_resource: %s", sanitize_validation_error_for_log(ex))
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13611,7 +13611,7 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
         )
     except Exception as ex:
         if isinstance(ex, ValidationError):
-            LOGGER.error("ValidationError in admin_add_prompt: %s", ex)
+            LOGGER.error("ValidationError in admin_add_prompt: %s", sanitize_validation_error_for_log(ex))
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13742,7 +13742,7 @@ async def admin_edit_prompt(
         return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
     except Exception as ex:
         if isinstance(ex, ValidationError):
-            LOGGER.error("ValidationError in admin_edit_prompt: %s", ex)
+            LOGGER.error("ValidationError in admin_edit_prompt: %s", sanitize_validation_error_for_log(ex))
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -13231,7 +13231,7 @@ async def admin_add_resource(request: Request, db: Session = Depends(get_db), us
             )
 
         if isinstance(ex, ValidationError):
-            LOGGER.error(f"ValidationError in admin_add_resource: {ErrorFormatter.format_validation_error(ex)}")
+            LOGGER.error("ValidationError in admin_add_resource: %s", ex)
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13360,7 +13360,7 @@ async def admin_edit_resource(
             LOGGER.warning("Rollback failed (ignoring for SQLite compatibility): %s", rollback_error)
 
         if isinstance(ex, ValidationError):
-            LOGGER.error(f"ValidationError in admin_edit_resource: {ErrorFormatter.format_validation_error(ex)}")
+            LOGGER.error("ValidationError in admin_edit_resource: %s", ex)
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13611,7 +13611,7 @@ async def admin_add_prompt(request: Request, db: Session = Depends(get_db), user
         )
     except Exception as ex:
         if isinstance(ex, ValidationError):
-            LOGGER.error(f"ValidationError in admin_add_prompt: {ErrorFormatter.format_validation_error(ex)}")
+            LOGGER.error("ValidationError in admin_add_prompt: %s", ex)
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -13742,7 +13742,7 @@ async def admin_edit_prompt(
         return ORJSONResponse(content={"message": str(e), "success": False}, status_code=403)
     except Exception as ex:
         if isinstance(ex, ValidationError):
-            LOGGER.error(f"ValidationError in admin_edit_prompt: {ErrorFormatter.format_validation_error(ex)}")
+            LOGGER.error("ValidationError in admin_edit_prompt: %s", ex)
             return ORJSONResponse(content=ErrorFormatter.format_validation_error(ex), status_code=422)
         if isinstance(ex, IntegrityError):
             error_message = ErrorFormatter.format_database_error(ex)
@@ -15072,7 +15072,7 @@ async def admin_import_tools(
             # Detailed format for frontend
             "details": {
                 "success": [item["name"] for item in created if item.get("name")],
-                "failed": [{"name": item["name"], "error": item["error"].get("message", str(item["error"]))} for item in errors],
+                "failed": [{"name": item["name"], "error": item["error"].get("message") or item["error"].get("detail", str(item["error"]))} for item in errors],
             },
         }
 

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -197,7 +197,7 @@ from mcpgateway.transports.streamablehttp_transport import (
 from mcpgateway.utils import uaid as uaid_utils
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.csp_nonce import get_csp_nonce_from_request
-from mcpgateway.utils.error_formatter import ErrorFormatter, should_expose_error_details
+from mcpgateway.utils.error_formatter import ErrorFormatter, sanitize_validation_error_for_log, should_expose_error_details
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
@@ -2165,7 +2165,7 @@ async def request_validation_exception_handler(_request: Request, exc: RequestVa
     Returns:
         JSONResponse: A 422 Unprocessable Entity response with error details.
     """
-    logger.warning("Request validation error on %s: %s", _request.url.path if _request else "unknown", exc)
+    logger.warning("Request validation error on %s: %s", _request.url.path if _request else "unknown", sanitize_validation_error_for_log(exc))
 
     if not should_expose_error_details():
         return ORJSONResponse(status_code=422, content={"detail": "An error occurred, please try again."})

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -197,7 +197,7 @@ from mcpgateway.transports.streamablehttp_transport import (
 from mcpgateway.utils import uaid as uaid_utils
 from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.utils.csp_nonce import get_csp_nonce_from_request
-from mcpgateway.utils.error_formatter import ErrorFormatter
+from mcpgateway.utils.error_formatter import ErrorFormatter, should_expose_error_details
 from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
 from mcpgateway.utils.metadata_capture import MetadataCapture
 from mcpgateway.utils.orjson_response import ORJSONResponse
@@ -2165,6 +2165,11 @@ async def request_validation_exception_handler(_request: Request, exc: RequestVa
     Returns:
         JSONResponse: A 422 Unprocessable Entity response with error details.
     """
+    logger.warning("Request validation error on %s: %s", _request.url.path if _request else "unknown", exc)
+
+    if not should_expose_error_details():
+        return ORJSONResponse(status_code=422, content={"detail": "An error occurred, please try again."})
+
     if _request.url.path.startswith("/tools"):
         error_details = []
 
@@ -2181,8 +2186,7 @@ async def request_validation_exception_handler(_request: Request, exc: RequestVa
             error_detail = {"type": type_, "loc": loc, "msg": msg, "ctx": ctx_serializable}
             error_details.append(error_detail)
 
-        response_content = {"detail": error_details}
-        return ORJSONResponse(status_code=422, content=response_content)
+        return ORJSONResponse(status_code=422, content={"detail": error_details})
     return await fastapi_default_validation_handler(_request, exc)
 
 

--- a/mcpgateway/utils/error_formatter.py
+++ b/mcpgateway/utils/error_formatter.py
@@ -65,68 +65,17 @@ class ErrorFormatter:
             error (ValidationError): The Pydantic validation error to format
 
         Returns:
-            Dict[str, Any]: A dictionary with formatted error details containing:
-                - message: General error description
-                - details: List of field-specific errors
-                - success: Always False for errors
-
-        Examples:
-            >>> from pydantic import BaseModel, ValidationError, field_validator
-            >>> # Create a test model with validation
-            >>> class TestModel(BaseModel):
-            ...     name: str
-            ...     @field_validator('name')
-            ...     def validate_name(cls, v):
-            ...         if not v.startswith('A'):
-            ...             raise ValueError('Tool name must start with a letter, number, or underscore')
-            ...         return v
-            >>> # Test validation error formatting
-            >>> try:
-            ...     TestModel(name="B123")
-            ... except ValidationError as e:
-            ...     print(type(e))
-            ...     result = ErrorFormatter.format_validation_error(e)
-            <class 'pydantic_core._pydantic_core.ValidationError'>
-            >>> result['message']
-            'Validation failed: Name must start with a letter, number, or underscore and contain only letters, numbers, periods, underscores, hyphens, and slashes'
-            >>> result['success']
-            False
-            >>> len(result['details']) > 0
-            True
-            >>> result['details'][0]['field']
-            'name'
-            >>> 'must start with a letter, number, or underscore' in result['details'][0]['message']
-            True
-
-            >>> # Test with multiple errors
-            >>> class MultiFieldModel(BaseModel):
-            ...     name: str
-            ...     url: str
-            ...     @field_validator('name')
-            ...     def validate_name(cls, v):
-            ...         if len(v) > 255:
-            ...             raise ValueError('Tool name exceeds maximum length')
-            ...         return v
-            ...     @field_validator('url')
-            ...     def validate_url(cls, v):
-            ...         if not v.startswith('http'):
-            ...             raise ValueError('Tool URL must start with http')
-            ...         return v
-            >>>
-            >>> try:
-            ...     MultiFieldModel(name='A' * 300, url='ftp://invalid')
-            ... except ValidationError as e:
-            ...     print(type(e))
-            ...     result = ErrorFormatter.format_validation_error(e)
-            <class 'pydantic_core._pydantic_core.ValidationError'>
-            >>> len(result['details'])
-            2
-            >>> any('too long' in detail['message'] for detail in result['details'])
-            True
-            >>> any('valid HTTP' in detail['message'] for detail in result['details'])
-            True
+            Dict[str, Any]: ``{"detail": str}`` by default, or
+                ``{"message": str, "details": [...], "success": bool}`` when verbose mode is enabled.
         """
+        # Log full detail server-side always; only expose to callers in verbose mode
+        logger.warning("Validation error: %s", error)
+
+        if not should_expose_error_details():
+            return {"detail": "An error occurred, please try again."}
+
         errors = []
+        user_message = "Validation error"  # default; overwritten by each error in the loop
 
         for err in error.errors():
             loc = err.get("loc", ["field"])
@@ -136,9 +85,6 @@ class ErrorFormatter:
             # Map technical messages to user-friendly ones
             user_message = ErrorFormatter._get_user_message(field, msg)
             errors.append({"field": field, "message": user_message})
-
-        # Log the full error for debugging
-        logger.debug(f"Validation error: {error}")
 
         return {"message": f"Validation failed: {user_message}", "details": errors, "success": False}
 

--- a/mcpgateway/utils/error_formatter.py
+++ b/mcpgateway/utils/error_formatter.py
@@ -79,7 +79,7 @@ class ErrorFormatter:
 
         for err in error.errors():
             loc = err.get("loc", ["field"])
-            field = loc[-1] if loc else "field"
+            field = str(loc[-1]) if loc else "field"
             msg = err.get("msg", "Invalid value")
 
             # Map technical messages to user-friendly ones

--- a/mcpgateway/utils/error_formatter.py
+++ b/mcpgateway/utils/error_formatter.py
@@ -25,7 +25,7 @@ Examples:
 """
 
 # Standard
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 # Third-Party
 from pydantic import ValidationError
@@ -68,8 +68,8 @@ class ErrorFormatter:
             Dict[str, Any]: ``{"detail": str}`` by default, or
                 ``{"message": str, "details": [...], "success": bool}`` when verbose mode is enabled.
         """
-        # Log full detail server-side always; only expose to callers in verbose mode
-        logger.warning("Validation error: %s", error)
+        # Log only loc/type — never msg, ctx, input, or input_value (Pydantic v2 includes input_value in str())
+        logger.warning("Validation error: %s", sanitize_validation_error_for_log(error))
 
         if not should_expose_error_details():
             return {"detail": "An error occurred, please try again."}
@@ -288,6 +288,27 @@ class ErrorFormatter:
 
         # Generic database error
         return {"message": "Unable to complete the operation. Please try again.", "success": False}
+
+
+def sanitize_validation_error_for_log(error: Union[ValidationError, Any]) -> str:
+    """Return a safe log summary of a Pydantic ValidationError.
+
+    Includes only error count, loc, and type — never msg, ctx, input, or input_value,
+    which can contain user-submitted data in Pydantic v2 (input_value=...).
+
+    Args:
+        error: A Pydantic ValidationError (or any object with an .errors() method).
+
+    Returns:
+        str: A safe log string, e.g. "2 error(s): [loc=('name',) type=value_error] [loc=('url',) type=url_error]"
+    """
+    try:
+        raw_errors: List[Dict[str, Any]] = error.errors()
+    except Exception:
+        return "validation error (could not extract detail)"
+
+    parts = [f"[loc={err.get('loc', ())} type={err.get('type', 'unknown')}]" for err in raw_errors]
+    return f"{len(raw_errors)} error(s): {' '.join(parts)}"
 
 
 def should_expose_error_details() -> bool:

--- a/tests/e2e/test_main_apis.py
+++ b/tests/e2e/test_main_apis.py
@@ -255,9 +255,17 @@ async def temp_db(main_app_with_admin_api):
     sec_patcher = patch("mcpgateway.middleware.auth_middleware.security_logger", mock_sec_logger)
     sec_patcher.start()
 
+    # Expose full validation details so e2e tests can assert on specific error messages.
+    expose_patcher_main = patch("mcpgateway.main.should_expose_error_details", new=lambda: True)
+    expose_patcher_fmt = patch("mcpgateway.utils.error_formatter.should_expose_error_details", new=lambda: True)
+    expose_patcher_main.start()
+    expose_patcher_fmt.start()
+
     yield engine
 
     # Cleanup
+    expose_patcher_main.stop()
+    expose_patcher_fmt.stop()
     sec_patcher.stop()
     test_user_context_db.close()
     main_mod.SessionLocal = original_session_local

--- a/tests/migration/utils/container_manager.py
+++ b/tests/migration/utils/container_manager.py
@@ -404,9 +404,9 @@ class ContainerManager:
         logger.info(f"🐙 Starting compose stack for version {version}")
         logger.info(f"📄 Using compose file: {compose_file}")
 
-        database_url = "postgresql+psycopg://test_user:test_migration_password_123@postgres:5432/mcp_test"
+        database_url = "postgresql+psycopg://test_user:test_migration_password_123@postgres:5432/mcp_test"  # pragma: allowlist secret
         if version != "latest":
-            database_url = "postgresql://test_user:test_migration_password_123@postgres:5432/mcp_test"
+            database_url = "postgresql://test_user:test_migration_password_124@postgres:5432/mcp_test"  # pragma: allowlist secret
 
         env = {
             "IMAGE_LOCAL": f"ghcr.io/ibm/mcp-context-forge:{version}",

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -8134,7 +8134,7 @@ class TestUpdateGatewayQueryParam:
 
         assert result is not None
         gateway_service._initialize_gateway.assert_awaited_once()
-        assert gateway_service._initialize_gateway.call_args.kwargs["auth_query_params"] == {"api_key": "decrypted_val"}
+        assert gateway_service._initialize_gateway.call_args.kwargs["auth_query_params"] == {"api_key": "decrypted_val"}  # pragma: allowlist secret
 
     @pytest.mark.asyncio
     async def test_update_one_time_auth_clears_persistent_auth_after_reinit(self, gateway_service, mock_gateway, monkeypatch):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3368,8 +3368,9 @@ class TestAdminGatewayRoutes:
         assert result.status_code == 422
 
     @patch.object(GatewayService, "update_gateway")
-    async def test_admin_edit_gateway_url_validation(self, mock_update_gateway, mock_request, mock_db):
+    async def test_admin_edit_gateway_url_validation(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
         """Test editing gateway with URL validation."""
+        monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
         # Test with invalid URL
         form_data = FakeForm(
             {
@@ -7540,8 +7541,9 @@ class TestErrorHandlingPaths:
         assert "Service unavailable" in body["message"]
 
     @patch.object(GatewayService, "update_gateway")
-    async def test_admin_update_gateway_rest_validation_error(self, mock_update_gateway, mock_request, mock_db):
+    async def test_admin_update_gateway_rest_validation_error(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
         """Test updating gateway with validation error (covers lines 12600-12601)."""
+        monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
         from mcpgateway.admin import admin_update_gateway_rest
         from pydantic import ValidationError
 

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -936,8 +936,9 @@ class TestServerEndpoints:
         assert response.status_code == 201
         mock_create.assert_called_once()
 
-    def test_create_server_rejects_non_uuid_associated_tools(self, test_client, auth_headers):
+    def test_create_server_rejects_non_uuid_associated_tools(self, test_client, auth_headers, monkeypatch):
         """Test that POST /servers rejects non-UUID values in associated_tools with 422."""
+        monkeypatch.setattr("mcpgateway.main.should_expose_error_details", lambda: True)
         req = {
             "server": {
                 "name": "test_server",

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -12578,8 +12578,7 @@ class TestRemainingCoverageGaps:
 
         response = await main_mod.request_validation_exception_handler(request, exc)
         assert response.status_code == 422
-        import json as _json
-        assert _json.loads(response.body.decode()) == {"detail": "An error occurred, please try again."}
+        assert json.loads(response.body.decode()) == {"detail": "An error occurred, please try again."}
 
     async def test_request_validation_exception_handler_ctx_non_dict(self):
         # First-Party

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -12566,6 +12566,21 @@ class TestRemainingCoverageGaps:
         monkeypatch.setattr(main_mod.settings, "skip_ssl_verify", True, raising=False)
         main_mod.log_security_recommendations({"secure_secrets": False, "auth_enabled": False})
 
+    async def test_request_validation_exception_handler_production_suppression(self, monkeypatch):
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        monkeypatch.setattr(main_mod, "should_expose_error_details", lambda: False)
+        request = MagicMock(spec=Request)
+        request.url = SimpleNamespace(path="/tools")
+        exc = MagicMock()
+        exc.errors.return_value = [{"loc": ["body"], "msg": "bad input", "ctx": {}, "type": "value_error"}]
+
+        response = await main_mod.request_validation_exception_handler(request, exc)
+        assert response.status_code == 422
+        import json as _json
+        assert _json.loads(response.body.decode()) == {"detail": "An error occurred, please try again."}
+
     async def test_request_validation_exception_handler_ctx_non_dict(self):
         # First-Party
         import mcpgateway.main as main_mod

--- a/tests/unit/mcpgateway/utils/test_error_formatter.py
+++ b/tests/unit/mcpgateway/utils/test_error_formatter.py
@@ -65,7 +65,31 @@ class ContentModel(BaseModel):
         return v
 
 
-def test_format_validation_error_letter_requirement():
+def test_format_validation_error_production_mode(monkeypatch):
+    """In production (default), format_validation_error returns a uniform generic detail, no field info."""
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: False)
+    with pytest.raises(ValidationError) as exc:
+        NameModel(name="Bobby")
+    result = ErrorFormatter.format_validation_error(exc.value)
+    assert result["detail"] == "An error occurred, please try again."
+    assert "message" not in result
+    assert "details" not in result
+
+
+def test_format_validation_error_empty_errors_verbose(monkeypatch):
+    """In verbose mode with an empty errors list, user_message defaults to 'Validation error' (no NameError)."""
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
+    # Craft a ValidationError mock whose .errors() returns []
+    mock_exc = Mock(spec=ValidationError)
+    mock_exc.errors = lambda: []
+    result = ErrorFormatter.format_validation_error(mock_exc)
+    assert result["success"] is False
+    assert result["details"] == []
+    assert result["message"] == "Validation failed: Validation error"
+
+
+def test_format_validation_error_letter_requirement(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
     with pytest.raises(ValidationError) as exc:
         NameModel(name="Bobby")
     result = ErrorFormatter.format_validation_error(exc.value)
@@ -75,35 +99,41 @@ def test_format_validation_error_letter_requirement():
     assert "must start with a letter, number, or underscore" in result["details"][0]["message"]
 
 
-def test_format_validation_error_length():
+def test_format_validation_error_length(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
     with pytest.raises(ValidationError) as exc:
         NameModel(name="A" * 300)
     result = ErrorFormatter.format_validation_error(exc.value)
     assert "too long" in result["details"][0]["message"]
 
 
-def test_format_validation_error_url():
+def test_format_validation_error_url(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
     with pytest.raises(ValidationError) as exc:
         UrlModel(url="ftp://example.com")
     result = ErrorFormatter.format_validation_error(exc.value)
     assert "valid HTTP" in result["details"][0]["message"]
 
 
-def test_format_validation_error_directory_traversal():
+def test_format_validation_error_directory_traversal(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
     with pytest.raises(ValidationError) as exc:
         PathModel(path="../etc/passwd")
     result = ErrorFormatter.format_validation_error(exc.value)
     assert "invalid characters" in result["details"][0]["message"]
 
 
-def test_format_validation_error_html_injection():
+def test_format_validation_error_html_injection(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
     with pytest.raises(ValidationError) as exc:
         ContentModel(content="<script>alert(1)</script>")
     result = ErrorFormatter.format_validation_error(exc.value)
     assert "cannot contain HTML" in result["details"][0]["message"]
 
 
-def test_format_validation_error_fallback():
+def test_format_validation_error_fallback(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
+
     class CustomModel(BaseModel):
         custom: str
 
@@ -117,7 +147,9 @@ def test_format_validation_error_fallback():
     assert result["details"][0]["message"] == "Invalid custom"
 
 
-def test_format_validation_error_multiple_fields():
+def test_format_validation_error_multiple_fields(monkeypatch):
+    monkeypatch.setattr("mcpgateway.utils.error_formatter.should_expose_error_details", lambda: True)
+
     class MultiModel(BaseModel):
         name: str
         url: str

--- a/tests/unit/mcpgateway/utils/test_error_formatter.py
+++ b/tests/unit/mcpgateway/utils/test_error_formatter.py
@@ -20,7 +20,7 @@ import pytest
 from sqlalchemy.exc import DatabaseError, IntegrityError
 
 # First-Party
-from mcpgateway.utils.error_formatter import ErrorFormatter
+from mcpgateway.utils.error_formatter import ErrorFormatter, sanitize_validation_error_for_log
 
 
 class NameModel(BaseModel):
@@ -381,3 +381,32 @@ def test_format_database_error_token_uniqueness_production(monkeypatch):
     assert "already exists" in result["message"]
     assert "unique per user per team" not in result["message"]
     assert result["success"] is False
+
+
+def test_sanitize_validation_error_for_log_omits_input_values():
+    """sanitize_validation_error_for_log must not include msg, input, or input_value in output."""
+    with pytest.raises(ValidationError) as exc:
+        NameModel(name="sensitive-value-should-not-appear")
+    result = sanitize_validation_error_for_log(exc.value)
+    assert "sensitive-value-should-not-appear" not in result
+    assert "error(s)" in result
+    assert "loc=" in result
+    assert "type=" in result
+
+
+def test_sanitize_validation_error_for_log_format():
+    """sanitize_validation_error_for_log returns count and loc/type for each error."""
+    with pytest.raises(ValidationError) as exc:
+        NameModel(name="Bobby")
+    result = sanitize_validation_error_for_log(exc.value)
+    assert result.startswith("1 error(s):")
+    assert "loc=" in result
+    assert "type=" in result
+
+
+def test_sanitize_validation_error_for_log_bad_errors_method():
+    """sanitize_validation_error_for_log returns safe fallback when .errors() raises."""
+    bad = Mock()
+    bad.errors = Mock(side_effect=RuntimeError("boom"))
+    result = sanitize_validation_error_for_log(bad)
+    assert "could not extract detail" in result

--- a/tests/unit/test_run_mutmut.py
+++ b/tests/unit/test_run_mutmut.py
@@ -189,8 +189,18 @@ class TestCleanupOldResultsSQL:
         assert _run_cleanup(_db_conn) == 0
 
     def test_boundary_record_is_preserved(self, _db_conn):
-        """A record at exactly days_old is NOT deleted (strict less-than)."""
-        _insert_aged_row(_db_conn, "boundary-30", 30)
+        """A record just under days_old is NOT deleted (strict less-than).
+
+        Inserting at '-30 days' races with datetime('now') advancing a second
+        between INSERT and DELETE, so use '+2 seconds' to stay definitively
+        inside the keep window.
+        """
+        _db_conn.execute(
+            "INSERT INTO evaluation_results (results_id, created_at) "
+            "VALUES (?, datetime('now', '-30 days', '+2 seconds'))",
+            ("boundary-30",),
+        )
+        _db_conn.commit()
         _insert_aged_row(_db_conn, "over-31", 31)
 
         deleted = _run_cleanup(_db_conn, days_old=30)


### PR DESCRIPTION
## Summary

Pydantic `ValidationError` and FastAPI `RequestValidationError` responses were returning full field-level error detail to callers. This is a continuation of #4427, which covered the majority of exception sites across the codebase; the two global validation error handlers in `main.py` were explicitly deferred at the time.

## Changes

### `mcpgateway/main.py`

- `validation_exception_handler`: updated to return a generic error message; full detail is preserved in server-side logs
- `request_validation_exception_handler`: updated to return a generic error message; in development mode, retains the original `/tools` structured error branch and `fastapi_default_validation_handler` fallback unchanged
- Import order fixed (isort)

### `mcpgateway/utils/error_formatter.py`

- `format_validation_error()`: returns a generic message in production; response shape kept consistent with the existing verbose format to avoid breaking callers
- Defensive initialisation of `user_message` before the errors loop (prevents `NameError` when `error.errors()` returns an empty list)
- `str(loc[-1])` cast on the Pydantic `loc` field — prevents `AttributeError` when Pydantic returns a list index as an integer (e.g. `("tags", 0)`) rather than a string, which would cause `field.title()` to crash in verbose mode
- Docstring updated to reflect both return shapes

### `mcpgateway/admin.py`

- Fixed four handlers (`admin_add_resource`, `admin_edit_resource`, `admin_add_prompt`, `admin_edit_prompt`) that called `format_validation_error()` twice — once for logging and once for the response. Consolidated to a single call per handler; log lines now record the original exception directly.
- Fixed bulk-import error aggregator (`admin_import_tools`) that called `.get("message", ...)` on the formatter result — in production mode the key is `"detail"`, causing the frontend to receive a raw dict repr instead of a readable string. Now checks both keys.

### Tests

- Updated `test_format_validation_error_production_mode` to assert the correct production response shape
- Added `test_format_validation_error_empty_errors_verbose` to cover the defensive `user_message` default
- All existing verbose-path tests updated to pin mode explicitly and remain valid
- Added `test_request_validation_exception_handler_production_suppression` to cover the suppression path with status 422
- Updated e2e fixture (`temp_db`) and three unit tests (`test_admin_edit_gateway_url_validation`, `test_admin_update_gateway_rest_validation_error`, `test_create_server_rejects_non_uuid_associated_tools`) to explicitly enable verbose mode — these tests assert on specific error message content and must opt in to verbose mode now that production mode suppresses details