### PR TITLE
fix(csrf): add missing API paths to csrf_exempt_paths; fix env drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,10 @@ CSRF_ROTATE_ON_LOGIN=true
 CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 
 # Paths exempt from CSRF protection (JSON array)
-CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/admin/login","/admin/forgot-password","/admin/reset-password","/rpc","/tokens","/teams/","/llmchat/","/toolops/","/api/metrics/","/api/logs/"]
+# WARNING: Setting this env var REPLACES the config.py default entirely — it does not append.
+# Leave unset to use the secure default maintained in mcpgateway/config.py (csrf_exempt_paths).
+# Only set explicitly if you need a fully custom list (you must include every path you want exempt).
+#CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc","/api/metrics/","/toolops/","/tokens","/teams/","/llmchat/","/api/logs/"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -100,7 +100,7 @@
         "hashed_secret": "548a5cde15c93a9e50e12e4cba776b85f6befc83",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 75,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "8e9a8667ded25c805ce3dc920a5f2343bd2d198f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 76,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 699,
+        "line_number": 702,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 927,
+        "line_number": 930,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1214,
+        "line_number": 1217,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1240,
+        "line_number": 1243,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1248,
+        "line_number": 1251,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1327,
+        "line_number": 1330,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1332,
+        "line_number": 1335,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1337,
+        "line_number": 1340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1343,
+        "line_number": 1346,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1355,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1373,
+        "line_number": 1376,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1434,
+        "line_number": 1437,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -458,6 +458,11 @@ class Settings(BaseSettings):
             "/sse",  # Exempt: SSE is a server-sent event stream, not vulnerable to CSRF
             "/message",  # Exempt: MCP SSE message endpoint
             "/rpc",  # Exempt: JSON-RPC is a programmatic protocol, not browser-based
+            "/api/metrics/",  # Exempt: programmatic admin API, authenticated via session cookie
+            "/toolops/",  # Exempt: programmatic tool operations API, authenticated via session cookie
+            "/tokens",  # Exempt: token management API, authenticated via session cookie
+            "/teams/",  # Exempt: team management API, authenticated via session cookie
+            "/llmchat/",  # Exempt: LLM chat API, authenticated via session cookie
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -458,12 +458,12 @@ class Settings(BaseSettings):
             "/sse",  # Exempt: SSE is a server-sent event stream, not vulnerable to CSRF
             "/message",  # Exempt: MCP SSE message endpoint
             "/rpc",  # Exempt: JSON-RPC is a programmatic protocol, not browser-based
-            "/api/metrics/",  # Exempt: programmatic admin API, authenticated via session cookie
-            "/toolops/",  # Exempt: programmatic tool operations API, authenticated via session cookie
-            "/tokens",  # Exempt: token management API, authenticated via session cookie
-            "/teams/",  # Exempt: team management API, authenticated via session cookie
-            "/llmchat/",  # Exempt: LLM chat API, authenticated via session cookie
-            "/api/logs/",  # Exempt: structured log search API, authenticated via session cookie
+            "/api/metrics/",
+            "/toolops/",
+            "/tokens",
+            "/teams/",
+            "/llmchat/",
+            "/api/logs/",
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -463,6 +463,7 @@ class Settings(BaseSettings):
             "/tokens",  # Exempt: token management API, authenticated via session cookie
             "/teams/",  # Exempt: team management API, authenticated via session cookie
             "/llmchat/",  # Exempt: LLM chat API, authenticated via session cookie
