### PR TITLE
feat(ui-rewrite): add Tools details view

### DIFF
--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolDetailsPanel } from "./ToolDetailsPanel";
+import type { Tool } from "@/types/tool";
+
+// Helper to create mock tools
+function createMockTool(id: number, overrides?: Partial<Tool>): Tool {
+  return {
+    id: `tool-${id}`,
+    name: `Tool ${id}`,
+    originalName: `tool_${id}`,
+    description: `Description for tool ${id}`,
+    originalDescription: `Original description for tool ${id}`,
+    title: `Tool ${id} Title`,
+    displayName: `Display Name ${id}`,
+    gatewayId: `gateway-id`,
+    gatewaySlug: "test-gateway",
+    customName: `Tool ${id}`,
+    customNameSlug: `tool-${id}`,
+    enabled: true,
+    reachable: true,
+    executionCount: 0,
+    tags: ["tag1", "tag2"],
+    integrationType: "MCP",
+    requestType: "http",
+    url: `https://example.com/tool-${id}`,
+    version: 1,
+    visibility: "team",
+    team: "Engineering",
+    teamId: "team-123",
+    ownerEmail: "owner@example.com",
+    createdAt: "2024-01-01T00:00:00",
+    updatedAt: "2024-01-02T00:00:00",
+    createdBy: "user@example.com",
+    createdVia: "api",
+    createdFromIp: "192.168.1.1",
+    createdUserAgent: "Mozilla/5.0",
+    modifiedBy: "admin@example.com",
+    modifiedFromIp: "192.168.1.2",
+    modifiedVia: "ui",
+    modifiedUserAgent: "Mozilla/5.0",
+    inputSchema: { type: "object" },
+    outputSchema: { type: "object" },
+    ...overrides,
+  };
+}
+
+describe("ToolDetailsPanel", () => {
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it("renders nothing when closed", () => {
+    const tools = [createMockTool(1)];
+    const { container } = render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={false}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const aside = container.querySelector('aside[role="region"]');
+    expect(aside).toHaveAttribute("data-state", "closed");
+    expect(aside).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders panel when open", () => {
+    const tools = [createMockTool(1)];
+    const { container } = render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const aside = container.querySelector('aside[role="region"]');
+    expect(aside).toHaveAttribute("data-state", "open");
+    expect(aside).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("displays gateway name and integration type", () => {
+    const tools = [createMockTool(1, { integrationType: "MCP" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(screen.getAllByText("test-gateway").length).toBeGreaterThan(0);
+    // "MCP Server" appears in the subtitle and in Component details Type row
+    expect(screen.getAllByText("MCP Server").length).toBeGreaterThan(0);
+  });
+
+  it("displays all tools in table", () => {
+    const tools = [createMockTool(1), createMockTool(2), createMockTool(3)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    expect(screen.getByText("tool_1")).toBeInTheDocument();
+    expect(screen.getByText("tool_2")).toBeInTheDocument();
+    expect(screen.getByText("tool_3")).toBeInTheDocument();
+  });
+
+  it("selects first tool by default when panel opens", async () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Component details")).toBeInTheDocument();
+    });
+
+    // First tool should be selected and its details shown
+    expect(screen.getByText("Display Name 1")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const closeButton = screen.getByLabelText("Close tool details");
+    await user.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape key is pressed", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    const { container } = render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const backdrop = container.querySelector('[data-state="open"][aria-hidden="true"]');
+    expect(backdrop).toBeInTheDocument();
+
+    if (backdrop) {
+      await user.click(backdrop);
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("displays tool status correctly", async () => {
+    const tools = [
+      createMockTool(1, { enabled: true, reachable: true }),
+      createMockTool(2, { enabled: false, reachable: false }),
+    ];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Active")).toBeInTheDocument();
+    });
+  });
+
+  it("displays visibility label correctly", async () => {
+    const tools = [createMockTool(1, { visibility: "team" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Team")).toBeInTheDocument();
+    });
+  });
+
+  it("displays public visibility correctly", async () => {
+    const tools = [createMockTool(1, { visibility: "public" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Public")).toBeInTheDocument();
+    });
+  });
+
+  it("displays private visibility correctly", async () => {
+    const tools = [createMockTool(1, { visibility: "private" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Private")).toBeInTheDocument();
+    });
+  });
+
+  it("displays integration type labels correctly", async () => {
+    const testCases = [
+      { type: "MCP", label: "MCP Server" },
+      { type: "REST", label: "REST API tools" },
+      { type: "GRPC", label: "gRPC Service" },
+    ];
+
+    for (const { type, label } of testCases) {
+      const tools = [createMockTool(1, { integrationType: type })];
+      const { unmount } = render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await waitFor(() => {
+        // label may appear in both the subtitle and the Component details Type row
+        expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+      });
+
+      unmount();
+    }
+  });
+
+  it("displays tool version", async () => {
+    const tools = [createMockTool(1, { version: 2 })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      const versionElements = screen.getAllByText("2");
+      expect(versionElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("displays tool URL with copy button", async () => {
+    // URL must be ≤24 chars (truncateMiddle default) to avoid truncation in the assertion
+    const tools = [createMockTool(1, { url: "https://api.example.com" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("https://api.example.com")).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("Copy URL")).toBeInTheDocument();
+  });
+
+  it("displays tool tags", async () => {
+    const tools = [createMockTool(1, { tags: ["production", "critical", "v2"] })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("production")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("critical")).toBeInTheDocument();
+    expect(screen.getByText("v2")).toBeInTheDocument();
+  });
+
+  it("displays add button when no tags", async () => {
+    const tools = [createMockTool(1, { tags: [] })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("add")).toBeInTheDocument();
+    });
+  });
+
+  it("displays formatted creation date", async () => {
+    const tools = [createMockTool(1, { createdAt: "2024-01-15T10:30:45.123Z" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-01-15T10:30:45")).toBeInTheDocument();
+    });
+  });
+
+  it("displays formatted update date", async () => {
+    const tools = [createMockTool(1, { updatedAt: "2024-02-20T14:25:30.456Z" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("2024-02-20T14:25:30")).toBeInTheDocument();
+    });
+  });
+
+  it("displays 'Not available' for missing dates", async () => {
+    const tools = [createMockTool(1, { createdAt: "", updatedAt: "" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      const notAvailableElements = screen.getAllByText("Not available");
+      expect(notAvailableElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("displays request type", async () => {
+    const tools = [createMockTool(1, { requestType: "websocket" })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("websocket")).toBeInTheDocument();
+    });
+  });
+
+  it("handles tool selection from table", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("tool_1")).toBeInTheDocument();
+    });
+
+    // Click on second tool
+    const tool2Row = screen.getByText("tool_2").closest("tr");
+    expect(tool2Row).toBeInTheDocument();
+
+    if (tool2Row) {
+      await user.click(tool2Row);
+
+      // Second tool details should now be shown
+      await waitFor(() => {
+        expect(screen.getByText("Display Name 2")).toBeInTheDocument();
+      });
+    }
+  });
+
+  it("resets selected tool when panel closes", async () => {
+    const tools = [createMockTool(1)];
+    const { rerender } = render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Display Name 1")).toBeInTheDocument();
+    });
+
+    // Close panel
+    rerender(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={false}
+        onClose={mockOnClose}
+      />,
+    );
+
+    // Reopen panel
+    rerender(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    // First tool should be selected again
+    await waitFor(() => {
+      expect(screen.getByText("Display Name 1")).toBeInTheDocument();
+    });
+  });
+
+  it("focuses close button when panel opens", async () => {
+    const tools = [createMockTool(1)];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      const closeButton = screen.getByLabelText("Close tool details");
+      expect(closeButton).toHaveFocus();
+    });
+  });
+
+  it("handles unreachable tool status", async () => {
+    const tools = [createMockTool(1, { enabled: true, reachable: false })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Unreachable")).toBeInTheDocument();
+    });
+  });
+
+  it("handles inactive tool status", async () => {
+    const tools = [createMockTool(1, { enabled: false, reachable: true })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Inactive")).toBeInTheDocument();
+    });
+  });
+
+  it("handles tools without URL", async () => {
+    const tools = [createMockTool(1, { url: null })];
+    render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="test-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Component details")).toBeInTheDocument();
+    });
+
+    // URL row should not be present
+    expect(screen.queryByLabelText("Copy URL")).not.toBeInTheDocument();
+  });
+
+  it("generates unique heading ID based on gateway slug", () => {
+    const tools = [createMockTool(1)];
+    const { container } = render(
+      <ToolDetailsPanel
+        tools={tools}
+        gatewaySlug="my-custom-gateway"
+        open={true}
+        onClose={mockOnClose}
+      />,
+    );
+
+    const heading = container.querySelector("#tool-details-heading-my-custom-gateway");
+    expect(heading).toBeInTheDocument();
+  });
+});

--- a/client/src/components/tools/ToolDetailsPanel.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Activity, Copy, Globe, PanelRightClose, Plus, Wrench } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Tool } from "@/types/tool";
+import { copyToClipboard, truncateMiddle } from "@/components/gateways/utils";
+import { ToolsTable } from "@/components/tools/ToolsTable";
+
+function DetailRow({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`grid grid-cols-[96px_minmax(0,1fr)] items-start gap-4 ${className ?? ""}`}>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 text-foreground">{children}</dd>
+    </div>
+  );
+}
+
+function CopyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="min-w-0 flex-1 truncate font-mono text-[12px]">{truncateMiddle(value)}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        className="size-5 text-muted-foreground"
+        aria-label={`Copy ${label}`}
+        onClick={() => copyToClipboard(value)}
+      >
+        <Copy className="size-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+function formatDateTime(value?: string, emptyLabel = "Not available") {
+  if (!value) return emptyLabel;
+  // Strip milliseconds and trailing timezone marker to match ISO display style
+  return value.replace(/\.\d+Z?$/, "");
+}
+
+export function ToolDetailsPanel({
+  tools,
+  gatewaySlug,
+  open,
+  onClose,
+}: {
+  tools: Tool[];
+  gatewaySlug: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const headingId = useMemo(() => `tool-details-heading-${gatewaySlug}`, [gatewaySlug]);
+
+  // Select first tool when panel opens or tools change
+  useEffect(() => {
+    if (open && tools.length > 0 && !selectedTool) {
+      setSelectedTool(tools[0]);
+    }
+  }, [open, tools, selectedTool]);
+
+  // Reset selected tool when panel closes
+  useEffect(() => {
+    if (!open) {
+      setSelectedTool(null);
+    }
+  }, [open]);
+
+  // Focus close on open; restore focus on close/unmount.
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+    closeButtonRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+      previousFocusRef.current = null;
+    };
+  }, [open]);
+
+  // ESC closes while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const getVisibilityLabel = useCallback((value?: string) => {
+    if (value === "team") return "Team";
+    if (value === "public") return "Public";
+    if (value === "private") return "Private";
+    return "Not available";
+  }, []);
+
+  const getIntegrationTypeLabel = useCallback((type?: string) => {
+    if (type === "MCP") return "MCP Server";
+    if (type === "REST") return "REST API tools";
+    if (type === "GRPC") return "gRPC Service";
+    return type ?? "Not available";
+  }, []);
+
+  return (
+    <>
+      <div
+        data-state={open ? "open" : "closed"}
+        aria-hidden="true"
+        onClick={onClose}
+        className={cn(
+          "absolute inset-0 z-10 bg-black/10 transition-opacity duration-150 supports-backdrop-filter:backdrop-blur-xs",
+          "data-[state=open]:opacity-100 data-[state=closed]:opacity-0 data-[state=closed]:pointer-events-none",
+        )}
+      />
+
+      <aside
+        role="region"
+        aria-labelledby={headingId}
+        aria-hidden={!open}
+        data-state={open ? "open" : "closed"}
+        className={cn(
+          "absolute inset-y-0 right-0 z-20 flex w-[min(1236px,calc(100%-2rem))] border-l border-border bg-popover text-[13px] shadow-lg",
+          "transition-transform duration-200 ease-out",
+          "data-[state=open]:translate-x-0 data-[state=closed]:translate-x-full",
+          "data-[state=closed]:pointer-events-none",
+        )}
+      >
+        {tools.length > 0 && (
+          <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="min-w-0 overflow-y-auto bg-background px-6 py-8 lg:px-12 dark:bg-neutral-900">
+              <h2 id={headingId} className="sr-only">
+                Tools for {gatewaySlug}
+              </h2>
+
+              {/* Header with icon and title */}
+              <div className="mb-6 flex items-center gap-3">
+                <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-tool-icon-bg">
+                  <Wrench className="h-3.5 w-3.5 text-black" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3 className="text-base font-semibold text-foreground">{gatewaySlug}</h3>
+                </div>
+              </div>
+
+              {/* Subtitle */}
+              <p className="mb-8 text-sm text-muted-foreground">
+                {getIntegrationTypeLabel(tools[0]?.integrationType)}
+              </p>
+
+              {/* Table */}
+              <ToolsTable
+                tools={tools}
+                selectedToolId={selectedTool?.id}
+                onSelectTool={setSelectedTool}
+              />
+            </div>
+
+            <aside className="relative border-t border-border bg-background lg:border-l lg:border-t-0">
+              <Button
+                ref={closeButtonRef}
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Close tool details"
+                className="absolute right-3 top-3 text-muted-foreground"
+                onClick={onClose}
+              >
+                <PanelRightClose className="size-4" />
+              </Button>
+
+              {selectedTool && (
+                <>
+                  <div className="border-b border-border p-4 pt-8">
+                    <h3 className="mb-7 text-sm font-semibold text-foreground">
+                      Component details
+                    </h3>
+
+                    <dl className="space-y-4">
+                      <DetailRow label="Status">
+                        <span className="flex items-center gap-2">
+                          <Activity
+                            className={`size-3.5 ${
+                              selectedTool.enabled && selectedTool.reachable
+                                ? "text-emerald-400"
+                                : "text-gray-400"
+                            }`}
+                          />
+                          {selectedTool.enabled
+                            ? selectedTool.reachable
+                              ? "Active"
+                              : "Unreachable"
+                            : "Inactive"}
+                        </span>
+                      </DetailRow>
+                      <DetailRow label="Visibility">
+                        <span className="flex items-center gap-2">
+                          <Globe className="size-3.5 text-muted-foreground" />
+                          {getVisibilityLabel(selectedTool.visibility)}
+                        </span>
+                      </DetailRow>
+                      <DetailRow label="Type">
+                        <span className="text-foreground">
+                          {getIntegrationTypeLabel(selectedTool.integrationType)}
+                        </span>
+                      </DetailRow>
+                      <DetailRow label="Version">
+                        <span className="text-foreground">{selectedTool.version ?? 1}</span>
+                      </DetailRow>
+                      <DetailRow label="Request type">
+                        <span className="text-foreground">{selectedTool.requestType}</span>
+                      </DetailRow>
+                      {selectedTool.url && (
+                        <DetailRow label="URL">
+                          <CopyValue label="URL" value={selectedTool.url} />
+                        </DetailRow>
+                      )}
+                      <DetailRow label="Tags" className="items-center">
+                        <div className="flex min-w-0 flex-wrap items-center gap-2">
+                          {(selectedTool.tags || []).length > 0 ? (
+                            <>
+                              {(selectedTool.tags || []).map((tag, index) => (
+                                <Badge
+                                  key={`${tag}-${index}`}
+                                  variant="outline"
+                                  className="rounded-full px-2 py-0 text-[11px] font-medium text-muted-foreground"
+                                >
+                                  {tag}
+                                </Badge>
+                              ))}
+                              <button
+                                type="button"
+                                tabIndex={-1}
+                                aria-hidden="true"
+                                className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+                              >
+                                <Plus className="size-3" aria-hidden="true" />
+                                add
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              type="button"
+                              tabIndex={-1}
+                              aria-hidden="true"
+                              className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+                            >
+                              <Plus className="size-3" aria-hidden="true" />
+                              add
+                            </button>
+                          )}
+                        </div>
+                      </DetailRow>
+                    </dl>
+                  </div>
+
+                  <div className="p-4">
+                    <h3 className="mb-7 text-sm font-semibold text-foreground">Activity</h3>
+                    <dl className="space-y-4">
+                      <DetailRow label="Created">
+                        {formatDateTime(selectedTool.createdAt)}
+                      </DetailRow>
+                      <DetailRow label="Last modified">
+                        {formatDateTime(selectedTool.updatedAt)}
+                      </DetailRow>
+                    </dl>
+                  </div>
+                </>
+              )}
+            </aside>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/client/src/components/tools/ToolsTable.test.tsx
+++ b/client/src/components/tools/ToolsTable.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolsTable } from "./ToolsTable";
+import * as gatewayUtils from "@/components/gateways/utils";
+import type { Tool } from "@/types/tool";
+
+// Helper to create mock tools
+function createMockTool(id: number, overrides?: Partial<Tool>): Tool {
+  return {
+    id: `tool-${id}`,
+    name: `Tool ${id}`,
+    originalName: `tool_${id}`,
+    description: `Description for tool ${id}`,
+    originalDescription: `Original description for tool ${id}`,
+    title: `Tool ${id} Title`,
+    displayName: `Display Name ${id}`,
+    gatewayId: `gateway-id`,
+    gatewaySlug: "test-gateway",
+    customName: `Tool ${id}`,
+    customNameSlug: `tool-${id}`,
+    enabled: true,
+    reachable: true,
+    executionCount: 0,
+    tags: ["tag1", "tag2"],
+    integrationType: "MCP",
+    requestType: "http",
+    url: `https://example.com/tool-${id}`,
+    version: 1,
+    visibility: "team",
+    createdAt: "2024-01-01T00:00:00",
+    updatedAt: "2024-01-02T00:00:00",
+    ...overrides,
+  };
+}
+
+describe("ToolsTable", () => {
+  const mockOnSelectTool = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnSelectTool.mockClear();
+    vi.spyOn(gatewayUtils, "copyToClipboard").mockImplementation(() => {});
+  });
+
+  it("renders table with correct headers", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Tool")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Tool ID")).toBeInTheDocument();
+    expect(screen.getByText("Schema")).toBeInTheDocument();
+  });
+
+  it("renders all tools in the table", () => {
+    const tools = [createMockTool(1), createMockTool(2), createMockTool(3)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Display Name 1")).toBeInTheDocument();
+    expect(screen.getByText("Display Name 2")).toBeInTheDocument();
+    expect(screen.getByText("Display Name 3")).toBeInTheDocument();
+  });
+
+  it("displays displayName when available", () => {
+    const tools = [createMockTool(1, { displayName: "Custom Display Name" })];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Custom Display Name")).toBeInTheDocument();
+  });
+
+  it("falls back to title when displayName is not available", () => {
+    const tools = [createMockTool(1, { displayName: undefined, title: "Tool Title" })];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Tool Title")).toBeInTheDocument();
+  });
+
+  it("falls back to name when displayName and title are not available", () => {
+    const tools = [
+      createMockTool(1, { displayName: undefined, title: undefined, name: "Tool Name" }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Tool Name")).toBeInTheDocument();
+  });
+
+  it("displays original name for each tool", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("tool_1")).toBeInTheDocument();
+    expect(screen.getByText("tool_2")).toBeInTheDocument();
+  });
+
+  it("displays truncated tool IDs", () => {
+    const tools = [
+      createMockTool(1, { id: "very-long-tool-id-that-should-be-truncated-in-the-middle" }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    // truncateMiddle("very-long-tool-id-...", 18) → edgeLength=7 → "very-lo...-middle"
+    const idCell = screen.getByText("very-lo...-middle");
+    expect(idCell).toBeInTheDocument();
+  });
+
+  it("calls onSelectTool when row is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const row = screen.getByText("Display Name 1").closest("tr");
+    expect(row).toBeInTheDocument();
+
+    if (row) {
+      await user.click(row);
+      expect(mockOnSelectTool).toHaveBeenCalledWith(tools[0]);
+    }
+  });
+
+  it("highlights selected tool row", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(<ToolsTable tools={tools} selectedToolId="tool-1" onSelectTool={mockOnSelectTool} />);
+
+    const selectedRow = screen.getByText("Display Name 1").closest("tr");
+    expect(selectedRow).toHaveAttribute("data-state", "selected");
+
+    const unselectedRow = screen.getByText("Display Name 2").closest("tr");
+    expect(unselectedRow).not.toHaveAttribute("data-state", "selected");
+  });
+
+  it("renders copy button for original name", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const copyButton = screen.getByLabelText("Copy tool_1");
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it("copies original name to clipboard when copy button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1, { originalName: "my_custom_tool" })];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const copyButton = screen.getByLabelText("Copy my_custom_tool");
+    await user.click(copyButton);
+
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith("my_custom_tool");
+  });
+
+  it("does not trigger row selection when copy button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const copyButton = screen.getByLabelText("Copy tool_1");
+    await user.click(copyButton);
+
+    expect(mockOnSelectTool).not.toHaveBeenCalled();
+  });
+
+  it("renders copy button for tool ID", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const copyButton = screen.getByLabelText("Copy tool ID");
+    expect(copyButton).toBeInTheDocument();
+  });
+
+  it("copies tool ID to clipboard when copy button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1, { id: "tool-abc-123" })];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const copyButtons = screen.getAllByLabelText("Copy tool ID");
+    await user.click(copyButtons[0]);
+
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith("tool-abc-123");
+  });
+
+  it("renders schema view button", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const schemaButton = screen.getByLabelText("View schema");
+    expect(schemaButton).toBeInTheDocument();
+  });
+
+  it("does not trigger row selection when schema button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const schemaButton = screen.getByLabelText("View schema");
+    await user.click(schemaButton);
+
+    expect(mockOnSelectTool).not.toHaveBeenCalled();
+  });
+
+  it("renders more options button", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const moreButton = screen.getByLabelText("More options");
+    expect(moreButton).toBeInTheDocument();
+  });
+
+  it("does not trigger row selection when more options button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const moreButton = screen.getByLabelText("More options");
+    await user.click(moreButton);
+
+    expect(mockOnSelectTool).not.toHaveBeenCalled();
+  });
+
+  it("renders empty table when no tools provided", () => {
+    render(<ToolsTable tools={[]} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Tool")).toBeInTheDocument();
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Tool ID")).toBeInTheDocument();
+    expect(screen.getByText("Schema")).toBeInTheDocument();
+
+    // No rows should be present — thead is first rowgroup, tbody is second
+    const [, tbody] = screen.getAllByRole("rowgroup");
+    expect(tbody.children).toHaveLength(0);
+  });
+
+  it("handles multiple tools with same display name", () => {
+    const tools = [
+      createMockTool(1, { displayName: "Same Name", originalName: "tool_a" }),
+      createMockTool(2, { displayName: "Same Name", originalName: "tool_b" }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const displayNames = screen.getAllByText("Same Name");
+    expect(displayNames).toHaveLength(2);
+
+    // Original names should be different
+    expect(screen.getByText("tool_a")).toBeInTheDocument();
+    expect(screen.getByText("tool_b")).toBeInTheDocument();
+  });
+
+  it("applies cursor-pointer class to rows", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const row = screen.getByText("Display Name 1").closest("tr");
+    expect(row).toHaveClass("cursor-pointer");
+  });
+
+  it("renders table with proper ARIA structure", () => {
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const table = screen.getByRole("table");
+    expect(table).toBeInTheDocument();
+
+    const columnHeaders = screen.getAllByRole("columnheader");
+    expect(columnHeaders).toHaveLength(5); // Tool, Name, Tool ID, Schema, More options
+
+    const rows = screen.getAllByRole("row");
+    expect(rows.length).toBeGreaterThan(1); // Header row + data rows
+  });
+
+  it("handles very long tool names with line-clamp", () => {
+    const tools = [
+      createMockTool(1, {
+        displayName: "This is a very long tool name that should be clamped to one line",
+      }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const displayName = screen.getByText(
+      "This is a very long tool name that should be clamped to one line",
+    );
+    const span = displayName.closest("span");
+    expect(span).toHaveClass("line-clamp-1");
+  });
+
+  it("handles tools with special characters in names", () => {
+    const tools = [
+      createMockTool(1, {
+        displayName: "Tool with @#$% special chars",
+        originalName: "tool_with_special_chars",
+      }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    expect(screen.getByText("Tool with @#$% special chars")).toBeInTheDocument();
+    expect(screen.getByText("tool_with_special_chars")).toBeInTheDocument();
+  });
+
+  it("maintains selection state across re-renders", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    const { rerender } = render(
+      <ToolsTable tools={tools} selectedToolId="tool-1" onSelectTool={mockOnSelectTool} />,
+    );
+
+    let selectedRow = screen.getByText("Display Name 1").closest("tr");
+    expect(selectedRow).toHaveAttribute("data-state", "selected");
+
+    // Re-render with same selection
+    rerender(<ToolsTable tools={tools} selectedToolId="tool-1" onSelectTool={mockOnSelectTool} />);
+
+    selectedRow = screen.getByText("Display Name 1").closest("tr");
+    expect(selectedRow).toHaveAttribute("data-state", "selected");
+  });
+
+  it("updates selection when selectedToolId changes", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    const { rerender } = render(
+      <ToolsTable tools={tools} selectedToolId="tool-1" onSelectTool={mockOnSelectTool} />,
+    );
+
+    const selectedRow = screen.getByText("Display Name 1").closest("tr");
+    expect(selectedRow).toHaveAttribute("data-state", "selected");
+
+    // Change selection
+    rerender(<ToolsTable tools={tools} selectedToolId="tool-2" onSelectTool={mockOnSelectTool} />);
+
+    const previouslySelectedRow = screen.getByText("Display Name 1").closest("tr");
+    expect(previouslySelectedRow).not.toHaveAttribute("data-state", "selected");
+
+    const newSelectedRow = screen.getByText("Display Name 2").closest("tr");
+    expect(newSelectedRow).toHaveAttribute("data-state", "selected");
+  });
+
+  it("handles null selectedToolId", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(<ToolsTable tools={tools} selectedToolId={null} onSelectTool={mockOnSelectTool} />);
+
+    const row1 = screen.getByText("Display Name 1").closest("tr");
+    const row2 = screen.getByText("Display Name 2").closest("tr");
+
+    expect(row1).not.toHaveAttribute("data-state", "selected");
+    expect(row2).not.toHaveAttribute("data-state", "selected");
+  });
+
+  it("handles undefined selectedToolId", () => {
+    const tools = [createMockTool(1), createMockTool(2)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const row1 = screen.getByText("Display Name 1").closest("tr");
+    const row2 = screen.getByText("Display Name 2").closest("tr");
+
+    expect(row1).not.toHaveAttribute("data-state", "selected");
+    expect(row2).not.toHaveAttribute("data-state", "selected");
+  });
+});

--- a/client/src/components/tools/ToolsTable.tsx
+++ b/client/src/components/tools/ToolsTable.tsx
@@ -1,0 +1,131 @@
+import { Copy, MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Tool } from "@/types/tool";
+import { copyToClipboard, truncateMiddle } from "@/components/gateways/utils";
+
+export function ToolsTable({
+  tools,
+  selectedToolId,
+  onSelectTool,
+}: {
+  tools: Tool[];
+  selectedToolId?: string | null;
+  onSelectTool: (tool: Tool) => void;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow className="hover:bg-transparent">
+          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool</TableHead>
+          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Name</TableHead>
+          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool ID</TableHead>
+          <TableHead className="h-9 w-[80px] px-4 py-2.5 text-xs font-medium">Schema</TableHead>
+          <TableHead className="h-9 w-[40px] px-4 py-2.5" />
+        </TableRow>
+      </TableHeader>
+      <TableBody className="[&_tr]:border-0">
+        {tools.map((tool) => (
+          <TableRow
+            key={tool.id}
+            data-state={selectedToolId === tool.id ? "selected" : undefined}
+            onClick={() => onSelectTool(tool)}
+            className="cursor-pointer"
+          >
+            <TableCell className="px-4 py-3 text-sm text-foreground">
+              <span className="line-clamp-1">{tool.displayName || tool.title || tool.name}</span>
+            </TableCell>
+
+            <TableCell className="px-4 py-3">
+              <div className="flex min-w-0 items-center">
+                <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                  {tool.originalName}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={`Copy ${tool.originalName}`}
+                  className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyToClipboard(tool.originalName);
+                  }}
+                >
+                  <Copy className="size-3" />
+                </Button>
+              </div>
+            </TableCell>
+
+            <TableCell className="px-4 py-3">
+              <div className="flex min-w-0 items-center">
+                <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                  {truncateMiddle(tool.id, 18)}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Copy tool ID"
+                  className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    copyToClipboard(tool.id);
+                  }}
+                >
+                  <Copy className="size-3" />
+                </Button>
+              </div>
+            </TableCell>
+
+            <TableCell className="px-4 py-3 text-center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="View schema"
+                className="size-5 text-muted-foreground hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  // TODO: Implement schema view
+                }}
+              >
+                <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                  />
+                </svg>
+              </Button>
+            </TableCell>
+
+            <TableCell className="px-4 py-3 text-center">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="More options"
+                className="size-5 text-muted-foreground hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  // TODO: Implement more options menu
+                }}
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -30,6 +30,7 @@ function createMockTool(id: number, gatewaySlug: string, enabled = true, reachab
     tags: [],
     integrationType: "mcp",
     requestType: "http",
+    url: `https://example.com/tool-${id}`,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
@@ -531,5 +532,423 @@ describe("Tools", () => {
     expect(screen.getByText("Tool 23")).toBeInTheDocument();
     expect(screen.queryByText("Tool 24")).not.toBeInTheDocument();
     expect(screen.getByText("+12")).toBeInTheDocument();
+  });
+
+  describe("Dropdown Menu and Details Panel", () => {
+    it("opens dropdown menu when clicking more options button", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+
+      // Dropdown menu should be visible
+      await waitFor(() => {
+        expect(screen.getByText("View Details")).toBeInTheDocument();
+      });
+    });
+
+    it("opens details panel when clicking View Details menu item", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        createMockTool(1, "test-gateway"),
+        createMockTool(2, "test-gateway"),
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open dropdown menu
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+
+      // Click View Details
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      // Details panel should be visible
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /Tools for test-gateway/i })).toBeInTheDocument();
+      });
+
+      // Panel shows the gateway name — it also appears in the card, so multiple matches expected
+      expect(screen.getAllByText("test-gateway").length).toBeGreaterThan(0);
+    });
+
+    it("closes details panel when clicking close button", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      // Wait for panel to open
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /Tools for test-gateway/i })).toBeInTheDocument();
+      });
+
+      // Close the panel
+      const closeButton = screen.getByLabelText("Close tool details");
+      await user.click(closeButton);
+
+      // Panel should be hidden
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("region", { name: /Tools for test-gateway/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("closes details panel when pressing Escape key", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      // Wait for panel to open
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /Tools for test-gateway/i })).toBeInTheDocument();
+      });
+
+      // Press Escape
+      await user.keyboard("{Escape}");
+
+      // Panel should be hidden
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("region", { name: /Tools for test-gateway/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("displays all tools from selected group in details panel", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        createMockTool(1, "multi-tool-gateway"),
+        createMockTool(2, "multi-tool-gateway"),
+        createMockTool(3, "multi-tool-gateway"),
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("multi-tool-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel
+      const moreOptionsButton = screen.getByLabelText("More options for multi-tool-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      // Wait for panel to open
+      await waitFor(() => {
+        expect(
+          screen.getByRole("region", { name: /Tools for multi-tool-gateway/i }),
+        ).toBeInTheDocument();
+      });
+
+      // All tools should be visible in the table (checking for original names)
+      expect(screen.getByText("tool_1")).toBeInTheDocument();
+      expect(screen.getByText("tool_2")).toBeInTheDocument();
+      expect(screen.getByText("tool_3")).toBeInTheDocument();
+    });
+
+    it("shows correct integration type in details panel", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "mcp-gateway"),
+          integrationType: "MCP",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("mcp-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel
+      const moreOptionsButton = screen.getByLabelText("More options for mcp-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      // "MCP Server" appears in both the panel subtitle and Component details Type row
+      await waitFor(() => {
+        expect(screen.getAllByText("MCP Server").length).toBeGreaterThan(0);
+      });
+    });
+
+    it("handles opening details panel for different tool groups", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [createMockTool(1, "gateway-a"), createMockTool(2, "gateway-b")];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("gateway-a")).toBeInTheDocument();
+      });
+
+      // Open details for gateway-a
+      const moreOptionsButtonA = screen.getByLabelText("More options for gateway-a");
+      await user.click(moreOptionsButtonA);
+      let viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /Tools for gateway-a/i })).toBeInTheDocument();
+      });
+
+      // Close panel
+      const closeButton = screen.getByLabelText("Close tool details");
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("region", { name: /Tools for gateway-a/i }),
+        ).not.toBeInTheDocument();
+      });
+
+      // Open details for gateway-b
+      const moreOptionsButtonB = screen.getByLabelText("More options for gateway-b");
+      await user.click(moreOptionsButtonB);
+      viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      await waitFor(() => {
+        expect(screen.getByRole("region", { name: /Tools for gateway-b/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Tool Interface Extended Fields", () => {
+    it("handles tools with displayName field", async () => {
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          displayName: "Custom Display Name",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // displayName is used in the details panel table, not in the card view
+      expect(screen.getByText("Tool 1")).toBeInTheDocument();
+    });
+
+    it("handles tools with url field", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          // URL must be ≤24 chars (truncateMiddle default) to avoid truncation in the assertion
+          url: "https://api.example.com",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel to see URL
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      await waitFor(() => {
+        expect(screen.getByText("https://api.example.com")).toBeInTheDocument();
+      });
+    });
+
+    it("handles tools with visibility field", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          visibility: "team",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel to see visibility
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      await waitFor(() => {
+        expect(screen.getByText("Team")).toBeInTheDocument();
+      });
+    });
+
+    it("handles tools with version field", async () => {
+      const user = userEvent.setup();
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          version: 2,
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Open details panel to see version
+      const moreOptionsButton = screen.getByLabelText("More options for test-gateway");
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+
+      await waitFor(() => {
+        // Version is displayed in the details panel
+        const versionElements = screen.getAllByText("2");
+        expect(versionElements.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("handles tools with audit fields", async () => {
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          createdBy: "user@example.com",
+          createdVia: "api",
+          createdFromIp: "192.168.1.1",
+          modifiedBy: "admin@example.com",
+          modifiedVia: "ui",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Audit fields are stored but not necessarily displayed in the UI
+      // This test ensures they don't break the component
+      expect(screen.getByText("Tool 1")).toBeInTheDocument();
+    });
+
+    it("handles tools with team and owner fields", async () => {
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          team: "Engineering",
+          teamId: "team-123",
+          ownerEmail: "owner@example.com",
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Team and owner fields are stored but not necessarily displayed in the card view
+      expect(screen.getByText("Tool 1")).toBeInTheDocument();
+    });
+
+    it("handles tools with inputSchema and outputSchema", async () => {
+      const mockTools: Tool[] = [
+        {
+          ...createMockTool(1, "test-gateway"),
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+          },
+          outputSchema: {
+            type: "object",
+            properties: {
+              result: { type: "string" },
+            },
+          },
+        },
+      ];
+
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+
+      await waitFor(() => {
+        expect(screen.getByText("test-gateway")).toBeInTheDocument();
+      });
+
+      // Schemas are stored but not displayed in the card view
+      expect(screen.getByText("Tool 1")).toBeInTheDocument();
+    });
   });
 });

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -4,6 +4,13 @@ import { useQuery } from "@/hooks/useQuery";
 import type { Tool, ToolGroup } from "@/types/tool";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ToolDetailsPanel } from "@/components/tools/ToolDetailsPanel";
 import { ToolForm } from "@/components/tools/ToolForm";
 
 function buildGroups(tools: Tool[]): ToolGroup[] {
@@ -20,10 +27,20 @@ function buildGroups(tools: Tool[]): ToolGroup[] {
   return Array.from(map.values());
 }
 
-function ToolGroupCard({ group }: { group: ToolGroup }) {
+function ToolGroupCard({
+  group,
+  onViewGroup,
+}: {
+  group: ToolGroup;
+  onViewGroup: (group: ToolGroup) => void;
+}) {
   const MAX_VISIBLE_TOOLS = 8;
   const visibleTools = group.tools.slice(0, MAX_VISIBLE_TOOLS);
   const remainingCount = group.tools.length - MAX_VISIBLE_TOOLS;
+
+  const handleView = () => {
+    onViewGroup(group);
+  };
 
   return (
     <Card size="sm">
@@ -45,15 +62,22 @@ function ToolGroupCard({ group }: { group: ToolGroup }) {
             />
           </div>
 
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            aria-label={`More options for ${group.gatewaySlug}`}
-            className="h-7 w-7 p-0"
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={`More options for ${group.gatewaySlug}`}
+                className="h-7 w-7 p-0"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={handleView}>View Details</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </CardHeader>
 
@@ -116,14 +140,26 @@ function AddToolsCard({ onAddTool }: { onAddTool: () => void }) {
 }
 
 export function Tools() {
-  const { data: toolsData, error, isLoading, refetch } = useQuery<Tool[]>("/tools?limit=0");
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const [selectedGroup, setSelectedGroup] = useState<ToolGroup | null>(null);
+  const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false);
+
+  const { data: toolsData, error, isLoading, refetch } = useQuery<Tool[]>("/tools?limit=0");
 
   const groups = useMemo(() => buildGroups(toolsData ?? []), [toolsData]);
 
   const handleFormSuccess = () => {
     setIsFormOpen(false);
     refetch();
+  };
+
+  const handleViewGroup = (group: ToolGroup) => {
+    setSelectedGroup(group);
+    setIsDetailsPanelOpen(true);
+  };
+
+  const handleCloseDetails = () => {
+    setIsDetailsPanelOpen(false);
   };
 
   return (
@@ -165,9 +201,22 @@ export function Tools() {
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-2 2xl:grid-cols-3">
               <AddToolsCard onAddTool={() => setIsFormOpen(true)} />
               {groups.map((group) => (
-                <ToolGroupCard key={group.gatewaySlug} group={group} />
+                <ToolGroupCard
+                  key={group.gatewaySlug}
+                  group={group}
+                  onViewGroup={handleViewGroup}
+                />
               ))}
             </div>
+          )}
+
+          {selectedGroup && (
+            <ToolDetailsPanel
+              tools={selectedGroup.tools}
+              gatewaySlug={selectedGroup.gatewaySlug}
+              open={isDetailsPanelOpen}
+              onClose={handleCloseDetails}
+            />
           )}
         </>
       )}

--- a/client/src/types/tool.ts
+++ b/client/src/types/tool.ts
@@ -5,6 +5,7 @@ export interface Tool {
   description?: string;
   originalDescription?: string;
   title?: string;
+  displayName?: string;
   gatewayId?: string;
   gatewaySlug: string;
   customName: string;
@@ -12,11 +13,27 @@ export interface Tool {
   enabled: boolean;
   reachable: boolean;
   executionCount?: number;
-  tags: Array<Record<string, string>>;
+  tags: string[];
   integrationType: string;
   requestType: string;
+  url?: string | null;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  version?: number;
+  visibility?: string;
+  team?: string;
+  teamId?: string;
+  ownerEmail?: string;
   createdAt: string;
   updatedAt: string;
+  createdBy?: string;
+  createdVia?: string;
+  createdFromIp?: string | null;
+  createdUserAgent?: string | null;
+  modifiedBy?: string | null;
+  modifiedFromIp?: string | null;
+  modifiedVia?: string | null;
+  modifiedUserAgent?: string | null;
 }
 
 export interface ToolGroup {


### PR DESCRIPTION
## Summary

Closes #5115 

### Tools view — details panel and table

- **`ToolDetailsPanel`** (`client/src/components/tools/ToolDetailsPanel.tsx`) — new slide-in panel that opens when "View Details" is selected from a tool group card. Shows a two-column layout: a table of all tools in the group on the left, and a **Component details** sidebar on the right displaying status, visibility, type, version, request type, URL, tags, and activity timestamps for the currently selected row.
  First row is auto-selected; Escape and the close button dismiss the panel.

- **`ToolsTable`** (`client/src/components/tools/ToolsTable.tsx`) — extracted from `ToolDetailsPanel` into its own component. Uses the shadcn/ui `Table` primitive, eliminating invalid nested `<button>` HTML that was present in the grid-based approach. Rows are selectable via `data-state="selected"`, copy buttons use `stopPropagation`, and there are no row borders.
 
- **`Tool` type** (`client/src/types/tool.ts`) — aligned with the backend `ToolRead` schema: added `displayName`, `version`, `url` (now optional/nullable), `inputSchema`, `outputSchema`, `visibility`, `team`, `teamId`, `ownerEmail`, and full audit fields (`createdBy`, `createdVia`, `modifiedBy`, etc.). Changed `tags` from `Array<Record<string, string>>` to `string[]`.

- **`Tools` page** (`client/src/pages/Tools.tsx`) — wired up the dropdown "View Details" menu item to open `ToolDetailsPanel` for the selected group. Removed the stray `relative` class from the page root so the panel's `absolute inset-y-0` anchors to the `AppShell` container and fills the full viewport height (matching `MCPServerDetailsPanel` behaviour).

### Tests

- **`ToolsTable.test.tsx`** and **`ToolDetailsPanel.test.tsx`** — new test suites covering rendering, row selection, copy buttons, schema/more-options actions, component details fields, date formatting, and panel open/close lifecycle (534 tests pass, 0 failures).

<img width="1691" height="960" alt="Screenshot 2026-06-11 at 19 50 36" src="https://github.com/user-attachments/assets/f828d0a3-f1b8-4a4c-9ec2-46bad3c6fcd8" />

<img width="1694" height="955" alt="Screenshot 2026-06-11 at 19 50 49" src="https://github.com/user-attachments/assets/026a0ad8-99c7-4b7f-8f84-6e2551949b96" />
