### PR TITLE
feat: add client_secret_basic auth support to SSO token exchange

### DIFF
--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1302,6 +1302,24 @@ class SSOService:
             self.db.commit()
             return None
 
+    @staticmethod
+    def _build_basic_auth_header(client_id: str, client_secret: str) -> str:
+        """Build an RFC 6749 Section 2.3.1 Basic Auth header value.
+
+        Client credentials are first URL-encoded per RFC 6749 Appendix B,
+        then combined as ``client_id:client_secret`` and base64-encoded.
+
+        Args:
+            client_id: OAuth client ID
+            client_secret: OAuth client secret
+
+        Returns:
+            ``Basic <base64>`` header value
+        """
+        credentials_str = f"{urllib.parse.quote(client_id, safe='')}:{urllib.parse.quote(client_secret, safe='')}"
+        encoded_credentials = base64.b64encode(credentials_str.encode("utf-8")).decode("utf-8")
+        return f"Basic {encoded_credentials}"
+
     async def _exchange_code_for_tokens(self, provider: SSOProvider, auth_session: SSOAuthSession, code: str) -> Optional[Dict[str, Any]]:
         """Exchange authorization code for access tokens.
 
@@ -1313,20 +1331,37 @@ class SSOService:
         Returns:
             Token response dict or None if failed
         """
