### PR TITLE
fix(compose): repoint fast_test_server build context to renamed rust crate

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-15T10:29:00Z",
+  "generated_at": "2026-06-08T14:11:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1082,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2189,
+        "line_number": 2190,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2647,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2646,
+        "line_number": 2647,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2659,
+        "line_number": 2660,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2807,
+        "line_number": 2808,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2828,
+        "line_number": 2829,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2836,
+        "line_number": 2837,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2841,
+        "line_number": 2842,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docker-compose-debug.yml
+++ b/docker-compose-debug.yml
@@ -1275,7 +1275,8 @@ services:
   ###############################################################################
   fast_test_server:
     build:
-      context: ./mcp-servers/rust/fast-test-server
+      # Context builds the renamed rust fast-time-server crate; image/service name kept as fast-test-server to avoid colliding with the Go fast_time_server.
+      context: ./mcp-servers/rust/fast-time-server
       dockerfile: Containerfile
     image: mcpgateway/fast-test-server:latest
     restart: unless-stopped

--- a/docker-compose-performance.yml
+++ b/docker-compose-performance.yml
@@ -1542,7 +1542,8 @@ services:
   ###############################################################################
   fast_test_server:
     build:
-      context: ./mcp-servers/rust/fast-test-server
+      # Context builds the renamed rust fast-time-server crate; image/service name kept as fast-test-server to avoid colliding with the Go fast_time_server.
+      context: ./mcp-servers/rust/fast-time-server
       dockerfile: Containerfile
     image: mcpgateway/fast-test-server:latest
     restart: unless-stopped

--- a/docker-compose-verbose-logging.yml
+++ b/docker-compose-verbose-logging.yml
@@ -1407,7 +1407,8 @@ services:
   ###############################################################################
   fast_test_server:
     build:
-      context: ./mcp-servers/rust/fast-test-server
+      # Context builds the renamed rust fast-time-server crate; image/service name kept as fast-test-server to avoid colliding with the Go fast_time_server.
+      context: ./mcp-servers/rust/fast-time-server
       dockerfile: Containerfile
     image: mcpgateway/fast-test-server:latest
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2063,7 +2063,8 @@ services:
   ###############################################################################
   fast_test_server:
     build:
-      context: ./mcp-servers/rust/fast-test-server
+      # Context builds the renamed rust fast-time-server crate; image/service name kept as fast-test-server to avoid colliding with the Go fast_time_server.
+      context: ./mcp-servers/rust/fast-time-server
       dockerfile: Containerfile
     image: mcpgateway/fast-test-server:latest
     restart: unless-stopped

--- a/tests/performance/utils/generate_docker_compose.py
+++ b/tests/performance/utils/generate_docker_compose.py
@@ -137,7 +137,8 @@ FAST_TIME_SERVER_TEMPLATE = """  fast_time_server:
 
 FAST_TEST_SERVER_TEMPLATE = """  fast_test_server:
     build:
-      context: ./mcp-servers/rust/fast-test-server
+      # Context builds the renamed rust fast-time-server crate; image/service name kept as fast-test-server to avoid colliding with the Go fast_time_server.
+      context: ./mcp-servers/rust/fast-time-server
       dockerfile: Dockerfile
     container_name: fast_test_server
     extra_hosts:


### PR DESCRIPTION
## Summary

#5059 renamed the rust crate `mcp-servers/rust/fast-test-server` → `mcp-servers/rust/fast-time-server` (and rewrote it without `rmcp`), and moved its `Containerfile`/`Dockerfile`/`Makefile` along with it. Nice cleanup. However, the top-level compose definitions that build the `fast_test_server` service were not updated, so they still point at the old, now-deleted build context.

## Impact

On a clean checkout (fresh clone / CI, where `mcpgateway/fast-test-server:latest` is not cached), `make testing-up` aborts:

