### PR TITLE
fix: add defer attribute to Alpine.js bundle script tags

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -242,10 +242,10 @@
       window.htmxConfig = window.htmxConfig || {};
       window.htmxConfig.inlineScriptNonce = "{{ csp_nonce(request) }}";
     </script>
-    <script src="{{ root_path }}/static/{{ bundle_js }}"></script>
+    <script defer src="{{ root_path }}/static/{{ bundle_js }}"></script>
     {% if is_admin %}
-    <script src="{{ root_path }}/static/gantt-chart.js?v=3"></script>
-    <script src="{{ root_path }}/static/flame-graph.js?v=1"></script>
+    <script defer src="{{ root_path }}/static/gantt-chart.js?v=3"></script>
+    <script defer src="{{ root_path }}/static/flame-graph.js?v=1"></script>
     {% endif %}
     <!-- CodeMirror CSS -->
     {% if ui_airgapped %}


### PR DESCRIPTION
## Summary
Fixed Alpine.js initialization failure by adding the `defer` attribute to script tags in the admin UI template.

## Problem
The JavaScript bundle containing Alpine.js was loading in the `<head>` section without the `defer` attribute. This caused the scripts to execute immediately, before the `<body>` element was available in the DOM. Alpine.js tried to initialize but couldn't find the body element, causing it to fail silently and leaving the admin UI with unstyled HTML.

The browser console showed:
```
Alpine Warning: Unable to initialize. Trying to load Alpine before `<body>` is available.
Did you forget to add `defer` in Alpine's `<script>` tag?
```

## Solution
Modified `mcpgateway/templates/admin.html` to add the `defer` attribute to:
- Main `bundle.js` (contains Alpine.js)
- `gantt-chart.js`
- `flame-graph.js`

The `defer` attribute ensures scripts execute in order after the HTML document is fully parsed, which is exactly what Alpine.js needs to properly initialize.

## Testing
- Verified the admin UI now loads and styles correctly
- Confirmed Alpine.js initializes without console warnings
- All interactive elements function as expected

## Priority
**URGENT** - This is a production-blocking bug that breaks the entire admin UI. Please review and merge ASAP.