### PR TITLE
fix(tokens): set EmailApiToken.is_active=False on auto-revocation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^\\.secrets\\.baseline$",
     "lines": null
   },
-  "generated_at": "2026-08-06T11:55:32Z",
+  "generated_at": "2026-08-06T14:18:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -258,7 +258,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2032,
+        "line_number": 2041,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2120,
+        "line_number": 2129,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2470,
+        "line_number": 2479,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3835,
+        "line_number": 3844,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3926,
+        "line_number": 3935,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3969,
+        "line_number": 3978,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3974,
+        "line_number": 3983,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3979,
+        "line_number": 3988,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1008,7 +1008,7 @@
         "hashed_secret": "4e5bc1605287fbb277825e7bbc61f06b673bc817",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 69,
+        "line_number": 70,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1016,7 +1016,7 @@
         "hashed_secret": "a8772222f1027d36898a1fcdd9ee49dcfe2fc9a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 71,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1024,7 +1024,7 @@
         "hashed_secret": "5db8c92354caf195bc47229ec1da9e26053269f9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 71,
+        "line_number": 72,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1032,7 +1032,7 @@
         "hashed_secret": "e340d79ff1184175ed44815db7440905ecb9a0dc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1040,7 +1040,7 @@
         "hashed_secret": "27a0146f1e78bf478b4d1195062638742878dae5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@
 
 ### Breaking Changes
 
