### PR TITLE
fix(ui): add defer attribute to script tags to prevent Alpine.js race condition

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4356,7 +4356,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15009,
+        "line_number": 15019,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -155,49 +155,56 @@
     </script>
 
     <!-- Password Validator (shared utility) -->
-    <script src="{{ root_path }}/static/js/password-validator.js" nonce="{{ csp_nonce(request) }}"></script>
+    <script defer src="{{ root_path }}/static/js/password-validator.js" nonce="{{ csp_nonce(request) }}"></script>
 
     <!-- CodeMirror -->
     {% if ui_airgapped %}
-    <script src="{{ root_path }}/static/vendor/codemirror/codemirror.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/addon/mode/simple.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/mode/javascript/javascript.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/mode/python/python.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/mode/shell/shell.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/mode/go/go.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/codemirror/mode/rust/rust.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/codemirror.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/addon/mode/simple.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/mode/javascript/javascript.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/mode/python/python.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/mode/shell/shell.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/mode/go/go.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/codemirror/mode/rust/rust.min.js"></script>
     {% else %}
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.js"
       integrity="{{ sri_hashes.codemirror_js }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/addon/mode/simple.min.js"
       integrity="{{ sri_hashes.codemirror_addon_simple }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/javascript/javascript.min.js"
       integrity="{{ sri_hashes.codemirror_mode_javascript }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/python/python.min.js"
       integrity="{{ sri_hashes.codemirror_mode_python }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/shell/shell.min.js"
       integrity="{{ sri_hashes.codemirror_mode_shell }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/go/go.min.js"
       integrity="{{ sri_hashes.codemirror_mode_go }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/rust/rust.min.js"
       integrity="{{ sri_hashes.codemirror_mode_rust }}"
       crossorigin="anonymous">
@@ -206,9 +213,10 @@
     {% if is_admin %}
     <!-- Chart.js -->
     {% if ui_airgapped %}
-    <script src="{{ root_path }}/static/vendor/chartjs/chart.umd.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/chartjs/chart.umd.min.js"></script>
     {% else %}
     <script
+      defer
       src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
       integrity="{{ sri_hashes.chartjs }}"
       crossorigin="anonymous">
@@ -217,15 +225,17 @@
     {% endif %}
     <!-- Markdown and Sanitization -->
     {% if ui_airgapped %}
-    <script src="{{ root_path }}/static/vendor/marked/marked.min.js"></script>
-    <script src="{{ root_path }}/static/vendor/dompurify/purify.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/marked/marked.min.js"></script>
+    <script defer src="{{ root_path }}/static/vendor/dompurify/purify.min.js"></script>
     {% else %}
     <script
+      defer
       src="https://cdn.jsdelivr.net/npm/marked@18.0.3/lib/marked.umd.js"
       integrity="{{ sri_hashes.marked }}"
       crossorigin="anonymous">
     </script>
     <script
+      defer
       src="https://cdn.jsdelivr.net/npm/dompurify@3.4.2/dist/purify.min.js"
       integrity="{{ sri_hashes.dompurify }}"
       crossorigin="anonymous">
@@ -242,10 +252,10 @@
       window.htmxConfig = window.htmxConfig || {};
       window.htmxConfig.inlineScriptNonce = "{{ csp_nonce(request) }}";
     </script>
-    <script src="{{ root_path }}/static/{{ bundle_js }}"></script>
+    <script defer src="{{ root_path }}/static/{{ bundle_js }}"></script>
     {% if is_admin %}
-    <script src="{{ root_path }}/static/gantt-chart.js?v=3"></script>
-    <script src="{{ root_path }}/static/flame-graph.js?v=1"></script>
+    <script defer src="{{ root_path }}/static/gantt-chart.js?v=3"></script>
+    <script defer src="{{ root_path }}/static/flame-graph.js?v=1"></script>
     {% endif %}
     <!-- CodeMirror CSS -->
     {% if ui_airgapped %}

--- a/mcpgateway/templates/change-password-required.html
+++ b/mcpgateway/templates/change-password-required.html
@@ -63,7 +63,7 @@
       }
     </script>
     <!-- Password Validator (shared utility) -->
-    <script src="{{ root_path }}/static/js/password-validator.js" nonce="{{ csp_nonce(request) }}"></script>
+    <script defer src="{{ root_path }}/static/js/password-validator.js" nonce="{{ csp_nonce(request) }}"></script>
     <!-- Font Awesome -->
     {% if ui_airgapped %}
     <link rel="stylesheet" href="{{ root_path }}/static/vendor/fontawesome/css/all.min.css" />


### PR DESCRIPTION
## 🔗 Related Issue
Closes #5116

---

## 📝 Summary

Fixed a race condition where the admin UI would fail to load properly on slow networks (2G/3G), displaying as unstyled HTML instead of the styled interface. The issue occurred because JavaScript libraries (Alpine.js, CodeMirror, Chart.js, etc.) were loading in the `<head>` section without the `defer` attribute, causing them to execute before the DOM was ready.

**Root Cause**: Introduced in PR #4676 (commit `22966d62f`) when Alpine.js was migrated from CDN to Vite-bundled build. The CDN version had `defer`, but it was accidentally omitted during migration.

**Solution**: Added `defer` attribute to all 25 script tags across 2 template files, ensuring scripts execute in order after HTML parsing is complete.

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

**Manual Testing**:
- ✅ Hard refresh browser after changes
- ✅ Verify page loads correctly on slow connections
- ✅ Confirm no Alpine.js initialization errors in console

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes (N/A - HTML template changes)
- [x] Documentation updated (if applicable) (N/A)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Files Changed
1. **`mcpgateway/templates/admin.html`** - Added `defer` to 24 script tags:
   - Main bundle (Alpine.js + HTMX)
   - Password validator utility
   - CodeMirror core + 6 language modes (both airgapped and CDN)
   - Chart.js (both airgapped and CDN)
   - Marked + DOMPurify (both airgapped and CDN)
   - Gantt chart and Flame graph utilities

2. **`mcpgateway/templates/change-password-required.html`** - Added `defer` to 1 script tag:
   - Password validator utility

### Why `defer` Fixes This

The `defer` attribute ensures:
- Scripts download in parallel without blocking HTML parsing
- Scripts execute in order after the HTML document is fully parsed
- The DOM is guaranteed to be ready when scripts run
- No race conditions, even on slow/throttled networks

### Browser Console Error (Before Fix)
```
Alpine Warning: Unable to initialize. Trying to load Alpine before `<body>` is available.
Did you forget to add `defer` in Alpine's `<script>` tag?
```

### Important Note
Tailwind CSS scripts intentionally do NOT have `defer` because Tailwind is a JIT CSS compiler that must run immediately before page render.

### Testing Instructions
1. Hard refresh browser (Ctrl+Shift+R / Cmd+Shift+R) to clear cache
2. Open DevTools → Network tab
3. Enable throttling (Good 2G or Regular 3G)
4. Navigate to admin UI and log in
5. Verify page loads with proper styling
6. Check console for no Alpine.js errors