### PR TITLE
Fix react UI auth bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8000","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/app/auth/login","/admin/login","/admin/forgot-password","/admin/reset-password"]
+CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/app/auth/login","/app/auth/logout","/admin/login","/admin/forgot-password","/admin/reset-password"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -2162,7 +2162,7 @@ async def get_user_email_from_token(payload: dict, db: Session) -> Optional[str]
     # Fall back to email (legacy format)
     return sub
 
-    
+
 async def get_current_user_from_cookie(
     request: Request,
 ) -> tuple[EmailUser, Optional[str]]:

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -2185,9 +2185,19 @@ async def get_current_user_from_cookie(
         logger.debug("JWT cookie validation failed: %s", e)
         raise_auth_error("invalid_token", "Invalid or expired token")
 
-    email = payload.get("sub")
-    if not email:
+    sub = payload.get("sub")
+    if not sub:
         raise_auth_error("invalid_token", "Invalid token: missing subject")
+
+    # If sub is a UUID (new token format), resolve to email via DB lookup
+    email = sub
+    try:
+        uuid.UUID(sub)
+        resolved = await asyncio.to_thread(_get_email_by_id_sync, sub)
+        if resolved is not None:
+            email = resolved
+    except ValueError:
+        pass  # sub is already an email (legacy format)
 
     jti = payload.get("jti")
     if jti:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -446,6 +446,7 @@ class Settings(BaseSettings):
             "/auth/email/forgot-password",
             "/auth/email/reset-password",
             "/app/auth/login",  # Exempt: React app login endpoint
+            "/app/auth/logout",  # Exempt: logout must clear cookies even if CSRF token is expired
             "/admin",  # Exempt: all admin routes use per-route enforce_admin_csrf dependency
             "/admin/login",
             "/admin/forgot-password",

--- a/mcpgateway/middleware/rbac.py
+++ b/mcpgateway/middleware/rbac.py
@@ -357,9 +357,6 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
     is_same_origin_referer = False
     if referer:
         try:
-            # Standard
-            from urllib.parse import urlparse
-
             referer_parsed = urlparse(referer)
             request_host = request.headers.get("host", "")
             # Match if referer host matches request host and path contains /admin or /oauth/callback
@@ -370,34 +367,44 @@ async def get_current_user_with_permissions(request: Request, credentials: Optio
 
     sec_fetch_mode = request.headers.get("sec-fetch-mode", "")
     sec_fetch_site = request.headers.get("sec-fetch-site", "")
-    is_admin_ui_request = "/admin" in referer
+    # Same-origin check (is_same_origin_referer) already covers /admin and /oauth/callback.
+    # Plain string matching on referer would allow cross-origin admin referers.
+    is_admin_ui_request = is_same_origin_referer
     request_path = request.url.path
     # SPA shell/document navigations — path == "/app" covers navigations without text/html Accept.
     is_spa_document_request = request_path == "/app"
-    referer_path = urlparse(referer).path if referer else ""
+    try:
+        referer_path = urlparse(referer).path if referer else ""
+    except Exception:
+        referer_path = ""
     is_app_referer = referer_path == "/app" or referer_path.startswith("/app/")
 
     # Validate full origin (scheme + host) when using X-Requested-With fallback
     # to prevent forged referers like https://evil.example/app/...
     referer_origin_valid = False
     if referer:
-        parsed_referer = urlparse(referer)
-        referer_origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
-        # Get allowed origins from app_domain and trusted origins
-        app_domain = str(settings.app_domain)
-        parsed_app = urlparse(app_domain)
-        app_origin = f"{parsed_app.scheme}://{parsed_app.netloc}"
-        allowed_origins = {app_origin}
-        allowed_origins.update(settings.csrf_trusted_origins)
-        referer_origin_valid = referer_origin in allowed_origins
+        try:
+            parsed_referer = urlparse(referer)
+            referer_origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
+            # Get allowed origins from app_domain and trusted origins
+            app_domain = str(settings.app_domain)
+            parsed_app = urlparse(app_domain)
+            app_origin = f"{parsed_app.scheme}://{parsed_app.netloc}"
+            allowed_origins = {app_origin}
+            allowed_origins.update(settings.csrf_trusted_origins)
+            referer_origin_valid = referer_origin in allowed_origins
+        except Exception:
+            pass  # Invalid referer URL, treat as not same-origin
 
     # First-party React fetches from the SPA. Sec-Fetch-* are forbidden request
     # headers in browsers, and the /app referer ties the request to the client UI
     # instead of allowing arbitrary cookie-authenticated API calls.
     # X-Requested-With: XMLHttpRequest requires both /app path AND valid origin.
+    # Only same-origin (not same-site) is accepted — same-site allows cross-subdomain
+    # requests which should not grant cookie-based API access.
     has_xhr_header = request.headers.get("x-requested-with") == "XMLHttpRequest"
-    is_first_party_app_fetch = is_app_referer and ((sec_fetch_site in {"same-origin", "same-site"} and sec_fetch_mode in {"cors", "same-origin"}) or (has_xhr_header and referer_origin_valid))
-    is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request or is_spa_document_request or is_first_party_app_fetch
+    is_first_party_app_fetch = is_app_referer and ((sec_fetch_site == "same-origin" and sec_fetch_mode in {"cors", "same-origin"}) or (has_xhr_header and referer_origin_valid))
+    is_browser_request = "text/html" in accept_header or is_htmx or is_admin_ui_request or is_spa_document_request or is_first_party_app_fetch or is_same_origin_referer
 
     # SECURITY: Reject cookie-only authentication for API requests
     # Cookies should only be used for browser/HTML requests (including admin UI and React SPA fetch calls)

--- a/mcpgateway/routers/app.py
+++ b/mcpgateway/routers/app.py
@@ -129,8 +129,9 @@ async def auth_login(
 
         payload = await verify_jwt_token_cached(token, request)
         session_id = payload.get("jti", "")
+        user_sub = payload.get("sub", user.email)
         csrf_service = get_csrf_service()
-        csrf_token = csrf_service.generate_csrf_token(user_id=user.email, session_id=session_id)
+        csrf_token = csrf_service.generate_csrf_token(user_id=user_sub, session_id=session_id)
         set_csrf_cookie(response, csrf_token, settings)
 
         logger.debug("User authenticated via cookie auth")
@@ -167,93 +168,58 @@ async def get_me(
 
 @app_router.post("/auth/logout")
 async def logout(
+    request: Request,
     response: Response,
-    user_ctx: Annotated[tuple[EmailUser, str | None], Depends(get_current_user_from_cookie)],
 ) -> dict[str, str]:
-    """Revoke JWT server-side and clear auth cookies.
+    """Clear auth cookies and revoke JWT server-side (best-effort).
 
-    Security Flow:
-        1. CSRF validation (via Depends) - prevents cross-site logout attacks
-        2. Authentication check (via get_current_user_from_cookie)
-        3. Server-side token revocation (best-effort)
-        4. Cookie clearing (always succeeds)
+    Cookie clearing always succeeds regardless of auth or revocation state.
+    This endpoint is CSRF-exempt so that logout works even when the CSRF token
+    has expired or is missing (e.g., after a long idle session).
 
-    Token Revocation Pattern (Best-Effort):
-        Token revocation is attempted but not required for logout success. This design
-        prioritizes user experience and availability over strict revocation guarantees:
-
-        Success Case:
-            - Token added to blocklist (Redis/DB)
-            - User immediately logged out client-side (cookies cleared)
-            - Token rejected on subsequent requests (blocklist check)
-
-        Failure Case (Redis/DB unavailable):
-            - Revocation fails but logout succeeds (cookies still cleared)
-            - User immediately logged out client-side
-            - Token remains valid until natural expiry (settings.token_expiry)
-            - Failure logged with correlation ID for monitoring/alerting
-            - Metric recorded for observability (auth.token_revocation_failure)
-
-        Rationale:
-            - Logout must always succeed from user perspective (UX requirement)
-            - Cookie clearing provides immediate client-side protection
-            - Token TTL bounds exposure window (default: 20 minutes)
-            - Monitoring/alerting enables operational response to blocklist outages
-            - Alternative: Fail logout on revocation failure (poor UX, availability impact)
-
-        Security Considerations:
-            - Tokens without JTI cannot be revoked (logged as warning)
-            - Short token_expiry (5-20 min recommended) limits exposure
-            - Monitor auth.token_revocation_failure metric for blocklist health
-            - Consider token_idle_timeout for additional protection
+    Token revocation is best-effort: if the blocklist is unavailable, cookies
+    are still cleared and the token expires naturally (settings.token_expiry).
 
     Returns:
         dict: Success message with "message" key
-
-    Raises:
-        HTTPException: 401 if authentication fails
-        HTTPException: 403 if CSRF validation fails
-        HTTPException: 500 if internal error occurs
     """
-    try:
-        user, jti = user_ctx
-        if jti:
-            try:
+    # Always clear cookies first — regardless of what follows.
+    clear_auth_cookie(response, path=JWT_COOKIE_PATH)
+    clear_csrf_cookie(response, settings)
+
+    # Best-effort: revoke the JWT so it cannot be reused before natural expiry.
+    raw_token = request.cookies.get("jwt_token")
+    if raw_token:
+        try:
+            from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
+
+            payload = await verify_jwt_token_cached(raw_token, request)
+            jti = payload.get("jti")
+            user_email = payload.get("email") or payload.get("sub", "unknown")
+            if jti:
                 blocklist_service = get_token_blocklist_service()
-                await asyncio.to_thread(blocklist_service.revoke_token, jti, user.email, "logout")
-            except Exception as e:
-                # Best-effort revocation: log but don't fail logout if blocklist is unavailable
-                correlation_id = str(uuid.uuid4())
-                logger.warning("Token revocation failed [%s]: %s", correlation_id, e, extra={"user_id": user.id})
+                await asyncio.to_thread(blocklist_service.revoke_token, jti, user_email, "logout")
+            else:
+                logger.warning("Logout: token missing jti — server-side revocation skipped")
+        except Exception as e:
+            correlation_id = str(uuid.uuid4())
+            logger.warning("Logout revocation failed [%s]: %s", correlation_id, e)
 
-                # Record metric for monitoring/alerting (only when observability is enabled)
-                if settings.observability_enabled:
-                    try:
-                        _svc = ObservabilityService()
-                        await asyncio.to_thread(
-                            _svc.record_metric,
-                            "auth.token_revocation_failure",
-                            1,
-                            metric_type="counter",
-                            attributes={"user_id": str(user.id), "correlation_id": correlation_id, "error_type": type(e).__name__},
-                        )
-                    except Exception as metric_error:
-                        logger.debug("Failed to record token revocation failure metric: %s", metric_error)
-        else:
-            logger.warning("Logout: token missing jti — server-side revocation skipped", extra={"user_id": user.id})
+            if settings.observability_enabled:
+                try:
+                    _svc = ObservabilityService()
+                    await asyncio.to_thread(
+                        _svc.record_metric,
+                        "auth.token_revocation_failure",
+                        1,
+                        metric_type="counter",
+                        attributes={"correlation_id": correlation_id, "error_type": type(e).__name__},
+                    )
+                except Exception as metric_error:
+                    logger.debug("Failed to record token revocation failure metric: %s", metric_error)
 
-        clear_auth_cookie(response, path=JWT_COOKIE_PATH)
-        clear_csrf_cookie(response, settings)
-
-        logger.debug("User logged out via cookie auth")
-
-        return {"message": "Logged out successfully"}
-    except HTTPException:
-        raise
-    except Exception as e:
-        correlation_id = str(uuid.uuid4())
-        logger.error("Logout failed [%s]: %s", correlation_id, e, exc_info=True)
-        raise_auth_error("internal_error", "Logout failed", status_code=500, correlation_id=correlation_id)
+    logger.debug("User logged out via cookie auth")
+    return {"message": "Logged out successfully"}
 
 
 # ---------------------------------------------------------------------------

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -184,12 +184,14 @@ async def login(login_request: LoginRequest, request: Request, db: Session = Dep
                 # First-Party
                 from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
 
-                # Decode JWT to get jti (don't verify since we just created it)
+                # Decode JWT to get jti and sub (don't verify since we just created it)
                 payload = jwt.decode(access_token, options={"verify_signature": False})
                 session_id = payload.get("jti", "")
 
-                # Generate CSRF token
-                csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+                # Generate CSRF token bound to the JWT sub (UUID) — must match
+                # what the CSRF middleware extracts from payload.get("sub")
+                user_sub = payload.get("sub", user.email)
+                csrf_token = generate_csrf_token(user_id=user_sub, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
 
                 auth_response = AuthenticationResponse(
                     access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)

--- a/mcpgateway/routers/email_auth.py
+++ b/mcpgateway/routers/email_auth.py
@@ -299,12 +299,14 @@ async def login(login_request: EmailLoginRequest, request: Request, db: Session 
             # First-Party
             from mcpgateway.services.csrf_service import generate_csrf_token, set_csrf_cookie
 
-            # Decode JWT to get jti (don't verify since we just created it)
+            # Decode JWT to get jti and sub (don't verify since we just created it)
             payload = jwt.decode(access_token, options={"verify_signature": False})
             session_id = payload.get("jti", "")
 
-            # Generate CSRF token
-            csrf_token = generate_csrf_token(user_id=user.email, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
+            # Generate CSRF token bound to the JWT sub (UUID) — must match
+            # what the CSRF middleware extracts from payload.get("sub")
+            user_sub = payload.get("sub", user.email)
+            csrf_token = generate_csrf_token(user_id=user_sub, session_id=session_id, secret=settings.csrf_secret_key, expiry=settings.csrf_token_expiry)
 
             auth_response = AuthenticationResponse(
                 access_token=access_token, token_type="bearer", expires_in=expires_in, user=EmailUserResponse.from_email_user(user)

--- a/tests/e2e/test_app_auth.py
+++ b/tests/e2e/test_app_auth.py
@@ -202,9 +202,12 @@ class TestFullLoginFlow:
 class TestCSRFProtection:
     """Test CSRF protection on state-changing operations."""
 
-    def test_logout_without_csrf_token_fails(self, client, setup_test_user, test_user_credentials):
-        """Test logout without CSRF token returns 403."""
-        # Login
+    def test_logout_without_csrf_token_still_succeeds(self, client, setup_test_user, test_user_credentials):
+        """Test logout without CSRF token succeeds and clears cookies.
+
+        /app/auth/logout is CSRF-exempt so that logout always works even when
+        the CSRF cookie has expired (e.g. long idle session).
+        """
         login_response = client.post(
             "/app/auth/login",
             json={
@@ -215,44 +218,32 @@ class TestCSRFProtection:
         jwt_token = login_response.cookies.get("jwt_token")
         csrf_token_cookie = login_response.cookies.get("mcpgateway_csrf_token")
 
-        # Attempt logout without CSRF header
+        # Logout without CSRF header — must still succeed
         logout_response = client.post(
             "/app/auth/logout",
             cookies={"jwt_token": jwt_token, "mcpgateway_csrf_token": csrf_token_cookie},
-            # No X-CSRF-Token header
         )
 
-        # Verify CSRF protection
-        assert logout_response.status_code == status.HTTP_403_FORBIDDEN
-        assert "CSRF token" in logout_response.json()["detail"]["message"]
+        assert logout_response.status_code == status.HTTP_200_OK
+        set_cookie_headers = _set_cookie_headers(logout_response)
+        jwt_clear = next((c for c in set_cookie_headers if "jwt_token=" in c), "")
+        csrf_clear = next((c for c in set_cookie_headers if "mcpgateway_csrf_token=" in c), "")
+        assert "max-age=0" in jwt_clear.lower(), "jwt_token cookie not cleared"
+        assert "max-age=0" in csrf_clear.lower(), "csrf_token cookie not cleared"
 
-    def test_logout_with_invalid_csrf_token_fails(self, client, setup_test_user, test_user_credentials):
-        """Test logout with mismatched CSRF token returns 403."""
-        # Login
-        login_response = client.post(
-            "/app/auth/login",
-            json={
-                "email": test_user_credentials["email"],
-                "password": test_user_credentials["password"],
-            },
-        )
-        jwt_token = login_response.cookies.get("jwt_token")
-        csrf_token_cookie = login_response.cookies.get("mcpgateway_csrf_token")
+    def test_logout_clears_cookies_even_without_jwt_cookie(self, client):
+        """Test logout clears cookies even when no JWT is present (already expired/cleared)."""
+        logout_response = client.post("/app/auth/logout")
 
-        # Attempt logout with wrong CSRF header
-        logout_response = client.post(
-            "/app/auth/logout",
-            cookies={"jwt_token": jwt_token, "mcpgateway_csrf_token": csrf_token_cookie},
-            headers={"X-CSRF-Token": "wrong-csrf-token"},
-        )
-
-        # Verify CSRF protection
-        assert logout_response.status_code == status.HTTP_403_FORBIDDEN
-        assert "CSRF token" in logout_response.json()["detail"]["message"]
+        assert logout_response.status_code == status.HTTP_200_OK
+        set_cookie_headers = _set_cookie_headers(logout_response)
+        jwt_clear = next((c for c in set_cookie_headers if "jwt_token=" in c), "")
+        csrf_clear = next((c for c in set_cookie_headers if "mcpgateway_csrf_token=" in c), "")
+        assert "max-age=0" in jwt_clear.lower(), "jwt_token cookie not cleared"
+        assert "max-age=0" in csrf_clear.lower(), "csrf_token cookie not cleared"
 
     def test_logout_with_valid_csrf_token_succeeds(self, client, setup_test_user, test_user_credentials):
-        """Test logout with valid CSRF token succeeds."""
-        # Login
+        """Test logout with CSRF token also succeeds (CSRF is optional, not rejected)."""
         login_response = client.post(
             "/app/auth/login",
             json={
@@ -264,14 +255,12 @@ class TestCSRFProtection:
         csrf_token_cookie = login_response.cookies.get("mcpgateway_csrf_token")
         csrf_token_header = login_response.json()["mcpgateway_csrf_token"]
 
-        # Logout with matching CSRF tokens
         logout_response = client.post(
             "/app/auth/logout",
             cookies={"jwt_token": jwt_token, "mcpgateway_csrf_token": csrf_token_cookie},
             headers={"X-CSRF-Token": csrf_token_header},
         )
 
-        # Verify success
         assert logout_response.status_code == status.HTTP_200_OK
 
 

--- a/tests/unit/mcpgateway/routers/test_app.py
+++ b/tests/unit/mcpgateway/routers/test_app.py
@@ -213,15 +213,16 @@ class TestGetCurrentUser:
 class TestLogout:
     """Tests for POST /app/auth/logout endpoint."""
 
-    def test_logout_without_authentication(self, client):
-        """Test logout without authentication returns 401."""
+    def test_logout_without_authentication_still_clears_cookies(self, client):
+        """Logout without any cookies still returns 200.
+
+        /app/auth/logout is CSRF-exempt and always clears cookies so that
+        users can log out even when their session has already expired.
+        """
         response = client.post("/app/auth/logout")
 
-        # Should return 401 or 403 depending on auth middleware
-        assert response.status_code in [
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-        ]
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["message"] == "Logged out successfully"
 
 
 class TestCSRFProtection:
@@ -296,8 +297,13 @@ class TestSecurityVectors:
         # Should fail safely with 401 (invalid credentials)
         assert response.status_code == 401
 
-    def test_csrf_token_wrong_length_rejected(self, client):
-        """Test CSRF validation rejects tokens that are not 64 characters."""
+    def test_logout_succeeds_with_wrong_length_csrf_token(self, client):
+        """Logout is CSRF-exempt so it succeeds even with a malformed CSRF token.
+
+        /app/auth/logout is exempt from CSRF validation to ensure users can
+        always log out — even when their CSRF token is expired or malformed.
+        Cookie clearing must not be gated on CSRF validity.
+        """
         short_token = "token-with-wrong-len"  # 20 chars, not 64
         response = client.post(
             "/app/auth/logout",
@@ -307,11 +313,10 @@ class TestSecurityVectors:
             },
             headers={"X-CSRF-Token": short_token},
         )
-        # Fails due to token length check (not XSS — JSON body is never reflected)
-        assert response.status_code in [401, 403]
+        assert response.status_code == status.HTTP_200_OK
 
-    def test_csrf_token_length_validation_oversized(self, client):
-        """Test CSRF validation rejects oversized tokens."""
+    def test_logout_succeeds_with_oversized_csrf_token(self, client):
+        """Logout is CSRF-exempt so it succeeds even with an oversized CSRF token."""
         oversized_token = "x" * 1000
         response = client.post(
             "/app/auth/logout",
@@ -321,13 +326,10 @@ class TestSecurityVectors:
             },
             headers={"X-CSRF-Token": oversized_token},
         )
-        # Should fail with 403 (invalid token format)
-        assert response.status_code in [401, 403]
-        if response.status_code == 403:
-            assert response.json()["detail"]["message"] == "Invalid CSRF token format"
+        assert response.status_code == status.HTTP_200_OK
 
-    def test_csrf_token_length_validation_undersized(self, client):
-        """Test CSRF validation rejects undersized tokens."""
+    def test_logout_succeeds_with_undersized_csrf_token(self, client):
+        """Logout is CSRF-exempt so it succeeds even with an undersized CSRF token."""
         undersized_token = "short"
         response = client.post(
             "/app/auth/logout",
@@ -337,10 +339,7 @@ class TestSecurityVectors:
             },
             headers={"X-CSRF-Token": undersized_token},
         )
-        # Should fail with 403 (invalid token format)
-        assert response.status_code in [401, 403]
-        if response.status_code == 403:
-            assert response.json()["detail"]["message"] == "Invalid CSRF token format"
+        assert response.status_code == status.HTTP_200_OK
 
 
 class TestRBACMiddleware:

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -6743,3 +6743,137 @@ class TestAuthJwtRoutingReturn:
             result = await handler._auth_jwt(token="unused")
 
         assert result is False
+
+
+class TestGetCurrentUserFromCookie:
+    """Tests for get_current_user_from_cookie — cookie-based auth used by the React SPA."""
+
+    @pytest.mark.asyncio
+    async def test_uuid_sub_resolved_to_email(self):
+        """JWT sub containing a UUID is resolved to email via _get_email_by_id_sync."""
+        from mcpgateway.auth import get_current_user_from_cookie
+
+        user_uuid = str(__import__("uuid").uuid4())
+        user_email = "cookie-user@example.com"
+
+        mock_user = MagicMock(spec=EmailUser)
+        mock_user.email = user_email
+        mock_user.is_active = True
+
+        jwt_payload = {
+            "sub": user_uuid,
+            "jti": str(__import__("uuid").uuid4()),
+            "exp": (__import__("datetime").datetime.now(__import__("datetime").timezone.utc) + __import__("datetime").timedelta(hours=1)).timestamp(),
+        }
+
+        mock_request = MagicMock()
+        mock_request.cookies = {"jwt_token": "fake.jwt.token"}
+        mock_request.state = SimpleNamespace()
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", return_value=jwt_payload),
+            patch("mcpgateway.auth._get_email_by_id_sync", return_value=user_email),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+        ):
+            user, jti = await get_current_user_from_cookie(mock_request)
+
+        assert user is mock_user
+        assert jti == jwt_payload["jti"]
+
+    @pytest.mark.asyncio
+    async def test_email_sub_used_directly(self):
+        """Legacy JWT where sub is already an email address works without DB UUID lookup."""
+        from mcpgateway.auth import get_current_user_from_cookie
+
+        user_email = "legacy@example.com"
+
+        mock_user = MagicMock(spec=EmailUser)
+        mock_user.email = user_email
+        mock_user.is_active = True
+
+        jwt_payload = {
+            "sub": user_email,
+            "jti": str(__import__("uuid").uuid4()),
+            "exp": (__import__("datetime").datetime.now(__import__("datetime").timezone.utc) + __import__("datetime").timedelta(hours=1)).timestamp(),
+        }
+
+        mock_request = MagicMock()
+        mock_request.cookies = {"jwt_token": "fake.jwt.token"}
+        mock_request.state = SimpleNamespace()
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", return_value=jwt_payload),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=mock_user),
+            patch("mcpgateway.auth._get_email_by_id_sync", side_effect=AssertionError("must not be called for email sub")),
+        ):
+            user, jti = await get_current_user_from_cookie(mock_request)
+
+        assert user is mock_user
+
+    @pytest.mark.asyncio
+    async def test_missing_jwt_cookie_raises_401(self):
+        """Request without jwt_token cookie raises 401."""
+        from mcpgateway.auth import get_current_user_from_cookie
+
+        mock_request = MagicMock()
+        mock_request.cookies = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user_from_cookie(mock_request)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_raises_401(self):
+        """Revoked token raises 401."""
+        from mcpgateway.auth import get_current_user_from_cookie
+
+        user_uuid = str(__import__("uuid").uuid4())
+        jwt_payload = {
+            "sub": user_uuid,
+            "jti": "revoked-jti",
+            "exp": (__import__("datetime").datetime.now(__import__("datetime").timezone.utc) + __import__("datetime").timedelta(hours=1)).timestamp(),
+        }
+
+        mock_request = MagicMock()
+        mock_request.cookies = {"jwt_token": "fake.jwt.token"}
+        mock_request.state = SimpleNamespace()
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", return_value=jwt_payload),
+            patch("mcpgateway.auth._get_email_by_id_sync", return_value="user@example.com"),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=True),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user_from_cookie(mock_request)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.asyncio
+    async def test_uuid_not_in_db_raises_401(self):
+        """UUID sub that resolves to no user raises 401."""
+        from mcpgateway.auth import get_current_user_from_cookie
+
+        user_uuid = str(__import__("uuid").uuid4())
+        jwt_payload = {
+            "sub": user_uuid,
+            "jti": str(__import__("uuid").uuid4()),
+            "exp": (__import__("datetime").datetime.now(__import__("datetime").timezone.utc) + __import__("datetime").timedelta(hours=1)).timestamp(),
+        }
+
+        mock_request = MagicMock()
+        mock_request.cookies = {"jwt_token": "fake.jwt.token"}
+        mock_request.state = SimpleNamespace()
+
+        with (
+            patch("mcpgateway.auth.verify_jwt_token_cached", return_value=jwt_payload),
+            patch("mcpgateway.auth._get_email_by_id_sync", return_value="user@example.com"),
+            patch("mcpgateway.auth._check_token_revoked_sync", return_value=False),
+            patch("mcpgateway.auth._get_user_by_email_sync", return_value=None),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user_from_cookie(mock_request)
+
+        assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary

  Fixes three interrelated authentication bugs in the React SPA auth flow, plus three pre-existing RBAC middleware defects surfaced by the test suite.

  ### Bug 1 — CSRF token always rejected (403 on all POST/PUT/DELETE)

  `create_access_token` sets `sub` to the user's UUID, but CSRF token generation at all three login endpoints (`/app/auth/login`, `/auth/login`, `/auth/email/login`) was using
  `user.email` as the `user_id` bound into the HMAC. The CSRF middleware extracts `payload.get("sub")` — the UUID — so the tokens never matched.

  Fixed by decoding the freshly-issued JWT after creation and using `payload.get("sub", user.email)` as `user_id` in all three login endpoints (`routers/app.py`, `routers/auth.py`, `routers/email_auth.py`).

  ### Bug 2 — Logout never cleared cookies; page reload always redirected to /app/login

  Two root causes:

  - `/app/auth/logout` was missing from `csrf_exempt_paths`, so the CSRF middleware blocked the POST before the handler ran, meaning `clear_auth_cookie` / `clear_csrf_cookie` never executed.
  - `get_current_user_from_cookie` passed the UUID `sub` directly to `_get_user_by_email_sync` (which queries `WHERE email = ?`), always returning `None` → 401, before the handler body could clear cookies.

  Fixed in `config.py` by adding `/app/auth/logout` to `csrf_exempt_paths` (and updating `.env` / `.env.example` which were overriding the default). Fixed in `routers/app.py` by restructuring logout to always clear cookies first, then attempt best-effort JWT revocation. Fixed in `auth.py` by adding UUID→email resolution: if `sub` parses as a UUID, look up the email via `_get_email_by_id_sync` before the user lookup.

  ### Bug 3 — Three RBAC middleware defects

  - `is_same_origin_referer` (checks host + `/admin` or `/oauth/callback`) was computed but never included in `is_browser_request`, so OAuth callback pages were incorrectly rejected with 401 "Cookie authentication not allowed".
  - `sec_fetch_site: "same-site"` was in the allowed set for first-party React fetches. `same-site` allows cross-subdomain requests and should not grant cookie-based API access; only `same-origin` is correct.
  - The inline `from urllib.parse import urlparse` inside the `try` block created a function-local binding that survived the `except` clause, causing subsequent `urlparse` calls (for referer path and origin validation) to also raise when the module was patched in tests. Removed the redundant local import and wrapped the referer path and origin blocks in their own `try/except`.
  - `is_admin_ui_request` used plain string containment on the full referer URL, which matched cross-origin admin referers (e.g. `https://attacker.example/admin`). Replaced with `is_same_origin_referer`, which enforces host matching.

  ## Files changed

  | File | Change |
  |------|--------|
  | `mcpgateway/auth.py` | UUID→email resolution in `get_current_user_from_cookie` |
  | `mcpgateway/config.py` | Add `/app/auth/logout` to `csrf_exempt_paths` default |
  | `mcpgateway/routers/app.py` | CSRF token uses JWT `sub`; logout always clears cookies first |
  | `mcpgateway/routers/auth.py` | CSRF token uses JWT `sub` at `/auth/login` |
  | `mcpgateway/routers/email_auth.py` | CSRF token uses JWT `sub` at `/auth/email/login` |
  | `mcpgateway/middleware/rbac.py` | Include `is_same_origin_referer` in browser check; restrict to `same-origin`; fix local `urlparse` shadowing; gate `is_admin_ui_request` on same-origin |
  | `.env` / `.env.example` | Add `/app/auth/logout` to `CSRF_EXEMPT_PATHS` |
  | `tests/unit/mcpgateway/test_auth.py` | New `TestGetCurrentUserFromCookie` tests |
  | `tests/unit/mcpgateway/routers/test_app.py` | Update 4 logout tests to reflect CSRF-exempt behavior |
  | `tests/e2e/test_app_auth.py` | Update 2 CSRF protection tests |

  ## Tests

  - `tests/unit/mcpgateway/test_auth.py`: new `TestGetCurrentUserFromCookie` class (5 tests) covering UUID resolution, legacy email sub, missing cookie, revoked token, and unknown UUID.
  - `tests/unit/mcpgateway/routers/test_app.py`: updated 4 tests that expected logout to fail with 403/401 — logout is intentionally CSRF-exempt so users can always log out even with expired or malformed tokens.
  - `tests/e2e/test_app_auth.py`: updated 2 tests in `TestCSRFProtection` to reflect that logout succeeds (200 + cookies cleared) regardless of CSRF token presence.