### PR TITLE
fix(fedramp): re-assert python3 symlink after subscription-manager clobbers it

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -130,6 +130,12 @@ RUN chown -R 1001:0 /app && \
 #           subscription-manager (RHEL-09-215010), pam_wheel (RHEL-09-432035),
 #           init file perms 0740 (RHEL-09-232045), home dir perms 0750 (RHEL-09-232050),
 #           rootfiles tmpfile.d (RHEL-09-232045), SSH RekeyLimit
+#
+# NOTE: subscription-manager pulls in UBI9's system python3 (3.9) as a
+# dependency, which overwrites /usr/bin/python3 and clobbers the
+# python3 -> python${PYTHON_VERSION} symlink set up earlier — surfacing at
+# runtime as a misleading "ModuleNotFoundError: No module named 'gunicorn'".
+# We re-create the symlink right after the package install below.
 RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         if ! grep -q "release 9" /etc/redhat-release 2>/dev/null; then \
             echo "ERROR: ENABLE_FIPS=true requires UBI 9 base images (UBI_MINIMAL must be ubi9/ubi-minimal)" >&2; \
@@ -138,6 +144,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         microdnf install -y crypto-policies crypto-policies-scripts rootfiles \
             gnutls-utils nss-tools subscription-manager \
         && microdnf clean all \
+        && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 \
         && (test -f /usr/share/crypto-policies/policies/modules/STIG.pmod \
             || printf '# STIG module stub — not shipped in UBI9 minimal\n' \
                > /usr/share/crypto-policies/policies/modules/STIG.pmod) \

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -450,6 +450,12 @@ EXPOSE 4444
 #           subscription-manager (RHEL-09-215010), pam_wheel (RHEL-09-432035),
 #           init file perms 0740 (RHEL-09-232045), home dir perms 0750 (RHEL-09-232050),
 #           rootfiles tmpfile.d (RHEL-09-232045), SSH RekeyLimit
+#
+# NOTE: subscription-manager pulls in UBI9's system python3 (3.9) as a
+# dependency, which overwrites /usr/bin/python3 and clobbers the
+# python3 -> python${PYTHON_VERSION} symlink set up earlier — surfacing at
+# runtime as a misleading "ModuleNotFoundError: No module named 'gunicorn'".
+# We re-create the symlink right after the package install below.
 RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         if ! grep -q "release 9" /etc/redhat-release 2>/dev/null; then \
             echo "ERROR: ENABLE_FIPS=true requires UBI 9 base images (UBI_MINIMAL must be ubi9/ubi-minimal)" >&2; \
@@ -458,6 +464,7 @@ RUN if [ "$ENABLE_FIPS" = "true" ]; then \
         microdnf install -y crypto-policies crypto-policies-scripts rootfiles \
             gnutls-utils nss-tools subscription-manager \
         && microdnf clean all \
+        && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 \
         && (test -f /usr/share/crypto-policies/policies/modules/STIG.pmod \
             || printf '# STIG module stub — not shipped in UBI9 minimal\n' \
                > /usr/share/crypto-policies/policies/modules/STIG.pmod) \

--- a/scripts/fedramp-validate.sh
+++ b/scripts/fedramp-validate.sh
@@ -93,6 +93,18 @@ check "/app dotfiles permissions 0740 or less (RHEL-09-232045)" \
     "find /app -maxdepth 1 -name '.*' -type f -perm /037 -printf '%f\n' | sort | tr '\n' ',' | sed 's/,$//'" \
     ""
 
+# Regression guard for WO issue #68373: "ModuleNotFoundError: No module named
+# 'gunicorn'" at pod startup has surfaced from two independent FIPS-block root
+# causes — (1) /app losing GID-0 access at 0750 (fixed by the group-ownership
+# check above) and (2) subscription-manager (RHEL-09-215010) silently
+# overwriting /usr/bin/python3 with UBI9's system python3 (3.9), breaking the
+# venv interpreter binding. This end-to-end check exercises the actual
+# failure mode directly, so either cause — or any future variant — fails here
+# instead of in a customer pod.
+check "runtime python3 can import gunicorn from the venv (regression: #68373)" \
+    "python3 -c 'import gunicorn; print(\"GUNICORN_OK\")'" \
+    "GUNICORN_OK"
+
 echo ""
 echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
 


### PR DESCRIPTION
## Summary
- `subscription-manager` (installed in the FIPS/FedRAMP compliance block for STIG control RHEL-09-215010) pulls in UBI9's system `python3` (3.9) as a transitive dependency, silently overwriting `/usr/bin/python3` and clobbering the `python3 -> python${PYTHON_VERSION}` binding configured earlier in the build
- The runtime interpreter then can't see the venv's `site-packages` (built against 3.11/3.12), surfacing at pod startup as a misleading `ModuleNotFoundError: No module named 'gunicorn'` — independent of, and with the same symptom as, the GID-0 access issue fixed in #5112
- Re-create the `python3` symlink immediately after the `subscription-manager` install in both `Containerfile` and `Containerfile.lite` (nothing later in the FIPS block reinstalls a conflicting `python3` package)
- Add an end-to-end regression check to `scripts/fedramp-validate.sh` that imports `gunicorn` through the runtime `python3`, so this — or any future variant producing the same symptom — fails validation immediately instead of surfacing in a customer pod

## Test plan
- [x] `make container-build-fips CONTAINER_FILE=Containerfile.lite` — build succeeds
- [x] Confirmed `readlink -f /usr/bin/python3` resolves to `python3.11` and matches `/app/.venv/bin/python3 --version` inside the built image
- [x] `make container-validate-fedramp` — all checks pass including the new `runtime python3 can import gunicorn from the venv` check
- [x] Live `docker run` smoke test — gunicorn workers boot and the app starts without `ModuleNotFoundError`
- [x] Repeated all of the above for the non-lite `Containerfile`