### PR TITLE
fix(gateway): handle empty auth_query_param_key from form submissions…

### DIFF
--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -2908,6 +2908,39 @@ class GatewayCreate(BaseModelWithConfigDict):
         """
         return v if v is not None else "cache"
 
+    @field_validator("auth_query_param_key", mode="before")
+    @classmethod
+    def validate_auth_query_param_key(cls, v: Optional[str]) -> Optional[str]:
+        """Validate query parameter key, converting empty strings to None.
+
+        Handles form submissions where empty string values are passed for optional
+        authentication fields. Only validates pattern when a non-empty value is provided.
+
+        Args:
+            v: Query parameter key value (may be empty string from form submission)
+
+        Returns:
+            None for empty/whitespace-only strings, otherwise validates against pattern
+
+        Raises:
+            ValueError: If non-empty value doesn't match required pattern
+
+        Examples:
+            >>> GatewayCreate.validate_auth_query_param_key('')
+            >>> GatewayCreate.validate_auth_query_param_key('   ')
+            >>> GatewayCreate.validate_auth_query_param_key('tavilyApiKey')
+            'tavilyApiKey'
+            >>> GatewayCreate.validate_auth_query_param_key('invalid-key!')
+            Traceback (most recent call last):
+                ...
+            ValueError: Query parameter key must start with a letter or underscore and contain only letters, numbers, underscores, and hyphens
+        """
+        if not v or (isinstance(v, str) and not v.strip()):
+            return None
+        if isinstance(v, str) and not re.match(r"^[a-zA-Z_][a-zA-Z0-9_\-]*$", v):
+            raise ValueError("Query parameter key must start with a letter or underscore and contain only letters, numbers, underscores, and hyphens")
+        return v
+
     @field_validator("tags")
     @classmethod
     def validate_tags(cls, v: Optional[List[str]]) -> List[str]:

--- a/tests/unit/mcpgateway/test_schemas_validators_extra.py
+++ b/tests/unit/mcpgateway/test_schemas_validators_extra.py
@@ -387,6 +387,82 @@ def test_gateway_update_query_param_validation():
     assert updated.auth_query_param_key == "api_key"
 
 
+def test_gateway_create_auth_query_param_key_empty_string_handling():
+    """Test that empty strings for auth_query_param_key are converted to None.
+
+    Regression test for issue #5133 - form submissions send empty strings for
+    optional auth fields, which should be treated as None.
+    """
+    # Empty string should be converted to None (with bearer auth)
+    gateway = GatewayCreate(
+        name="test-gateway",
+        url="http://localhost:9000/mcp",
+        auth_type="bearer",
+        auth_token="token123",
+        auth_query_param_key="",
+    )
+    assert gateway.auth_query_param_key is None
+
+    # Whitespace-only string should be converted to None
+    gateway = GatewayCreate(
+        name="test-gateway",
+        url="http://localhost:9000/mcp",
+        auth_type="bearer",
+        auth_token="token123",
+        auth_query_param_key="   ",
+    )
+    assert gateway.auth_query_param_key is None
+
+    # None should remain None (omitting auth_query_param_key entirely)
+    gateway = GatewayCreate(
+        name="test-gateway",
+        url="http://localhost:9000/mcp",
+        auth_type="bearer",
+        auth_token="token123",
+    )
+    assert gateway.auth_query_param_key is None
+
+
+def test_gateway_create_auth_query_param_key_pattern_validation():
+    """Test that non-empty auth_query_param_key values are validated against pattern.
+
+    The pattern requires: start with letter/underscore, contain only letters/numbers/underscores/hyphens.
+    """
+    # Valid patterns (testing the validator independent of auth_type)
+    valid_keys = ["api_key", "tavilyApiKey", "_private", "key123", "my-api-key", "a", "_"]
+
+    for key in valid_keys:
+        gateway = GatewayCreate(
+            name="test-gateway",
+            url="http://localhost:9000/mcp",
+            auth_type="bearer",
+            auth_token="token123",
+            auth_query_param_key=key,
+        )
+        assert gateway.auth_query_param_key == key
+
+    # Invalid patterns
+    invalid_keys = [
+        "123invalid",  # starts with number
+        "-invalid",  # starts with hyphen
+        "invalid key",  # contains space
+        "invalid!key",  # contains special char
+        "invalid@key",  # contains @
+        "invalid.key",  # contains dot
+    ]
+
+    for key in invalid_keys:
+        with pytest.raises(ValidationError) as exc_info:
+            GatewayCreate(
+                name="test-gateway",
+                url="http://localhost:9000/mcp",
+                auth_type="bearer",
+                auth_token="token123",
+                auth_query_param_key=key,
+            )
+        assert "Query parameter key must start with a letter or underscore" in str(exc_info.value)
+
+
 def test_gateway_read_mask_and_populate_auth():
     masked = GatewayRead._mask_query_param_auth({"auth_query_params": {"api_key": "enc"}})  # pragma: allowlist secret
     assert masked["auth_query_param_key"] == "api_key"


### PR DESCRIPTION
Closes #5133

Problem

Gateway registration through the Admin UI failed with a Pydantic validation error when auth_query_param_key was submitted as an empty string (which happens when Query Parameter authentication is not being used). The validation pattern ^[a-zA-Z_][a-zA-Z0-9_\-]*$ rejected empty strings, blocking the basic gateway registration workflow.

Error:
String should match pattern '^[a-zA-Z_][a-zA-Z0-9_\-]*$'

Root Cause

Introduced in PR #4808 (commit 8d56b6d26), which refactored gateway creation to use _parse_gateway_data_from_request(). This function passes all form fields including empty strings directly to the schema, whereas the previous implementation explicitly converted empty strings to None:

Before #4808:
auth_query_param_key=str(form.get("auth_query_param_key", "")) or None

After #4808:
GatewayCreate(**data)  # Empty strings included in data dict

Solution

Added a field_validator for auth_query_param_key in GatewayCreate schema that:
1. Converts empty/whitespace-only strings to None (matching previous behavior)
2. Validates non-empty values against the required pattern
3. Provides clear error messages for invalid patterns

Changes

- Added validate_auth_query_param_key validator in mcpgateway/schemas.py
- Includes comprehensive docstring with examples (including doctests)
- Consistent with validation approach for other optional auth fields



Impact

- Fixes: Gateway registration workflow blocked since PR #4808
- Severity: P1/MUST - Critical UI functionality restored


