### PR TITLE
fix: bind join requests to team context

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-11T09:41:14Z",
+  "generated_at": "2026-06-12T17:37:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5068,7 +5068,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17773,
+        "line_number": 17775,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/design/images/classes.svg
+++ b/docs/docs/design/images/classes.svg
@@ -10430,7 +10430,7 @@
 <text text-anchor="start" x="167377.5" y="-4306.3" font-family="Arial" font-size="14.00">role_service</text>
 <polyline fill="none" stroke="#ffaabb" points="166596.5,-4298.5 168231.5,-4298.5 "/>
 <text text-anchor="start" x="166604.5" y="-4283.3" font-family="Arial" font-size="14.00">add_member_to_team(team_id: str, user_email: str, role: str, invited_by: Optional[str]): EmailTeamMember</text>
-<text text-anchor="start" x="166604.5" y="-4268.3" font-family="Arial" font-size="14.00">approve_join_request(team_id: str, request_id: str, approved_by: str): Optional[EmailTeamMember]</text>
+<text text-anchor="start" x="166604.5" y="-4268.3" font-family="Arial" font-size="14.00">approve_join_request(request_id: str, approved_by: str): Optional[EmailTeamMember]</text>
 <text text-anchor="start" x="166604.5" y="-4253.3" font-family="Arial" font-size="14.00">cancel_join_request(request_id: str, user_email: str): bool</text>
 <text text-anchor="start" x="166604.5" y="-4238.3" font-family="Arial" font-size="14.00">count_team_owners(team_id: str): int</text>
 <text text-anchor="start" x="166604.5" y="-4223.3" font-family="Arial" font-size="14.00">create_join_request(team_id: str, user_email: str, message: Optional[str]): &#39;EmailTeamJoinRequest&#39;</text>
