### PR TITLE
fix(fedramp): keep /app group-owned by root for FIPS 0750 mode

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -159,6 +159,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
             | tee /usr/lib/tmpfiles.d/rootfiles.conf > /etc/tmpfiles.d/rootfiles.conf \
         && find /root -maxdepth 1 -name '.*' -type f -exec chmod 0740 {} \; \
         && chmod 0750 /root \
+        && (chgrp 0 /app 2>/dev/null || true) \
         && (chmod 0750 /app 2>/dev/null || true) \
         && (find /app -maxdepth 1 -name '.*' -type f -exec chmod 0740 {} \; 2>/dev/null || true) \
         && find /home -maxdepth 1 -mindepth 1 -type d -exec chmod 0750 {} \; \

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -479,6 +479,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
             | tee /usr/lib/tmpfiles.d/rootfiles.conf > /etc/tmpfiles.d/rootfiles.conf \
         && find /root -maxdepth 1 -name '.*' -type f -exec chmod 0740 {} \; \
         && chmod 0750 /root \
+        && (chgrp 0 /app 2>/dev/null || true) \
         && (chmod 0750 /app 2>/dev/null || true) \
         && (find /app -maxdepth 1 -name '.*' -type f -exec chmod 0740 {} \; 2>/dev/null || true) \
         && find /home -maxdepth 1 -mindepth 1 -type d -exec chmod 0750 {} \; \

--- a/scripts/fedramp-validate.sh
+++ b/scripts/fedramp-validate.sh
@@ -79,6 +79,14 @@ check "/app home dir permissions 0750 (RHEL-09-232050)" \
     "stat -c '%a' /app" \
     "750"
 
+# /app must stay group-owned by root (GID 0): OpenShift's arbitrary-UID model always
+# runs containers with GID 0, and 0750 strips "other" access — without group=root,
+# arbitrary-UID pods lose all access to /app (ModuleNotFoundError: No module named
+# 'gunicorn' at startup). Owner-UID match (10001) still works via owner bits regardless.
+check "/app group ownership is root (OpenShift arbitrary-UID compatibility)" \
+    "stat -c '%G' /app" \
+    "root"
+
 # RHEL-09-232045: /app user dotfiles must be 0740 or less permissive
 # -perm /037 matches: group-write (020), group-execute (010), other-rwx (007)
 check "/app dotfiles permissions 0740 or less (RHEL-09-232045)" \


### PR DESCRIPTION
## Summary
- The FIPS compliance block sets `/app` to mode `0750` to satisfy RHEL-09-232050 (interactive user home dir permissions). On `Containerfile.lite`, `/app` is owned `10001:10001`, so once the "other" bits are stripped, any runtime identity that doesn't match that UID/GID (e.g. OpenShift's arbitrary-UID model, which always runs with GID 0) loses all access to `/app/.venv` — surfacing as `ModuleNotFoundError: No module named 'gunicorn'` at startup.
- `chgrp 0 /app` before the `chmod 0750 /app` keeps the directory group-readable/traversable for GID-0 runtimes while still satisfying the `<= 0750` STIG requirement, matching the ownership pattern already used in the non-lite `Containerfile`.
- Extends `scripts/fedramp-validate.sh` with a check that `/app`'s group stays `root` so this can't silently regress.

## Test plan
- [ ] Build with `--build-arg ENABLE_FIPS=true` (UBI 9 base) and run `scripts/fedramp-validate.sh` inside the image
- [ ] Start the container under an arbitrary-UID/GID-0 security context and confirm gunicorn imports/starts successfully