### PR TITLE
fix: respect token expiry for session auth reuse

### DIFF
--- a/crates/mcp_runtime/src/lib.rs
+++ b/crates/mcp_runtime/src/lib.rs
@@ -385,6 +385,8 @@ struct InternalAuthContext {
     #[serde(default)]
     auth_method: Option<String>,
     #[serde(default)]
+    exp: Option<u64>,
+    #[serde(default)]
     permission_is_admin: Option<bool>,
     #[serde(default)]
     is_admin: bool,
@@ -4052,12 +4054,19 @@ fn maybe_bind_session_auth_context(
         return;
     };
 
-    record.encoded_auth_context = Some(encoded_auth_context);
-    record.auth_binding_fingerprint = Some(fingerprint);
     let auth_context_ttl_ms =
         u64::try_from(state.session_auth_reuse_ttl().as_millis()).unwrap_or(u64::MAX);
-    record.auth_context_expires_at_epoch_ms =
-        Some(unix_epoch_millis().saturating_add(auth_context_ttl_ms));
+    let ttl_expires_at = unix_epoch_millis().saturating_add(auth_context_ttl_ms);
+    let expires_at = auth_context
+        .exp
+        .and_then(|exp| exp.checked_mul(1_000))
+        .map_or(ttl_expires_at, |token_expires_at| {
+            ttl_expires_at.min(token_expires_at)
+        });
+
+    record.encoded_auth_context = Some(encoded_auth_context);
+    record.auth_binding_fingerprint = Some(fingerprint);
+    record.auth_context_expires_at_epoch_ms = Some(expires_at);
 }
 
 fn inject_session_header(incoming_headers: &mut HeaderMap, session_id: &str) {
@@ -12134,6 +12143,7 @@ mod unit_tests {
             teams: Some(vec!["team-1".to_string()]),
             team_name: Some("Team 1".to_string()),
             auth_method: Some("jwt".to_string()),
+            exp: None,
             permission_is_admin: Some(false),
             is_admin: false,
             is_authenticated: true,
@@ -12181,6 +12191,35 @@ mod unit_tests {
                 > super::unix_epoch_millis()
         );
         assert!(runtime_session_access_outcome(&record, Some(&auth_context), &headers).is_ok());
+
+        let token_exp = (super::unix_epoch_millis() / 1_000).saturating_add(1);
+        let expiring_auth_context = InternalAuthContext {
+            exp: Some(token_exp),
+            ..auth_context.clone()
+        };
+        let mut expiring_record = RuntimeSessionRecord {
+            owner_email: Some("owner@example.com".to_string()),
+            server_id: Some("server-1".to_string()),
+            protocol_version: None,
+            client_capabilities: None,
+            encoded_auth_context: None,
+            auth_binding_fingerprint: None,
+            auth_context_expires_at_epoch_ms: None,
+            created_at: std::time::Instant::now(),
+            last_used: std::time::Instant::now(),
+        };
+        maybe_bind_session_auth_context(
+            &state,
+            &mut expiring_record,
+            &headers,
+            Some(&expiring_auth_context),
+        );
+        assert!(
+            expiring_record
+                .auth_context_expires_at_epoch_ms
+                .expect("ttl is set")
+                <= token_exp.saturating_mul(1_000)
+        );
 
         upsert_runtime_session(&state, "session-validate".to_string(), record.clone()).await;
 
@@ -12549,6 +12588,7 @@ mod unit_tests {
             teams: Some(vec!["team-1".to_string()]),
             team_name: Some("Team 1".to_string()),
             auth_method: Some("jwt".to_string()),
+            exp: None,
             permission_is_admin: Some(false),
             is_admin: false,
             is_authenticated: true,

--- a/crates/mcp_runtime/src/observability.rs
+++ b/crates/mcp_runtime/src/observability.rs
@@ -1465,6 +1465,7 @@ mod tests {
             teams: Some(vec!["team-a".to_string()]),
             team_name: Some("Team A".to_string()),
             auth_method: Some("jwt".to_string()),
+            exp: None,
             permission_is_admin: Some(true),
             is_admin: true,
             is_authenticated: true,

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4766,6 +4766,7 @@ def get_streamable_http_auth_context() -> dict[str, Any]:
         "is_authenticated",
         "is_admin",
         "auth_method",
+        "exp",
         "token_use",
         "permission_is_admin",
         "scoped_permissions",
@@ -5199,6 +5200,7 @@ class _StreamableHttpAuthHandler:
                 "is_authenticated": True,
                 "is_admin": effective_is_admin,
                 "auth_method": "jwt",
+                "exp": user_payload.get("exp"),
                 "permission_is_admin": effective_is_admin,
                 "token_use": token_use,  # propagated for downstream RBAC (check_any_team)
             }
@@ -5507,6 +5509,7 @@ class _StreamableHttpAuthHandler:
                 "is_authenticated": True,
                 "is_admin": is_admin,
                 "permission_is_admin": is_admin,
+                "exp": claims.get("exp"),
                 "token_use": "session",  # nosec B105 - JWT claim type marker, not a password
                 "auth_method": "oauth_access_token",
             }

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -396,6 +396,7 @@ def test_get_streamable_http_auth_context_copies_supported_keys_and_lists():
         "email": "user@example.com",
         "teams": ["team-a"],
         "auth_method": "jwt",
+        "exp": 1_800_000_000,
         "is_authenticated": True,
         "is_admin": False,
         "token_use": "session",
@@ -414,6 +415,7 @@ def test_get_streamable_http_auth_context_copies_supported_keys_and_lists():
         "email": "user@example.com",
         "teams": ["team-a"],
         "auth_method": "jwt",
+        "exp": 1_800_000_000,
         "is_authenticated": True,
         "is_admin": False,
         "token_use": "session",
@@ -13320,6 +13322,39 @@ async def test_streamable_http_auth_allows_authenticated_oauth_server(monkeypatc
 
     user_ctx = tr.user_context_var.get()
     assert user_ctx.get("is_authenticated") is True
+
+
+@pytest.mark.asyncio
+async def test_oauth_access_token_context_preserves_exp(monkeypatch):
+    """Verified OAuth claims should preserve exp for Rust session auth reuse."""
+    token_exp = 1_800_000_000
+    mock_server = MagicMock()
+    mock_server.oauth_enabled = True
+    mock_server.oauth_config = {
+        "authorization_servers": ["https://issuer.example.com"],
+        "resource": "https://gateway.example.com/servers/oauth-server/mcp",
+    }
+    mock_db = MagicMock()
+    mock_db.execute.return_value.scalar_one_or_none.return_value = mock_server
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", _make_fake_get_db(mock_db))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.verify_oauth_access_token", AsyncMock(return_value={"email": "user@example.com", "exp": token_exp}))
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport._persist_learned_server_audience", MagicMock())
+
+    mock_user = MagicMock()
+    mock_user.is_active = True
+    mock_user.is_admin = False
+    monkeypatch.setattr("mcpgateway.auth._get_user_by_email_sync", MagicMock(return_value=mock_user))
+    monkeypatch.setattr("mcpgateway.auth._resolve_teams_from_db", AsyncMock(return_value=["team-a"]))
+
+    handler = tr._StreamableHttpAuthHandler(scope=_make_scope("/servers/oauth-server/mcp"), receive=AsyncMock(), send=AsyncMock())
+
+    result = await handler._try_oauth_access_token(
+        "oauth-token",
+        {"iss": "https://issuer.example.com"},
+    )
+
+    assert result is tr.OAuthAuthResult.SUCCESS
+    assert tr.user_context_var.get()["exp"] == token_exp
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# 🐛 Bug-fix PR

Before opening this PR please:

1. `make lint`            - not run
2. `make test`            - not run
3. `make coverage`        - not run
4. `make docker docker-run-ssl` or `make podman podman-run-ssl` - not run
5. Update relevant documentation. - not applicable
6. Tested with sqlite and postgres + redis. - not run
7. Manual regression no longer fails. Ensure the UI and /version work correctly. - covered by targeted regression tests

---

## 📌 Summary
Preserves token expiry in forwarded MCP auth context and caps Rust session auth reuse to the earlier of the token expiry or the configured reuse TTL.

## 🔁 Reproduction Steps
A request authenticated with a short-lived JWT or OAuth access token can initialize a Rust-managed MCP session while session auth reuse is enabled. After the token expires, a request with the same session and binding can still hit the cached auth context until the reuse TTL expires.

## 🐞 Root Cause
The Rust runtime cached authenticated session context with an expiry derived only from `session_auth_reuse_ttl`. The forwarded auth context did not carry the token `exp`, so Rust could not clamp the cache lifetime to the credential lifetime.

## 💡 Fix Description
- Forward `exp` in MCP auth context for JWT and OAuth access-token flows.
- Store `exp` in the Rust internal auth context.
- Clamp cached auth-context expiry to `min(now + session_auth_reuse_ttl, token_exp)` when `exp` is available.
- Add targeted coverage for JWT forwarding, OAuth forwarding, and Rust-side clamping.

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `cargo clippy -- -D warnings` | Passed |
| Unit tests                            | `cargo test` in `crates/mcp_runtime` | Passed |
| Targeted Python tests                 | `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -k 'get_streamable_http_auth_context_copies_supported_keys_and_lists or oauth_access_token_context_preserves_exp'` | Passed |
| Format check                          | `cargo fmt --check` | Passed |
| Coverage ≥ 80 %                       | `make coverage`      | Not run |
| Manual regression no longer fails     | Targeted regression tests | Passed |

## 📐 MCP Compliance (if relevant)
- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist
- [x] Code formatted (`cargo fmt --check`)
- [x] No secrets/credentials committed