@@ -10453,7 +10453,7 @@
 <text text-anchor="start" x="166604.5" y="-3968.3" font-family="Arial" font-size="14.00">invalidate_team_member_count_cache(team_id: str): None</text>
 <text text-anchor="start" x="166604.5" y="-3953.3" font-family="Arial" font-size="14.00">list_join_requests(team_id: str): List[&#39;EmailTeamJoinRequest&#39;]</text>
 <text text-anchor="start" x="166604.5" y="-3938.3" font-family="Arial" font-size="14.00">list_teams(limit: int, offset: int, cursor: Optional[str], page: Optional[int], per_page: int, include_inactive: bool, visibility_filter: Optional[str], base_url: Optional[str], include_personal: bool, search_query: Optional[str]): Union[Tuple[List[EmailTeam], Optional[str]], Dict[str, Any]]</text>
-<text text-anchor="start" x="166604.5" y="-3923.3" font-family="Arial" font-size="14.00">reject_join_request(team_id: str, request_id: str, rejected_by: str): bool</text>
+<text text-anchor="start" x="166604.5" y="-3923.3" font-family="Arial" font-size="14.00">reject_join_request(request_id: str, rejected_by: str): bool</text>
 <text text-anchor="start" x="166604.5" y="-3908.3" font-family="Arial" font-size="14.00">remove_member_from_team(team_id: str, user_email: str, removed_by: Optional[str]): bool</text>
 <text text-anchor="start" x="166604.5" y="-3893.3" font-family="Arial" font-size="14.00">update_member_role(team_id: str, user_email: str, new_role: str, updated_by: Optional[str]): bool</text>
 <text text-anchor="start" x="166604.5" y="-3878.3" font-family="Arial" font-size="14.00">update_team(team_id: str, name: Optional[str], description: Optional[str], visibility: Optional[str], max_members: Optional[int], updated_by: Optional[str]): bool</text>

--- a/docs/docs/design/images/classes.svg
+++ b/docs/docs/design/images/classes.svg
@@ -10430,7 +10430,7 @@
 <text text-anchor="start" x="167377.5" y="-4306.3" font-family="Arial" font-size="14.00">role_service</text>
 <polyline fill="none" stroke="#ffaabb" points="166596.5,-4298.5 168231.5,-4298.5 "/>
 <text text-anchor="start" x="166604.5" y="-4283.3" font-family="Arial" font-size="14.00">add_member_to_team(team_id: str, user_email: str, role: str, invited_by: Optional[str]): EmailTeamMember</text>
-<text text-anchor="start" x="166604.5" y="-4268.3" font-family="Arial" font-size="14.00">approve_join_request(request_id: str, approved_by: str): Optional[EmailTeamMember]</text>
+<text text-anchor="start" x="166604.5" y="-4268.3" font-family="Arial" font-size="14.00">approve_join_request(team_id: str, request_id: str, approved_by: str): Optional[EmailTeamMember]</text>
 <text text-anchor="start" x="166604.5" y="-4253.3" font-family="Arial" font-size="14.00">cancel_join_request(request_id: str, user_email: str): bool</text>
 <text text-anchor="start" x="166604.5" y="-4238.3" font-family="Arial" font-size="14.00">count_team_owners(team_id: str): int</text>
 <text text-anchor="start" x="166604.5" y="-4223.3" font-family="Arial" font-size="14.00">create_join_request(team_id: str, user_email: str, message: Optional[str]): &#39;EmailTeamJoinRequest&#39;</text>
@@ -10453,7 +10453,7 @@
 <text text-anchor="start" x="166604.5" y="-3968.3" font-family="Arial" font-size="14.00">invalidate_team_member_count_cache(team_id: str): None</text>
 <text text-anchor="start" x="166604.5" y="-3953.3" font-family="Arial" font-size="14.00">list_join_requests(team_id: str): List[&#39;EmailTeamJoinRequest&#39;]</text>
 <text text-anchor="start" x="166604.5" y="-3938.3" font-family="Arial" font-size="14.00">list_teams(limit: int, offset: int, cursor: Optional[str], page: Optional[int], per_page: int, include_inactive: bool, visibility_filter: Optional[str], base_url: Optional[str], include_personal: bool, search_query: Optional[str]): Union[Tuple[List[EmailTeam], Optional[str]], Dict[str, Any]]</text>
-<text text-anchor="start" x="166604.5" y="-3923.3" font-family="Arial" font-size="14.00">reject_join_request(request_id: str, rejected_by: str): bool</text>
+<text text-anchor="start" x="166604.5" y="-3923.3" font-family="Arial" font-size="14.00">reject_join_request(team_id: str, request_id: str, rejected_by: str): bool</text>
 <text text-anchor="start" x="166604.5" y="-3908.3" font-family="Arial" font-size="14.00">remove_member_from_team(team_id: str, user_email: str, removed_by: Optional[str]): bool</text>
 <text text-anchor="start" x="166604.5" y="-3893.3" font-family="Arial" font-size="14.00">update_member_role(team_id: str, user_email: str, new_role: str, updated_by: Optional[str]): bool</text>
 <text text-anchor="start" x="166604.5" y="-3878.3" font-family="Arial" font-size="14.00">update_team(team_id: str, name: Optional[str], description: Optional[str], visibility: Optional[str], max_members: Optional[int], updated_by: Optional[str]): bool</text>

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4839,7 +4839,7 @@ async def _admin_logout(request: Request) -> Response:
                 # Match if referer host matches request host and path contains /admin or /oauth/callback
                 if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
                     is_same_origin_referer = True
-            except Exception: # nosec B110
+            except Exception:  # nosec B110
                 pass  # Invalid referer URL, treat as not same-origin
 
         is_browser_request = "text/html" in accept_header or is_htmx or is_same_origin_referer
@@ -7256,7 +7256,7 @@ async def admin_approve_join_request(
             return HTMLResponse(content='<div class="text-red-500">Only team owners can approve join requests</div>', status_code=403)
 
         # Approve join request
-        member = await team_service.approve_join_request(request_id, approved_by=user_email)
+        member = await team_service.approve_join_request(team_id, request_id, approved_by=user_email)
         if not member:
             return HTMLResponse(content='<div class="text-red-500">Join request not found</div>', status_code=404)
 
@@ -7308,7 +7308,7 @@ async def admin_reject_join_request(
             return HTMLResponse(content='<div class="text-red-500">Only team owners can reject join requests</div>', status_code=403)
 
         # Reject join request
-        success = await team_service.reject_join_request(request_id, rejected_by=user_email)
+        success = await team_service.reject_join_request(team_id, request_id, rejected_by=user_email)
         if not success:
             return HTMLResponse(content='<div class="text-red-500">Join request not found</div>', status_code=404)
 
@@ -16929,12 +16929,7 @@ async def get_resources_section(
         LOGGER.debug(f"User {user_email} requesting resources section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all resources with token_teams for proper scoping
-        resources_result = await local_resource_service.list_resources(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        resources_result = await local_resource_service.list_resources(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(resources_result, tuple):
             resources_list = resources_result[0]
         else:
@@ -16995,12 +16990,7 @@ async def get_prompts_section(
         LOGGER.debug(f"User {user_email} requesting prompts section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all prompts with token_teams for proper scoping
-        prompts_result = await local_prompt_service.list_prompts(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        prompts_result = await local_prompt_service.list_prompts(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(prompts_result, tuple):
             prompts_list = prompts_result[0]
         else:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -7257,8 +7257,6 @@ async def admin_approve_join_request(
 
         # Approve join request
         member = await team_service.approve_join_request(team_id, request_id, approved_by=user_email)
-        if not member:
-            return HTMLResponse(content='<div class="text-red-500">Join request not found</div>', status_code=404)
 
         response = HTMLResponse(
             content=f"""
@@ -7271,6 +7269,10 @@ async def admin_approve_join_request(
         response.headers["HX-Trigger"] = orjson.dumps({"adminTeamAction": {"teamId": team_id, "refreshJoinRequests": True, "delayMs": 1000}}).decode()
         return response
 
+    except ValueError as e:
+        if str(e) == "Join request not found or already processed":
+            return HTMLResponse(content=f'<div class="text-red-500">{html.escape(str(e))}</div>', status_code=404)
+        return HTMLResponse(content=f'<div class="text-red-500">Error approving join request: {html.escape(str(e))}</div>', status_code=400)
     except Exception as e:
         LOGGER.error(f"Error approving join request {request_id}: {e}")
         return HTMLResponse(content=f'<div class="text-red-500">Error approving join request: {html.escape(str(e))}</div>', status_code=400)
@@ -7308,9 +7310,7 @@ async def admin_reject_join_request(
             return HTMLResponse(content='<div class="text-red-500">Only team owners can reject join requests</div>', status_code=403)
 
         # Reject join request
-        success = await team_service.reject_join_request(team_id, request_id, rejected_by=user_email)
-        if not success:
-            return HTMLResponse(content='<div class="text-red-500">Join request not found</div>', status_code=404)
+        await team_service.reject_join_request(team_id, request_id, rejected_by=user_email)
 
         response = HTMLResponse(
             content="""
@@ -7323,6 +7323,10 @@ async def admin_reject_join_request(
         response.headers["HX-Trigger"] = orjson.dumps({"adminTeamAction": {"teamId": team_id, "refreshJoinRequests": True, "delayMs": 1000}}).decode()
         return response
 
+    except ValueError as e:
+        if str(e) == "Join request not found or already processed":
+            return HTMLResponse(content=f'<div class="text-red-500">{html.escape(str(e))}</div>', status_code=404)
+        return HTMLResponse(content=f'<div class="text-red-500">Error rejecting join request: {html.escape(str(e))}</div>', status_code=400)
     except Exception as e:
         LOGGER.error(f"Error rejecting join request {request_id}: {e}")
         return HTMLResponse(content=f'<div class="text-red-500">Error rejecting join request: {html.escape(str(e))}</div>', status_code=400)

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -1137,8 +1137,6 @@ async def approve_join_request(
 
         # Approve join request
         member = await team_service.approve_join_request(team_id, request_id, approved_by=current_user["email"])
-        if not member:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Join request not found")
 
         db.commit()
         db.close()
@@ -1152,8 +1150,9 @@ async def approve_join_request(
             is_active=member.is_active,
         )
     except (ValueError, TeamMemberLimitExceededError) as e:
-        # Handle validation errors with 400 Bad Request
         error_msg = str(e)
+        if error_msg == "Join request not found or already processed":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error_msg)
         if "maximum team limit" in error_msg:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Cannot approve: {error_msg.lower()}")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
@@ -1201,15 +1200,16 @@ async def reject_join_request(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only team owners can reject join requests")
 
         # Reject join request
-        success = await team_service.reject_join_request(team_id, request_id, rejected_by=current_user["email"])
-        if not success:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Join request not found")
+        await team_service.reject_join_request(team_id, request_id, rejected_by=current_user["email"])
 
         db.commit()
         db.close()
         return SuccessResponse(message="Join request rejected successfully")
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+        error_msg = str(e)
+        if error_msg == "Join request not found or already processed":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=error_msg)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=error_msg)
     except HTTPException:
         raise
     except Exception as e:

--- a/mcpgateway/routers/teams.py
+++ b/mcpgateway/routers/teams.py
@@ -1136,7 +1136,7 @@ async def approve_join_request(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only team owners can approve join requests")
 
         # Approve join request
-        member = await team_service.approve_join_request(request_id, approved_by=current_user["email"])
+        member = await team_service.approve_join_request(team_id, request_id, approved_by=current_user["email"])
         if not member:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Join request not found")
 
@@ -1201,13 +1201,15 @@ async def reject_join_request(
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only team owners can reject join requests")
 
         # Reject join request
-        success = await team_service.reject_join_request(request_id, rejected_by=current_user["email"])
+        success = await team_service.reject_join_request(team_id, request_id, rejected_by=current_user["email"])
         if not success:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Join request not found")
 
         db.commit()
         db.close()
         return SuccessResponse(message="Join request rejected successfully")
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except HTTPException:
         raise
     except Exception as e:

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -1763,10 +1763,11 @@ class TeamManagementService:
             logger.error("Failed to list join requests for team %s: %s", SecurityValidator.sanitize_log_message(team_id), e)
             return []
 
-    async def approve_join_request(self, request_id: str, approved_by: str) -> Optional[EmailTeamMember]:
+    async def approve_join_request(self, team_id: str, request_id: str, approved_by: str) -> Optional[EmailTeamMember]:
         """Approve a team join request.
 
         Args:
+            team_id: ID of the team that owns the join request
             request_id: ID of the join request
             approved_by: Email of the user approving the request
 
@@ -1778,7 +1779,7 @@ class TeamManagementService:
         """
         try:
             # Get join request
-            join_request = self.db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id, EmailTeamJoinRequest.status == "pending").first()
+            join_request = self.db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id, EmailTeamJoinRequest.team_id == team_id, EmailTeamJoinRequest.status == "pending").first()
 
             if not join_request:
                 raise ValueError("Join request not found or already processed")
@@ -1828,10 +1829,11 @@ class TeamManagementService:
             logger.error("Failed to approve join request %s: %s", request_id, e)
             raise
 
-    async def reject_join_request(self, request_id: str, rejected_by: str) -> bool:
+    async def reject_join_request(self, team_id: str, request_id: str, rejected_by: str) -> bool:
         """Reject a team join request.
 
         Args:
+            team_id: ID of the team that owns the join request
             request_id: ID of the join request
             rejected_by: Email of the user rejecting the request
 
@@ -1843,7 +1845,7 @@ class TeamManagementService:
         """
         try:
             # Get join request
-            join_request = self.db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id, EmailTeamJoinRequest.status == "pending").first()
+            join_request = self.db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id, EmailTeamJoinRequest.team_id == team_id, EmailTeamJoinRequest.status == "pending").first()
 
             if not join_request:
                 raise ValueError("Join request not found or already processed")

--- a/tests/unit/mcpgateway/routers/test_teams.py
+++ b/tests/unit/mcpgateway/routers/test_teams.py
@@ -1207,7 +1207,7 @@ class TestTeamsRouter:
             result = await approve_join_request(team_id, request_id, current_user=mock_user_context, db=mock_db)
 
             assert result.id == mock_team_member.id
-            mock_service.approve_join_request.assert_called_once_with(request_id, approved_by=mock_user_context["email"])
+            mock_service.approve_join_request.assert_called_once_with(team_id, request_id, approved_by=mock_user_context["email"])
 
     @pytest.mark.asyncio
     async def test_reject_join_request_success(self, mock_user_context, mock_db, mock_public_team):
@@ -1227,6 +1227,7 @@ class TestTeamsRouter:
             result = await reject_join_request(team_id, request_id, current_user=mock_user_context, db=mock_db)
 
             assert result.message == "Join request rejected successfully"
+            mock_service.reject_join_request.assert_called_once_with(team_id, request_id, rejected_by=mock_user_context["email"])
 
     @pytest.mark.asyncio
     async def test_reject_join_request_not_owner(self, mock_user_context, mock_db, mock_public_team):

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -804,18 +804,19 @@ class TestApproveJoinRequestErrors:
             assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.asyncio
-    async def test_member_none(self, user_ctx, db, mock_team):
+    async def test_value_error_not_found(self, user_ctx, db, mock_team):
         with (
             mock_permission_check(is_admin=user_ctx.get("is_admin", False)),
             _svc(
                 get_team_by_id=AsyncMock(return_value=mock_team),
                 get_user_role_in_team=AsyncMock(return_value="owner"),
-                approve_join_request=AsyncMock(return_value=None),
+                approve_join_request=AsyncMock(side_effect=ValueError("Join request not found or already processed")),
             ),
         ):
             with pytest.raises(HTTPException) as exc:
                 await teams.approve_join_request(mock_team.id, "rid", current_user=user_ctx, db=db)
             assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+            assert "not found" in exc.value.detail
 
     @pytest.mark.asyncio
     async def test_value_error_max_team_limit(self, user_ctx, db, mock_team):
@@ -881,20 +882,6 @@ class TestRejectJoinRequestErrors:
         with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(get_team_by_id=AsyncMock(return_value=None)):
             with pytest.raises(HTTPException) as exc:
                 await teams.reject_join_request("tid", "rid", current_user=user_ctx, db=db)
-            assert exc.value.status_code == status.HTTP_404_NOT_FOUND
-
-    @pytest.mark.asyncio
-    async def test_request_not_found(self, user_ctx, db, mock_team):
-        with (
-            mock_permission_check(is_admin=user_ctx.get("is_admin", False)),
-            _svc(
-                get_team_by_id=AsyncMock(return_value=mock_team),
-                get_user_role_in_team=AsyncMock(return_value="owner"),
-                reject_join_request=AsyncMock(return_value=False),
-            ),
-        ):
-            with pytest.raises(HTTPException) as exc:
-                await teams.reject_join_request(mock_team.id, "rid", current_user=user_ctx, db=db)
             assert exc.value.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -898,6 +898,21 @@ class TestRejectJoinRequestErrors:
             assert exc.value.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.asyncio
+    async def test_value_error_not_found(self, user_ctx, db, mock_team):
+        with (
+            mock_permission_check(is_admin=user_ctx.get("is_admin", False)),
+            _svc(
+                get_team_by_id=AsyncMock(return_value=mock_team),
+                get_user_role_in_team=AsyncMock(return_value="owner"),
+                reject_join_request=AsyncMock(side_effect=ValueError("Join request not found or already processed")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await teams.reject_join_request(mock_team.id, "rid", current_user=user_ctx, db=db)
+            assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+            assert "not found" in exc.value.detail
+
+    @pytest.mark.asyncio
     async def test_exception(self, user_ctx, db):
         with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(get_team_by_id=AsyncMock(side_effect=RuntimeError("crash"))):
             with pytest.raises(HTTPException) as exc:

--- a/tests/unit/mcpgateway/routers/test_teams_coverage.py
+++ b/tests/unit/mcpgateway/routers/test_teams_coverage.py
@@ -900,6 +900,21 @@ class TestRejectJoinRequestErrors:
             assert "not found" in exc.value.detail
 
     @pytest.mark.asyncio
+    async def test_value_error_generic(self, user_ctx, db, mock_team):
+        with (
+            mock_permission_check(is_admin=user_ctx.get("is_admin", False)),
+            _svc(
+                get_team_by_id=AsyncMock(return_value=mock_team),
+                get_user_role_in_team=AsyncMock(return_value="owner"),
+                reject_join_request=AsyncMock(side_effect=ValueError("some other validation error")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await teams.reject_join_request(mock_team.id, "rid", current_user=user_ctx, db=db)
+            assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+            assert "some other validation error" in exc.value.detail
+
+    @pytest.mark.asyncio
     async def test_exception(self, user_ctx, db):
         with mock_permission_check(is_admin=user_ctx.get("is_admin", False)), _svc(get_team_by_id=AsyncMock(side_effect=RuntimeError("crash"))):
             with pytest.raises(HTTPException) as exc:

--- a/tests/unit/mcpgateway/services/test_team_management_service.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service.py
@@ -10,8 +10,9 @@ Comprehensive tests for Team Management Service functionality.
 # Standard
 import asyncio
 import base64
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 # Third-Party
 import orjson
@@ -1309,9 +1310,44 @@ class TestTeamManagementService:
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="not found"):
-            await service.approve_join_request("req-1", "admin@example.com")
+            await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
+        filter_args = mock_db.query.return_value.filter.call_args.args
+        assert len(filter_args) == 3
+        assert filter_args[1].left.name == "team_id"
+        assert filter_args[1].right.value == "team-1"
         mock_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_approve_join_request_rejects_request_from_different_team(self, test_db):
+        """Approving with Team A path must not approve Team B's pending request."""
+        suffix = uuid4().hex
+        owner_email = f"owner-{suffix}@example.com"
+        user_email = f"user-{suffix}@example.com"
+        team_a_id = f"team-a-{suffix}"
+        team_b_id = f"team-b-{suffix}"
+        request_id = f"request-{suffix}"
+
+        test_db.add_all(
+            [
+                EmailUser(email=owner_email, password_hash="hash"),
+                EmailUser(email=user_email, password_hash="hash"),
+                EmailTeam(id=team_a_id, name="Team A", slug=f"team-a-{suffix}", created_by=owner_email),
+                EmailTeam(id=team_b_id, name="Team B", slug=f"team-b-{suffix}", created_by=owner_email),
+                EmailTeamJoinRequest(id=request_id, team_id=team_b_id, user_email=user_email, status="pending", expires_at=datetime.now(timezone.utc) + timedelta(days=7)),
+            ]
+        )
+        test_db.commit()
+
+        real_service = TeamManagementService(test_db)
+        real_service._get_user_team_count = MagicMock(return_value=0)
+
+        with pytest.raises(ValueError, match="not found"):
+            await real_service.approve_join_request(team_a_id, request_id, owner_email)
+
+        join_request = test_db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id).one()
+        assert join_request.status == "pending"
+        assert test_db.query(EmailTeamMember).filter(EmailTeamMember.team_id == team_b_id, EmailTeamMember.user_email == user_email).count() == 0
 
     @pytest.mark.asyncio
     async def test_approve_join_request_expired(self, service, mock_db):
@@ -1321,7 +1357,7 @@ class TestTeamManagementService:
         mock_db.query.return_value.filter.return_value.first.return_value = join_request
 
         with pytest.raises(ValueError, match="expired"):
-            await service.approve_join_request("req-1", "admin@example.com")
+            await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         assert join_request.status == "expired"
         mock_db.commit.assert_called_once()
@@ -1360,7 +1396,7 @@ class TestTeamManagementService:
             patch("mcpgateway.services.team_management_service.auth_cache.invalidate_team_membership", new=AsyncMock()),
             patch("mcpgateway.services.team_management_service.admin_stats_cache.invalidate_teams", new=AsyncMock()),
         ):
-            result = await service.approve_join_request("req-1", "admin@example.com")
+            result = await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         assert result is member
         mock_db.flush.assert_called_once()
@@ -1417,7 +1453,7 @@ class TestTeamManagementService:
                 patch("mcpgateway.services.team_management_service.auth_cache.invalidate_team_membership", new=AsyncMock()),
                 patch("mcpgateway.services.team_management_service.admin_stats_cache.invalidate_teams", new=AsyncMock()),
             ):
-                result = await service.approve_join_request("req-1", "admin@example.com")
+                result = await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         assert result is member
         mock_role_service.get_role_by_name.assert_called_once_with("viewer", scope="team")
@@ -1470,7 +1506,7 @@ class TestTeamManagementService:
                 patch("mcpgateway.services.team_management_service.auth_cache.invalidate_team_membership", new=AsyncMock()),
                 patch("mcpgateway.services.team_management_service.admin_stats_cache.invalidate_teams", new=AsyncMock()),
             ):
-                result = await service.approve_join_request("req-1", "admin@example.com")
+                result = await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         # Should still return member even without role
         assert result is member
@@ -1496,7 +1532,7 @@ class TestTeamManagementService:
 
             with patch.object(service, "get_team_by_id", new=AsyncMock(return_value=mock_team)):
                 with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
-                    await service.approve_join_request("req-1", "admin@example.com")
+                    await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         mock_db.rollback.assert_called_once()
 
@@ -1514,7 +1550,7 @@ class TestTeamManagementService:
 
             with patch.object(service, "get_team_by_id", new=AsyncMock(return_value=None)):
                 with pytest.raises(ValueError, match="not found or inactive"):
-                    await service.approve_join_request("req-1", "admin@example.com")
+                    await service.approve_join_request("team-1", "req-1", "admin@example.com")
 
         mock_db.rollback.assert_called_once()
 
@@ -1526,7 +1562,7 @@ class TestTeamManagementService:
         join_request.team_id = "team-1"
         mock_db.query.return_value.filter.return_value.first.return_value = join_request
 
-        result = await service.reject_join_request("req-1", "admin@example.com")
+        result = await service.reject_join_request("team-1", "req-1", "admin@example.com")
 
         assert result is True
         assert join_request.status == "rejected"
@@ -1538,9 +1574,43 @@ class TestTeamManagementService:
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
         with pytest.raises(ValueError, match="not found"):
-            await service.reject_join_request("req-1", "admin@example.com")
+            await service.reject_join_request("team-1", "req-1", "admin@example.com")
 
+        filter_args = mock_db.query.return_value.filter.call_args.args
+        assert len(filter_args) == 3
+        assert filter_args[1].left.name == "team_id"
+        assert filter_args[1].right.value == "team-1"
         mock_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_join_request_rejects_request_from_different_team(self, test_db):
+        """Rejecting with Team A path must not reject Team B's pending request."""
+        suffix = uuid4().hex
+        owner_email = f"owner-{suffix}@example.com"
+        user_email = f"user-{suffix}@example.com"
+        team_a_id = f"team-a-{suffix}"
+        team_b_id = f"team-b-{suffix}"
+        request_id = f"request-{suffix}"
+
+        test_db.add_all(
+            [
+                EmailUser(email=owner_email, password_hash="hash"),
+                EmailUser(email=user_email, password_hash="hash"),
+                EmailTeam(id=team_a_id, name="Team A", slug=f"team-a-{suffix}", created_by=owner_email),
+                EmailTeam(id=team_b_id, name="Team B", slug=f"team-b-{suffix}", created_by=owner_email),
+                EmailTeamJoinRequest(id=request_id, team_id=team_b_id, user_email=user_email, status="pending", expires_at=datetime.now(timezone.utc) + timedelta(days=7)),
+            ]
+        )
+        test_db.commit()
+
+        real_service = TeamManagementService(test_db)
+
+        with pytest.raises(ValueError, match="not found"):
+            await real_service.reject_join_request(team_a_id, request_id, owner_email)
+
+        join_request = test_db.query(EmailTeamJoinRequest).filter(EmailTeamJoinRequest.id == request_id).one()
+        assert join_request.status == "pending"
+        assert join_request.reviewed_by is None
 
     @pytest.mark.asyncio
     async def test_get_user_join_requests_with_team_filter(self, service, mock_db):

--- a/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_management_service_coverage.py
@@ -812,7 +812,7 @@ class TestApproveJoinRequestEdge:
             mock_settings.default_team_owner_role = "team_admin"
             mock_asyncio.create_task = MagicMock(side_effect=RuntimeError("no loop"))
 
-            result = await svc.approve_join_request("jr1", "owner@t.com")
+            result = await svc.approve_join_request("team-1", "jr1", "owner@t.com")
 
         assert result is not None
 
@@ -1448,7 +1448,7 @@ class TestApproveJoinRequestMaxTeamsLimit:
         with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
             mock_settings.max_teams_per_user = 50
             with pytest.raises(ValueError, match="maximum team limit"):
-                await svc.approve_join_request("jr1", approved_by="owner@t.com")
+                await svc.approve_join_request("team-1", "jr1", approved_by="owner@t.com")
 
     @pytest.mark.asyncio
     async def test_raises_when_team_at_max_members(self, svc, db):
@@ -1474,7 +1474,7 @@ class TestApproveJoinRequestMaxTeamsLimit:
             with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
                 mock_settings.max_teams_per_user = 50
                 with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
-                    await svc.approve_join_request("jr1", approved_by="owner@t.com")
+                    await svc.approve_join_request("team-1", "jr1", approved_by="owner@t.com")
 
 
 # ===========================================================================

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -19222,6 +19222,18 @@ class TestTeamJoinRequests:
         assert result.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_admin_approve_join_request_value_error(self, monkeypatch, allow_permission, mock_db):
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", True, raising=False)
+        ts = MagicMock()
+        ts.get_user_role_in_team = AsyncMock(return_value="owner")
+        ts.approve_join_request = AsyncMock(side_effect=ValueError("some other validation error"))
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: ts)
+
+        result = await admin_approve_join_request("team-1", "req-1", mock_db, user={"email": "owner@test.com"})
+        assert result.status_code == 400
+        assert "some other validation error" in result.body.decode()
+
+    @pytest.mark.asyncio
     async def test_admin_approve_join_request_exception(self, monkeypatch, allow_permission, mock_db):
         monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", True, raising=False)
         ts = MagicMock()
@@ -19255,6 +19267,18 @@ class TestTeamJoinRequests:
 
         result = await admin_reject_join_request("team-1", "req-1", mock_db, user={"email": "owner@test.com"})
         assert result.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_admin_reject_join_request_value_error(self, monkeypatch, allow_permission, mock_db):
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", True, raising=False)
+        ts = MagicMock()
+        ts.get_user_role_in_team = AsyncMock(return_value="owner")
+        ts.reject_join_request = AsyncMock(side_effect=ValueError("some other validation error"))
+        monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: ts)
+
+        result = await admin_reject_join_request("team-1", "req-1", mock_db, user={"email": "owner@test.com"})
+        assert result.status_code == 400
+        assert "some other validation error" in result.body.decode()
 
     @pytest.mark.asyncio
     async def test_admin_reject_join_request_email_auth_disabled(self, monkeypatch, allow_permission, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -6761,6 +6761,7 @@ class TestOAuthFunctionality:
             assert gateway_update.oauth_config["client_id"] == "client-id"
             assert gateway_update.oauth_config["client_secret"] == "enc-secret"
             assert gateway_update.oauth_config["scopes"] == ["a", "b", "c"]
+
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_with_audience_parameter(self, mock_update_gateway, mock_request, mock_db):
         """Test editing gateway with OAuth audience parameter (for Atlassian, Auth0, etc.)."""
@@ -6797,7 +6798,6 @@ class TestOAuthFunctionality:
             assert gateway_update.oauth_config["audience"] == "api.atlassian.com"
             assert gateway_update.oauth_config["client_id"] == "client-id"
             assert gateway_update.oauth_config["scopes"] == ["read:jira-work", "write:jira-work"]
-
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
@@ -17485,6 +17485,7 @@ async def test_admin_add_a2a_agent_oauth_assembled_from_form_fields(monkeypatch,
     assert agent_data.oauth_config["client_secret"] == "enc"
     assert agent_data.oauth_config["scopes"] == ["a", "b", "c"]
 
+
 @pytest.mark.asyncio
 async def test_admin_add_a2a_agent_oauth_with_audience(monkeypatch, mock_db):
     """Test adding A2A agent with OAuth audience parameter (for Atlassian, Auth0, etc.)."""
@@ -17759,6 +17760,7 @@ async def test_admin_edit_a2a_agent_oauth_config_invalid_json(monkeypatch, mock_
     assert response.status_code == 200
     agent_update = service.update_agent.call_args.kwargs["agent_data"]
     assert agent_update.oauth_config is None
+
 
 @pytest.mark.asyncio
 async def test_admin_edit_a2a_agent_oauth_with_audience(monkeypatch, mock_db):
@@ -19213,7 +19215,7 @@ class TestTeamJoinRequests:
         monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", True, raising=False)
         ts = MagicMock()
         ts.get_user_role_in_team = AsyncMock(return_value="owner")
-        ts.approve_join_request = AsyncMock(return_value=None)
+        ts.approve_join_request = AsyncMock(side_effect=ValueError("Join request not found or already processed"))
         monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: ts)
 
         result = await admin_approve_join_request("team-1", "req-1", mock_db, user={"email": "owner@test.com"})
@@ -19248,7 +19250,7 @@ class TestTeamJoinRequests:
         monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", True, raising=False)
         ts = MagicMock()
         ts.get_user_role_in_team = AsyncMock(return_value="owner")
-        ts.reject_join_request = AsyncMock(return_value=False)
+        ts.reject_join_request = AsyncMock(side_effect=ValueError("Join request not found or already processed"))
         monkeypatch.setattr("mcpgateway.admin.TeamManagementService", lambda db: ts)
 
         result = await admin_reject_join_request("team-1", "req-1", mock_db, user={"email": "owner@test.com"})

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -523,6 +523,21 @@ async def test_admin_logout_paths():
 
 
 @pytest.mark.asyncio
+async def test_admin_logout_invalid_referer_fails_closed(monkeypatch):
+    parse_referer = MagicMock(side_effect=ValueError("bad referer"))
+    monkeypatch.setattr("urllib.parse.urlparse", parse_referer)
+
+    request = _make_request(root_path="/root")
+    request.method = "GET"
+    request.headers = {"accept": "application/json", "referer": "http://bad.example/admin", "host": "localhost:4444"}
+
+    response = await admin._admin_logout(request)
+    assert response.status_code == 200
+    assert response.body == b"Logged out"
+    parse_referer.assert_called_once_with("http://bad.example/admin")
+
+
+@pytest.mark.asyncio
 async def test_admin_logout_keycloak_redirect(monkeypatch):
     request = _make_request(root_path="/root")
     request.method = "POST"

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -188,12 +188,12 @@ class _StubTeamService:
     async def list_join_requests(self, team_id: str):
         return self.join_requests
 
-    async def approve_join_request(self, request_id: str, approved_by: str):
-        self.approve_args = (request_id, approved_by)
+    async def approve_join_request(self, team_id: str, request_id: str, approved_by: str):
+        self.approve_args = (team_id, request_id, approved_by)
         return self.approve_member
 
-    async def reject_join_request(self, request_id: str, rejected_by: str):
-        self.reject_args = (request_id, rejected_by)
+    async def reject_join_request(self, team_id: str, request_id: str, rejected_by: str):
+        self.reject_args = (team_id, request_id, rejected_by)
         return self.reject_ok
 
     def count_team_owners(self, team_id: str) -> int:

--- a/tests/unit/mcpgateway/test_team_governance_flags.py
+++ b/tests/unit/mcpgateway/test_team_governance_flags.py
@@ -441,7 +441,7 @@ class TestMaxTeamsInApproveJoinRequest:
         with patch("mcpgateway.services.team_management_service.settings") as mock_settings:
             mock_settings.max_teams_per_user = 5
             with pytest.raises(ValueError, match="maximum team limit"):
-                await service.approve_join_request(request_id="req-1", approved_by="admin@example.com")
+                await service.approve_join_request(team_id="team-1", request_id="req-1", approved_by="admin@example.com")
 
 
 class TestAdminJoinRequestFlag:


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary
Bind join request approvals and rejections to the route team before updating request state. This keeps the service behavior aligned with the team context checked by the routes.

## 🔁 Reproduction Steps
1. Have a pending join request for one team.
2. Call an approve or reject route using a different team in the path and the pending request id.
3. The request action should only apply when the path team matches the request team.

## 🐞 Root Cause
The route validated the caller against the path team, but the service loaded the join request by request id and status only.

## 💡 Fix Description
The team management service now requires `team_id` for approve and reject operations and includes it in the join request lookup. Admin and API routes pass the path team through to the service. Tests cover mismatched team/request handling with real database rows.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | focused pytest       | Passed |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | focused unit coverage | Passed |

## 📐 MCP Compliance (if relevant)
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`pre-commit`)
- [x] No secrets/credentials committed