### PR TITLE
fix(chore): make tag length configurable via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -302,6 +302,15 @@ VALIDATION_MIDDLEWARE_ENABLED=true
 # VALIDATION_PERIOD_TYPE_PATTERN=^(hourly|daily)$
 # VALIDATION_AGGREGATION_PATTERN=^(5m|24h)$
 # VALIDATION_ENTITY_TYPES_PATTERN=^[a-zA-Z,]*$
+
+# Tag length validation (applies to all resources: tools, prompts, resources, servers, gateways)
+# Minimum tag length (default: 2, range: 1-10)
+# VALIDATION_MIN_TAG_LENGTH=2
+# Maximum tag length (default: 100, range: 10-255)
+# Supports system-generated tags, hashes, and namespaced identifiers
+# Example: VALIDATION_MAX_TAG_LENGTH=150 for very long descriptive tags
+# VALIDATION_MAX_TAG_LENGTH=100
+
 # Permission audit logging (RBAC checks) - disabled by default for performance
 PERMISSION_AUDIT_ENABLED=false
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-11T13:01:14Z",
+  "generated_at": "2026-06-11T09:41:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -116,7 +116,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 690,
+        "line_number": 699,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 918,
+        "line_number": 927,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1205,
+        "line_number": 1214,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1239,
+        "line_number": 1248,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1318,
+        "line_number": 1327,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1332,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1328,
+        "line_number": 1337,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1334,
+        "line_number": 1343,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1346,
+        "line_number": 1355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1364,
+        "line_number": 1373,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1425,
+        "line_number": 1434,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -354,7 +354,7 @@ class SecurityValidator:
     MAX_TEMPLATE_LENGTH = settings.validation_max_template_length  # Default: 65536
     MAX_CONTENT_LENGTH = settings.validation_max_content_length  # Default: 1048576 (1MB)
     MAX_JSON_DEPTH = settings.validation_max_json_depth  # Default: 30
-    MAX_URL_LENGTH = settings.validation_max_url_length  # Default: 767 (matches DB String(767) limit)
+    MAX_URL_LENGTH = settings.validation_max_url_length  # Default: 2048
 
     @classmethod
     def sanitize_display_text(cls, value: str, field_name: str) -> str:
@@ -1072,11 +1072,11 @@ class SecurityValidator:
 
             Length validation:
 
-            >>> long_url = 'https://example.com/' + 'a' * 800
+            >>> long_url = 'https://example.com/' + 'a' * 2100
             >>> SecurityValidator.validate_url(long_url)
             Traceback (most recent call last):
                 ...
-            ValueError: URL exceeds maximum length of 767
+            ValueError: URL exceeds maximum length of 2048
 
             Scheme validation:
 

--- a/mcpgateway/common/validators.py
+++ b/mcpgateway/common/validators.py
@@ -354,7 +354,7 @@ class SecurityValidator:
     MAX_TEMPLATE_LENGTH = settings.validation_max_template_length  # Default: 65536
     MAX_CONTENT_LENGTH = settings.validation_max_content_length  # Default: 1048576 (1MB)
     MAX_JSON_DEPTH = settings.validation_max_json_depth  # Default: 30
-    MAX_URL_LENGTH = settings.validation_max_url_length  # Default: 2048
+    MAX_URL_LENGTH = settings.validation_max_url_length  # Default: 767 (matches DB String(767) limit)
 
     @classmethod
     def sanitize_display_text(cls, value: str, field_name: str) -> str:
@@ -1072,11 +1072,11 @@ class SecurityValidator:
 
             Length validation:
 
-            >>> long_url = 'https://example.com/' + 'a' * 2100
+            >>> long_url = 'https://example.com/' + 'a' * 800
             >>> SecurityValidator.validate_url(long_url)
             Traceback (most recent call last):
                 ...
-            ValueError: URL exceeds maximum length of 2048
+            ValueError: URL exceeds maximum length of 767
 
             Scheme validation:
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -3253,20 +3253,20 @@ Disallow: /
         ge=1,
         le=100,
     )
-    validation_max_url_length: int = 767  # Match database String(767) limit to prevent validation/storage mismatch
+    validation_max_url_length: int = 2048
     validation_max_rpc_param_size: int = 262144  # 256KB
 
     validation_max_method_length: int = 128
 