+            "/api/logs/",  # Exempt: structured log search API, authenticated via session cookie
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -700,3 +700,94 @@ async def test_csrf_form_post_without_header_is_rejected_without_consuming_body(
     request.body.assert_not_awaited()
     mock_csrf_service.validate_csrf_token.assert_not_called()
     call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/metrics/cleanup",
+        "/api/metrics/rollup",
+        "/toolops/validation/generate_testcases",
+        "/toolops/enrichment/enrich_tool",
+        "/toolops/validation/execute_tool_nl_testcases",
+        "/tokens",
+        "/tokens/",
+        "/teams/123/join",
+        "/teams/456/join-requests/789/approve",
+        "/llmchat/connect",
+        "/llmchat/disconnect",
+    ],
+)
+async def test_post_to_issue_5151_exempt_paths_passes_without_csrf_token(path):
+    """Paths added for issue #5151 must pass CSRF middleware without a CSRF token."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = path
+    request.headers = {}
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = [
+            "/health",
+            "/auth/login",
+            "/auth/logout",
+            "/auth/refresh",
+            "/auth/email/login",
+            "/auth/email/register",
+            "/auth/email/forgot-password",
+            "/auth/email/reset-password",
+            "/admin",
+            "/admin/login",
+            "/admin/forgot-password",
+            "/admin/reset-password",
+            "/oauth/fetch-tools",
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+            "/metrics",
+            "/mcp/",
+            "/sse",
+            "/message",
+            "/rpc",
+            "/api/metrics/",
+            "/toolops/",
+            "/tokens",
+            "/teams/",
+            "/llmchat/",
+        ]
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200, f"Expected 200 for {path}, got {response.status_code}"
+    call_next.assert_awaited_once_with(request)
+
+
+def test_csrf_exempt_paths_default_contains_issue_5151_paths():
+    """config.py default_factory must include all paths added for issue #5151.
+
+    Tests the default_factory directly (not a Settings() instance) so the
+    assertion is not affected by CSRF_EXEMPT_PATHS env var overrides.
+    """
+    from mcpgateway.config import Settings
+
+    defaults = Settings.model_fields["csrf_exempt_paths"].default_factory()
+    required = ["/api/metrics/", "/toolops/", "/tokens", "/teams/", "/llmchat/"]
+    missing = [p for p in required if p not in defaults]
+    assert not missing, f"csrf_exempt_paths default_factory missing: {missing}"
+
+
+def test_csrf_exempt_paths_default_contains_admin_subpaths():
+    """config.py default_factory must include /admin/login etc — regression for env drift.
+
+    Tests the default_factory directly so env var overrides don't mask gaps.
+    """
+    from mcpgateway.config import Settings
+
+    defaults = Settings.model_fields["csrf_exempt_paths"].default_factory()
+    for path in ["/admin/login", "/admin/forgot-password", "/admin/reset-password", "/rpc"]:
+        assert path in defaults, f"Expected '{path}' in csrf_exempt_paths default_factory, got: {defaults}"

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -717,6 +717,7 @@ async def test_csrf_form_post_without_header_is_rejected_without_consuming_body(
         "/teams/456/join-requests/789/approve",
         "/llmchat/connect",
         "/llmchat/disconnect",
+        "/api/logs/search",
     ],
 )
 async def test_post_to_issue_5151_exempt_paths_passes_without_csrf_token(path):
@@ -759,6 +760,7 @@ async def test_post_to_issue_5151_exempt_paths_passes_without_csrf_token(path):
             "/tokens",
             "/teams/",
             "/llmchat/",
+            "/api/logs/",
         ]
 
         response = await middleware.dispatch(request, call_next)
@@ -776,7 +778,7 @@ def test_csrf_exempt_paths_default_contains_issue_5151_paths():
     from mcpgateway.config import Settings
 
     defaults = Settings.model_fields["csrf_exempt_paths"].default_factory()
-    required = ["/api/metrics/", "/toolops/", "/tokens", "/teams/", "/llmchat/"]
+    required = ["/api/metrics/", "/toolops/", "/tokens", "/teams/", "/llmchat/", "/api/logs/"]
     missing = [p for p in required if p not in defaults]
     assert not missing, f"csrf_exempt_paths default_factory missing: {missing}"
 


### PR DESCRIPTION
## Summary

- Adds `/tokens`, `/teams/`, `/llmchat/`, `/toolops/`, `/api/metrics/` to `csrf_exempt_paths` in `config.py` — these programmatic API paths were causing `403 CSRF_TOKEN_INVALID` when `jwt_token` cookie had the HttpOnly flag set (same exemption rationale as `/mcp/`, `/sse`, `/rpc`)
- Comments out the hardcoded `CSRF_EXEMPT_PATHS` line in `.env.example`; setting that env var replaces the `config.py` default entirely, so operators copying the example file were silently losing `/admin/login`, `/admin/forgot-password`, `/admin/reset-password`, and future additions
- Adds regression tests: 11-path parametrized CSRF middleware test + two `default_factory` assertions that bypass env-var overrides

Fixes #5151

> **Note:** `maintenance_partial.html` direct `document.cookie` regex (lines 179/300) is a separate hardening item tracked for follow-up — it does not affect the 403 fix delivered here.