-        token_params = {
-            "client_id": provider.client_id,
-            "client_secret": await self._decrypt_secret(provider.client_secret_encrypted),
+        metadata = provider.provider_metadata or {}
+        auth_method = metadata.get("token_endpoint_auth_method", "client_secret_post")
+
+        client_secret = await self._decrypt_secret(provider.client_secret_encrypted)
+
+        token_params: Dict[str, Any] = {
             "code": code,
             "grant_type": "authorization_code",
             "redirect_uri": auth_session.redirect_uri,
             "code_verifier": auth_session.code_verifier,
         }
+        headers = {"Accept": "application/json"}
+
+        if auth_method == "client_secret_basic" and client_secret:
+            headers["Authorization"] = self._build_basic_auth_header(provider.client_id, client_secret)
+            logger.debug("Using HTTP Basic Auth for SSO token endpoint authentication")
+        elif auth_method == "client_secret_basic" and not client_secret:
+            logger.warning("Basic Auth requested but client_secret is missing - falling back to POST body mode")
+            token_params["client_id"] = provider.client_id
+            logger.debug("Using POST body for SSO token endpoint authentication")
+        else:
+            token_params["client_id"] = provider.client_id
+            if client_secret:
+                token_params["client_secret"] = client_secret
+            logger.debug("Using POST body for SSO token endpoint authentication")
 
         # First-Party
         from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
 
         client = await get_http_client()
-        response = await client.post(provider.token_url, data=token_params, headers={"Accept": "application/json"})
+        response = await client.post(provider.token_url, data=token_params, headers=headers)
 
         if response.status_code == 200:
             return response.json()

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -661,6 +661,180 @@ class TestTokenExchange:
         with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
             mock_get_client.return_value = mock_client
 
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_basic_auth(self, sso_service):
+        """client_secret_basic: credentials in Authorization header, not in body."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider(provider_metadata={"token_endpoint_auth_method": "client_secret_basic"})
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result == {"access_token": "tok", "token_type": "bearer"}
+        _call_kwargs = mock_client.post.call_args.kwargs
+        assert "data" in _call_kwargs
+        assert "client_secret" not in _call_kwargs["data"]
+        assert "client_id" not in _call_kwargs["data"]
+        assert "Authorization" in _call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_basic_auth_no_secret(self, sso_service):
+        """client_secret_basic without decrypted secret falls back to POST body."""
+        sso_service._encryption.decrypt_secret_async = AsyncMock(return_value=None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider(provider_metadata={"token_endpoint_auth_method": "client_secret_basic"})
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result == {"access_token": "tok", "token_type": "bearer"}
+        _call_kwargs = mock_client.post.call_args.kwargs
+        assert "client_id" in _call_kwargs["data"]
+        assert "Authorization" not in _call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_default_post_body(self, sso_service):
+        """Default (client_secret_post): credentials in POST body, no Authorization header."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider()  # No provider_metadata set
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result == {"access_token": "tok", "token_type": "bearer"}
+        _call_kwargs = mock_client.post.call_args.kwargs
+        assert "client_id" in _call_kwargs["data"]
+        assert "client_secret" in _call_kwargs["data"]
+        assert "Authorization" not in _call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_basic_auth_header_format(self, sso_service):
+        """Verify Basic Auth header is correctly formatted."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider(client_id="test-client-id", provider_metadata={"token_endpoint_auth_method": "client_secret_basic"})
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        _call_kwargs = mock_client.post.call_args.kwargs
+        auth_header = _call_kwargs["headers"]["Authorization"]
+        assert auth_header.startswith("Basic ")
+        # Verify it's valid base64
+        import base64
+        payload = auth_header[len("Basic "):]
+        decoded = base64.b64decode(payload).decode("utf-8")
+        assert decoded.startswith("test-client-id:")
+        assert decoded.count(":") == 1
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_default_post_body_no_secret(self, sso_service):
+        """Default (client_secret_post) without decrypted secret sends client_id only."""
+        sso_service._encryption.decrypt_secret_async = AsyncMock(return_value=None)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider()
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result == {"access_token": "tok", "token_type": "bearer"}
+        _call_kwargs = mock_client.post.call_args.kwargs
+        assert "client_id" in _call_kwargs["data"]
+        assert "client_secret" not in _call_kwargs["data"]
+        assert "Authorization" not in _call_kwargs["headers"]
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_http_error(self, sso_service):
+        """Non-200 response from token endpoint returns None."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider()
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_build_basic_auth_header_url_encodes_special_chars(self, sso_service):
+        """Special characters in client_id/secret are URL-encoded per RFC 6749 Appendix B."""
+        header = sso_service._build_basic_auth_header("client@id", "secret:+?")
+        assert header.startswith("Basic ")
+        import base64
+        payload = base64.b64decode(header[len("Basic "):]).decode("utf-8")
+        assert payload == "client%40id:secret%3A%2B%3F"
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_for_tokens_provider_metadata_none(self, sso_service):
+        """provider_metadata=None is treated the same as {} (defaults to client_secret_post)."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "tok", "token_type": "bearer"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        provider = _make_provider(provider_metadata=None)
+        auth_session = _make_auth_session()
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client:
+            mock_get_client.return_value = mock_client
+            result = await sso_service._exchange_code_for_tokens(provider, auth_session, "code123")
+
+        assert result == {"access_token": "tok", "token_type": "bearer"}
+        _call_kwargs = mock_client.post.call_args.kwargs
+        assert "client_id" in _call_kwargs["data"]
+        assert "client_secret" in _call_kwargs["data"]
+        assert "Authorization" not in _call_kwargs["headers"]
+
 
 # ---------------------------------------------------------------------------
 # User info extraction tests


### PR DESCRIPTION
## Problem

The SSO service\s `_exchange_code_for_tokens` always sends OAuth2 client credentials in the POST request body (`client_secret_post`). Many enterprise OAuth2/OIDC providers require `client_secret_basic` authentication (RFC 6749 §2.3.1), where credentials are sent via an HTTP `Authorization: Basic` header instead.

Providers affected include:
- IBM Cloud IAM
- Notion
- Freshworks/Freshservice
- Azure AD (certain configurations)
- Okta (certain configurations)
- Any enterprise provider enforcing `client_secret_basic`

The OAuth Manager (`oauth_manager.py`) already supported `client_secret_basic` across all its flows (client credentials, authorization code, PKCE, refresh token — fixed in PRs #4717, #4407), but the SSO service was never updated to match.

## Closes #5015 

## Solution

### `_build_basic_auth_header()` — new static method

Added a helper that builds an RFC 6749 §2.3.1 compliant `Basic` header value:
- URL-encodes `client_id` and `client_secret` per RFC 6749 Appendix B
- Base64-encodes the combined `client_id:client_secret` string
- Same proven pattern as `oauth_manager.py:_build_basic_auth_header()`

### `_exchange_code_for_tokens()` — modified

Added three-branch logic reading `token_endpoint_auth_method` from the provider\s `provider_metadata` JSON field (which already existed on the `SSOProvider` model — no schema changes needed):

| `auth_method` | `client_secret` | Behavior |
|---|---|---|
| `client_secret_basic` | present | Credentials in `Authorization: Basic` header; **omitted from POST body** |
| `client_secret_basic` | `None` (decryption failed) | **Warning logged**, falls back to POST body with `client_id` only |
| `client_secret_post` / unset | either | **Unchanged** — existing behavior preserved |

### What did NOT change

- No DB schema changes (`provider_metadata` JSON column already exists on `SSOProvider`)
- No API schema changes (`provider_metadata` already in `SSOProviderCreateRequest` / `SSOProviderUpdateRequest`)
- No router changes
- No changes to OAuth Manager or DCR (already handled)
- Existing providers are completely unaffected (default remains `client_secret_post`)

## Security

- `client_secret_basic` is **more secure** than `client_secret_post` per RFC 6749 — credentials in headers are less likely to appear in proxy/access logs
- No secrets or header values are logged (distinct debug messages per auth method)
- URL-encoding applied before base64 encoding (RFC 6749 Appendix B compliance)
- Graceful fallback prevents hard failures on misconfiguration

## Testing

8 tests covering all branches of the modified code:

| Test | Coverage |
|---|---|
| `test_exchange_code_for_tokens_basic_auth` | Happy path: creds in header, not in body |
| `test_exchange_code_for_tokens_basic_auth_no_secret` | Fallback: basic auth requested, no secret |
| `test_exchange_code_for_tokens_default_post_body` | Backward compat: default path with secret |
| `test_exchange_code_for_tokens_default_post_body_no_secret` | Default path without secret |
| `test_exchange_code_for_tokens_http_error` | Non-200 response returns None |
| `test_exchange_code_for_tokens_basic_auth_header_format` | Validates `Basic <base64>` structure |
| `test_build_basic_auth_header_url_encodes_special_chars` | Special characters URL-encoded per RFC |
| `test_exchange_code_for_tokens_provider_metadata_none` | None handled same as empty dict |

All 277 SSO service tests pass. 100% branch coverage of added/modified code.

## How to use

An admin configures an SSO provider requiring `client_secret_basic` by setting `provider_metadata`:

```json
{
  "id": "ibm_cloud_iam",
  "provider_metadata": {
    "token_endpoint_auth_method": "client_secret_basic"
  }
}
```

No built-in provider entry is needed — any `client_secret_basic` provider can be registered as a generic OAuth2/OIDC provider via the existing SSO API.