-    # Tag validation limits (configurable via env) - Issue #XXXX
+    # Tag validation limits (configurable via env) - Issue #5175
     validation_min_tag_length: int = Field(
-        default=int(os.getenv("VALIDATION_MIN_TAG_LENGTH", "2")),
+        default=2,
         description=("Minimum length for individual tags. Tags shorter than this will be rejected. " "Override with VALIDATION_MIN_TAG_LENGTH environment variable. Minimum: 1, Maximum: 10"),
         ge=1,
         le=10,
     )
     validation_max_tag_length: int = Field(
-        default=int(os.getenv("VALIDATION_MAX_TAG_LENGTH", "100")),
+        default=100,
         description=(
             "Maximum length for individual tags. Tags longer than this will be rejected. "
             "Default: 100 characters. Supports system-generated tags, hashes, and namespaced identifiers. "

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2740,9 +2740,7 @@ class Settings(BaseSettings):
     # Experimental dataplane config
     # ===================================
 
-    dataplane_publisher: bool = Field(default=False,
-        description="Send data from CF to Rust experimental dataplane"
-    )
+    dataplane_publisher: bool = Field(default=False, description="Send data from CF to Rust experimental dataplane")
 
     # Well-Known URI Configuration
     # ===================================
@@ -3255,10 +3253,29 @@ Disallow: /
         ge=1,
         le=100,
     )
-    validation_max_url_length: int = 2048
+    validation_max_url_length: int = 767  # Match database String(767) limit to prevent validation/storage mismatch
     validation_max_rpc_param_size: int = 262144  # 256KB
 
     validation_max_method_length: int = 128
+
+    # Tag validation limits (configurable via env) - Issue #XXXX
+    validation_min_tag_length: int = Field(
+        default=int(os.getenv("VALIDATION_MIN_TAG_LENGTH", "2")),
+        description=("Minimum length for individual tags. Tags shorter than this will be rejected. " "Override with VALIDATION_MIN_TAG_LENGTH environment variable. Minimum: 1, Maximum: 10"),
+        ge=1,
+        le=10,
+    )
+    validation_max_tag_length: int = Field(
+        default=int(os.getenv("VALIDATION_MAX_TAG_LENGTH", "100")),
+        description=(
+            "Maximum length for individual tags. Tags longer than this will be rejected. "
+            "Default: 100 characters. Supports system-generated tags, hashes, and namespaced identifiers. "
+            "Override with VALIDATION_MAX_TAG_LENGTH environment variable. "
+            "Minimum: 10, Maximum: 255 (database constraint)"
+        ),
+        ge=10,
+        le=255,
+    )
 
     # Allowed MIME types
     validation_allowed_mime_types: List[str] = [

--- a/mcpgateway/validation/tags.py
+++ b/mcpgateway/validation/tags.py
@@ -27,7 +27,7 @@ class TagValidator:
 
     Ensures tags follow consistent formatting rules:
     - Minimum length: Configurable via VALIDATION_MIN_TAG_LENGTH (default: 2 characters)
-    - Maximum length: Configurable via VALIDATION_MAX_TAG_LENGTH (default: 50 characters)
+    - Maximum length: Configurable via VALIDATION_MAX_TAG_LENGTH (default: 100 characters)
     - Allowed characters: lowercase letters, numbers, hyphens, colons, dots
     - Must start and end with alphanumeric characters
     - Automatic normalization to lowercase, trimmed
@@ -46,7 +46,7 @@ class TagValidator:
 
     Attributes:
         MIN_LENGTH (int): Minimum allowed tag length (configurable, default: 2).
-        MAX_LENGTH (int): Maximum allowed tag length (configurable, default: 50).
+        MAX_LENGTH (int): Maximum allowed tag length (configurable, default: 100).
         ALLOWED_PATTERN (str): Regular expression pattern for valid tags.
     """
 

--- a/mcpgateway/validation/tags.py
+++ b/mcpgateway/validation/tags.py
@@ -13,6 +13,9 @@ all ContextForge entities (tools, resources, prompts, servers, gateways).
 import re
 from typing import Dict, List, Optional, Pattern
 
+# First-Party
+from mcpgateway.config import settings
+
 # Pattern: start with alphanumeric, middle can have hyphen/colon/dot, end with alphanumeric
 _TAG_ALLOWED_PATTERN = r"^[a-z0-9]([a-z0-9\-\:\.]*[a-z0-9])?$"
 # Precompiled regex pattern for tag validation (compiled once at module load)
@@ -23,8 +26,8 @@ class TagValidator:
     """Validator and normalizer for entity tags.
 
     Ensures tags follow consistent formatting rules:
-    - Minimum length: 2 characters
-    - Maximum length: 50 characters
+    - Minimum length: Configurable via VALIDATION_MIN_TAG_LENGTH (default: 2 characters)
+    - Maximum length: Configurable via VALIDATION_MAX_TAG_LENGTH (default: 50 characters)
     - Allowed characters: lowercase letters, numbers, hyphens, colons, dots
     - Must start and end with alphanumeric characters
     - Automatic normalization to lowercase, trimmed
@@ -42,13 +45,15 @@ class TagValidator:
         [{'id': 'finance', 'label': 'Finance'}]
 
     Attributes:
-        MIN_LENGTH (int): Minimum allowed tag length (2).
-        MAX_LENGTH (int): Maximum allowed tag length (50).
+        MIN_LENGTH (int): Minimum allowed tag length (configurable, default: 2).
+        MAX_LENGTH (int): Maximum allowed tag length (configurable, default: 50).
         ALLOWED_PATTERN (str): Regular expression pattern for valid tags.
     """
 
-    MIN_LENGTH = 2
-    MAX_LENGTH = 50
+    # Read from settings instead of hardcoding
+    # These are class attributes that read from config at module load time
+    MIN_LENGTH = settings.validation_min_tag_length
+    MAX_LENGTH = settings.validation_max_tag_length
     # Single character tags are allowed if they are alphanumeric
     ALLOWED_PATTERN = _TAG_ALLOWED_PATTERN
 

--- a/tests/unit/mcpgateway/validation/test_tags.py
+++ b/tests/unit/mcpgateway/validation/test_tags.py
@@ -7,9 +7,6 @@ Authors: Mihai Criveti
 Tests for tag validation and normalization.
 """
 
-# Standard
-from unittest.mock import patch
-
 # Third-Party
 import pytest
 
@@ -170,7 +167,16 @@ class TestTagPatterns:
 
 
 class TestConfigurableTagLimits:
-    """Test suite for configurable tag length limits (Issue #XXXX)."""
+    """Test suite for configurable tag length limits (Issue #5175)."""
+
+    @pytest.fixture(autouse=True)
+    def _restore_limits(self):
+        """Restore TagValidator class attributes after each test to prevent pollution."""
+        original_min = TagValidator.MIN_LENGTH
+        original_max = TagValidator.MAX_LENGTH
+        yield
+        TagValidator.MIN_LENGTH = original_min
+        TagValidator.MAX_LENGTH = original_max
 
     def test_default_limits(self):
         """Test that default limits are applied from settings."""
@@ -206,16 +212,11 @@ class TestConfigurableTagLimits:
         # Single character should fail (min is 2 by default)
         assert TagValidator.validate("a") is False
 
-    @patch("mcpgateway.validation.tags.settings")
-    def test_custom_max_length_100(self, mock_settings):
+    def test_custom_max_length_100(self):
         """Test validation with custom max length of 100 characters."""
-        # Mock settings to have max_tag_length = 100
-        mock_settings.validation_min_tag_length = 2
-        mock_settings.validation_max_tag_length = 100
-
-        # Reload class attributes to pick up mocked settings
-        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
-        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+        # Set class attributes directly (fixture will restore them)
+        TagValidator.MIN_LENGTH = 2
+        TagValidator.MAX_LENGTH = 100
 
         # Tag with 100 characters (should be valid)
         tag_100 = "a" * 100
@@ -229,15 +230,11 @@ class TestConfigurableTagLimits:
         tag_99 = "a" * 99
         assert TagValidator.validate(tag_99) is True
 
-    @patch("mcpgateway.validation.tags.settings")
-    def test_custom_max_length_200(self, mock_settings):
+    def test_custom_max_length_200(self):
         """Test validation with custom max length of 200 characters (system-generated tags)."""
-        # Mock settings for longer tags (e.g., hashes, identifiers)
-        mock_settings.validation_min_tag_length = 2
-        mock_settings.validation_max_tag_length = 200
-
-        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
-        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+        # Set class attributes directly (fixture will restore them)
+        TagValidator.MIN_LENGTH = 2
+        TagValidator.MAX_LENGTH = 200
 
         # Simulate system-generated tag with hash
         system_tag = "deployment-prod-us-west-2-sha256-" + "a" * 64  # 97 chars total
@@ -252,15 +249,11 @@ class TestConfigurableTagLimits:
         too_long = "a" * 201
         assert TagValidator.validate(too_long) is False
 
-    @patch("mcpgateway.validation.tags.settings")
-    def test_custom_min_length(self, mock_settings):
+    def test_custom_min_length(self):
         """Test validation with custom minimum length."""
-        # Allow single-character tags
-        mock_settings.validation_min_tag_length = 1
-        mock_settings.validation_max_tag_length = 50
-
-        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
-        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+        # Set class attributes directly (fixture will restore them)
+        TagValidator.MIN_LENGTH = 1
+        TagValidator.MAX_LENGTH = 50
 
         # Single character should now be valid
         assert TagValidator.validate("a") is True

--- a/tests/unit/mcpgateway/validation/test_tags.py
+++ b/tests/unit/mcpgateway/validation/test_tags.py
@@ -7,6 +7,12 @@ Authors: Mihai Criveti
 Tests for tag validation and normalization.
 """
 
+# Standard
+from unittest.mock import patch
+
+# Third-Party
+import pytest
+
 # First-Party
 from mcpgateway.validation.tags import TagValidator, validate_tags_field
 
@@ -39,7 +45,7 @@ class TestTagValidator:
         assert TagValidator.validate("a") is False  # Too short
         assert TagValidator.validate("-invalid") is False  # Starts with hyphen
         assert TagValidator.validate("invalid-") is False  # Ends with hyphen
-        assert TagValidator.validate("x" * 51) is False  # Too long
+        assert TagValidator.validate("x" * 101) is False  # Too long (exceeds new default of 100)
         assert TagValidator.validate("invalid tag") is False  # Contains space
         assert TagValidator.validate("invalid@tag") is False  # Invalid character
         assert TagValidator.validate("invalid#tag") is False  # Invalid character
@@ -75,8 +81,8 @@ class TestTagValidator:
         errors = TagValidator.get_validation_errors(["valid", "another-valid"])
         assert errors == []
 
-        # Test with long tag
-        long_tag = "x" * 51
+        # Test with long tag (exceeds new default max of 100)
+        long_tag = "x" * 101
         errors = TagValidator.get_validation_errors([long_tag])
         assert len(errors) == 1
         assert "too long" in errors[0]
@@ -161,3 +167,132 @@ class TestTagPatterns:
         assert TagValidator.validate("critical") is True
         assert TagValidator.validate("p0") is True
         assert TagValidator.validate("p1") is True
+
+
+class TestConfigurableTagLimits:
+    """Test suite for configurable tag length limits (Issue #XXXX)."""
+
+    def test_default_limits(self):
+        """Test that default limits are applied from settings."""
+        # Default min: 2, max: 100 (from config.py)
+        assert TagValidator.MIN_LENGTH >= 1
+        assert TagValidator.MAX_LENGTH >= 10
+        assert TagValidator.MAX_LENGTH <= 255
+
+    def test_tag_at_max_length_default(self):
+        """Test tag at exactly the default maximum length (100 chars)."""
+        # 100 characters exactly
+        tag_100 = "a" * 100
+        # Should be valid at default settings (max=100)
+        # Note: Actual behavior depends on current settings
+        result = TagValidator.validate(tag_100)
+        # Just verify it doesn't crash - actual validation depends on env config
+        assert isinstance(result, bool)
+
+    def test_tag_exceeds_max_length(self):
+        """Test that tags exceeding MAX_LENGTH are rejected."""
+        # Create tag that's definitely longer than max possible (255)
+        too_long = "a" * 256
+        assert TagValidator.validate(too_long) is False
+
+    def test_tag_at_min_length(self):
+        """Test tag at exactly the minimum length."""
+        # Minimum is typically 2
+        tag_min = "ab"
+        assert TagValidator.validate(tag_min) is True
+
+    def test_tag_below_min_length(self):
+        """Test that tags below MIN_LENGTH are rejected."""
+        # Single character should fail (min is 2 by default)
+        assert TagValidator.validate("a") is False
+
+    @patch("mcpgateway.validation.tags.settings")
+    def test_custom_max_length_100(self, mock_settings):
+        """Test validation with custom max length of 100 characters."""
+        # Mock settings to have max_tag_length = 100
+        mock_settings.validation_min_tag_length = 2
+        mock_settings.validation_max_tag_length = 100
+
+        # Reload class attributes to pick up mocked settings
+        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
+        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+
+        # Tag with 100 characters (should be valid)
+        tag_100 = "a" * 100
+        assert TagValidator.validate(tag_100) is True
+
+        # Tag with 101 characters (should be invalid)
+        tag_101 = "a" * 101
+        assert TagValidator.validate(tag_101) is False
+
+        # Tag with 99 characters (should be valid)
+        tag_99 = "a" * 99
+        assert TagValidator.validate(tag_99) is True
+
+    @patch("mcpgateway.validation.tags.settings")
+    def test_custom_max_length_200(self, mock_settings):
+        """Test validation with custom max length of 200 characters (system-generated tags)."""
+        # Mock settings for longer tags (e.g., hashes, identifiers)
+        mock_settings.validation_min_tag_length = 2
+        mock_settings.validation_max_tag_length = 200
+
+        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
+        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+
+        # Simulate system-generated tag with hash
+        system_tag = "deployment-prod-us-west-2-sha256-" + "a" * 64  # 97 chars total
+        assert TagValidator.validate(system_tag) is True
+
+        # Very long descriptive tag (186 chars - adjusted)
+        long_tag = "machine-learning-natural-language-processing-transformer-based-sentiment-analysis-production-deployment-version-2-team-ai-research-department-engineering-organization-enterprise-customer"
+        assert len(long_tag) == 186
+        assert TagValidator.validate(long_tag) is True
+
+        # Just over limit (201 chars)
+        too_long = "a" * 201
+        assert TagValidator.validate(too_long) is False
+
+    @patch("mcpgateway.validation.tags.settings")
+    def test_custom_min_length(self, mock_settings):
+        """Test validation with custom minimum length."""
+        # Allow single-character tags
+        mock_settings.validation_min_tag_length = 1
+        mock_settings.validation_max_tag_length = 50
+
+        TagValidator.MIN_LENGTH = mock_settings.validation_min_tag_length
+        TagValidator.MAX_LENGTH = mock_settings.validation_max_tag_length
+
+        # Single character should now be valid
+        assert TagValidator.validate("a") is True
+        assert TagValidator.validate("x") is True
+
+    def test_error_messages_reflect_limits(self):
+        """Test that error messages include current limit values."""
+        # Create a tag that's too long
+        too_long = "a" * 300
+        errors = TagValidator.get_validation_errors([too_long])
+
+        assert len(errors) == 1
+        # Error message should mention the limit
+        assert "too long" in errors[0].lower()
+        assert str(TagValidator.MAX_LENGTH) in errors[0]
+
+    def test_validate_list_with_mixed_lengths(self):
+        """Test validate_list with tags at various lengths."""
+        # Mix of valid and invalid lengths
+        # Note: Single-char tags are currently invalid by default (MIN_LENGTH >= 2)
+        # but validate_list may accept them if they're alphanumeric
+        tags = [
+            "ab",  # Min length (valid)
+            "valid-tag",  # Normal length (valid)
+            "x" * (TagValidator.MAX_LENGTH + 1),  # Too long (invalid)
+        ]
+
+        result = TagValidator.validate_list(tags)
+
+        # Should only include valid tags
+        valid_ids = [tag["id"] for tag in result]
+        assert "ab" in valid_ids
+        assert "valid-tag" in valid_ids
+        # Too long tags should be filtered out
+        assert len([t for t in result if len(t["id"]) > TagValidator.MAX_LENGTH]) == 0


### PR DESCRIPTION
## 🔗 Related Issue
Closes #5175

---

## 📝 Summary

Makes tag length limits configurable via environment variables for all ContextForge resources (tools, prompts, resources, servers, gateways). Previously, tag lengths were hardcoded at 2-50 characters. This change allows operators to configure limits based on their needs (e.g., longer tags for system-generated identifiers, hashes, or namespaced tags).

**Key Changes:**
- Added `VALIDATION_MIN_TAG_LENGTH` environment variable (default: 2, range: 1-10)
- Added `VALIDATION_MAX_TAG_LENGTH` environment variable (default: 100, range: 10-255)
- **Breaking Change**: Default max tag length increased from 50 to 100 characters to better support real-world use cases

**Affected Resources:**
All tag fields across tools, prompts, resources, servers, and gateways now use configurable validation.

---

## 🏷️ Type of Change
- [x] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |    Pass ✅    |
| Unit tests                | `make test`     |    Pass ✅    |
| Coverage ≥ 80%            | `make coverage` |    Pass ✅    |

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Breaking Change:**
Default max tag length increased from 50 → 100 characters. Tags between 51-100 chars that were previously rejected will now be accepted. To restore previous behavior, set `VALIDATION_MAX_TAG_LENGTH=50`.

**Files Modified:**
- `mcpgateway/config.py` - Added configurable settings
- `mcpgateway/validation/tags.py` - Use settings instead of hardcoded constants
- `.env.example` - Documented new environment variables
- `tests/unit/mcpgateway/validation/test_tags.py` - Added 10 test cases for configurable limits
- `.secrets.baseline` - Updated baseline

**Usage Example:**
```bash
# Support longer tags (e.g., for deployment identifiers)
VALIDATION_MAX_TAG_LENGTH=150

# Allow single-character tags
VALIDATION_MIN_TAG_LENGTH=1
