### PR TITLE
fix: use value='' for auth type None option and fix registry grid vis…

### DIFF
--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3904,7 +3904,7 @@
                   id="auth-type"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 >
-                  <option value="none">None</option>
+                  <option value="">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -5452,7 +5452,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   id="auth-type-gw"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 >
-                  <option value="none">None</option>
+                  <option value="">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -6894,7 +6894,7 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
                   name="auth_type"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                 >
-                  <option value="none">None</option>
+                  <option value="">None</option>
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
@@ -8803,7 +8803,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         id="edit-auth-type"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
-                        <option value="none">None</option>
+                        <option value="">None</option>
                         <option value="basic">Basic</option>
                         <option value="bearer">Bearer Token</option>
                         <option value="authheaders">Custom Headers</option>
@@ -9988,7 +9988,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                         id="auth-type-gw-edit"
                         class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                       >
-                        <option value="none">None</option>
+                        <option value="">None</option>
                         <option value="basic">Basic</option>
                         <option value="bearer">Bearer Token</option>
                         <option value="authheaders">Custom Headers</option>
@@ -10495,7 +10495,7 @@ class="fixed z-40 inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-ce
                           class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm
                                 focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:text-gray-300"
                         >
-                          <option value="none">None</option>
+                          <option value="">None</option>
                           <option value="basic">Basic</option>
                           <option value="bearer">Bearer Token</option>
                           <option value="authheaders">Custom Headers</option>

--- a/mcpgateway/templates/mcp_registry_partial.html
+++ b/mcpgateway/templates/mcp_registry_partial.html
@@ -399,6 +399,29 @@
     class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
     id="server-grid"
   >
+    {% if not servers %}
+    <div class="col-span-full bg-gray-50 rounded-lg p-8 text-center dark:bg-gray-800">
+      <svg
+        class="mx-auto h-12 w-12 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+        />
+      </svg>
+      <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+        No servers found
+      </h3>
+      <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        No servers match your current filters.
+      </p>
+    </div>
+    {% endif %}
     {% for server in servers %}
     <div
       class="server-card bg-white rounded-lg shadow-lg p-6 hover:shadow-xl transition-shadow dark:bg-gray-800"
@@ -534,29 +557,6 @@
     {% endfor %}
   </div>
 
-  {% if not servers %}
-  <div class="bg-gray-50 rounded-lg p-8 text-center dark:bg-gray-800">
-    <svg
-      class="mx-auto h-12 w-12 text-gray-400"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-      />
-    </svg>
-    <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
-      No servers found
-    </h3>
-    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-      No servers match your current filters.
-    </p>
-  </div>
-  {% endif %}
 </div>
 
 <!-- API Key Modal (for servers requiring API key) -->

--- a/tests/playwright/pages/mcp_registry_page.py
+++ b/tests/playwright/pages/mcp_registry_page.py
@@ -294,12 +294,10 @@ class MCPRegistryPage(BasePage):
             document.getElementById('search-input').value = '';
         """)
 
-        # Trigger a single HTMX request and wait for the response to land.
-        with self.page.expect_response("**/admin/mcp-registry/partial**", timeout=5000):
-            self.category_filter.select_option("")
-
-        # Wait for HTMX swap to complete and DOM to settle
-        self.wait_for_registry_results_ready(timeout=10000)
+        # Use _wait_for_registry_refresh to properly wait for DOM update after clearing.
+        # This waits for the HTMX response AND verifies the DOM has actually changed,
+        # which is more robust than just waiting for a network response.
+        self._wait_for_registry_refresh(lambda: self.category_filter.select_option(""))
 
     def click_category_badge(self, category: str) -> None:
         """Click on a category badge to filter by that category.

--- a/tests/playwright/security/test_team_selector_e2e.py
+++ b/tests/playwright/security/test_team_selector_e2e.py
@@ -215,7 +215,7 @@ def iframe_host_with_teams(page: Page, base_url: str):
         style="width:100%;height:100vh;border:none"
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals">
 </iframe>
-</body></html>""")
+</body></html>""", wait_until="domcontentloaded")
 
     frame_locator = page.frame_locator("#admin-frame")
     try:


### PR DESCRIPTION
## 🔗 Related Issue
Closes # *(no linked issue — discovered via test suite)*

---

## 📝 Summary

Three separate bugs were causing 12 test failures and 1 error in the Playwright UI test suite:

1. **Auth type `None` option used `value="none"` instead of `value=""`** (10 failures)  
   All 6 auth type `<select>` elements in admin.html (tools, gateways, agents — both add forms and edit modals) had `<option value="none">None</option>`. Tests expect `option[value=""]` (which is what the JS already sets via `authTypeField.value = entity.authType || ""`), and `select_option("")` timed out because no option with `value=""` existed. The backend's `normalize_auth_type` validator already treats `""` as the canonical "no auth" sentinel, making `""` the correct value.

2. **MCP Registry `#server-grid` had zero height when empty** (1 failure)  
   When a filter returned 0 servers, the `#server-grid` grid container had no children and therefore no height, causing Playwright's `to_be_visible()` to fail. The "No servers found" empty state was placed *outside* the grid div. Moved it inside as a `col-span-full` child so the grid always has content and a non-zero bounding box.

3. **`clear_filters()` used a weaker wait than `_wait_for_registry_refresh()`** (1 failure)  
   The old implementation confirmed the HTTP response arrived but didn't verify the HTMX DOM swap completed before counting server cards, causing a race condition. Replaced with the existing `_wait_for_registry_refresh()` helper which additionally verifies the DOM `innerHTML` has changed.

4. **`page.set_content()` in security test fixture timed out** (1 error)  
   The `iframe_host_with_teams` fixture used `page.set_content()` without `wait_until`, defaulting to `"load"` which waits for the iframe's full admin UI to load — exceeding the 60 s timeout. Added `wait_until="domcontentloaded"` so it returns as soon as the host HTML is parsed, leaving iframe load to the individual test assertions.

---

## 🏷️ Type of Change
- [x] Bug fix

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | Pending |
| Unit tests                | `make test`     | Pending |
| Coverage ≥ 80%            | `make coverage` | Pending |

*Running the 12 previously failing Playwright tests individually to confirm fixes — in progress.*

---

## ✅ Checklist
- [x] Tests added/updated for changes
- [x] No secrets or credentials committed
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Documentation updated (if applicable)

---

## 📓 Notes