```
Image mcpgateway/fast-test-server:latest Building
 #2 load build definition from Containerfile
failed to solve: failed to read dockerfile: open Containerfile: no such file or directory
make: *** [testing-up] Error 1
```

The `fast_test_server` service uses a local-only image tag with a `build:` section, so `docker compose up` falls back to building from `./mcp-servers/rust/fast-test-server`, which no longer contains a `Containerfile`. This breaks the testing stack that the release validation runs against.

## Change

Repoint the build context from `./mcp-servers/rust/fast-test-server` to `./mcp-servers/rust/fast-time-server` in every place that referenced the old path:

- `docker-compose.yml`
- `docker-compose-debug.yml`
- `docker-compose-performance.yml`
- `docker-compose-verbose-logging.yml`
- `tests/performance/utils/generate_docker_compose.py` (compose generator)

The renamed crate is a drop-in for this service: same tools (echo, get_system_time, convert_time, get_stats, schema_success, schema_error), same `/health` and `/api` endpoints, and it honors `BIND_ADDRESS` (compose overrides to `0.0.0.0:8880`).

## Verification

- **Before (unfixed main):** removed the cached image, `make testing-up` → fails with `failed to read dockerfile: open Containerfile`.
- **After (this change):** `make testing-up` → `fast-test-server:latest Built`, stack starts, gateway `/health` 200, the `fast_test` gateway registers and is reachable.
- All four compose files pass `docker compose config`.

## Note

The service is still named `fast_test_server` and tagged `mcpgateway/fast-test-server:latest` while building the `fast-time-server` crate. This PR keeps the change minimal (path-only) to unblock the testing stack; a follow-up could align the service/image names with the new crate name if desired.

Related: #5059

---

## Verification: clean `make testing-up` after the fix

Full teardown → clean → rebuild → up (`make testing-down compose-clean` + `make testing-up`), exit `0`:

```
🧪 Starting testing stack (fast_test_server)...
 Container mcp-context-forge-fast_test_server-1  Built / Started (healthy)
✅ Testing stack started!

Service              URL                           Purpose
Gateway (nginx)      http://localhost:8080         API proxy
Fast Test Server     http://localhost:8880         MCP benchmark target
...
   📝 Auto-registered:
      • MCP gateway: fast_test (from fast_test_server)
```

All services healthy:

```
fast_test_server   Up (healthy)      gateway x3   Up (healthy)      nginx      Up (healthy)
postgres           Up (healthy)      redis        Up (healthy)      pgbouncer  Up (healthy)
keycloak           Up (healthy)      a2a_echo     Up (healthy)      ...
```

Endpoint checks:

```
gateway /health (8080)         : 200
fast_test_server /health (8880): 200
fast_test gateway reachable    : true
```

Confirms the renamed rust crate builds from the corrected context and the full testing stack comes up healthy.


## Verification: `make benchmark-mcp-tools` works

Tools-only MCP load benchmark driven through the gateway against the rebuilt rust `fast_test_server`, exit `0`:

```
📊 Running tools-only MCP benchmark...
   Host: http://localhost:8080
   Server: b8e3f1a2c4d5e6f7a1b2c3d4e5f6a7b8
   Users: 10, Spawn: 2/s, Duration: 30s
==========================================================================================
MCP STREAMABLE HTTP PROTOCOL — RESULTS
==========================================================================================
  Total Requests:              740
  Total Failures:                0 (0.00%)
  Requests/sec (RPS):        24.83
  Response Times (ms):
    Average:      309.75
    p50:          270.00
    p90:          540.00
    p95:          700.00
    p99:         1200.00

  Name                          Reqs   Fails    RPS   Avg(ms)  p99(ms)
  MCP tools/call [rapid]         695      0     23.3    313.8   1200.0
  MCP tools/list [rapid]          35      0      1.2    304.2   1200.0
  MCP initialize                  10      0      0.3     45.7     90.0
==========================================================================================
```

0% failures over 740 requests confirms the command works end to end against the fixed server.
