### PR TITLE
fix(charts): align TOKEN_EXPIRY default with config.py le=1440 constr…

### DIFF
--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -838,7 +838,7 @@ mcpContextForge:
     JWT_ALGORITHM: HS256                   # signing algorithm for JWT tokens
     JWT_AUDIENCE: mcpgateway-api           # JWT audience claim for token validation
     JWT_ISSUER: mcpgateway                 # JWT issuer claim for token validation
-    TOKEN_EXPIRY: "10080"                  # JWT validity (minutes); 10080 = 7 days
+    TOKEN_EXPIRY: "1440"                   # JWT validity (minutes); max allowed: 1440 = 24 hours
     REQUIRE_TOKEN_EXPIRATION: "true"       # require all JWT tokens to have expiration claims
     REQUIRE_JTI: "true"                    # require JTI (JWT ID) claim for revocation support
     REQUIRE_USER_IN_DB: "false"            # require all users to exist in database (disables platform admin bootstrap)


### PR DESCRIPTION
## 🔗 Related Issue
Closes #

---

## 📝 Summary
The `mcp-stack` Helm chart shipped with `TOKEN_EXPIRY: "10080"` (7 days), but
`mcpgateway/config.py` enforces `token_expiry <= 1440` (24 hours) via an
**unconditional** pydantic `Field` validator (`ge=5, le=1440`, no environment
gating). This mismatch caused **both the gateway pods and the migration job to
crash on startup** with a pydantic `ValidationError`, breaking the Helm
deployment out of the box.

The `le=1440` constraint was introduced in #4371 (shipped in v1.0.0), but the
chart default was never updated to match — so the chart has been broken since
v1.0.0:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
token_expiry
  Input should be less than or equal to 1440 [input_value='10080']
```

This PR sets the chart default `TOKEN_EXPIRY` to `1440` (the maximum allowed
value) to align with the application constraint:

```diff
-    TOKEN_EXPIRY: "10080"                  # JWT validity (minutes); 10080 = 7 days
+    TOKEN_EXPIRY: "1440"                   # JWT validity (minutes); max allowed: 1440 = 24 hours
```


---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                              | Command                                              | Status |
|------------------------------------|------------------------------------------------------|--------|
| Helm lint                          | `make helm-lint`                                     | ✅ Pass |
| Chart deploy (Minikube, e2e)       | `helm upgrade --install mcp-stack charts/mcp-stack`  | ✅ Pass |
| Pods healthy                       | `kubectl get pods -n mcp` (all `1/1 Running`)        | ✅ Pass |
| Smoke test — `/health`             | `curl .../health` → `{"status":"healthy"}`           | ✅ Pass |
| Smoke test — `/ready`              | `curl .../ready` → `{"status":"ready"}` (DB + Cache) | ✅ Pass |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
- This is the **minimal fix** for the release — a single-value chart default change.
- Follow-up (separate PR): the now-unreachable dead-code branch at
  `mcpgateway/config.py:1536` (`if self.token_expiry > 10080:`) can never be
  true given `le=1440` and could be removed.
- Heads-up unrelated to this PR: `charts/mcp-stack/values-minikube.yaml`
  hardcodes a stale image tag (`1.0.0-RC-3`) — worth refreshing separately.
