### PR TITLE
fix(api): oauth offered as auth_type in Add Tool form but silently ignored by POST /tools and POST /admin/tools

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4224,7 +4224,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4403,
+        "line_number": 4411,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4244,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15017,
+        "line_number": 15016,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5060,7 +5060,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11379,
+        "line_number": 11389,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5068,7 +5068,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17773,
+        "line_number": 17783,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -5068,7 +5068,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17783,
+        "line_number": 17785,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4839,7 +4839,7 @@ async def _admin_logout(request: Request) -> Response:
                 # Match if referer host matches request host and path contains /admin or /oauth/callback
                 if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
                     is_same_origin_referer = True
-            except Exception: # nosec B110
+            except Exception:  # nosec B110
                 pass  # Invalid referer URL, treat as not same-origin
 
         is_browser_request = "text/html" in accept_header or is_htmx or is_same_origin_referer
@@ -16931,12 +16931,7 @@ async def get_resources_section(
         LOGGER.debug(f"User {user_email} requesting resources section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all resources with token_teams for proper scoping
-        resources_result = await local_resource_service.list_resources(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        resources_result = await local_resource_service.list_resources(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(resources_result, tuple):
             resources_list = resources_result[0]
         else:
@@ -16997,12 +16992,7 @@ async def get_prompts_section(
         LOGGER.debug(f"User {user_email} requesting prompts section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all prompts with token_teams for proper scoping
-        prompts_result = await local_prompt_service.list_prompts(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        prompts_result = await local_prompt_service.list_prompts(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(prompts_result, tuple):
             prompts_list = prompts_result[0]
         else:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11651,6 +11651,8 @@ def _build_auth_obj_from_form(form: Any) -> Optional[dict[str, Any]]:
             auth_headers = []
 
     auth_type = form.get("auth_type", "")
+    if auth_type and auth_type.lower() == "oauth":
+        raise HTTPException(status_code=422, detail="auth_type 'oauth' is not supported on tools; configure OAuth on the gateway instead")
     auth_obj: Optional[dict[str, Any]] = None
     if auth_type:
         if auth_type == "basic":

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -498,6 +498,14 @@ class AuthenticationValues(BaseModelWithConfigDict):
     auth_type: Optional[str] = Field(None, description="Type of authentication: basic, bearer, authheaders or None")
     auth_value: Optional[str] = Field(None, description="Encoded Authentication values")
 
+    @field_validator("auth_type")
+    @classmethod
+    def reject_oauth_auth_type(cls, v: Optional[str]) -> Optional[str]:
+        """Reject oauth as a tool auth_type — OAuth must be configured on the gateway."""
+        if v is not None and v.lower() == "oauth":
+            raise ValueError("auth_type 'oauth' is not supported on tools; configure OAuth on the gateway instead")
+        return v
+
     # Only For tool read and view tool
     username: Optional[str] = Field("", description="Username for basic authentication")
     password: Optional[str] = Field("", description="Password for basic authentication")

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3908,7 +3908,6 @@
                   <option value="basic">Basic</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="authheaders">Custom Headers</option>
-                  <option value="oauth">OAuth 2.0</option>
                 </select>
               </div>
               <div id="auth-basic-fields" style="display: none">

--- a/tests/playwright/entities/test_tools_extended.py
+++ b/tests/playwright/entities/test_tools_extended.py
@@ -225,9 +225,12 @@ class TestToolsAddForm:
 
         auth_type = tools_page.add_tool_form.locator('[name="auth_type"]')
 
-        # None (empty value), Basic, Bearer Token, Custom Headers, OAuth 2.0
-        for value in ["", "basic", "bearer", "authheaders", "oauth"]:
+        # None (empty value), Basic, Bearer Token, Custom Headers
+        for value in ["", "basic", "bearer", "authheaders"]:
             expect(auth_type.locator(f'option[value="{value}"]')).to_be_attached()
+
+        # OAuth must NOT appear — tool auth_type=oauth is unsupported (configure OAuth on the gateway)
+        expect(auth_type.locator('option[value="oauth"]')).not_to_be_attached()
 
     def test_visibility_radios_present(self, tools_page: ToolsPage):
         """Test that visibility radio buttons (public/team/private) are present."""

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -6771,6 +6771,7 @@ class TestOAuthFunctionality:
             assert gateway_update.oauth_config["client_id"] == "client-id"
             assert gateway_update.oauth_config["client_secret"] == "enc-secret"
             assert gateway_update.oauth_config["scopes"] == ["a", "b", "c"]
+
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_with_audience_parameter(self, mock_update_gateway, mock_request, mock_db):
         """Test editing gateway with OAuth audience parameter (for Atlassian, Auth0, etc.)."""
@@ -6807,7 +6808,6 @@ class TestOAuthFunctionality:
             assert gateway_update.oauth_config["audience"] == "api.atlassian.com"
             assert gateway_update.oauth_config["client_id"] == "client-id"
             assert gateway_update.oauth_config["scopes"] == ["read:jira-work", "write:jira-work"]
-
 
     @patch.object(GatewayService, "update_gateway")
     async def test_admin_edit_gateway_oauth_assembled_minimal_fields_covers_false_branches(self, mock_update_gateway, mock_request, mock_db, monkeypatch):
@@ -17495,6 +17495,7 @@ async def test_admin_add_a2a_agent_oauth_assembled_from_form_fields(monkeypatch,
     assert agent_data.oauth_config["client_secret"] == "enc"
     assert agent_data.oauth_config["scopes"] == ["a", "b", "c"]
 
+
 @pytest.mark.asyncio
 async def test_admin_add_a2a_agent_oauth_with_audience(monkeypatch, mock_db):
     """Test adding A2A agent with OAuth audience parameter (for Atlassian, Auth0, etc.)."""
@@ -17769,6 +17770,7 @@ async def test_admin_edit_a2a_agent_oauth_config_invalid_json(monkeypatch, mock_
     assert response.status_code == 200
     agent_update = service.update_agent.call_args.kwargs["agent_data"]
     assert agent_update.oauth_config is None
+
 
 @pytest.mark.asyncio
 async def test_admin_edit_a2a_agent_oauth_with_audience(monkeypatch, mock_db):

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2008,6 +2008,16 @@ class TestAdminToolRoutes:
         )
         assert _build_auth_obj_from_form(form) is None
 
+    def test_build_auth_obj_from_form_oauth_raises_422(self, mock_request, mock_db):
+        """_build_auth_obj_from_form raises 422 when auth_type is oauth."""
+        from fastapi import HTTPException
+
+        form = FakeForm({"auth_type": "oauth"})
+        with pytest.raises(HTTPException) as exc_info:
+            _build_auth_obj_from_form(form)
+        assert exc_info.value.status_code == 422
+        assert "oauth" in exc_info.value.detail.lower()
+
     @patch.object(ToolService, "set_tool_state")
     async def test_admin_set_tool_state_various_activate_values(self, mock_toggle_status, mock_request, mock_db):
         """Test setting tool state with various activate values."""

--- a/tests/unit/mcpgateway/test_schemas.py
+++ b/tests/unit/mcpgateway/test_schemas.py
@@ -1951,3 +1951,27 @@ class TestAuthValidationErrors:
             )
 
         assert "either 'auth_headers' list or both 'auth_header_key' and 'auth_header_value' must be provided" in str(exc_info.value)
+
+    def test_authentication_values_rejects_oauth(self):
+        """AuthenticationValues raises ValidationError when auth_type is 'oauth'."""
+        from mcpgateway.schemas import AuthenticationValues
+
+        with pytest.raises(ValidationError) as exc_info:
+            AuthenticationValues(auth_type="oauth")
+        assert "oauth" in str(exc_info.value).lower()
+
+    def test_authentication_values_rejects_oauth_case_insensitive(self):
+        """AuthenticationValues rejects oauth regardless of case."""
+        from mcpgateway.schemas import AuthenticationValues
+
+        for value in ("OAuth", "OAUTH", "oAuth"):
+            with pytest.raises(ValidationError):
+                AuthenticationValues(auth_type=value)
+
+    def test_authentication_values_accepts_valid_auth_types(self):
+        """AuthenticationValues accepts basic, bearer, and authheaders."""
+        from mcpgateway.schemas import AuthenticationValues
+
+        for auth_type in ("basic", "bearer", "authheaders"):
+            obj = AuthenticationValues(auth_type=auth_type)
+            assert obj.auth_type == auth_type


### PR DESCRIPTION
Closes #5164

## Summary

OAuth 2.0 appeared as a selectable authentication type in the Add Tool form, but submitting it was silently accepted with no effect — the tool was created with no authentication configured. This happens because `ToolCreate` and the `Tool` DB model have no `oauth_config` field; Pydantic silently drops unknown fields. OAuth on tools is inherited from the gateway the tool is registered under — the tool service reads `gateway.oauth_config` at invocation time. Direct OAuth configuration on a tool was never wired up, and `_build_auth_obj_from_form` in `admin.py` had no branch for `oauth`, so it returned `None` silently.

## Changes

### `mcpgateway/templates/admin.html`
Removed `<option value="oauth">OAuth 2.0</option>` from the Add Tool form (`#add-tool-form`). The option remains on gateway and A2A agent forms where OAuth is fully wired up.

### `mcpgateway/schemas.py`
Added a `field_validator` on `AuthenticationValues.auth_type` that raises a `ValueError` (Pydantic 422) when `auth_type` is `"oauth"` (case-insensitive). This blocks `POST /tools` and `POST /admin/tools` API calls that submit `auth_type=oauth`.

### `mcpgateway/admin.py`
Added an early `HTTPException(422)` in `_build_auth_obj_from_form` for `auth_type == "oauth"`, covering the form-submission path.

## Tests
  - `test_admin.py`: new test asserts `_build_auth_obj_from_form` raises 422 when `auth_type=oauth`
  - `test_schemas.py`: three new tests covering `AuthenticationValues` rejection of `oauth` (exact, case-insensitive, and valid-type acceptance)
  - `test_tools_extended.py` (Playwright): updated `test_auth_type_options` to assert `oauth` is **not** attached to the add-tool form and to serve as a regression guard
  