-- **TokenBlocklistService revocation is async** - `TokenBlocklistService.revoke_token()` is now an async method and must be awaited. Existing sync callers must change `service.revoke_token(...)` to `await service.revoke_token(...)`; otherwise Python returns a truthy coroutine object and the token is not revoked.
+- **TokenBlocklistService revocation is async** - `TokenBlocklistService.revoke_token()` is now an async method and must be awaited. Existing sync callers must change `service.revoke_token(...)` to `await service.revoke_token(...)`; otherwise Python returns a truthy coroutine, logout can return HTTP 200, and the token remains valid. (#5136)
 
 ### Fixed
 
-- **Auto-revoked token status consistency** - Auto-revocation now marks matching API tokens inactive, invalidates auth-cache revocation entries, and renders a single revoked badge in the Admin UI.
+- **Auto-revoked token status consistency** - Auto-revocation now marks matching API tokens inactive, invalidates auth-cache revocation entries, and renders a single revoked badge in the Admin UI. (#5136)
+- **Logout revocation transaction isolation** - Logout now revokes tokens in an independent database session so revocation persists even if later request work fails. (#5136)
 
 ## [1.0.7] - 2026-08-04 - Security Hardening, Unified Search, OAuth Improvements, Dataplane Enhancements, and Operational Reliability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **TokenBlocklistService revocation is async** - `TokenBlocklistService.revoke_token()` is now an async method and must be awaited. Existing sync callers must change `service.revoke_token(...)` to `await service.revoke_token(...)`; otherwise Python returns a truthy coroutine object and the token is not revoked.
+
+### Fixed
+
+- **Auto-revoked token status consistency** - Auto-revocation now marks matching API tokens inactive, invalidates auth-cache revocation entries, and renders a single revoked badge in the Admin UI.
+
 ## [1.0.7] - 2026-08-04 - Security Hardening, Unified Search, OAuth Improvements, Dataplane Enhancements, and Operational Reliability
 
 ### Overview

--- a/docs/docs/architecture/adr/028-auth-caching.md
+++ b/docs/docs/architecture/adr/028-auth-caching.md
@@ -52,6 +52,7 @@ Implement a two-tier authentication caching system with Redis as the primary sto
 3. **Cache invalidation hooks in services**
 
    - `token_catalog_service.py:revoke_token()` - Invalidates revocation cache
+   - `token_blocklist_service.py:revoke_token()` - Invalidates revocation cache after auto-revocation
    - `email_auth_service.py:change_password()` - Invalidates user cache
    - `team_management_service.py:add_member_to_team/remove_member_from_team()` - Invalidates team cache
 

--- a/docs/security/JWT_TOKEN_SECURITY_IMPLEMENTATION.md
+++ b/docs/security/JWT_TOKEN_SECURITY_IMPLEMENTATION.md
@@ -121,7 +121,7 @@ if last_activity_ts and settings.token_idle_timeout > 0:
     idle_duration = current_time - last_activity
     if idle_duration > max_idle:
         # Revoke token and reject request
-        blocklist_service.revoke_token(jti, email, "idle_timeout", ...)
+        await blocklist_service.revoke_token(jti, email, "idle_timeout", ...)
         raise HTTPException(401, "Token exceeded idle timeout")
 
     # Update activity for valid tokens

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -5022,7 +5022,7 @@ async def _admin_logout(request: Request) -> Response:
                     if last_activity_ts:
                         last_activity = datetime.fromtimestamp(last_activity_ts, tz=timezone.utc)
 
-                    blocklist_service.revoke_token(jti=jti, revoked_by=user_id, reason="admin_logout", token_expiry=token_expiry, last_activity=last_activity)
+                    await blocklist_service.revoke_token(jti=jti, revoked_by=user_id, reason="admin_logout", token_expiry=token_expiry, last_activity=last_activity)
                     LOGGER.info(f"Token revoked during admin logout: jti={jti}", extra={"security_event": "admin_logout_token_revoked", "security_severity": "low", "jti": jti, "user_id": user_id})
             except Exception as revoke_error:
                 # Log but don't fail logout if token revocation fails

--- a/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
+++ b/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Repair active API-token rows that already have revocation records.
+
+Revision ID: e5136a7c9d01
+Revises: d21698ae4a19
+Create Date: 2026-07-27
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e5136a7c9d01"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "d21698ae4a19"  # pragma: allowlist secret
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Mark previously revoked API tokens inactive."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    tables = inspector.get_table_names()
+    if "email_api_tokens" not in tables or "token_revocations" not in tables:
+        return
+
+    email_api_token_columns = {column["name"] for column in inspector.get_columns("email_api_tokens")}
+    token_revocation_columns = {column["name"] for column in inspector.get_columns("token_revocations")}
+    if not {"jti", "is_active"}.issubset(email_api_token_columns) or "jti" not in token_revocation_columns:
+        return
+
+    bind.execute(
+        sa.text(
+            "UPDATE email_api_tokens SET is_active = false "
+            "WHERE is_active = true AND jti IN (SELECT jti FROM token_revocations)"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Keep revoked tokens inactive because this data repair is not reversible."""

--- a/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
+++ b/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 Repair active API-token rows that already have revocation records.
 
 Revision ID: e5136a7c9d01
-Revises: 7ab59991e017
+Revises: e4f5a6b7c8d9
 Create Date: 2026-07-27
 """
 
@@ -18,9 +18,29 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "e5136a7c9d01"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "7ab59991e017"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "e4f5a6b7c8d9"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
+
+
+def _repair_statement() -> sa.Update:
+    """Build a database-portable update for revoked API-token rows."""
+    email_api_tokens = sa.table(
+        "email_api_tokens",
+        sa.column("jti", sa.String()),
+        sa.column("is_active", sa.Boolean()),
+    )
+    token_revocations = sa.table(
+        "token_revocations",
+        sa.column("jti", sa.String()),
+    )
+
+    return (
+        sa.update(email_api_tokens)
+        .where(email_api_tokens.c.is_active.is_(sa.true()))
+        .where(email_api_tokens.c.jti.in_(sa.select(token_revocations.c.jti)))
+        .values(is_active=sa.false())
+    )
 
 
 def upgrade() -> None:
@@ -36,7 +56,7 @@ def upgrade() -> None:
     if not {"jti", "is_active"}.issubset(email_api_token_columns) or "jti" not in token_revocation_columns:
         return
 
-    bind.execute(sa.text("UPDATE email_api_tokens SET is_active = 0 " "WHERE is_active = 1 AND jti IN (SELECT jti FROM token_revocations)"))
+    bind.execute(_repair_statement())
 
 
 def downgrade() -> None:

--- a/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
+++ b/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
@@ -6,17 +6,19 @@ SPDX-License-Identifier: Apache-2.0
 Repair active API-token rows that already have revocation records.
 
 Revision ID: e5136a7c9d01
-Revises: d21698ae4a19
+Revises: 7ab59991e017
 Create Date: 2026-07-27
 """
 
+# Standard
 from typing import Sequence, Union
 
+# Third-Party
 from alembic import op
 import sqlalchemy as sa
 
 revision: str = "e5136a7c9d01"  # pragma: allowlist secret
-down_revision: Union[str, Sequence[str], None] = "d21698ae4a19"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "7ab59991e017"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -34,13 +36,9 @@ def upgrade() -> None:
     if not {"jti", "is_active"}.issubset(email_api_token_columns) or "jti" not in token_revocation_columns:
         return
 
-    bind.execute(
-        sa.text(
-            "UPDATE email_api_tokens SET is_active = false "
-            "WHERE is_active = true AND jti IN (SELECT jti FROM token_revocations)"
-        )
-    )
+    bind.execute(sa.text("UPDATE email_api_tokens SET is_active = 0 " "WHERE is_active = 1 AND jti IN (SELECT jti FROM token_revocations)"))
 
 
 def downgrade() -> None:
     """Keep revoked tokens inactive because this data repair is not reversible."""
+    pass  # Data repair is intentionally irreversible: revoked tokens must remain inactive.

--- a/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
+++ b/mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-"""Repair active API-token rows that already have revocation records.
+"""Location: ./mcpgateway/alembic/versions/e5136a7c9d01_repair_revoked_api_token_status.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Repair active API-token rows that already have revocation records.
 
 Revision ID: e5136a7c9d01
 Revises: d21698ae4a19

--- a/mcpgateway/auth.py
+++ b/mcpgateway/auth.py
@@ -1860,7 +1860,7 @@ async def get_current_user(
                                 exp_ts = payload.get("exp")
                                 token_expiry = datetime.fromtimestamp(exp_ts, tz=timezone.utc) if exp_ts else None
 
-                                blocklist_service.revoke_token(jti=jti, revoked_by=email, reason="idle_timeout", token_expiry=token_expiry, last_activity=last_activity)
+                                await blocklist_service.revoke_token(jti=jti, revoked_by=email, reason="idle_timeout", token_expiry=token_expiry, last_activity=last_activity)
                             except Exception as revoke_error:
                                 logger.warning(f"Failed to revoke idle token: {revoke_error}")
 

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -334,8 +334,8 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
             token_expiry = datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
             last_activity_dt = datetime.fromtimestamp(last_activity, tz=timezone.utc) if last_activity else None
 
-            # Revoke token using blocklist service
-            blocklist_service = get_token_blocklist_service(db=db)
+            # Revoke token using blocklist service (don't pass db - service creates its own session)
+            blocklist_service = get_token_blocklist_service()
             success = await blocklist_service.revoke_token(jti=jti, revoked_by=user.email, reason="logout", token_expiry=token_expiry, last_activity=last_activity_dt)
 
             if not success:

--- a/mcpgateway/routers/auth.py
+++ b/mcpgateway/routers/auth.py
@@ -336,7 +336,7 @@ async def logout(request: Request, current_user: EmailUser = Depends(get_current
 
             # Revoke token using blocklist service
             blocklist_service = get_token_blocklist_service(db=db)
-            success = blocklist_service.revoke_token(jti=jti, revoked_by=user.email, reason="logout", token_expiry=token_expiry, last_activity=last_activity_dt)
+            success = await blocklist_service.revoke_token(jti=jti, revoked_by=user.email, reason="logout", token_expiry=token_expiry, last_activity=last_activity_dt)
 
             if not success:
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to revoke token")

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -24,7 +24,6 @@ Security Compliance:
 """
 
 # Standard
-import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
@@ -80,7 +79,7 @@ class TokenBlocklistService:
 
         return self._redis_client if self._redis_client is not False else None
 
-    def revoke_token(self, jti: str, revoked_by: str, reason: str = "logout", token_expiry: Optional[datetime] = None, last_activity: Optional[datetime] = None) -> bool:
+    async def revoke_token(self, jti: str, revoked_by: str, reason: str = "logout", token_expiry: Optional[datetime] = None, last_activity: Optional[datetime] = None) -> bool:
         """Revoke a token by adding it to the blocklist.
 
         Args:
@@ -96,7 +95,7 @@ class TokenBlocklistService:
         Examples:
             >>> service = TokenBlocklistService()
             >>> # Requires database connection - see unit tests for examples
-            >>> # service.revoke_token(jti="abc-123", revoked_by="user@example.com", reason="logout")
+            >>> # await service.revoke_token(jti="abc-123", revoked_by="user@example.com", reason="logout")
         """
         try:
             if self.db is not None:
@@ -118,7 +117,13 @@ class TokenBlocklistService:
                         db.commit()
                     logger.debug("Token %s already revoked", jti)
                     # Invalidate auth cache to ensure revoked token is rejected immediately
-                    self._invalidate_auth_cache(jti)
+                    try:
+                        # First-Party
+                        from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                        await auth_cache.invalidate_revocation(jti)
+                    except Exception as cache_error:
+                        logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
                     return True
 
                 # Create revocation record
@@ -145,7 +150,13 @@ class TokenBlocklistService:
                             db.commit()
                         logger.debug("Token %s already revoked", jti)
                         # Invalidate auth cache to ensure revoked token is rejected immediately
-                        self._invalidate_auth_cache(jti)
+                        try:
+                            # First-Party
+                            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                            await auth_cache.invalidate_revocation(jti)
+                        except Exception as cache_error:
+                            logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
                         return True
 
                     # Create revocation record
@@ -169,7 +180,13 @@ class TokenBlocklistService:
                     logger.warning("Failed to cache revocation in Redis: %s", e)
 
             # Invalidate auth cache to ensure revoked token is rejected immediately
-            self._invalidate_auth_cache(jti)
+            try:
+                # First-Party
+                from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+                await auth_cache.invalidate_revocation(jti)
+            except Exception as cache_error:
+                logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
 
             logger.info(
                 "Token revoked: jti=%s, reason=%s, revoked_by=%s",
@@ -184,33 +201,6 @@ class TokenBlocklistService:
         except Exception as e:
             logger.error("Failed to revoke token %s: %s", jti, e)
             return False
-
-    def _invalidate_auth_cache(self, jti: str) -> None:
-        """Invalidate auth cache for a revoked token.
-
-        This is a synchronous wrapper that runs the async invalidation in the current
-        or new event loop, ensuring revoked tokens are rejected immediately.
-
-        Args:
-            jti: JWT ID to invalidate
-        """
-        try:
-            # First-Party
-            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
-
-            # Try to get the current event loop
-            try:
-                loop = asyncio.get_running_loop()
-                # We're in an async context, create a task (fire-and-forget is acceptable here
-                # since the Redis/local cache update is best-effort, and the DB write is authoritative)
-                task = loop.create_task(auth_cache.invalidate_revocation(jti))
-                # Suppress the unawaited coroutine warning by adding a dummy done callback
-                task.add_done_callback(lambda t: None)
-            except RuntimeError:
-                # No running loop, create a new one for this operation
-                asyncio.run(auth_cache.invalidate_revocation(jti))
-        except Exception as cache_error:
-            logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
 
     def is_token_revoked(self, jti: str) -> bool:
         """Check if a token is revoked.

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -33,7 +33,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.db import fresh_db_session, TokenRevocation, utc_now
+from mcpgateway.db import EmailApiToken, fresh_db_session, TokenRevocation, utc_now
 from mcpgateway.services.logging_service import LoggingService
 
 # Initialize logging
@@ -108,6 +108,13 @@ class TokenBlocklistService:
                     logger.debug("Token %s already revoked", jti)
                     return True
 
+                # Update EmailApiToken.is_active if token exists
+                # Note: Session tokens don't have EmailApiToken records, so this is optional
+                api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
+                if api_token:
+                    api_token.is_active = False
+                    logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
+
                 # Create revocation record
                 revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
 
@@ -122,6 +129,13 @@ class TokenBlocklistService:
                     if existing:
                         logger.debug("Token %s already revoked", jti)
                         return True
+
+                    # Update EmailApiToken.is_active if token exists
+                    # Note: Session tokens don't have EmailApiToken records, so this is optional
+                    api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
+                    if api_token:
+                        api_token.is_active = False
+                        logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
 
                     # Create revocation record
                     revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -24,6 +24,7 @@ Security Compliance:
 """
 
 # Standard
+import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional
 
@@ -104,16 +105,21 @@ class TokenBlocklistService:
                 # Check if already revoked
                 existing = db.execute(select(TokenRevocation).where(TokenRevocation.jti == jti)).scalar_one_or_none()
 
-                if existing:
-                    logger.debug("Token %s already revoked", jti)
-                    return True
-
-                # Update EmailApiToken.is_active if token exists
+                # Update EmailApiToken.is_active if token exists (repair inconsistent state if needed)
                 # Note: Session tokens don't have EmailApiToken records, so this is optional
                 api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
-                if api_token:
+                if api_token and api_token.is_active:
                     api_token.is_active = False
                     logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
+
+                if existing:
+                    # Commit the repair if we updated is_active
+                    if api_token and not api_token.is_active:
+                        db.commit()
+                    logger.debug("Token %s already revoked", jti)
+                    # Invalidate auth cache to ensure revoked token is rejected immediately
+                    self._invalidate_auth_cache(jti)
+                    return True
 
                 # Create revocation record
                 revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
@@ -126,16 +132,21 @@ class TokenBlocklistService:
                     # Check if already revoked
                     existing = db.execute(select(TokenRevocation).where(TokenRevocation.jti == jti)).scalar_one_or_none()
 
-                    if existing:
-                        logger.debug("Token %s already revoked", jti)
-                        return True
-
-                    # Update EmailApiToken.is_active if token exists
+                    # Update EmailApiToken.is_active if token exists (repair inconsistent state if needed)
                     # Note: Session tokens don't have EmailApiToken records, so this is optional
                     api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
-                    if api_token:
+                    if api_token and api_token.is_active:
                         api_token.is_active = False
                         logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
+
+                    if existing:
+                        # Commit the repair if we updated is_active
+                        if api_token and not api_token.is_active:
+                            db.commit()
+                        logger.debug("Token %s already revoked", jti)
+                        # Invalidate auth cache to ensure revoked token is rejected immediately
+                        self._invalidate_auth_cache(jti)
+                        return True
 
                     # Create revocation record
                     revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
@@ -157,6 +168,9 @@ class TokenBlocklistService:
                 except Exception as e:
                     logger.warning("Failed to cache revocation in Redis: %s", e)
 
+            # Invalidate auth cache to ensure revoked token is rejected immediately
+            self._invalidate_auth_cache(jti)
+
             logger.info(
                 "Token revoked: jti=%s, reason=%s, revoked_by=%s",
                 jti,
@@ -170,6 +184,33 @@ class TokenBlocklistService:
         except Exception as e:
             logger.error("Failed to revoke token %s: %s", jti, e)
             return False
+
+    def _invalidate_auth_cache(self, jti: str) -> None:
+        """Invalidate auth cache for a revoked token.
+
+        This is a synchronous wrapper that runs the async invalidation in the current
+        or new event loop, ensuring revoked tokens are rejected immediately.
+
+        Args:
+            jti: JWT ID to invalidate
+        """
+        try:
+            # First-Party
+            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+            # Try to get the current event loop
+            try:
+                loop = asyncio.get_running_loop()
+                # We're in an async context, create a task (fire-and-forget is acceptable here
+                # since the Redis/local cache update is best-effort, and the DB write is authoritative)
+                task = loop.create_task(auth_cache.invalidate_revocation(jti))
+                # Suppress the unawaited coroutine warning by adding a dummy done callback
+                task.add_done_callback(lambda t: None)
+            except RuntimeError:
+                # No running loop, create a new one for this operation
+                asyncio.run(auth_cache.invalidate_revocation(jti))
+        except Exception as cache_error:
+            logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
 
     def is_token_revoked(self, jti: str) -> bool:
         """Check if a token is revoked.

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -107,13 +107,15 @@ class TokenBlocklistService:
                 # Update EmailApiToken.is_active if token exists (repair inconsistent state if needed)
                 # Note: Session tokens don't have EmailApiToken records, so this is optional
                 api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
+                repaired = False
                 if api_token and api_token.is_active:
+                    repaired = True
                     api_token.is_active = False
-                    logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
+                    logger.debug("Set EmailApiToken.is_active=False for jti=%s", jti[:8])
 
                 if existing:
                     # Commit the repair if we updated is_active
-                    if api_token and not api_token.is_active:
+                    if repaired:
                         db.commit()
                     logger.debug("Token %s already revoked", jti)
                     # Invalidate auth cache to ensure revoked token is rejected immediately
@@ -123,7 +125,12 @@ class TokenBlocklistService:
 
                         await auth_cache.invalidate_revocation(jti)
                     except Exception as cache_error:
-                        logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
+                        logger.warning(
+                            "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
+                            jti,
+                            cache_error,
+                            extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
+                        )
                     return True
 
                 # Create revocation record
@@ -140,13 +147,15 @@ class TokenBlocklistService:
                     # Update EmailApiToken.is_active if token exists (repair inconsistent state if needed)
                     # Note: Session tokens don't have EmailApiToken records, so this is optional
                     api_token = db.execute(select(EmailApiToken).where(EmailApiToken.jti == jti)).scalar_one_or_none()
+                    repaired = False
                     if api_token and api_token.is_active:
+                        repaired = True
                         api_token.is_active = False
-                        logger.debug(f"Set EmailApiToken.is_active=False for jti={jti}")
+                        logger.debug("Set EmailApiToken.is_active=False for jti=%s", jti[:8])
 
                     if existing:
                         # Commit the repair if we updated is_active
-                        if api_token and not api_token.is_active:
+                        if repaired:
                             db.commit()
                         logger.debug("Token %s already revoked", jti)
                         # Invalidate auth cache to ensure revoked token is rejected immediately
@@ -156,7 +165,12 @@ class TokenBlocklistService:
 
                             await auth_cache.invalidate_revocation(jti)
                         except Exception as cache_error:
-                            logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
+                            logger.warning(
+                                "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
+                                jti,
+                                cache_error,
+                                extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
+                            )
                         return True
 
                     # Create revocation record
@@ -186,7 +200,12 @@ class TokenBlocklistService:
 
                 await auth_cache.invalidate_revocation(jti)
             except Exception as cache_error:
-                logger.debug("Failed to invalidate auth cache for revoked token %s: %s", jti, cache_error)
+                logger.warning(
+                    "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
+                    jti,
+                    cache_error,
+                    extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
+                )
 
             logger.info(
                 "Token revoked: jti=%s, reason=%s, revoked_by=%s",

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -135,14 +135,12 @@ class TokenBlocklistService:
                     if repaired:
                         db.commit()
                     logger.debug("Token %s already revoked", SecurityValidator.sanitize_log_message(jti[:8]))
-                    await self._invalidate_auth_cache(jti)
-                    return True
+                else:
+                    # Create revocation record
+                    revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
 
-                # Create revocation record
-                revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
-
-                db.add(revocation)
-                db.commit()
+                    db.add(revocation)
+                    db.commit()
             else:
                 # Create own session
                 with fresh_db_session() as db:
@@ -163,14 +161,12 @@ class TokenBlocklistService:
                         if repaired:
                             db.commit()
                         logger.debug("Token %s already revoked", SecurityValidator.sanitize_log_message(jti[:8]))
-                        await self._invalidate_auth_cache(jti)
-                        return True
+                    else:
+                        # Create revocation record
+                        revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
 
-                    # Create revocation record
-                    revocation = TokenRevocation(jti=jti, revoked_by=revoked_by, reason=reason, token_expiry=token_expiry, last_activity=last_activity or utc_now())
-
-                    db.add(revocation)
-                    db.commit()
+                        db.add(revocation)
+                        db.commit()
 
             # Cache in Redis for fast lookup
             redis_client = self._get_redis_client()

--- a/mcpgateway/services/token_blocklist_service.py
+++ b/mcpgateway/services/token_blocklist_service.py
@@ -32,6 +32,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailApiToken, fresh_db_session, TokenRevocation, utc_now
 from mcpgateway.services.logging_service import LoggingService
@@ -56,6 +57,22 @@ class TokenBlocklistService:
         """
         self.db = db
         self._redis_client = None
+
+    async def _invalidate_auth_cache(self, jti: str) -> None:
+        """Best-effort invalidate cached authentication state for a revoked token."""
+        safe_jti = SecurityValidator.sanitize_log_message(jti)
+        try:
+            # First-Party
+            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+
+            await auth_cache.invalidate_revocation(jti)
+        except Exception as cache_error:
+            logger.warning(
+                "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
+                safe_jti,
+                cache_error,
+                extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": safe_jti},
+            )
 
     def _get_redis_client(self):
         """Get Redis client for caching (lazy initialization).
@@ -111,26 +128,14 @@ class TokenBlocklistService:
                 if api_token and api_token.is_active:
                     repaired = True
                     api_token.is_active = False
-                    logger.debug("Set EmailApiToken.is_active=False for jti=%s", jti[:8])
+                    logger.debug("Set EmailApiToken.is_active=False for jti=%s", SecurityValidator.sanitize_log_message(jti[:8]))
 
                 if existing:
                     # Commit the repair if we updated is_active
                     if repaired:
                         db.commit()
-                    logger.debug("Token %s already revoked", jti)
-                    # Invalidate auth cache to ensure revoked token is rejected immediately
-                    try:
-                        # First-Party
-                        from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
-
-                        await auth_cache.invalidate_revocation(jti)
-                    except Exception as cache_error:
-                        logger.warning(
-                            "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
-                            jti,
-                            cache_error,
-                            extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
-                        )
+                    logger.debug("Token %s already revoked", SecurityValidator.sanitize_log_message(jti[:8]))
+                    await self._invalidate_auth_cache(jti)
                     return True
 
                 # Create revocation record
@@ -151,26 +156,14 @@ class TokenBlocklistService:
                     if api_token and api_token.is_active:
                         repaired = True
                         api_token.is_active = False
-                        logger.debug("Set EmailApiToken.is_active=False for jti=%s", jti[:8])
+                        logger.debug("Set EmailApiToken.is_active=False for jti=%s", SecurityValidator.sanitize_log_message(jti[:8]))
 
                     if existing:
                         # Commit the repair if we updated is_active
                         if repaired:
                             db.commit()
-                        logger.debug("Token %s already revoked", jti)
-                        # Invalidate auth cache to ensure revoked token is rejected immediately
-                        try:
-                            # First-Party
-                            from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
-
-                            await auth_cache.invalidate_revocation(jti)
-                        except Exception as cache_error:
-                            logger.warning(
-                                "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
-                                jti,
-                                cache_error,
-                                extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
-                            )
+                        logger.debug("Token %s already revoked", SecurityValidator.sanitize_log_message(jti[:8]))
+                        await self._invalidate_auth_cache(jti)
                         return True
 
                     # Create revocation record
@@ -193,32 +186,23 @@ class TokenBlocklistService:
                 except Exception as e:
                     logger.warning("Failed to cache revocation in Redis: %s", e)
 
-            # Invalidate auth cache to ensure revoked token is rejected immediately
-            try:
-                # First-Party
-                from mcpgateway.cache.auth_cache import auth_cache  # pylint: disable=import-outside-toplevel
+            await self._invalidate_auth_cache(jti)
 
-                await auth_cache.invalidate_revocation(jti)
-            except Exception as cache_error:
-                logger.warning(
-                    "Auth cache invalidation failed for revoked token; token may be accepted until cache TTL expiry: jti=%s: %s",
-                    jti,
-                    cache_error,
-                    extra={"security_event": "revocation_cache_invalidation_failed", "security_severity": "high", "jti": jti},
-                )
-
+            safe_jti = SecurityValidator.sanitize_log_message(jti)
+            safe_reason = SecurityValidator.sanitize_log_message(reason)
+            safe_revoked_by = SecurityValidator.sanitize_log_message(revoked_by)
             logger.info(
                 "Token revoked: jti=%s, reason=%s, revoked_by=%s",
-                jti,
-                reason,
-                revoked_by,
-                extra={"security_event": "token_revocation", "security_severity": "medium", "jti": jti, "reason": reason, "revoked_by": revoked_by},
+                safe_jti,
+                safe_reason,
+                safe_revoked_by,
+                extra={"security_event": "token_revocation", "security_severity": "medium", "jti": safe_jti, "reason": safe_reason, "revoked_by": safe_revoked_by},
             )
 
             return True
 
         except Exception as e:
-            logger.error("Failed to revoke token %s: %s", jti, e)
+            logger.error("Failed to revoke token %s: %s", SecurityValidator.sanitize_log_message(jti), e)
             return False
 
     def is_token_revoked(self, jti: str) -> bool:

--- a/mcpgateway/templates/tokens_partial.html
+++ b/mcpgateway/templates/tokens_partial.html
@@ -7,7 +7,12 @@
         <h4 class="text-lg font-medium text-gray-900 dark:text-white">
           {{ token.name }}
         </h4>
-        {% if token.is_active %}
+        {% if token.is_revoked %}
+        <span
+          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100"
+          >Revoked</span
+        >
+        {% elif token.is_active %}
         <span
           class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100"
           >Active</span
@@ -16,11 +21,6 @@
         <span
           class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100"
           >Inactive</span
-        >
-        {% endif %} {% if token.is_revoked %}
-        <span
-          class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100"
-          >Revoked</span
         >
         {% endif %} {% if token.team_name %}
         <span

--- a/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
+++ b/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
@@ -39,13 +39,32 @@ def test_upgrade_repairs_only_revoked_active_tokens():
         engine.dispose()
 
 
-def test_upgrade_is_idempotent_and_skips_missing_tables():
-    """Repeated runs and partial schemas remain safe."""
+def test_upgrade_skips_missing_tables():
+    """Partial schemas remain safe."""
     engine = sa.create_engine("sqlite:///:memory:")
     try:
         with engine.begin() as connection:
             _run_upgrade(connection)
             connection.execute(sa.text("CREATE TABLE email_api_tokens (jti VARCHAR PRIMARY KEY, is_active BOOLEAN NOT NULL)"))
             _run_upgrade(connection)
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_is_idempotent():
+    """Repeated upgrades leave repaired and valid rows unchanged."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text("CREATE TABLE email_api_tokens (jti VARCHAR PRIMARY KEY, is_active BOOLEAN NOT NULL)"))
+            connection.execute(sa.text("CREATE TABLE token_revocations (jti VARCHAR PRIMARY KEY)"))
+            connection.execute(sa.text("INSERT INTO email_api_tokens (jti, is_active) VALUES ('revoked', 1), ('valid', 1)"))
+            connection.execute(sa.text("INSERT INTO token_revocations (jti) VALUES ('revoked')"))
+
+            _run_upgrade(connection)
+            _run_upgrade(connection)
+
+            states = dict(connection.execute(sa.text("SELECT jti, is_active FROM email_api_tokens")).all())
+            assert states == {"revoked": 0, "valid": 1}
     finally:
         engine.dispose()

--- a/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
+++ b/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
@@ -1,5 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Tests for migration e5136a7c9d01."""
+"""Location: ./tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Tests for migration e5136a7c9d01.
+"""
 
 import importlib
 

--- a/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
+++ b/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""Tests for migration e5136a7c9d01."""
+
+import importlib
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import sqlalchemy as sa
+
+MODULE_NAME = "mcpgateway.alembic.versions.e5136a7c9d01_repair_revoked_api_token_status"
+
+
+def _run_upgrade(connection) -> None:
+    context = MigrationContext.configure(connection, opts={"as_sql": False})
+    with Operations.context(context):
+        importlib.import_module(MODULE_NAME).upgrade()
+
+
+def test_upgrade_repairs_only_revoked_active_tokens():
+    """Existing revoked rows become inactive without changing valid tokens."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text("CREATE TABLE email_api_tokens (jti VARCHAR PRIMARY KEY, is_active BOOLEAN NOT NULL)"))
+            connection.execute(sa.text("CREATE TABLE token_revocations (jti VARCHAR PRIMARY KEY)"))
+            connection.execute(sa.text("INSERT INTO email_api_tokens (jti, is_active) VALUES ('revoked-active', true), ('valid-active', true), ('revoked-inactive', false)"))
+            connection.execute(sa.text("INSERT INTO token_revocations (jti) VALUES ('revoked-active'), ('revoked-inactive')"))
+
+            _run_upgrade(connection)
+
+            states = dict(connection.execute(sa.text("SELECT jti, is_active FROM email_api_tokens")).all())
+            assert states == {"revoked-active": 0, "valid-active": 1, "revoked-inactive": 0}
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_is_idempotent_and_skips_missing_tables():
+    """Repeated runs and partial schemas remain safe."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            _run_upgrade(connection)
+            connection.execute(sa.text("CREATE TABLE email_api_tokens (jti VARCHAR PRIMARY KEY, is_active BOOLEAN NOT NULL)"))
+            _run_upgrade(connection)
+    finally:
+        engine.dispose()

--- a/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
+++ b/tests/unit/mcpgateway/db/test_revoked_api_token_status_migration.py
@@ -11,6 +11,7 @@ import importlib
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 MODULE_NAME = "mcpgateway.alembic.versions.e5136a7c9d01_repair_revoked_api_token_status"
 
@@ -19,6 +20,23 @@ def _run_upgrade(connection) -> None:
     context = MigrationContext.configure(connection, opts={"as_sql": False})
     with Operations.context(context):
         importlib.import_module(MODULE_NAME).upgrade()
+
+
+def test_repair_statement_uses_postgresql_booleans():
+    """PostgreSQL SQL must not compare BOOLEAN columns with integer literals."""
+    migration = importlib.import_module(MODULE_NAME)
+
+    sql = str(
+        migration._repair_statement().compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    assert "SET is_active=false" in sql
+    assert "is_active IS true" in sql
+    assert "is_active = 0" not in sql
+    assert "is_active = 1" not in sql
 
 
 def test_upgrade_repairs_only_revoked_active_tokens():

--- a/tests/unit/mcpgateway/routers/test_auth.py
+++ b/tests/unit/mcpgateway/routers/test_auth.py
@@ -409,7 +409,7 @@ class TestLogout:
 
             # Setup blocklist service
             mock_service = MagicMock()
-            mock_service.revoke_token.return_value = True
+            mock_service.revoke_token = AsyncMock(return_value=True)
             mock_blocklist_service.return_value = mock_service
 
             # Mock jwt.decode inside the function

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22212,6 +22212,88 @@ class TestTemplateButtonGating:
         html = self._render_tokens_partial(jinja_env, [token_data])
         assert 'data-action="token-revoke"' not in html
 
+    def test_tokens_revoked_badge_takes_priority_over_active_badge(self, jinja_env):
+        """Revoked badge must take priority over active/inactive badges to prevent dual badges."""
+        # Test case 1: Token is revoked and active (inconsistent state pre-fix)
+        revoked_active_token = {
+            "id": "tok-revoked-active",
+            "name": "Revoked Active Token",
+            "description": None,
+            "user_email": "user@example.com",
+            "team_id": None,
+            "team_name": None,
+            "created_at": "2026-04-01T00:00:00",
+            "expires_at": None,
+            "last_used": None,
+            "is_active": True,  # Inconsistent state
+            "is_revoked": True,
+            "revoked_at": "2026-04-02T00:00:00",
+            "revoked_by": "admin@example.com",
+            "revocation_reason": "Test",
+            "tags": [],
+            "server_id": None,
+            "resource_scopes": [],
+            "ip_restrictions": [],
+            "time_restrictions": {},
+            "usage_limits": {},
+            "_json": "{}",
+        }
+
+        # Test case 2: Token is revoked and inactive (correct state post-fix)
+        revoked_inactive_token = {
+            "id": "tok-revoked-inactive",
+            "name": "Revoked Inactive Token",
+            "description": None,
+            "user_email": "user@example.com",
+            "team_id": None,
+            "team_name": None,
+            "created_at": "2026-04-01T00:00:00",
+            "expires_at": None,
+            "last_used": None,
+            "is_active": False,
+            "is_revoked": True,
+            "revoked_at": "2026-04-02T00:00:00",
+            "revoked_by": "admin@example.com",
+            "revocation_reason": "Test",
+            "tags": [],
+            "server_id": None,
+            "resource_scopes": [],
+            "ip_restrictions": [],
+            "time_restrictions": {},
+            "usage_limits": {},
+            "_json": "{}",
+        }
+
+        # Render both tokens
+        html = self._render_tokens_partial(jinja_env, [revoked_active_token, revoked_inactive_token])
+
+        # Verify that "Revoked" badge appears but "Active" and "Inactive" badges do not
+        # for tokens where is_revoked=True
+
+        # Count occurrences of status badges (account for whitespace/newlines in HTML)
+        # Standard
+        import re
+
+        # Search for badges with flexible whitespace matching (including newlines)
+        # The closing tag might be split across lines like: >Revoked</span\n>
+        active_count = len(re.findall(r">Active</span", html))
+        inactive_count = len(re.findall(r">Inactive</span", html))
+        revoked_count = len(re.findall(r">Revoked</span", html))
+
+        # Should have exactly 2 "Revoked" badges (one per token)
+        assert revoked_count == 2, f"Expected 2 'Revoked' badges, found {revoked_count}"
+
+        # Should have NO "Active" or "Inactive" badges when tokens are revoked
+        assert active_count == 0, f"Expected 0 'Active' badges for revoked tokens, found {active_count}"
+        assert inactive_count == 0, f"Expected 0 'Inactive' badges for revoked tokens, found {inactive_count}"
+
+        # Additional verification: ensure template uses {% elif %} not {% if %} for active/inactive
+        # This ensures mutually exclusive badge rendering
+        with open("mcpgateway/templates/tokens_partial.html", encoding="utf-8") as f:
+            template_content = f.read()
+        assert "{% elif token.is_active %}" in template_content, \
+            "Template should use {% elif %} to ensure mutually exclusive badges"
+
 
 class TestAdminGetToolPassesTeamRoles:
     """Tests that admin_get_tool and admin_list_tools pass requesting_user_team_roles."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -22287,13 +22287,6 @@ class TestTemplateButtonGating:
         assert active_count == 0, f"Expected 0 'Active' badges for revoked tokens, found {active_count}"
         assert inactive_count == 0, f"Expected 0 'Inactive' badges for revoked tokens, found {inactive_count}"
 
-        # Additional verification: ensure template uses {% elif %} not {% if %} for active/inactive
-        # This ensures mutually exclusive badge rendering
-        with open("mcpgateway/templates/tokens_partial.html", encoding="utf-8") as f:
-            template_content = f.read()
-        assert "{% elif token.is_active %}" in template_content, \
-            "Template should use {% elif %} to ensure mutually exclusive badges"
-
 
 class TestAdminGetToolPassesTeamRoles:
     """Tests that admin_get_tool and admin_list_tools pass requesting_user_team_roles."""

--- a/tests/unit/mcpgateway/test_auth_idle_timeout.py
+++ b/tests/unit/mcpgateway/test_auth_idle_timeout.py
@@ -166,6 +166,8 @@ def _patched_settings(token_idle_timeout: int):
 
 def _make_blocklist_mock(*, last_activity_returns=None, last_activity_raises=None, update_activity_raises=False, revoke_raises=False):
     """Construct a configurable ``TokenBlocklistService`` mock."""
+    from unittest.mock import AsyncMock
+    
     mock = MagicMock()
     if last_activity_raises is not None:
         mock.get_last_activity.side_effect = last_activity_raises
@@ -176,9 +178,9 @@ def _make_blocklist_mock(*, last_activity_returns=None, last_activity_raises=Non
     else:
         mock.update_activity.return_value = True
     if revoke_raises:
-        mock.revoke_token.side_effect = RuntimeError("blocklist write failed")
+        mock.revoke_token = AsyncMock(side_effect=RuntimeError("blocklist write failed"))
     else:
-        mock.revoke_token.return_value = True
+        mock.revoke_token = AsyncMock(return_value=True)
     return mock
 
 

--- a/tests/unit/mcpgateway/test_auth_idle_timeout.py
+++ b/tests/unit/mcpgateway/test_auth_idle_timeout.py
@@ -167,7 +167,7 @@ def _patched_settings(token_idle_timeout: int):
 def _make_blocklist_mock(*, last_activity_returns=None, last_activity_raises=None, update_activity_raises=False, revoke_raises=False):
     """Construct a configurable ``TokenBlocklistService`` mock."""
     from unittest.mock import AsyncMock
-    
+
     mock = MagicMock()
     if last_activity_raises is not None:
         mock.get_last_activity.side_effect = last_activity_raises

--- a/tests/unit/mcpgateway/test_auth_logout.py
+++ b/tests/unit/mcpgateway/test_auth_logout.py
@@ -77,9 +77,9 @@ def setup_test_db(test_engine, test_session_factory):
     original_engine = mcpgateway.db.engine
     mcpgateway.db.SessionLocal = test_session_factory
     mcpgateway.db.engine = test_engine
-    
+
     yield
-    
+
     mcpgateway.db.SessionLocal = original_session_local
     mcpgateway.db.engine = original_engine
 

--- a/tests/unit/mcpgateway/test_auth_logout.py
+++ b/tests/unit/mcpgateway/test_auth_logout.py
@@ -7,32 +7,81 @@ Unit tests for logout endpoint in auth router.
 """
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from mcpgateway.config import get_settings
 from mcpgateway.main import app
 from mcpgateway.routers.auth import get_db
 from mcpgateway.auth import get_current_user
+from mcpgateway.db import Base, EmailUser
+import mcpgateway.db
 
 
 @pytest.fixture
-def mock_db():
-    """Mock database session."""
-    db = MagicMock()
-    return db
+def test_engine():
+    """Create in-memory SQLite engine with proper schema."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return engine
 
 
 @pytest.fixture
-def mock_current_user():
-    """Mock current user."""
-    user = MagicMock()
-    user.email = "test@example.com"
+def test_session_factory(test_engine):
+    """Create session factory for test database."""
+    return sessionmaker(bind=test_engine)
+
+
+@pytest.fixture
+def mock_db(test_session_factory):
+    """Mock database session with proper schema."""
+    db = test_session_factory()
+    # Add test user
+    user = EmailUser(
+        email="test@example.com",
+        password_hash="x",
+        full_name="Test User",
+        is_admin=False,
+        is_active=True,
+        auth_provider="local",
+        email_verified_at=datetime.now(timezone.utc),
+    )
+    db.add(user)
+    db.commit()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def mock_current_user(mock_db):
+    """Mock current user from database."""
+    user = mock_db.query(EmailUser).filter_by(email="test@example.com").first()
     return user
+
+
+@pytest.fixture
+def setup_test_db(test_engine, test_session_factory):
+    """Setup test database for authentication middleware."""
+    original_session_local = mcpgateway.db.SessionLocal
+    original_engine = mcpgateway.db.engine
+    mcpgateway.db.SessionLocal = test_session_factory
+    mcpgateway.db.engine = test_engine
+    
+    yield
+    
+    mcpgateway.db.SessionLocal = original_session_local
+    mcpgateway.db.engine = original_engine
 
 
 @pytest.fixture
@@ -64,7 +113,7 @@ def valid_token():
 class TestLogoutEndpoint:
     """Tests for /auth/logout endpoint."""
 
-    def test_logout_success(self, mock_db, mock_current_user, valid_token):
+    def test_logout_success(self, setup_test_db, mock_db, mock_current_user, valid_token):
         """Test successful logout."""
         # Override FastAPI dependencies
         app.dependency_overrides[get_current_user] = lambda: mock_current_user
@@ -73,7 +122,7 @@ class TestLogoutEndpoint:
         try:
             with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
                 mock_blocklist = MagicMock()
-                mock_blocklist.revoke_token.return_value = True
+                mock_blocklist.revoke_token = AsyncMock(return_value=True)
                 mock_service.return_value = mock_blocklist
 
                 client = TestClient(app)
@@ -94,7 +143,7 @@ class TestLogoutEndpoint:
             # Clean up overrides
             app.dependency_overrides.clear()
 
-    def test_logout_missing_authorization_header(self, mock_db):
+    def test_logout_missing_authorization_header(self, setup_test_db, mock_db):
         """Test logout without Authorization header."""
 
         def mock_auth_fail():
@@ -111,7 +160,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_invalid_bearer_format(self, mock_db, mock_current_user):
+    def test_logout_invalid_bearer_format(self, setup_test_db, mock_db, mock_current_user):
         """Test logout with invalid Bearer format."""
         app.dependency_overrides[get_current_user] = lambda: mock_current_user
         app.dependency_overrides[get_db] = lambda: mock_db
@@ -127,7 +176,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_token_without_jti(self, mock_db, mock_current_user):
+    def test_logout_token_without_jti(self, setup_test_db, mock_db, mock_current_user):
         """Test logout with token missing JTI."""
         settings = get_settings()
 
@@ -160,7 +209,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_invalid_token_format(self, mock_db, mock_current_user):
+    def test_logout_invalid_token_format(self, setup_test_db, mock_db, mock_current_user):
         """Test logout with malformed token."""
         app.dependency_overrides[get_current_user] = lambda: mock_current_user
         app.dependency_overrides[get_db] = lambda: mock_db
@@ -175,7 +224,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_revocation_failure(self, mock_db, mock_current_user, valid_token):
+    def test_logout_revocation_failure(self, setup_test_db, mock_db, mock_current_user, valid_token):
         """Test logout when token revocation fails."""
         app.dependency_overrides[get_current_user] = lambda: mock_current_user
         app.dependency_overrides[get_db] = lambda: mock_db
@@ -183,7 +232,7 @@ class TestLogoutEndpoint:
         try:
             with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
                 mock_blocklist = MagicMock()
-                mock_blocklist.revoke_token.return_value = False
+                mock_blocklist.revoke_token = AsyncMock(return_value=False)
                 mock_service.return_value = mock_blocklist
 
                 client = TestClient(app)
@@ -194,7 +243,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_unexpected_error(self, mock_db, mock_current_user, valid_token):
+    def test_logout_unexpected_error(self, setup_test_db, mock_db, mock_current_user, valid_token):
         """Test logout with unexpected error."""
         app.dependency_overrides[get_current_user] = lambda: mock_current_user
         app.dependency_overrides[get_db] = lambda: mock_db
@@ -211,7 +260,7 @@ class TestLogoutEndpoint:
         finally:
             app.dependency_overrides.clear()
 
-    def test_logout_with_secretstr_jwt_key(self, mock_db, mock_current_user, valid_token):
+    def test_logout_with_secretstr_jwt_key(self, setup_test_db, mock_db, mock_current_user, valid_token):
         """Test logout with SecretStr jwt_secret_key (covers line 244 in routers/auth.py)."""
         from pydantic import SecretStr
 
@@ -231,7 +280,7 @@ class TestLogoutEndpoint:
 
                 with patch("mcpgateway.services.token_blocklist_service.get_token_blocklist_service") as mock_service:
                     mock_blocklist = MagicMock()
-                    mock_blocklist.revoke_token.return_value = True
+                    mock_blocklist.revoke_token = AsyncMock(return_value=True)
                     mock_service.return_value = mock_blocklist
 
                     client = TestClient(app)

--- a/tests/unit/mcpgateway/test_auth_logout.py
+++ b/tests/unit/mcpgateway/test_auth_logout.py
@@ -13,7 +13,7 @@ import jwt
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -21,7 +21,7 @@ from mcpgateway.config import get_settings
 from mcpgateway.main import app
 from mcpgateway.routers.auth import get_db
 from mcpgateway.auth import get_current_user
-from mcpgateway.db import Base, EmailUser
+from mcpgateway.db import Base, EmailApiToken, EmailUser, TokenRevocation
 import mcpgateway.db
 
 
@@ -141,6 +141,32 @@ class TestLogoutEndpoint:
                 assert call_args.kwargs["reason"] == "logout"
         finally:
             # Clean up overrides
+            app.dependency_overrides.clear()
+
+    def test_logout_persists_inactive_token_and_revocation(self, setup_test_db, mock_db, mock_current_user, valid_token):
+        """Real logout keeps catalog and blocklist state consistent."""
+        api_token = EmailApiToken(user_email="test@example.com", name="Logout integration token", jti="test-jti-123", token_hash="test-hash", is_active=True)
+        mock_db.add(api_token)
+        mock_db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: mock_current_user
+        app.dependency_overrides[get_db] = lambda: mock_db
+
+        try:
+            with (
+                patch("mcpgateway.services.token_blocklist_service.TokenBlocklistService._get_redis_client", return_value=None),
+                patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock) as mock_invalidate,
+            ):
+                response = TestClient(app).post("/auth/logout", headers={"Authorization": f"Bearer {valid_token}"})
+
+            assert response.status_code == 200
+            mock_db.expire_all()
+            persisted_token = mock_db.execute(select(EmailApiToken).where(EmailApiToken.jti == "test-jti-123")).scalar_one()
+            revocation = mock_db.execute(select(TokenRevocation).where(TokenRevocation.jti == "test-jti-123")).scalar_one()
+            assert persisted_token.is_active is False
+            assert revocation.reason == "logout"
+            mock_invalidate.assert_awaited_once_with("test-jti-123")
+        finally:
             app.dependency_overrides.clear()
 
     def test_logout_missing_authorization_header(self, setup_test_db, mock_db):

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -17,6 +17,7 @@ Tests cover:
 # Standard
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+import logging
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
@@ -428,6 +429,46 @@ class TestTokenRevocation:
         assert revocation_check.reason == "idle_timeout"  # Original reason preserved
 
     @pytest.mark.asyncio
+    async def test_revoke_token_duplicate_already_inactive_does_not_commit(self, blocklist_service, test_db):
+        """Test duplicate revocation only commits when it repairs active token state."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Already Inactive",
+            slug="test-team-already-inactive",
+            created_by="test@example.com",
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Already Inactive",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=False,
+        )
+        revocation = TokenRevocation(jti=jti, revoked_by="system@example.com", reason="logout")
+        test_db.add_all([api_token, revocation])
+        test_db.commit()
+
+        with (
+            patch.object(test_db, "commit", wraps=test_db.commit) as mock_commit,
+            patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock) as mock_invalidate,
+        ):
+            result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+
+        assert result is True
+        mock_commit.assert_not_called()
+        mock_invalidate.assert_awaited_once_with(jti)
+
+    @pytest.mark.asyncio
     async def test_revoke_token_repairs_inconsistent_state_without_db_session(self, test_db):
         """Test that revoking an already-revoked token repairs EmailApiToken.is_active using fresh_db_session."""
         # First-Party
@@ -540,7 +581,7 @@ class TestTokenRevocation:
             mock_invalidate.assert_awaited_once_with(jti)
 
     @pytest.mark.asyncio
-    async def test_revoke_token_cache_invalidation_exception_handling(self, blocklist_service, test_db):
+    async def test_revoke_token_cache_invalidation_exception_handling(self, blocklist_service, test_db, caplog):
         """Test that cache invalidation exceptions are handled gracefully."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -571,7 +612,10 @@ class TestTokenRevocation:
         test_db.commit()
 
         # Mock auth_cache.invalidate_revocation to raise an exception
-        with patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock, side_effect=Exception("Cache error")):
+        with (
+            caplog.at_level(logging.WARNING, logger="mcpgateway.services.token_blocklist_service"),
+            patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock, side_effect=Exception("Cache error")),
+        ):
             # Should still succeed even if cache invalidation fails
             result = await blocklist_service.revoke_token(
                 jti=jti,
@@ -587,6 +631,7 @@ class TestTokenRevocation:
             ).scalar_one_or_none()
 
             assert revocation is not None
+            assert "token may be accepted until cache TTL expiry" in caplog.text
 
 
 class TestRevocationCheck:
@@ -954,6 +999,7 @@ class TestErrorHandling:
 
             # Should fail closed (treat as revoked on error)
             result = service.is_token_revoked(str(uuid.uuid4()))
+            assert result is True
 
     @pytest.mark.asyncio
     @patch("mcpgateway.services.token_blocklist_service.TokenBlocklistService._get_redis_client")

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -273,6 +273,121 @@ class TestTokenRevocation:
         assert revocation is not None
         assert revocation.reason == "security"
 
+    def test_revoke_token_invalidates_auth_cache(self, blocklist_service, test_db):
+        """Test that revoking a token invalidates the auth cache."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Cache",
+            slug="test-team-cache",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Cache",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Mock asyncio.run to verify it's called without actually running the coroutine
+        with patch("mcpgateway.services.token_blocklist_service.asyncio.run") as mock_asyncio_run:
+            # Revoke the token
+            result = blocklist_service.revoke_token(
+                jti=jti,
+                revoked_by="test@example.com",
+                reason="logout"
+            )
+
+            assert result is True
+
+            # Verify cache invalidation was called (we're outside an async context, so asyncio.run should be called)
+            mock_asyncio_run.assert_called_once()
+
+            # Verify the call was for auth_cache.invalidate_revocation by checking the coroutine name
+            call_args = mock_asyncio_run.call_args
+            coro = call_args[0][0]  # First positional argument
+            assert coro.__name__ == "invalidate_revocation"
+
+    def test_revoke_token_repairs_inconsistent_state(self, blocklist_service, test_db):
+        """Test that revoking an already-revoked token repairs EmailApiToken.is_active if inconsistent."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Repair",
+            slug="test-team-repair",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Repair",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Create TokenRevocation entry directly (simulating inconsistent state)
+        revocation = TokenRevocation(
+            jti=jti,
+            revoked_by="system@example.com",
+            reason="idle_timeout"
+        )
+        test_db.add(revocation)
+        test_db.commit()
+
+        # Verify token is still active (inconsistent state)
+        test_db.refresh(api_token)
+        assert api_token.is_active is True
+
+        # Call revoke_token again (idempotent path should repair)
+        result = blocklist_service.revoke_token(
+            jti=jti,
+            revoked_by="test@example.com",
+            reason="logout"
+        )
+
+        assert result is True
+
+        # Refresh the token from database
+        test_db.refresh(api_token)
+
+        # Verify token is now inactive (repaired)
+        assert api_token.is_active is False
+
+        # Verify TokenRevocation still exists with original data
+        revocation_check = test_db.execute(
+            select(TokenRevocation).where(TokenRevocation.jti == jti)
+        ).scalar_one_or_none()
+
+        assert revocation_check is not None
+        assert revocation_check.reason == "idle_timeout"  # Original reason preserved
+
 
 class TestRevocationCheck:
     """Tests for checking if tokens are revoked."""

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -388,6 +388,171 @@ class TestTokenRevocation:
         assert revocation_check is not None
         assert revocation_check.reason == "idle_timeout"  # Original reason preserved
 
+    def test_revoke_token_repairs_inconsistent_state_without_db_session(self, test_db):
+        """Test that revoking an already-revoked token repairs EmailApiToken.is_active using fresh_db_session."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Repair Fresh",
+            slug="test-team-repair-fresh",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Repair Fresh",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Create TokenRevocation entry directly (simulating inconsistent state)
+        revocation = TokenRevocation(
+            jti=jti,
+            revoked_by="system@example.com",
+            reason="idle_timeout"
+        )
+        test_db.add(revocation)
+        test_db.commit()
+
+        # Verify token is still active (inconsistent state)
+        test_db.refresh(api_token)
+        assert api_token.is_active is True
+
+        # Create service without db to test fresh_db_session path
+        service = TokenBlocklistService(db=None)
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.token_blocklist_service.fresh_db_session") as mock_session:
+            mock_session.return_value.__enter__.return_value = test_db
+            mock_session.return_value.__exit__.return_value = None
+
+            # Call revoke_token (idempotent path should repair via fresh_db_session)
+            result = service.revoke_token(
+                jti=jti,
+                revoked_by="test@example.com",
+                reason="logout"
+            )
+
+            assert result is True
+
+        # Refresh the token from database
+        test_db.refresh(api_token)
+
+        # Verify token is now inactive (repaired via fresh_db_session path)
+        assert api_token.is_active is False
+
+    @patch("mcpgateway.services.token_blocklist_service.asyncio.get_running_loop")
+    def test_revoke_token_invalidates_auth_cache_in_async_context(self, mock_get_loop, blocklist_service, test_db):
+        """Test that cache invalidation uses create_task when in async context."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Async",
+            slug="test-team-async",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Async",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Mock event loop
+        mock_loop = MagicMock()
+        mock_task = MagicMock()
+        mock_loop.create_task.return_value = mock_task
+        mock_get_loop.return_value = mock_loop
+
+        # Revoke the token
+        result = blocklist_service.revoke_token(
+            jti=jti,
+            revoked_by="test@example.com",
+            reason="logout"
+        )
+
+        assert result is True
+
+        # Verify create_task was called (async context path)
+        mock_loop.create_task.assert_called_once()
+        # Verify done_callback was added to suppress warning
+        mock_task.add_done_callback.assert_called_once()
+
+    def test_revoke_token_cache_invalidation_exception_handling(self, blocklist_service, test_db):
+        """Test that cache invalidation exceptions are handled gracefully."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team Exception",
+            slug="test-team-exception",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token Exception",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Mock the auth_cache import to raise an exception
+        with patch("mcpgateway.services.token_blocklist_service.asyncio.run", side_effect=Exception("Cache error")):
+            # Should still succeed even if cache invalidation fails
+            result = blocklist_service.revoke_token(
+                jti=jti,
+                revoked_by="test@example.com",
+                reason="logout"
+            )
+
+            assert result is True
+
+            # Verify token was still revoked in DB
+            revocation = test_db.execute(
+                select(TokenRevocation).where(TokenRevocation.jti == jti)
+            ).scalar_one_or_none()
+
+            assert revocation is not None
+
 
 class TestRevocationCheck:
     """Tests for checking if tokens are revoked."""

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -131,6 +131,84 @@ class TestTokenRevocation:
         assert revocation.last_activity is not None
         assert revocation.reason == "idle_timeout"
 
+    def test_revoke_token_sets_api_token_inactive(self, blocklist_service, test_db):
+        """Test that revoking a token sets EmailApiToken.is_active to False."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team",
+            slug="test-team",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Verify token is initially active
+        assert api_token.is_active is True
+
+        # Revoke the token
+        result = blocklist_service.revoke_token(
+            jti=jti,
+            revoked_by="test@example.com",
+            reason="idle_timeout"
+        )
+
+        assert result is True
+
+        # Refresh the token from database
+        test_db.refresh(api_token)
+
+        # Verify token is now inactive
+        assert api_token.is_active is False
+
+        # Verify revocation record exists
+        revocation = test_db.execute(
+            select(TokenRevocation).where(TokenRevocation.jti == jti)
+        ).scalar_one_or_none()
+
+        assert revocation is not None
+        assert revocation.reason == "idle_timeout"
+
+    def test_revoke_token_without_api_token_record(self, blocklist_service, test_db):
+        """Test that revoking a session token (no EmailApiToken) works correctly."""
+        # Session tokens don't have EmailApiToken records
+        jti = str(uuid.uuid4())
+
+        # Revoke the token (should not fail even though no EmailApiToken exists)
+        result = blocklist_service.revoke_token(
+            jti=jti,
+            revoked_by="test@example.com",
+            reason="logout"
+        )
+
+        assert result is True
+
+        # Verify revocation record exists
+        revocation = test_db.execute(
+            select(TokenRevocation).where(TokenRevocation.jti == jti)
+        ).scalar_one_or_none()
+
+        assert revocation is not None
+        assert revocation.reason == "logout"
+
 
 class TestRevocationCheck:
     """Tests for checking if tokens are revoked."""

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -209,6 +209,70 @@ class TestTokenRevocation:
         assert revocation is not None
         assert revocation.reason == "logout"
 
+    def test_revoke_token_sets_api_token_inactive_without_db_session(self, test_db):
+        """Test that revoking a token sets EmailApiToken.is_active to False when using fresh_db_session."""
+        # First-Party
+        from mcpgateway.db import EmailApiToken, EmailTeam
+
+        # Create a test team
+        team = EmailTeam(
+            id=str(uuid.uuid4()),
+            name="Test Team No Session",
+            slug="test-team-no-session",
+            created_by="test@example.com",
+            is_active=True
+        )
+        test_db.add(team)
+        test_db.commit()
+
+        # Create an API token
+        jti = str(uuid.uuid4())
+        api_token = EmailApiToken(
+            id=str(uuid.uuid4()),
+            user_email="test@example.com",
+            team_id=team.id,
+            name="Test Token No Session",
+            jti=jti,
+            token_hash="test_hash",
+            is_active=True
+        )
+        test_db.add(api_token)
+        test_db.commit()
+
+        # Verify token is initially active
+        assert api_token.is_active is True
+
+        # Create service without db to test fresh_db_session path
+        service = TokenBlocklistService(db=None)
+
+        # Mock fresh_db_session to use test_db
+        with patch("mcpgateway.services.token_blocklist_service.fresh_db_session") as mock_session:
+            mock_session.return_value.__enter__.return_value = test_db
+            mock_session.return_value.__exit__.return_value = None
+
+            # Revoke the token
+            result = service.revoke_token(
+                jti=jti,
+                revoked_by="test@example.com",
+                reason="security"
+            )
+
+            assert result is True
+
+        # Refresh the token from database
+        test_db.refresh(api_token)
+
+        # Verify token is now inactive
+        assert api_token.is_active is False
+
+        # Verify revocation record exists
+        revocation = test_db.execute(
+            select(TokenRevocation).where(TokenRevocation.jti == jti)
+        ).scalar_one_or_none()
+
+        assert revocation is not None
+        assert revocation.reason == "security"
+
 
 class TestRevocationCheck:
     """Tests for checking if tokens are revoked."""

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -18,7 +18,7 @@ Tests cover:
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 # Third-Party
@@ -59,13 +59,14 @@ def blocklist_service(test_db):
 class TestTokenRevocation:
     """Tests for token revocation functionality."""
 
-    def test_revoke_token_success(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_success(self, blocklist_service, test_db):
         """Test successful token revocation."""
         jti = str(uuid.uuid4())
         # Use utc_now() to ensure consistent timezone handling
         token_expiry = utc_now() + timedelta(minutes=20)
 
-        result = blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout", token_expiry=token_expiry)
+        result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout", token_expiry=token_expiry)
 
         assert result is True
 
@@ -86,19 +87,21 @@ class TestTokenRevocation:
             # Both are timezone-aware
             assert abs((revocation.token_expiry - token_expiry).total_seconds()) < 1
 
-    def test_revoke_token_duplicate(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_duplicate(self, blocklist_service, test_db):
         """Test revoking an already revoked token."""
         jti = str(uuid.uuid4())
 
         # Revoke once
-        blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         # Revoke again - should succeed (idempotent)
-        result = blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         assert result is True
 
-    def test_revoke_token_duplicate_without_db_session(self, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_duplicate_without_db_session(self, test_db):
         """Test revoking an already revoked token without db session."""
         # Create service without db to test fresh_db_session path
         service = TokenBlocklistService(db=None)
@@ -110,19 +113,20 @@ class TestTokenRevocation:
             mock_session.return_value.__exit__.return_value = None
 
             # Revoke once
-            service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+            await service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
             # Revoke again - should succeed (idempotent) and hit the duplicate check path
-            result = service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+            result = await service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
             assert result is True
 
-    def test_revoke_token_with_last_activity(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_with_last_activity(self, blocklist_service, test_db):
         """Test token revocation with last activity timestamp."""
         jti = str(uuid.uuid4())
         last_activity = utc_now() - timedelta(minutes=30)
 
-        result = blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="idle_timeout", last_activity=last_activity)
+        result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="idle_timeout", last_activity=last_activity)
 
         assert result is True
 
@@ -131,7 +135,8 @@ class TestTokenRevocation:
         assert revocation.last_activity is not None
         assert revocation.reason == "idle_timeout"
 
-    def test_revoke_token_sets_api_token_inactive(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_sets_api_token_inactive(self, blocklist_service, test_db):
         """Test that revoking a token sets EmailApiToken.is_active to False."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -165,7 +170,7 @@ class TestTokenRevocation:
         assert api_token.is_active is True
 
         # Revoke the token
-        result = blocklist_service.revoke_token(
+        result = await blocklist_service.revoke_token(
             jti=jti,
             revoked_by="test@example.com",
             reason="idle_timeout"
@@ -187,13 +192,14 @@ class TestTokenRevocation:
         assert revocation is not None
         assert revocation.reason == "idle_timeout"
 
-    def test_revoke_token_without_api_token_record(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_without_api_token_record(self, blocklist_service, test_db):
         """Test that revoking a session token (no EmailApiToken) works correctly."""
         # Session tokens don't have EmailApiToken records
         jti = str(uuid.uuid4())
 
         # Revoke the token (should not fail even though no EmailApiToken exists)
-        result = blocklist_service.revoke_token(
+        result = await blocklist_service.revoke_token(
             jti=jti,
             revoked_by="test@example.com",
             reason="logout"
@@ -209,7 +215,8 @@ class TestTokenRevocation:
         assert revocation is not None
         assert revocation.reason == "logout"
 
-    def test_revoke_token_sets_api_token_inactive_without_db_session(self, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_sets_api_token_inactive_without_db_session(self, test_db):
         """Test that revoking a token sets EmailApiToken.is_active to False when using fresh_db_session."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -251,7 +258,7 @@ class TestTokenRevocation:
             mock_session.return_value.__exit__.return_value = None
 
             # Revoke the token
-            result = service.revoke_token(
+            result = await service.revoke_token(
                 jti=jti,
                 revoked_by="test@example.com",
                 reason="security"
@@ -273,7 +280,8 @@ class TestTokenRevocation:
         assert revocation is not None
         assert revocation.reason == "security"
 
-    def test_revoke_token_invalidates_auth_cache(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_invalidates_auth_cache(self, blocklist_service, test_db):
         """Test that revoking a token invalidates the auth cache."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -303,10 +311,10 @@ class TestTokenRevocation:
         test_db.add(api_token)
         test_db.commit()
 
-        # Mock asyncio.run to verify it's called without actually running the coroutine
-        with patch("mcpgateway.services.token_blocklist_service.asyncio.run") as mock_asyncio_run:
+        # Mock auth_cache.invalidate_revocation to verify it's called
+        with patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock) as mock_invalidate:
             # Revoke the token
-            result = blocklist_service.revoke_token(
+            result = await blocklist_service.revoke_token(
                 jti=jti,
                 revoked_by="test@example.com",
                 reason="logout"
@@ -314,15 +322,11 @@ class TestTokenRevocation:
 
             assert result is True
 
-            # Verify cache invalidation was called (we're outside an async context, so asyncio.run should be called)
-            mock_asyncio_run.assert_called_once()
+            # Verify cache invalidation was awaited
+            mock_invalidate.assert_awaited_once_with(jti)
 
-            # Verify the call was for auth_cache.invalidate_revocation by checking the coroutine name
-            call_args = mock_asyncio_run.call_args
-            coro = call_args[0][0]  # First positional argument
-            assert coro.__name__ == "invalidate_revocation"
-
-    def test_revoke_token_repairs_inconsistent_state(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_repairs_inconsistent_state(self, blocklist_service, test_db):
         """Test that revoking an already-revoked token repairs EmailApiToken.is_active if inconsistent."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -366,7 +370,7 @@ class TestTokenRevocation:
         assert api_token.is_active is True
 
         # Call revoke_token again (idempotent path should repair)
-        result = blocklist_service.revoke_token(
+        result = await blocklist_service.revoke_token(
             jti=jti,
             revoked_by="test@example.com",
             reason="logout"
@@ -388,7 +392,8 @@ class TestTokenRevocation:
         assert revocation_check is not None
         assert revocation_check.reason == "idle_timeout"  # Original reason preserved
 
-    def test_revoke_token_repairs_inconsistent_state_without_db_session(self, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_repairs_inconsistent_state_without_db_session(self, test_db):
         """Test that revoking an already-revoked token repairs EmailApiToken.is_active using fresh_db_session."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -440,7 +445,7 @@ class TestTokenRevocation:
             mock_session.return_value.__exit__.return_value = None
 
             # Call revoke_token (idempotent path should repair via fresh_db_session)
-            result = service.revoke_token(
+            result = await service.revoke_token(
                 jti=jti,
                 revoked_by="test@example.com",
                 reason="logout"
@@ -454,9 +459,9 @@ class TestTokenRevocation:
         # Verify token is now inactive (repaired via fresh_db_session path)
         assert api_token.is_active is False
 
-    @patch("mcpgateway.services.token_blocklist_service.asyncio.get_running_loop")
-    def test_revoke_token_invalidates_auth_cache_in_async_context(self, mock_get_loop, blocklist_service, test_db):
-        """Test that cache invalidation uses create_task when in async context."""
+    @pytest.mark.asyncio
+    async def test_revoke_token_invalidates_auth_cache_in_async_context(self, blocklist_service, test_db):
+        """Test that cache invalidation is properly awaited in async context."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
 
@@ -485,27 +490,22 @@ class TestTokenRevocation:
         test_db.add(api_token)
         test_db.commit()
 
-        # Mock event loop
-        mock_loop = MagicMock()
-        mock_task = MagicMock()
-        mock_loop.create_task.return_value = mock_task
-        mock_get_loop.return_value = mock_loop
+        # Mock auth_cache.invalidate_revocation to verify it's awaited
+        with patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock) as mock_invalidate:
+            # Revoke the token
+            result = await blocklist_service.revoke_token(
+                jti=jti,
+                revoked_by="test@example.com",
+                reason="logout"
+            )
 
-        # Revoke the token
-        result = blocklist_service.revoke_token(
-            jti=jti,
-            revoked_by="test@example.com",
-            reason="logout"
-        )
+            assert result is True
 
-        assert result is True
+            # Verify cache invalidation was awaited (not fire-and-forget)
+            mock_invalidate.assert_awaited_once_with(jti)
 
-        # Verify create_task was called (async context path)
-        mock_loop.create_task.assert_called_once()
-        # Verify done_callback was added to suppress warning
-        mock_task.add_done_callback.assert_called_once()
-
-    def test_revoke_token_cache_invalidation_exception_handling(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_revoke_token_cache_invalidation_exception_handling(self, blocklist_service, test_db):
         """Test that cache invalidation exceptions are handled gracefully."""
         # First-Party
         from mcpgateway.db import EmailApiToken, EmailTeam
@@ -535,10 +535,10 @@ class TestTokenRevocation:
         test_db.add(api_token)
         test_db.commit()
 
-        # Mock the auth_cache import to raise an exception
-        with patch("mcpgateway.services.token_blocklist_service.asyncio.run", side_effect=Exception("Cache error")):
+        # Mock auth_cache.invalidate_revocation to raise an exception
+        with patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock, side_effect=Exception("Cache error")):
             # Should still succeed even if cache invalidation fails
-            result = blocklist_service.revoke_token(
+            result = await blocklist_service.revoke_token(
                 jti=jti,
                 revoked_by="test@example.com",
                 reason="logout"
@@ -557,12 +557,13 @@ class TestTokenRevocation:
 class TestRevocationCheck:
     """Tests for checking if tokens are revoked."""
 
-    def test_is_token_revoked_true(self, blocklist_service, test_db):
+    @pytest.mark.asyncio
+    async def test_is_token_revoked_true(self, blocklist_service, test_db):
         """Test checking a revoked token."""
         jti = str(uuid.uuid4())
 
         # Revoke token
-        blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         # Check if revoked
         assert blocklist_service.is_token_revoked(jti) is True
@@ -573,8 +574,9 @@ class TestRevocationCheck:
 
         assert blocklist_service.is_token_revoked(jti) is False
 
+    @pytest.mark.asyncio
     @patch("mcpgateway.services.token_blocklist_service.TokenBlocklistService._get_redis_client")
-    def test_is_token_revoked_with_redis_cache(self, mock_redis, blocklist_service, test_db):
+    async def test_is_token_revoked_with_redis_cache(self, mock_redis, blocklist_service, test_db):
         """Test revocation check with Redis caching."""
         jti = str(uuid.uuid4())
 
@@ -584,13 +586,14 @@ class TestRevocationCheck:
         mock_redis.return_value = redis_mock
 
         # Revoke token (should cache in Redis)
-        blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         # Check revocation (should hit Redis cache)
         assert blocklist_service.is_token_revoked(jti) is True
 
+    @pytest.mark.asyncio
     @patch("mcpgateway.services.token_blocklist_service.TokenBlocklistService._get_redis_client")
-    def test_revoke_token_redis_cache_error(self, mock_redis, blocklist_service, test_db):
+    async def test_revoke_token_redis_cache_error(self, mock_redis, blocklist_service, test_db):
         """Test token revocation when Redis caching fails."""
         jti = str(uuid.uuid4())
 
@@ -600,7 +603,7 @@ class TestRevocationCheck:
         mock_redis.return_value = redis_mock
 
         # Should still succeed even if Redis caching fails
-        result = blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout", token_expiry=utc_now() + timedelta(hours=1))
+        result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout", token_expiry=utc_now() + timedelta(hours=1))
 
         assert result is True
 
@@ -608,13 +611,14 @@ class TestRevocationCheck:
         revocation = test_db.execute(select(TokenRevocation).where(TokenRevocation.jti == jti)).scalar_one_or_none()
         assert revocation is not None
 
-    def test_is_token_revoked_without_db_session(self):
+    @pytest.mark.asyncio
+    async def test_is_token_revoked_without_db_session(self):
         """Test checking revocation without db session."""
         service = TokenBlocklistService(db=None)
         jti = str(uuid.uuid4())
 
         # Revoke token first
-        service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        await service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         # Check if revoked (should use fresh_db_session)
         assert service.is_token_revoked(jti) is True
@@ -890,7 +894,8 @@ class TestSingletonService:
 class TestErrorHandling:
     """Tests for error handling."""
 
-    def test_revoke_token_database_error(self):
+    @pytest.mark.asyncio
+    async def test_revoke_token_database_error(self):
         """Test token revocation with database error."""
         # Create a service with no database (will use fresh_db_session)
         service = TokenBlocklistService(db=None)
@@ -899,7 +904,7 @@ class TestErrorHandling:
         with patch("mcpgateway.services.token_blocklist_service.fresh_db_session") as mock_session:
             mock_session.side_effect = Exception("Database connection failed")
 
-            result = service.revoke_token(jti=str(uuid.uuid4()), revoked_by="test@example.com", reason="logout")
+            result = await service.revoke_token(jti=str(uuid.uuid4()), revoked_by="test@example.com", reason="logout")
 
             assert result is False
 
@@ -915,13 +920,14 @@ class TestErrorHandling:
             # Should fail closed (treat as revoked on error)
             result = service.is_token_revoked(str(uuid.uuid4()))
 
+    @pytest.mark.asyncio
     @patch("mcpgateway.services.token_blocklist_service.TokenBlocklistService._get_redis_client")
-    def test_is_token_revoked_redis_error_fallback_to_db(self, mock_redis, blocklist_service, test_db):
+    async def test_is_token_revoked_redis_error_fallback_to_db(self, mock_redis, blocklist_service, test_db):
         """Test revocation check falls back to DB when Redis fails."""
         jti = str(uuid.uuid4())
 
         # Revoke token in database
-        blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+        await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
         # Mock Redis to raise an error
         redis_mock = MagicMock()

--- a/tests/unit/mcpgateway/test_token_blocklist_service.py
+++ b/tests/unit/mcpgateway/test_token_blocklist_service.py
@@ -101,6 +101,20 @@ class TestTokenRevocation:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_revoke_token_duplicate_cache_invalidation_error(self, blocklist_service, test_db):
+        """Test duplicate revocation succeeds when auth cache invalidation fails."""
+        jti = str(uuid.uuid4())
+        revocation = TokenRevocation(jti=jti, revoked_by="system@example.com", reason="logout")
+        test_db.add(revocation)
+        test_db.commit()
+
+        with patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock, side_effect=Exception("Cache error")) as mock_invalidate:
+            result = await blocklist_service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+
+        assert result is True
+        mock_invalidate.assert_awaited_once_with(jti)
+
+    @pytest.mark.asyncio
     async def test_revoke_token_duplicate_without_db_session(self, test_db):
         """Test revoking an already revoked token without db session."""
         # Create service without db to test fresh_db_session path
@@ -119,6 +133,27 @@ class TestTokenRevocation:
             result = await service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
 
             assert result is True
+
+    @pytest.mark.asyncio
+    async def test_revoke_token_duplicate_without_db_session_cache_invalidation_error(self, test_db):
+        """Test duplicate revocation with fresh_db_session succeeds when cache invalidation fails."""
+        service = TokenBlocklistService(db=None)
+        jti = str(uuid.uuid4())
+        revocation = TokenRevocation(jti=jti, revoked_by="system@example.com", reason="logout")
+        test_db.add(revocation)
+        test_db.commit()
+
+        with (
+            patch("mcpgateway.services.token_blocklist_service.fresh_db_session") as mock_session,
+            patch("mcpgateway.cache.auth_cache.auth_cache.invalidate_revocation", new_callable=AsyncMock, side_effect=Exception("Cache error")) as mock_invalidate,
+        ):
+            mock_session.return_value.__enter__.return_value = test_db
+            mock_session.return_value.__exit__.return_value = None
+
+            result = await service.revoke_token(jti=jti, revoked_by="test@example.com", reason="logout")
+
+        assert result is True
+        mock_invalidate.assert_awaited_once_with(jti)
 
     @pytest.mark.asyncio
     async def test_revoke_token_with_last_activity(self, blocklist_service, test_db):


### PR DESCRIPTION
## Related Issue

Closes #5136

## Summary

Fixes inconsistent token state where a token could have both `EmailApiToken.is_active=True` and a matching `TokenRevocation` row, producing conflicting status badges and API fields.

## Changes

- `TokenBlocklistService.revoke_token()` now:
  - is async and must be awaited;
  - marks a matching `EmailApiToken` inactive;
  - repairs an active catalog row when revocation already exists;
  - awaits auth-cache invalidation after the database commit;
  - emits a high-severity warning if cache invalidation fails;
  - sanitizes token identifiers and user-controlled reason/revoker values before logging.
- Logout now obtains `TokenBlocklistService` without passing the request-scoped database session. Revocation uses an independent session and persists even if later request work fails.
- Admin token badge rendering gives `Revoked` priority over `Active` or `Inactive`, so each row shows one status.
- Alembic migration `e5136a7c9d01` repairs historical rows that are active despite having a revocation record.
- Security documentation now awaits `revoke_token()`.
- Tests cover service-owned and supplied sessions, cache invalidation, repair/idempotent paths, logging failures, badge priority, logout callers, and migration behavior.

## Breaking Change / Release Requirement

`TokenBlocklistService.revoke_token()` changed from synchronous to asynchronous. Downstream callers must change:

```python
success = service.revoke_token(...)
```

to:

```python
success = await service.revoke_token(...)
```

An unmodified synchronous caller receives a truthy coroutine, may report successful logout, and does not revoke the token. Because this public API change can cause insufficient session expiration, this PR must ship in a minor release (minimum `1.1.0`), not a `1.0.x` patch.

All in-repository callers await the method.

## Reachable Scenarios

Normal API tokens with `token_use="api"` bypass idle-timeout enforcement, so idle timeout is not the normal reproduction path for those rows. Reachable affected paths include:

- `POST /auth/logout` with an API token;
- legacy API tokens missing `token_use`;
- other automatic/security revocation paths that call `TokenBlocklistService.revoke_token()`.

## Expected Behavior

- Revoked tokens have `is_active=False` and a matching revocation record.
- Historical inconsistent rows are repaired during upgrade.
- Admin UI renders only `Revoked` for revoked tokens.
- Authentication cache is invalidated before revocation returns.
