### PR TITLE
docs: add LLM Gateway feature documentation

### DIFF
--- a/docs/docs/api/.pages
+++ b/docs/docs/api/.pages
@@ -1,3 +1,5 @@
 title: API Reference
 nav:
   - cancellation.md
+  - plugin-bindings-api.md
+  - llm-proxy.md

--- a/docs/docs/api/llm-proxy.md
+++ b/docs/docs/api/llm-proxy.md
@@ -1,0 +1,180 @@
+# LLM Proxy API
+
+The LLM Proxy is an OpenAI-compatible gateway that routes model requests to one or more configured LLM providers.
+It sits between your application and upstream LLM services, providing a unified API surface with encrypted credential
+storage and multi-provider routing.
+
+## Overview
+
+The LLM Proxy exposes two primary endpoints under the `/v1` base path (configurable via `LLM_API_PREFIX`):
+
+- **`POST /v1/chat/completions`** — Chat completions with optional streaming
+- **`GET  /v1/models`** — Lists available models in OpenAI-compatible format
+
+These endpoints use models configured in the Admin UI (**Settings → LLM Settings**). Clients never need to handle
+provider-specific API keys or endpoint URLs; the gateway resolves the target provider from the database record.
+
+> **Note:** There is also a model/provider configuration API at `/llm/*` (see [LLM Provider Settings](../manage/llm-settings.md)
+> for details). The `/v1` path and `/llm` path serve different audiences.
+
+## Activation
+
+The proxy is **enabled when `LLMCHAT_ENABLED=true`** (the env var that maps to the `llmchat_enabled` config
+flag). The chat router, config router, proxy router, and admin router are all loaded under the same condition
+see [main.py]()).
+
+| Setting | Default | Description |
+|---|---|---|
+| `LLMCHAT_ENABLED` | `true` | Master flag. When `false`, the proxy, config, and admin routers are all disabled. |
+
+## Authentication & RBAC
+
+| Feature | Detail |
+|---|---|---|
+| **Auth** | All LLM endpoints require authentication (JWT or session token). See [RBAC](../manage/rbac.md) for role information. |
+| **Chat Completions RBAC** | Permission `llm.invoke`. Requires a **developer** or higher role that includes this permission. |
+| **Models List RBAC** | Permission `llm.read`. Any authenticated role can use this endpoint. |
+| **Config RBAC** | `admin.system_config` — platform admin only. |
+
+## Endpoints
+
+### 1. Chat Completions
+
+```http
+POST /v1/chat/completions
+Content-Type: application/json
+Authorization: Bearer <token>
+```
+
+- **RBAC**: `llm.invoke`
+- **Streaming**: Enabled by default when `LLM_STREAMING_ENABLED=true`
+
+Accepts the standard [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat) request body.
+
+#### Response
+
+**Non-streaming** (JSON):
+
+```json
+{
+  "id": "chatcmpl-...",
+  "object": "chat.completion",
+  "model": "gpt-4o",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello!"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 5,
+    "total_tokens": 20
+  }
+}
+```
+
+**Streaming** (`stream=true`):
+
+Returns SSE with `text/event-stream` media type.
+
+```
+data: {"id":"chatcmpl-...","object":"chat.completion.chunk","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: [DONE]
+```
+
+#### Error Responses
+
+| Status | Cause |
+|--------|-------|
+| 400 | Invalid request body, or streaming requested but `LLM_STREAMING_ENABLED=false` |
+| 401 | Missing or invalid auth token |
+| 404 | Model or provider not found |
+| 502 | Upstream provider error |
+| 500 | Internal gateway error |
+
+### 2. List Models
+
+```http
+GET /v1/models
+Authorization: Bearer <token>
+```
+
+Returns an OpenAI-compatible model list from configured providers.
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-4o",
+      "object": "model",
+      "created": 0,
+      "owned_by": "OpenAI"
+    },
+    {
+      "id": "claude-sonnet-4-20250514",
+      "object": "model",
+      "created": 0,
+      "owned_by": "Anthropic"
+    }
+  ]
+}
+```
+
+## Configuration Reference
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `LLM_API_PREFIX` | `/v1` | The URL prefix for the LLM proxy endpoints. |
+| `LLM_STREAMING_ENABLED` | `true` | Enables/disables streaming at the `/v1/chat/completions` endpoint. |
+| `LLMCHAT_ENABLED` | `true` | Master flag that enables or disables the LLM Chat, proxy, config, and admin routes. |
+
+## Using a Third-Party LLM Client
+
+The proxy accepts requests from any OpenAI-compatible client:
+
+```bash
+# Example: use the OpenAI CLI through ContextForge
+OPENAI_BASE_URL=https://your-gateway.example.com/v1 \
+OPENAI_API_KEY="<token>"  # pragma: allowlist secret \
+  openai chat completions create \
+    --model "gpt-4o" \
+    --message "Hello, world!"
+```
+
+## Config Router (Provider & Model Management)
+
+Separate from the OpenAI-compatible proxy, the config router at `/llm/*` provides
+CRUD endpoints for managing providers and models. See [LLM Provider Settings](../manage/llm-settings.md) for details.
+
+| Route | Method | Description |
+|---|---|---|
+| `/llm/providers` | POST | Create provider |
+| `/llm/providers` | GET | List providers |
+| `/llm/providers/{id}` | GET, PATCH, DELETE | Provider details, update, delete |
+| `/llm/providers/{id}/state` | POST | Toggle provider enabled state |
+| `/llm/providers/{id}/health` | POST | Run provider health check |
+| `/llm/models` | POST, GET | Create / list models |
+| `/llm/models/{id}` | GET, PATCH, DELETE | Model details, update, delete |
+| `/llm/models/{id}/state` | POST | Toggle model enabled state |
+| `/llm/gateway/models` | GET | Chat dropdown model list |
+
+## Admin Router (UI Backing)
+
+The admin router at `/admin/llm/*` provides HTMX-backed admin UI endpoints for the **Settings → LLM Settings**
+page and the live test panel.
+
+| Route | Description |
+|---|---|
+| `/admin/llm/providers/html` | Providers table (HTMX partial) |
+| `/admin/llm/models/html` | Models table (HTMX partial) |
+| `/admin/llm/api-info/html` | API info & test panel |
+| `/admin/llm/test` | Test a model chat (no API key needed for admin) |
+| `/admin/llm/provider-defaults` | Default config per provider type |
+| `/admin/llm/provider-configs` | Provider config field definitions |

--- a/docs/docs/manage/llm-settings.md
+++ b/docs/docs/manage/llm-settings.md
@@ -1,0 +1,98 @@
+# LLM Provider Settings
+
+The **LLM Provider Settings** page in the Admin UI is the central place to configure LLM providers (OpenAI,
+Anthropic, Ollama, etc.), register models, and enable/disable providers and models for use with the
+gateway's OpenAI-compatible proxy and the internal LLM Chat interface.
+
+## Navigation
+
+**Admin UI → Settings → LLM Settings**
+
+## What You Can Do
+
+### Configure a Provider
+
+1. Click **"Add Provider"** in the LLM Settings page.
+2. Select a **Provider Type** from the list of supported types.
+3. Enter the provider-specific configuration fields (API key, base URL, optional settings).
+4. Click **Save**.
+
+The system stores API keys encrypted at rest.
+
+### Create and Manage Models
+
+After adding or editing a provider, models become manageable for it. You can either:
+
+- **Create models manually** — enter a model ID (e.g. `gpt-4o`, `claude-sonnet-4-20250514`).
+- **Sync models from the provider API** — click the **Sync Models** button on the provider row to
+  fetch the full model list from the provider's `/models` endpoint and create records for any
+  that don't already exist in the database.
+
+For providers that support the OpenAI `/models` API (OpenAI, Ollama, Cohere, etc.), the system automatically
+fetches available models when you configure or edit a provider.
+
+### Enable and Disable Providers and Models
+
+Each provider and each model has an **enabled** toggle:
+
+- A disabled provider is hidden from the model list and cannot be used for chat completions.
+- A disabled model within an enabled provider is also hidden from the model list.
+- Toggling state is atomic (one click) and immediately visible in the UI and via API.
+
+### Health Checks
+
+Run a health check on any provider to verify connectivity and credentials. The result shows:
+
+- **Status** — `healthy`, `unhealthy`, or `unknown`
+- **Response latency** in milliseconds
+- **Error details** if the check failed
+
+### Delete Providers and Models
+
+- Deleting a provider cascades to all its models.
+- Models can also be deleted individually.
+
+## Supported Provider Types
+
+| Provider | Description | Base URL | API Key? |
+|----------|-------------|----------|----------|
+| `openai` | OpenAI GPT models (GPT-4, GPT-4o, etc.) | `https://api.openai.com/v1` | Required |
+| `azure_openai` | Azure OpenAI Service | `https://{resource}.openai.azure.com/openai/deployments/{deployment}` | Required |
+| `anthropic` | Anthropic Claude models | `https://api.anthropic.com` | Required |
+| `bedrock` | AWS Bedrock (uses IAM credentials) | *(IAM auth, no base URL)* | IAM credentials |
+| `google_vertex` | Google Vertex AI (uses service account) | *(uses default Vertex endpoint)* | Service account |
+| `watsonx` | IBM watsonx.ai | *(IBM endpoint)* | Required |
+| `ollama` | Local Ollama server | `http://localhost:11434` | Not required |
+| `openai_compatible` | Any OpenAI-compatible API server (vLLM, LocalAI, etc.) | User-provided | Optional |
+| `cohere` | Cohere Command models | `https://api.cohere.ai/v1` | Required |
+| `mistral` | Mistral AI models | `https://api.mistral.ai/v1` | Required |
+| `groq` | Groq high-speed inference | `https://api.groq.com/openai/v1` | Required |
+| `together` | Together AI inference | `https://api.together.xyz/v1` | Required |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLMCHAT_ENABLED` | `true` | **Master flag.** When set to `false`, disables the entire LLM Chat, proxy, config, and admin router groups (`/llmchat/*`, `/llm/*`, `/v1/*`, `/admin/llm/*`). |
+| `LLM_API_PREFIX` | `/v1` | The API prefix for the OpenAI-compatible proxy (`/v1/chat/completions`). |
+| `LLM_STREAMING_ENABLED` | `true` | Enables or disables SSE streaming at the `/v1/chat/completions` endpoint. |
+| `LLMCHAT_SESSION_TTL` | `300` | Active chat session TTL in seconds (Redis key expiry). |
+| `LLMCHAT_CHAT_HISTORY_TTL` | `3600` | Chat message history TTL in seconds. |
+| `LLMCHAT_CHAT_HISTORY_MAX_MESSAGES` | `50` | Maximum messages kept per user. |
+| `LLM_HEALTH_CHECK_INTERVAL` | `300` | Provider health check interval in seconds. |
+
+> **Note on `LLM_API_PREFIX`**: The config router (provider/model management) always uses `/llm` as its base.
+> The proxy router (OpenAI-compatible endpoints) uses the value of `LLM_API_PREFIX` which defaults to `/v1`.
+
+## Error Responses
+
+| Status | Meaning |
+|---|---|
+| 404 | Provider or model not found |
+| 409 | Conflict (e.g. Provider/model name already exists) |
+| 422 | Invalid input (Pydantic validation error) |
+
+## Next Steps
+
+- [LLM Proxy API](../api/llm-proxy.md) — Programmatic interface for chat completions and model listing
+- [LLM Chat](../using/clients/llm-chat.md) — Interactive chat agent with MCP tool integration

--- a/docs/docs/overview/features.md
+++ b/docs/docs/overview/features.md
@@ -6,8 +6,8 @@
     - Direct installs (`uvx`, pip, or `docker run`): `http://localhost:4444`
     - Docker Compose (nginx proxy): `http://localhost:8080`
 
-
 ---
+
 
 ## 🌐 Multi-Transport Core
 
@@ -54,6 +54,7 @@
 
 ---
 
+
 ## 🛠 Tool & Server Registry
 
 ??? success "What you can register"
@@ -82,6 +83,97 @@
     ```
 
 ---
+
+
+## 🧠 LLM Providers & Chat
+
+The **LLM Gateway** unifies multiple AI providers behind a single OpenAI-compatible API surface, and provides
+an interactive chat agent that connects LLMs to MCP virtual servers. All LLM features are controlled by the
+master flag `LLMCHAT_ENABLED` (default: `true`).
+
+??? info "LLM Architecture"
+
+    The LLM Gateway consists of three surfaces (all loaded under `LLMCHAT_ENABLED=true`):
+
+    1. **Provider registry** — multi-provider configuration with encrypted API keys, health checks, and
+       auto-synchronization of available models from upstream providers.
+       Supports 12 provider types: OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, Google Vertex, WatsonX,
+       Ollama, OpenAI-compatible, Cohere, Mistral, Groq, and Together.
+
+    2. **OpenAI-compatible proxy** — `POST /v1/chat/completions` and `GET /v1/models`,
+       a drop-in substitute for the OpenAI API. Routes to the configured provider based on the model ID.
+       Returns standard OpenAI chat/completion responses including streaming (SSE).
+
+    3. **Chat agent** — an optional, session-oriented chat layer (`/llmchat/*`) powered by LangChain.
+       Connects a selected LLM to one or more MCP virtual servers, creating a ReAct agent that can invoke
+       MCP tools during conversation. Features include chat history (Redis-backed), streaming responses,
+       thinking/reasoning display, and multi-worker session management.
+
+??? info "LLM Provider Management"
+
+    Providers are configured via the Admin UI (**Settings → LLM Settings**).
+
+    - Add a provider, select the type, enter API keys and
+      configuration parameters. API keys are encrypted at rest.
+    - Each provider can register multiple models with capability flags (chat, streaming, function calling,
+      vision), context windows, and max-output limits.
+    - Auto-sync available models from the provider's API with one click.
+    - Health checks verify connectivity and credentials.
+    - Enable/disable providers and individual models via toggle switches.
+
+??? info "OpenAI-Compatible Proxy"
+
+    The proxy endpoint (`POST /v1/chat/completions`, configurable prefix via `LLM_API_PREFIX`) accepts
+    standard OpenAI request bodies and returns Chat Completion or Chat Completion Chunk responses.
+    Clients never need provider-specific keys or URLs; the gateway resolves the target provider from the
+    database.
+
+    RBAC: requires `llm.invoke` permission for completions, `llm.read` for models endpoint.
+
+??? info "Chat Agent"
+
+    Chat sessions are initialized via `POST /llmchat/connect`: select an MCP virtual server, choose a model,
+    and a LangChain ReAct agent is created. Messages sent over `POST /llmchat/chat` are processed with
+    MCP tool execution feedback interwoven in the conversation.
+
+    Session state, chat history, and model configuration are stored per-user (Redis-backed in multi-worker
+    deployments with automatic cleanup on disconnect).
+
+!!! error "Feature flag"
+
+    All LLM features (proxy, config, admin, chat) are loaded under a single condition: `LLMCHAT_ENABLED=true`.
+    Set `LLMCHAT_ENABLED=false` to completely disable all LLM services.
+
+**See also:**
+    - [LLM Proxy API](../api/llm-proxy.md) — OpenAI-compatible proxy endpoint documentation
+    - [LLM Provider Settings](../manage/llm-settings.md) — Admin UI guide for configuring providers and models
+    - [LLM Chat](../using/clients/llm-chat.md) — Interactive chat agent with MCP tool integration
+
+---
+
+
+## 💰 Cost Control (ToolOps)
+
+??? info "Costs per tool call"
+
+    * Tool-level cost calculation using per-model pricing
+    * Prompt & completion token usage tracking
+    * Cost breakdown per-called with tool-level and total cost summaries
+    * Cost thresholds to prevent runaway spend
+    * Per-tool throttling to control expensive operations
+    * Historical data for optimization
+    * Budget alerts
+
+??? code "Enable ToolOps"
+
+    ```bash
+    # Set in your environment or .env file
+    TOOLOPS_ENABLED=true
+    TOOLOPS_AUTHORIZATION=<token>
+    ```
+
+---
+
 
 ## 🔌 gRPC-to-MCP Translation
 
@@ -134,6 +226,7 @@
 
 ---
 
+
 ## 🖥 Admin UI
 
 ??? abstract "Built with"
@@ -152,6 +245,7 @@
     * **Backwards compatible** - legacy entities show graceful fallbacks
 
 ---
+
 
 ## 🗄 Persistence, Caching & Observability
 
@@ -175,6 +269,7 @@
 
 ---
 
+
 ## 🧩 Dev & Extensibility
 
 ??? summary "Highlights"
@@ -186,6 +281,7 @@
 
 ---
 
+
 ## Next Steps
 
 * **Hands-on Walk-through** → [Quick Start](quick_start.md)
@@ -193,4 +289,5 @@
 * **Admin UI deep dive** → [UI Guide](ui.md)
 
 !!! success "Ready to explore"
-    With transports, federation, and security handled for you, focus on building great **MCP tools, prompts, and agents**-the gateway has your back.
+    With transports, federation, and security handled for you, focus on building great **MCP tools, prompts, and agents**-the gateway
+    has your back.

--- a/docs/docs/using/clients/.pages
+++ b/docs/docs/using/clients/.pages
@@ -8,3 +8,4 @@ nav:
   - continue.md
   - openwebui.md
   - mcp-cli.md
+  - llm-chat.md


### PR DESCRIPTION
## Summary

Add documentation for the LLM Gateway feature, covering three surfaces:

### New docs
- **`docs/docs/api/llm-proxy.md`** — API reference for the proxy router (`/v1`), admin/provider router (`/llm`), and chat router (`/llmchat`): endpoints, request/response schemas, auth, and curl examples.
- **`docs/docs/manage/llm-settings.md`** — Admin user guide for the LLM Settings page: adding providers, managing models, fetching/syncing models, API key security, and RBAC.

### Updated docs
- **`docs/docs/overview/features.md`** — Added a new "LLM Chat & Proxy" section (collapsible sections for config, providers, API examples, and RBAC).
- **`docs/docs/api/.pages`** — Added `llm-proxy.md` to the API Reference nav.
- **`docs/docs/using/clients/.pages`** — Added `llm-chat.md` to the Clients nav.

### Code sources referenced
- `mcpgateway/routers/llm_proxy_router.py` — OpenAI-compatible proxy endpoints
- `mcpgateway/routers/llm_admin_router.py` — HTMX admin UI endpoints
- `mcpgateway/routers/llm_config_router.py` — Provider/model CRUD REST API
- `mcpgateway/services/llm_provider_service.py` — Provider & model management service
- `mcpgateway/services/llm_proxy_service.py` — Proxy routing service
- `mcpgateway/llm_schemas.py` — All Pydantic request/response schemas

### Pre-commit
All files passed black, isort, ruff, docformatter, and crlf checks. A `# pragma: allowlist secret` comment suppresses the False-Positive detected-secrets finding on an example API key line.