### PR TITLE
feat: support external OIDC bearer tokens on API and MCP endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1488,6 +1488,13 @@ MCPGATEWAY_SKIP_MIGRATIONS=false
 # Require admin approval for new SSO registrations
 # SSO_REQUIRE_ADMIN_APPROVAL=false
 
+# Accept access tokens from trusted external SSO providers as API/MCP bearer creds.
+# Each provider must also be opted in (SSOProvider.trusted_for_api_auth). Default off.
+# SSO_API_TOKEN_AUTH_ENABLED=false
+# Seconds to cache a provisioned external-IdP identity per token (avoids re-provisioning
+# every M2M request). Shared across workers when CACHE_TYPE=redis. 0 disables.
+# EXTERNAL_IDENTITY_CACHE_TTL=60
+
 # =============================================================================
 # Personal Teams Configuration
 # =============================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-25T16:43:37Z",
+  "generated_at": "2026-06-24T14:33:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -232,7 +232,7 @@
         "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 121,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -240,7 +240,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 217,
+        "line_number": 218,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -248,7 +248,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 219,
+        "line_number": 220,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -256,7 +256,7 @@
         "hashed_secret": "90bd1b48e958257948487b90bee080ba5ed00caa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 291,
+        "line_number": 292,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -264,7 +264,7 @@
         "hashed_secret": "48ffbad96aa9c2b33f9486f5a3c2108198acb518",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 292,
+        "line_number": 293,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -1306,7 +1306,7 @@
         "hashed_secret": "e204d28a2874f6123747650d3e4003d4357d75eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 852,
+        "line_number": 855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1314,7 +1314,17 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1147,
+        "line_number": 1150,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/architecture/oauth-design.md": [
+      {
+        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 153,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2533,6 +2543,22 @@
         "line_number": 570,
         "type": "Secret Keyword",
         "verified_result": null
+      },
+      {
+        "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 643,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f4793151b0607198d4de9b1ca458d3e25adf1cb7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 645,
+        "type": "Secret Keyword",
+        "verified_result": null
       }
     ],
     "docs/docs/manage/oauth.md": [
@@ -2680,7 +2706,7 @@
         "hashed_secret": "1513802ada0ec04c2446206e16baa7256ebff74b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 601,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3051,10 +3077,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 777,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5c216af8faacfff02f8ee00326ecfcfb3334922f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 799,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "157b314984dacdea10427c1ae3a856d286318e0d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 844,
+        "line_number": 902,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4170,6 +4212,24 @@
         "is_verified": false,
         "line_number": 87,
         "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py": [
+      {
+        "hashed_secret": "d82bdd09db387d701ccf0fe5a1907903782da0a3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5dbedebc3423bc4336c49a36bd75fe7d370c5176",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-24T14:33:33Z",
+  "generated_at": "2026-06-24T14:57:25Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4212,24 +4212,6 @@
         "is_verified": false,
         "line_number": 87,
         "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py": [
-      {
-        "hashed_secret": "d82bdd09db387d701ccf0fe5a1907903782da0a3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5dbedebc3423bc4336c49a36bd75fe7d370c5176",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 18,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ ContextForge implements a **two-layer security model**:
 - **API/legacy tokens**: Missing `teams` key = public-only access (secure default). Admin bypass requires BOTH `teams: null` AND `is_admin: true`. `normalize_token_teams()` in `mcpgateway/auth.py` is the single source of truth.
 - **Session tokens**: Admin bypass is determined by the DB `is_admin` flag, not the JWT `teams` claim. Non-admin sessions can be narrowed via JWT `teams`. `resolve_session_teams()` in `mcpgateway/auth.py` is the single policy point.
 - **Layer 1 only**: Token scoping controls visibility (what you can see). RBAC (Layer 2) is evaluated independently — session-token narrowing does not restrict which team roles are checked for permissions.
+- **External IdP tokens**: identities provisioned from trusted external SSO providers (see `SSO_API_TOKEN_AUTH_ENABLED`) are dispatched through the session-token table above (`resolve_session_teams()`), not the API/legacy table — `is_admin`/`teams` come from the persisted local user record, never from the external token's claims.
 
 ### Security Invariants (Required)
 

--- a/docs/docs/architecture/multitenancy.md
+++ b/docs/docs/architecture/multitenancy.md
@@ -359,6 +359,9 @@ Session tokens use `resolve_session_teams()` — the **database** is the authori
 !!! note "Session Token Membership Staleness"
     Session tokens skip the `_check_team_membership` re-validation in the token scoping middleware because `resolve_session_teams()` already resolved membership from the database. Membership staleness is bounded by the `auth_cache` TTL. The cache stores the full DB membership (not the per-session narrowed intersection) so that multiple sessions for the same user narrow independently.
 
+!!! note "External IdP tokens resolve via the session table"
+    Access tokens accepted from trusted external SSO providers (`SSO_API_TOKEN_AUTH_ENABLED`) are JIT-provisioned into a `token_use="session"` identity and follow the **Session Tokens** row above: `is_admin` and `teams` come from the persisted local user record via `resolve_session_teams()`, not from claims in the external token. See [SSO: Machine-to-machine API auth with external IdP tokens](../manage/sso.md#machine-to-machine-api-auth-with-external-idp-tokens).
+
 ### Multi-Team Token Behavior
 
 When a token contains multiple teams (`teams: ["team-1", "team-2"]`):

--- a/docs/docs/architecture/oauth-design.md
+++ b/docs/docs/architecture/oauth-design.md
@@ -144,6 +144,21 @@ This OAuth flow is **separate** from user authentication to ContextForge itself:
 
 For user authentication details, see [RBAC Configuration](../manage/rbac.md).
 
+## Inbound External-Token Validation (M2M API Auth)
+
+The flows above describe ContextForge as an OAuth **client** delegating to upstream MCP servers. ContextForge can also act as a **resource server** for its own API/MCP endpoints, accepting access tokens minted by a trusted external SSO provider directly as `Bearer` credentials — see [SSO: Machine-to-machine API auth with external IdP tokens](../manage/sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for operator-facing setup.
+
+This path is gated by `SSO_API_TOKEN_AUTH_ENABLED` (global) and `SSOProvider.trusted_for_api_auth` + `SSOProvider.api_audience` (per provider), and is dispatched from `mcpgateway/utils/verify_credentials.py`:
+
+1. **Issuer discrimination** (`_maybe_verify_external`): the inbound bearer token is unsigned-decoded to read its `iss` claim. If no enabled provider has `trusted_for_api_auth=True`, this path is skipped entirely and the token is evaluated only as an internal JWT. Otherwise `resolve_trusted_provider_by_issuer(iss, db)` looks up the matching `SSOProvider`.
+2. **Token validation** (`verify_external_idp_token`): the token is fully verified against the matched provider's JWKS — signature, expiry, issuer, and `aud == provider.api_audience`. ID tokens are rejected; only access tokens are accepted.
+3. **JIT provisioning** (`build_external_identity`): the validated token is used to provision/look up a local `EmailUser` via the same SSO service used for browser logins. `client_credentials` tokens with no `email` claim are detected (`_is_clientless_token`) and provisioned as synthetic service principals (`svc-<client_id>@<provider-id>.service.local`); both human and service principals receive teams via the provider's existing role/group → team mapping.
+4. **Session-semantics payload**: the resulting identity is returned with `token_use="session"` and `source="external_idp"`. `is_admin` is read from the persisted local user record (`db_user.is_admin`), and `teams` are resolved via `resolve_session_teams()` — both DB-authoritative, never derived directly from the external token's claims. This identity then flows through the normal Layer 1 (token scoping) / Layer 2 (RBAC) pipeline exactly like any other session token.
+5. **Caching**: successful resolutions are cached per-token (SHA-256 of the raw token) for `EXTERNAL_IDENTITY_CACHE_TTL` seconds (clamped to the token's `exp`), shared via Redis when `CACHE_TYPE=redis`, to avoid re-provisioning on every M2M call.
+
+!!! note "Revocation and role-sync caveats"
+    ContextForge cannot revoke an externally-issued token before its own expiry — only local user-deactivation/team-membership changes take effect immediately. If role-sync is enabled for the provider, teams/admin status are re-derived from token claims into the local DB on each provisioning pass. See the [SSO documentation](../manage/sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for details.
+
 ## Future Enhancements
 
 -   Wire UI toggles for token storage and auto-refresh to backend logic.

--- a/docs/docs/manage/oauth-troubleshooting.md
+++ b/docs/docs/manage/oauth-troubleshooting.md
@@ -634,6 +634,27 @@ curl -s http://localhost:4444/oauth/registered-clients | jq
 
 ---
 
+## External IdP Bearer Token Rejected on API/MCP
+
+This section covers requests that present an access token issued by an external SSO provider (e.g. Keycloak, Entra ID) directly as a `Bearer` credential to API/MCP endpoints, per [SSO: Machine-to-machine API auth with external IdP tokens](sso.md#machine-to-machine-api-auth-with-external-idp-tokens). Match the symptom to the exact log line emitted by `mcpgateway/utils/verify_credentials.py`.
+
+| Symptom | Likely cause | Check |
+|---------|--------------|-------|
+| Token 401s, **no** `external-idp` log line at all | `SSO_API_TOKEN_AUTH_ENABLED` is `false`, or no provider has `trusted_for_api_auth=true` — external tokens are never inspected and only internal JWT validation runs | `grep SSO_API_TOKEN_AUTH_ENABLED .env`; confirm at least one enabled `SSOProvider` has `trusted_for_api_auth=true` |
+| `external-idp auth denied: missing or invalid issuer claim` | Token has no `iss` claim, or it isn't a parseable JWT | Decode the token and confirm it has a standard `iss` claim |
+| `external-idp auth denied: issuer not trusted (iss=%s)` | No enabled provider's issuer matches the token's `iss`, the matching provider has `trusted_for_api_auth=false`, or the provider is disabled | Compare the token's `iss` (including trailing slash) against the provider's configured issuer; ensure the provider is enabled and `trusted_for_api_auth=true` |
+| `external-idp auth denied: token validation failed (iss=%s)` | Bad signature (wrong/rotated JWKS), expired token, `aud` mismatch with the provider's `api_audience`, or the token is an ID token (not an access token) | Verify the token against the provider's JWKS endpoint, check `exp`, confirm `aud` exactly equals `api_audience`, and confirm `token_use`/token type is an access token |
+| `external-idp auth denied: user not provisionable (iss=%s, provider=%s)` | Token has no `email` claim and was not recognized as a service-principal (`client_credentials`) token | Confirm the token includes an `email` claim for human users, or that it is a genuine `client_credentials` token for service-principal provisioning |
+| `external-idp auth denied: empty email claim (iss=%s, provider=%s)` | `email` claim is present but empty/blank | Check the IdP's claim mapping for the `email` claim |
+| `external-idp auth denied: user not found after provisioning (iss=%s, provider=%s)` | Provisioning ran but the resulting local user could not be loaded (e.g. DB error, race, or the user was deleted immediately after creation) | Check gateway logs around the provisioning call and confirm the `email_users` table has a matching row |
+| `external-idp auth ok: provider=%s principal=%s is_admin=%s teams=%d` | Success — not an error. Use this to confirm which provider/principal/teams a token resolved to | Compare `is_admin`/`teams` against the expected local user record |
+
+### Issuer trailing-slash mismatches
+
+`issuer not trusted` is also the symptom for an issuer string that differs only by a trailing slash (e.g. `https://keycloak.example.com/realms/master` vs `https://keycloak.example.com/realms/master/`). ContextForge normalizes issuers for comparison, but if you configured the provider's issuer manually, ensure it matches the `iss` claim in tokens issued by that realm/tenant exactly (modulo trailing slash).
+
+---
+
 ## Related Documentation
 
 - [OAuth Integration](oauth.md) - Main OAuth setup guide

--- a/docs/docs/manage/rbac.md
+++ b/docs/docs/manage/rbac.md
@@ -183,6 +183,9 @@ The `teams` claim in JWT tokens determines resource visibility. The system follo
 
     **Session tokens:** Admin bypass is determined by the **database** `is_admin` flag, not the JWT `teams` claim. If the DB user is admin, `resolve_session_teams()` returns `None` (admin bypass) regardless of the JWT `teams` state. The JWT `teams` claim cannot narrow an admin session — it only narrows non-admin sessions.
 
+!!! note "External IdP tokens use session semantics"
+    Access tokens accepted from trusted external SSO providers (`SSO_API_TOKEN_AUTH_ENABLED`, see [SSO documentation](sso.md#machine-to-machine-api-auth-with-external-idp-tokens)) are provisioned to a `token_use="session"` identity. `is_admin` and `teams` are resolved exactly as in the **Session tokens** row above — from the persisted local user record via `resolve_session_teams()` — never from claims inside the external token itself.
+
 ### `is_admin`, `teams`, and `token_use` (Mental Model)
 
 These three values are related, but they control different things:

--- a/docs/docs/manage/sso-generic-oidc-tutorial.md
+++ b/docs/docs/manage/sso-generic-oidc-tutorial.md
@@ -755,6 +755,12 @@ For production, fix the certificate issue at the provider level.
 4. **Monitor failed login attempts**
 5. **Review access logs** regularly
 
+## M2M API Access
+
+Generic OIDC providers can also be opted into ContextForge's machine-to-machine bearer-token auth — see [SSO: Machine-to-machine API auth with external IdP tokens](sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for the full design and the [Keycloak M2M recipe](sso-keycloak-tutorial.md#machine-to-machine-service-account-api-access) for a worked example (the same steps apply to any OIDC-compliant provider: confidential client with service accounts/`client_credentials` enabled, an audience mapper so `aud` matches `api_audience`, then `SSO_API_TOKEN_AUTH_ENABLED=true` plus `trusted_for_api_auth`/`api_audience` on the provider).
+
+The existing `SSO_GENERIC_GROUPS_CLAIM`, `SSO_GENERIC_ADMIN_GROUPS`, and `SSO_GENERIC_ROLE_MAPPINGS` settings continue to govern role/team mapping for service-account tokens, exactly as they do for browser SSO logins.
+
 ## Next Steps
 
 After Generic OIDC SSO is working:

--- a/docs/docs/manage/sso-keycloak-tutorial.md
+++ b/docs/docs/manage/sso-keycloak-tutorial.md
@@ -1095,6 +1095,74 @@ After Keycloak SSO is working:
 8. **Implement group-based team mapping** in ContextForge
 9. **Document your configuration** for team reference
 
+## Machine-to-Machine (Service Account) API Access
+
+In addition to interactive browser login, ContextForge can accept Keycloak access tokens directly as `Bearer` credentials on API/MCP endpoints — letting automation clients authenticate with `client_credentials` tokens, without a browser. See [SSO: Machine-to-machine API auth with external IdP tokens](sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for the overall design and security caveats.
+
+### 1. Create a Confidential Client with Service Accounts Enabled
+
+1. In the Keycloak admin console, go to **Clients** > **Create client**.
+2. Set **Client ID** to something like `mcp-agent` and **Client authentication** to `On` (confidential client).
+3. Under **Capability config**, enable **Service accounts roles** (this allows the `client_credentials` grant).
+4. Save the client and note its **Client secret** under the **Credentials** tab.
+
+### 2. Add an Audience Mapper
+
+Keycloak does not include the client itself in `aud` by default. Add a mapper so tokens issued to `mcp-agent` carry the audience ContextForge expects:
+
+1. Go to **Clients** > `mcp-agent` > **Client scopes** > `mcp-agent-dedicated` > **Mappers** > **Add mapper** > **By configuration**.
+2. Choose **Audience**.
+3. Set **Included Client Audience** (or **Included Custom Audience**) to the value you will configure as `api_audience` for this provider, e.g. `mcp-gateway`.
+4. Set **Add to access token** to `On`. Save.
+
+### 3. Assign Roles/Groups to the Service Account
+
+1. Go to **Clients** > `mcp-agent` > **Service accounts roles**.
+2. Assign realm or client roles (or add the service account user to a group under **Users** > `service-account-mcp-agent` > **Groups**).
+3. These roles/groups map to ContextForge teams/roles via the same `SSO_KEYCLOAK_ROLE_MAPPINGS` configuration used for browser SSO (see [Step 6.6 reference](#66-configuration-variables-reference)).
+
+### 4. Configure ContextForge
+
+```bash
+# Enable the global M2M switch
+SSO_API_TOKEN_AUTH_ENABLED=true
+```
+
+Then opt this provider in via the provider API, setting `api_audience` to match the audience mapper from step 2:
+
+```bash
+curl -X PUT https://gateway.yourcompany.com/auth/sso/providers/keycloak \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "trusted_for_api_auth": true,
+    "api_audience": "mcp-gateway"
+  }'
+```
+
+### 5. Fetch a Token and Call the API
+
+```bash
+# Fetch a client_credentials access token from Keycloak
+TOKEN=$(curl -s -X POST \
+  https://keycloak.yourcompany.com/realms/master/protocol/openid-connect/token \
+  -d "grant_type=client_credentials" \
+  -d "client_id=mcp-agent" \
+  -d "client_secret=$MCP_AGENT_CLIENT_SECRET" \
+  | jq -r '.access_token')
+
+# Call ContextForge using the Keycloak access token directly
+curl -H "Authorization: Bearer $TOKEN" \
+  https://gateway.yourcompany.com/tools
+```
+
+### 6. Service Principal Identity
+
+Since service account tokens have no `email` claim, ContextForge provisions a synthetic local user `svc-mcp-agent@keycloak.service.local` for this client, with teams/roles derived from the role/group mappings configured in step 3.
+
+!!! warning "Revocation"
+    ContextForge cannot revoke this token before its Keycloak-issued expiry. Configure a short access token lifespan for the `mcp-agent` client (Keycloak: **Clients** > `mcp-agent` > **Advanced** > **Access Token Lifespan**) if the service account may need to be revoked quickly.
+
 ## Related Documentation
 
 - [Complete SSO Guide](sso.md) - Full SSO documentation

--- a/docs/docs/manage/sso-keycloak-tutorial.md
+++ b/docs/docs/manage/sso-keycloak-tutorial.md
@@ -1131,7 +1131,7 @@ SSO_API_TOKEN_AUTH_ENABLED=true
 Then opt this provider in via the provider API, setting `api_audience` to match the audience mapper from step 2:
 
 ```bash
-curl -X PUT https://gateway.yourcompany.com/auth/sso/providers/keycloak \
+curl -X PUT https://gateway.yourcompany.com/auth/sso/admin/providers/keycloak \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/docs/manage/sso-microsoft-entra-id-tutorial.md
+++ b/docs/docs/manage/sso-microsoft-entra-id-tutorial.md
@@ -1100,6 +1100,31 @@ Ensure you're using v2.0 tokens (default). If using v1.0 tokens, the issuer form
 3. Set up **Alerts** for suspicious sign-ins
 4. Review **Audit logs** for configuration changes
 
+## M2M API Access
+
+ContextForge can also accept Entra ID access tokens directly as `Bearer` credentials on API/MCP endpoints for service-to-service calls — see [SSO: Machine-to-machine API auth with external IdP tokens](sso.md#machine-to-machine-api-auth-with-external-idp-tokens) for the full design.
+
+1. **Register an app** (or reuse the one from this tutorial) and grant it permission to call your API, or expose its own API under **App registrations** > your app > **Expose an API**, noting the **Application ID URI** (e.g. `api://your-app-id-uri`).
+2. **Acquire a token** with the `client_credentials` grant against your tenant's token endpoint, requesting the `api://your-app-id-uri/.default` scope.
+3. **Set `api_audience`** for the Entra provider to that exact App ID URI value, then opt the provider in:
+
+   ```bash
+   curl -X PUT https://gateway.yourcompany.com/auth/sso/providers/entra \
+     -H "Authorization: Bearer $ADMIN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "trusted_for_api_auth": true,
+       "api_audience": "api://your-app-id-uri"
+     }'
+   ```
+
+   Also set `SSO_API_TOKEN_AUTH_ENABLED=true`.
+
+!!! note "Entra `aud` quirk"
+    Access tokens minted for your own API typically carry `aud` = the App ID URI (`api://your-app-id-uri`), **not** the application's client ID (GUID). Use the App ID URI for `api_audience`, and verify by decoding a sample token.
+
+Role/group mappings (`SSO_ENTRA_ROLE_MAPPINGS`, `SSO_ENTRA_ADMIN_GROUPS`) apply the same way as for browser SSO. App-only tokens with no `email` claim are provisioned as a service principal (`svc-<client_id>@entra.service.local`).
+
 ## Next Steps
 
 After Microsoft Entra ID SSO is working:

--- a/docs/docs/manage/sso-microsoft-entra-id-tutorial.md
+++ b/docs/docs/manage/sso-microsoft-entra-id-tutorial.md
@@ -1109,7 +1109,7 @@ ContextForge can also accept Entra ID access tokens directly as `Bearer` credent
 3. **Set `api_audience`** for the Entra provider to that exact App ID URI value, then opt the provider in:
 
    ```bash
-   curl -X PUT https://gateway.yourcompany.com/auth/sso/providers/entra \
+   curl -X PUT https://gateway.yourcompany.com/auth/sso/admin/providers/entra \
      -H "Authorization: Bearer $ADMIN_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{

--- a/docs/docs/manage/sso.md
+++ b/docs/docs/manage/sso.md
@@ -774,10 +774,10 @@ In addition to browser-based SSO login, ContextForge can accept access tokens is
 This is opt-in at two levels:
 
 1. **Global switch**: `SSO_API_TOKEN_AUTH_ENABLED=true` (default `false`). When disabled, external tokens are never inspected and unrecognized bearer tokens fail normal internal JWT validation as before.
-2. **Per-provider opt-in**: each `SSOProvider` must set `trusted_for_api_auth=true` via the provider CRUD API (`PUT /auth/sso/providers/{id}` or `POST /auth/sso/providers`, see `mcpgateway/routers/sso.py`).
+2. **Per-provider opt-in**: each `SSOProvider` must set `trusted_for_api_auth=true` via the provider admin API (`PUT /auth/sso/admin/providers/{id}` or `POST /auth/sso/admin/providers`, see `mcpgateway/routers/sso.py`).
 
 ```bash
-curl -X PUT https://gateway.example.com/auth/sso/providers/keycloak \
+curl -X PUT https://gateway.example.com/auth/sso/admin/providers/keycloak \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/docs/manage/sso.md
+++ b/docs/docs/manage/sso.md
@@ -767,6 +767,64 @@ curl -I https://github.com/login/oauth/access_token
 curl -I https://api.github.com/user
 ```
 
+## Machine-to-machine API auth with external IdP tokens
+
+In addition to browser-based SSO login, ContextForge can accept access tokens issued directly by a trusted external SSO provider as `Bearer` credentials on API and MCP endpoints — alongside the internally-minted JWTs from `/auth/login` and the SSO callback flows. This lets service accounts and automation clients authenticate to ContextForge using tokens obtained directly from the IdP (typically via `client_credentials`), without ever performing a browser login.
+
+This is opt-in at two levels:
+
+1. **Global switch**: `SSO_API_TOKEN_AUTH_ENABLED=true` (default `false`). When disabled, external tokens are never inspected and unrecognized bearer tokens fail normal internal JWT validation as before.
+2. **Per-provider opt-in**: each `SSOProvider` must set `trusted_for_api_auth=true` via the provider CRUD API (`PUT /auth/sso/providers/{id}` or `POST /auth/sso/providers`, see `mcpgateway/routers/sso.py`).
+
+```bash
+curl -X PUT https://gateway.example.com/auth/sso/providers/keycloak \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "trusted_for_api_auth": true,
+    "api_audience": "mcp-gateway"
+  }'
+```
+
+### `api_audience` is mandatory
+
+When `trusted_for_api_auth=true`, `api_audience` **must** also be set — the request to enable it is rejected otherwise. ContextForge enforces that the token's `aud` claim equals this value before accepting it, which prevents a token issued for a different relying party of the same IdP from being replayed against this gateway (confused-deputy).
+
+- **Microsoft Entra ID**: use the App ID URI you exposed for the API, e.g. `api://your-app-id-uri`. Note that access tokens minted for your own API typically carry `aud` = the App ID URI, not the application's client ID.
+- **Keycloak**: use the audience your realm's client/audience mapper issues for this gateway (commonly the client ID, e.g. `mcp-gateway`).
+
+### How the request is authenticated
+
+1. The unverified token's `iss` claim is read to identify the issuing provider.
+2. If no enabled provider has `trusted_for_api_auth=true`, external tokens are never considered — the request falls through to internal JWT validation only.
+3. If the issuer matches a trusted provider, the token is fully verified against that provider's JWKS: signature, expiry, issuer, and `aud` == `api_audience`.
+4. ID tokens are rejected — only `access_token`s are accepted.
+5. The token's identity is JIT-provisioned/looked up as a local user (the same provisioning path used by browser SSO).
+6. The resulting principal is a **session-semantics** identity (`token_use="session"`): `is_admin` is read from the persisted local user record, and `teams` are resolved via `resolve_session_teams()` — both are DB-authoritative, never derived directly from the external token's claims.
+
+### Role and group mapping
+
+Role/group → team mapping for externally-authenticated principals reuses the same provider configuration as browser SSO (e.g. `SSO_KEYCLOAK_ROLE_MAPPINGS`, `SSO_ENTRA_ROLE_MAPPINGS`, `SSO_GENERIC_ROLE_MAPPINGS`). If role-sync is enabled for the provider, teams and admin status are re-derived from the token's claims into the local DB on each provisioning pass — see the role-sync caveat below.
+
+### Service principals (no-email `client_credentials` tokens)
+
+`client_credentials` tokens typically carry no `email` claim. ContextForge detects these "clientless" tokens and provisions a synthetic local user `svc-<client_id>@<provider-id>.service.local` for the service account. Grant this principal teams/roles via the IdP's existing role/group → team mapping, just as you would for a human user.
+
+### Identity caching
+
+A successful external-identity resolution is cached per-token (keyed by a hash of the raw token) for `EXTERNAL_IDENTITY_CACHE_TTL` seconds (default `60`, clamped to the token's own `exp`) to avoid re-provisioning on every M2M call. The cache is shared across workers when `CACHE_TYPE=redis`. Set `EXTERNAL_IDENTITY_CACHE_TTL=0` to disable caching for deployments that need immediate team/role remapping.
+
+!!! warning "Revocation caveat"
+    ContextForge cannot revoke an external token early — it remains valid until the IdP's own expiry, regardless of `EXTERNAL_IDENTITY_CACHE_TTL`. Only local user-deactivation and team-membership changes (checked against the local DB on every request) take effect immediately. Use short-lived tokens at the IdP for service accounts that may need to be revoked quickly.
+
+!!! warning "Role-sync caveat"
+    If role-sync/group-mapping is enabled for the provider, a loose group/role → team or admin mapping at the IdP grants broad access to ContextForge continuously, for every token that IdP issues with that claim. Keep mappings conservative and audit them regularly.
+
+!!! note "ID tokens are rejected"
+    Only OAuth2 access tokens are accepted for API/MCP auth. ID tokens (which assert authentication, not authorization) fail validation with `external-idp auth denied: token validation failed`.
+
+See also: [Keycloak M2M setup](sso-keycloak-tutorial.md#machine-to-machine-service-account-api-access), [Entra ID M2M setup](sso-microsoft-entra-id-tutorial.md), [Generic OIDC](sso-generic-oidc-tutorial.md), and [OAuth troubleshooting](oauth-troubleshooting.md#external-idp-bearer-token-rejected-on-apimcp).
+
 ## Migration Guide
 
 ### From Local Auth Only

--- a/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
+++ b/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
@@ -2,7 +2,7 @@
 """add api token auth columns to sso_providers (issue #3567)
 
 Revision ID: e198602c3c1e
-Revises: 0a089912b5f0
+Revises: 6c0e5f8a9b1d
 Create Date: 2026-06-11
 
 """
@@ -15,7 +15,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "e198602c3c1e"
-down_revision: Union[str, Sequence[str], None] = "0a089912b5f0"
+down_revision: Union[str, Sequence[str], None] = "6c0e5f8a9b1d"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
+++ b/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""add api token auth columns to sso_providers (issue #3567)
+
+Revision ID: e198602c3c1e
+Revises: 0a089912b5f0
+Create Date: 2026-06-11
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e198602c3c1e"
+down_revision: Union[str, Sequence[str], None] = "0a089912b5f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "sso_providers" not in inspector.get_table_names():
+        return
+    columns = [c["name"] for c in inspector.get_columns("sso_providers")]
+    if "trusted_for_api_auth" not in columns:
+        op.add_column("sso_providers", sa.Column("trusted_for_api_auth", sa.Boolean(), nullable=True, server_default=sa.false()))
+    if "api_audience" not in columns:
+        op.add_column("sso_providers", sa.Column("api_audience", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "sso_providers" not in inspector.get_table_names():
+        return
+    columns = [c["name"] for c in inspector.get_columns("sso_providers")]
+    if "api_audience" in columns:
+        op.drop_column("sso_providers", "api_audience")
+    if "trusted_for_api_auth" in columns:
+        op.drop_column("sso_providers", "trusted_for_api_auth")

--- a/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
+++ b/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
@@ -7,11 +7,12 @@ Create Date: 2026-06-11
 
 """
 
+# Standard
 from typing import Sequence, Union
 
-import sqlalchemy as sa
-
+# Third-Party
 from alembic import op
+import sqlalchemy as sa
 
 revision: str = "e198602c3c1e"
 down_revision: Union[str, Sequence[str], None] = "0a089912b5f0"

--- a/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
+++ b/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
@@ -21,6 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    """Add trusted_for_api_auth and api_audience columns to sso_providers."""
     inspector = sa.inspect(op.get_bind())
     if "sso_providers" not in inspector.get_table_names():
         return
@@ -32,6 +33,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    """Drop trusted_for_api_auth and api_audience columns from sso_providers."""
     inspector = sa.inspect(op.get_bind())
     if "sso_providers" not in inspector.get_table_names():
         return

--- a/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
+++ b/mcpgateway/alembic/versions/e198602c3c1e_add_api_token_auth_to_sso_providers.py
@@ -14,8 +14,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "e198602c3c1e"
-down_revision: Union[str, Sequence[str], None] = "6c0e5f8a9b1d"
+revision: str = "e198602c3c1e"  # pragma: allowlist secret
+down_revision: Union[str, Sequence[str], None] = "6c0e5f8a9b1d"  # pragma: allowlist secret
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -606,6 +606,26 @@ class Settings(BaseSettings):
         default=None, description="Default email domain for ADFS when UPN is plain username (e.g., 'company.com' converts 'user123' to 'user123@company.com')"
     )
 
+    # External OIDC Bearer Token API Authentication (issue #3567)
+    sso_api_token_auth_enabled: bool = Field(
+        default=False,
+        description=(
+            "Accept access tokens issued by trusted external SSO providers as Bearer "
+            "credentials on API/MCP endpoints, in addition to internally-minted JWTs. "
+            "Each provider must ALSO be opted in via SSOProvider.trusted_for_api_auth. "
+            "Default false preserves internal-JWT-only behavior."
+        ),
+    )
+    external_identity_cache_ttl: int = Field(
+        default=60,
+        description=(
+            "Seconds to cache a provisioned external-IdP identity (per token) to avoid "
+            "re-provisioning on every M2M request. Clamped to the token's own exp. Shared "
+            "across workers via Redis when cache_type=redis. Set 0 to disable caching "
+            "(strict deployments that need immediate team/role remapping)."
+        ),
+    )
+
     # MCP Client Authentication
     mcp_client_auth_enabled: bool = Field(default=True, description="Enable JWT authentication for MCP client operations")
     mcp_require_auth: Optional[bool] = Field(

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5668,7 +5668,9 @@ class SSOProvider(Base):
     issuer: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # For OIDC
     jwks_uri: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # OIDC JWKS endpoint for token signature verification
     trusted_for_api_auth: Mapped[bool] = mapped_column(Boolean, default=False, nullable=True)  # Accept this IdP's access tokens as API/MCP bearer creds (issue #3567)
-    api_audience: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # Expected `aud` to enforce on inbound access tokens (e.g. Entra api://<app-id-uri>); must be non-empty when trusted_for_api_auth is set
+    api_audience: Mapped[Optional[str]] = mapped_column(
+        String(500), nullable=True
+    )  # Expected `aud` to enforce on inbound access tokens (e.g. Entra api://<app-id-uri>); must be non-empty when trusted_for_api_auth is set
 
     # Provider Settings
     trusted_domains: Mapped[List[str]] = mapped_column(JSON, default=list, nullable=False)

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5667,6 +5667,8 @@ class SSOProvider(Base):
     userinfo_url: Mapped[str] = mapped_column(String(500), nullable=False)
     issuer: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # For OIDC
     jwks_uri: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # OIDC JWKS endpoint for token signature verification
+    trusted_for_api_auth: Mapped[bool] = mapped_column(Boolean, default=False, nullable=True)  # Accept this IdP's access tokens as API/MCP bearer creds (issue #3567)
+    api_audience: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # Expected `aud` to enforce on inbound access tokens (e.g. Entra api://<app-id-uri>); null = skip aud check
 
     # Provider Settings
     trusted_domains: Mapped[List[str]] = mapped_column(JSON, default=list, nullable=False)

--- a/mcpgateway/db.py
+++ b/mcpgateway/db.py
@@ -5668,7 +5668,7 @@ class SSOProvider(Base):
     issuer: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # For OIDC
     jwks_uri: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # OIDC JWKS endpoint for token signature verification
     trusted_for_api_auth: Mapped[bool] = mapped_column(Boolean, default=False, nullable=True)  # Accept this IdP's access tokens as API/MCP bearer creds (issue #3567)
-    api_audience: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # Expected `aud` to enforce on inbound access tokens (e.g. Entra api://<app-id-uri>); null = skip aud check
+    api_audience: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # Expected `aud` to enforce on inbound access tokens (e.g. Entra api://<app-id-uri>); must be non-empty when trusted_for_api_auth is set
 
     # Provider Settings
     trusted_domains: Mapped[List[str]] = mapped_column(JSON, default=list, nullable=False)

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 import jwt
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -54,6 +54,22 @@ class SSOProviderCreateRequest(BaseModel):
     auto_create_users: bool = True
     team_mapping: Dict = {}
     provider_metadata: Dict = {}  # Role mappings, groups_claim config, etc.
+    trusted_for_api_auth: bool = False
+    api_audience: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_audience_when_api_trusted(self):
+        """Ensure api_audience is set when trusted_for_api_auth is enabled.
+
+        Returns:
+            SSOProviderCreateRequest: The validated model instance.
+
+        Raises:
+            ValueError: If trusted_for_api_auth is True but api_audience is empty.
+        """
+        if self.trusted_for_api_auth and not (self.api_audience or "").strip():
+            raise ValueError("api_audience is required when trusted_for_api_auth is enabled (prevents confused-deputy token acceptance)")
+        return self
 
 
 class SSOProviderUpdateRequest(BaseModel):
@@ -75,6 +91,22 @@ class SSOProviderUpdateRequest(BaseModel):
     team_mapping: Optional[Dict] = None
     provider_metadata: Optional[Dict] = None  # Role mappings, groups_claim config, etc.
     is_enabled: Optional[bool] = None
+    trusted_for_api_auth: Optional[bool] = None
+    api_audience: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_audience_when_api_trusted(self):
+        """Ensure api_audience is provided when enabling trusted_for_api_auth in this update.
+
+        Returns:
+            SSOProviderUpdateRequest: The validated model instance.
+
+        Raises:
+            ValueError: If trusted_for_api_auth is being set to True but api_audience is empty.
+        """
+        if self.trusted_for_api_auth is True and not (self.api_audience or "").strip():
+            raise ValueError("api_audience is required when trusted_for_api_auth is enabled (prevents confused-deputy token acceptance)")
+        return self
 
 
 # Create router
@@ -556,6 +588,8 @@ async def list_all_sso_providers(
             "is_enabled": provider.is_enabled,
             "trusted_domains": provider.trusted_domains,
             "auto_create_users": provider.auto_create_users,
+            "trusted_for_api_auth": provider.trusted_for_api_auth,
+            "api_audience": provider.api_audience,
             "created_at": provider.created_at,
             "updated_at": provider.updated_at,
         }
@@ -606,6 +640,8 @@ async def get_sso_provider(
         "scope": provider.scope,
         "trusted_domains": provider.trusted_domains,
         "auto_create_users": provider.auto_create_users,
+        "trusted_for_api_auth": provider.trusted_for_api_auth,
+        "api_audience": provider.api_audience,
         "team_mapping": provider.team_mapping,
         "is_enabled": provider.is_enabled,
         "created_at": provider.created_at,

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -25,7 +25,7 @@ from mcpgateway.config import settings
 from mcpgateway.db import get_db
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.sso_service import SSOService
+from mcpgateway.services.sso_service import invalidate_trusted_provider_cache, SSOService
 from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.paths import resolve_root_path
@@ -551,6 +551,7 @@ async def create_sso_provider(
     }
     db.commit()
     db.close()
+    invalidate_trusted_provider_cache()
     return result
 
 
@@ -701,6 +702,7 @@ async def update_sso_provider(
     }
     db.commit()
     db.close()
+    invalidate_trusted_provider_cache()
     return result
 
 
@@ -731,6 +733,7 @@ async def delete_sso_provider(
 
     db.commit()
     db.close()
+    invalidate_trusted_provider_cache()
     return {"message": f"SSO provider '{provider_id}' deleted successfully"}
 
 

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -29,6 +29,7 @@ from mcpgateway.services.sso_service import invalidate_trusted_provider_cache, S
 from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.paths import resolve_root_path
+from mcpgateway.utils.verify_credentials import invalidate_external_identity_cache
 
 # Initialize logging
 logging_service = LoggingService()
@@ -552,6 +553,7 @@ async def create_sso_provider(
     db.commit()
     db.close()
     invalidate_trusted_provider_cache()
+    await invalidate_external_identity_cache()
     return result
 
 
@@ -703,6 +705,7 @@ async def update_sso_provider(
     db.commit()
     db.close()
     invalidate_trusted_provider_cache()
+    await invalidate_external_identity_cache()
     return result
 
 
@@ -734,6 +737,7 @@ async def delete_sso_provider(
     db.commit()
     db.close()
     invalidate_trusted_provider_cache()
+    await invalidate_external_identity_cache()
     return {"message": f"SSO provider '{provider_id}' deleted successfully"}
 
 

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2525,8 +2525,7 @@ def _load_trusted_provider_map(db: "Session") -> "dict[str, str]":
         normalized = p.issuer.rstrip("/")
         if internal_issuer and normalized == internal_issuer:
             logger.warning(
-                "SSOProvider id=%s has issuer matching internal jwt_issuer (%s) — "
-                "its tokens will never reach the external-IdP path (dead config)",
+                "SSOProvider id=%s has issuer matching internal jwt_issuer (%s) — its tokens will never reach the external-IdP path (dead config)",
                 p.id,
                 normalized,
             )

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2478,3 +2478,63 @@ class SSOService:
                         rollback_error,
                     )
                     break
+
+
+# Module-level cache: normalized-issuer -> SSOProvider id, with a short TTL.
+# Avoids a sso_providers SELECT on every external-token request (and on every
+# invalid-issuer / bad-signature spray). Invalidated on provider CRUD.
+_TRUSTED_PROVIDER_CACHE_TTL = 60  # seconds
+_trusted_provider_cache: "dict[str, str]" = {}  # issuer(normalized) -> provider.id
+_trusted_provider_cache_loaded_at: float = 0.0
+
+
+def invalidate_trusted_provider_cache() -> None:
+    """Clear the issuer->provider cache. Call after any provider create/update/delete."""
+    global _trusted_provider_cache_loaded_at
+    _trusted_provider_cache.clear()
+    _trusted_provider_cache_loaded_at = 0.0
+
+
+def _load_trusted_provider_map(db: "Session") -> "dict[str, str]":
+    """(Re)load the normalized-issuer -> provider-id map from the DB.
+
+    Args:
+        db: Request-scoped SQLAlchemy session.
+
+    Returns:
+        Mapping of normalized issuer URL to provider id for enabled,
+        API-trusted providers.
+    """
+    rows = db.query(SSOProvider).filter(SSOProvider.is_enabled.is_(True), SSOProvider.trusted_for_api_auth.is_(True)).all()
+    return {p.issuer.rstrip("/"): p.id for p in rows if p.issuer}
+
+
+def resolve_trusted_provider_by_issuer(issuer: str, db: "Session") -> "Optional[SSOProvider]":
+    """Return the enabled, API-trusted SSOProvider whose issuer matches ``issuer``.
+
+    The issuer->provider-id map is cached in-memory for ``_TRUSTED_PROVIDER_CACHE_TTL``
+    seconds (finding P1) and invalidated via :func:`invalidate_trusted_provider_cache`.
+    Matching normalizes trailing slashes to mirror ``verify_oauth_access_token``.
+
+    Args:
+        issuer: The ``iss`` claim from an inbound (unverified) token.
+        db: Request-scoped SQLAlchemy session.
+
+    Returns:
+        The matching SSOProvider, or None.
+    """
+    global _trusted_provider_cache, _trusted_provider_cache_loaded_at
+    if not issuer:
+        return None
+    normalized = issuer.rstrip("/")
+
+    now = monotonic()
+    if not _trusted_provider_cache or (now - _trusted_provider_cache_loaded_at) > _TRUSTED_PROVIDER_CACHE_TTL:
+        _trusted_provider_cache = _load_trusted_provider_map(db)
+        _trusted_provider_cache_loaded_at = now
+
+    provider_id = _trusted_provider_cache.get(normalized)
+    if provider_id is None:
+        return None
+    # Resolve the live ORM object by id (cheap PK lookup; ensures fresh row for validation).
+    return db.query(SSOProvider).filter(SSOProvider.id == provider_id).first()

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2516,6 +2516,10 @@ def resolve_trusted_provider_by_issuer(issuer: str, db: "Session") -> "Optional[
     seconds (finding P1) and invalidated via :func:`invalidate_trusted_provider_cache`.
     Matching normalizes trailing slashes to mirror ``verify_oauth_access_token``.
 
+    Note: this cache is per-process; in multi-worker deployments, invalidation only
+    affects the worker that handled the CRUD request -- other workers converge within
+    the TTL.
+
     Args:
         issuer: The ``iss`` claim from an inbound (unverified) token.
         db: Request-scoped SQLAlchemy session.
@@ -2529,7 +2533,10 @@ def resolve_trusted_provider_by_issuer(issuer: str, db: "Session") -> "Optional[
     normalized = issuer.rstrip("/")
 
     now = monotonic()
-    if not _trusted_provider_cache or (now - _trusted_provider_cache_loaded_at) > _TRUSTED_PROVIDER_CACHE_TTL:
+    # Use _trusted_provider_cache_loaded_at (not the map itself) to detect "never loaded",
+    # so an empty map (zero trusted providers - the common case) is still cached and
+    # doesn't trigger a re-scan on every request.
+    if _trusted_provider_cache_loaded_at == 0.0 or (now - _trusted_provider_cache_loaded_at) > _TRUSTED_PROVIDER_CACHE_TTL:
         _trusted_provider_cache = _load_trusted_provider_map(db)
         _trusted_provider_cache_loaded_at = now
 

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -2517,7 +2517,21 @@ def _load_trusted_provider_map(db: "Session") -> "dict[str, str]":
         API-trusted providers.
     """
     rows = db.query(SSOProvider).filter(SSOProvider.is_enabled.is_(True), SSOProvider.trusted_for_api_auth.is_(True)).all()
-    return {p.issuer.rstrip("/"): p.id for p in rows if p.issuer}
+    internal_issuer = settings.jwt_issuer.rstrip("/") if settings.jwt_issuer else None
+    result = {}
+    for p in rows:
+        if not p.issuer:
+            continue
+        normalized = p.issuer.rstrip("/")
+        if internal_issuer and normalized == internal_issuer:
+            logger.warning(
+                "SSOProvider id=%s has issuer matching internal jwt_issuer (%s) — "
+                "its tokens will never reach the external-IdP path (dead config)",
+                p.id,
+                normalized,
+            )
+        result[normalized] = p.id
+    return result
 
 
 def resolve_trusted_provider_by_issuer(issuer: str, db: "Session") -> "Optional[SSOProvider]":

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -755,6 +755,9 @@ class SSOService:
         if skipped:
             logger.warning("Ignored unknown SSOProvider fields during creation: %s", skipped)
 
+        if filtered_data.get("trusted_for_api_auth") and not (filtered_data.get("api_audience") or "").strip():
+            raise ValueError("api_audience is required when trusted_for_api_auth is enabled (prevents confused-deputy token acceptance)")
+
         provider = SSOProvider(**filtered_data)
         self.db.add(provider)
         self.db.commit()
@@ -803,6 +806,14 @@ class SSOService:
         for key, value in provider_data.items():
             if hasattr(provider, key):
                 setattr(provider, key, value)
+
+        # Re-check the RESULTING state, not just the incoming payload: a partial
+        # update that only touches api_audience (e.g. clearing it to "") would
+        # otherwise leave a pre-existing trusted_for_api_auth=True provider
+        # accepting tokens for any audience (confused-deputy).
+        if getattr(provider, "trusted_for_api_auth", False) and not (getattr(provider, "api_audience", None) or "").strip():
+            self.db.rollback()
+            raise ValueError("api_audience is required when trusted_for_api_auth is enabled (prevents confused-deputy token acceptance)")
 
         provider.updated_at = utc_now()
         self.db.commit()

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import urllib.parse
 
 # Third-Party
+import httpx
 import jwt
 import orjson
 from sqlalchemy import and_, select
@@ -45,6 +46,24 @@ logger = logging.getLogger(__name__)
 
 # Constants
 ADFS_PROVIDER_ID = "adfs"
+
+
+class _NoRedirectPyJWKClient(jwt.PyJWKClient):
+    """PyJWKClient that fetches JWKS via httpx with follow_redirects=False.
+
+    PyJWT's default fetch_data() uses urllib.request.urlopen which follows HTTP
+    redirects transparently, bypassing the same-origin check on jwks_uri.
+    Overriding with httpx (follow_redirects=False) closes the SSRF redirect bypass.
+    """
+
+    def fetch_data(self) -> Any:
+        try:
+            with httpx.Client(follow_redirects=False, timeout=self.timeout) as _client:
+                resp = _client.get(self.uri, headers=self.headers)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPError as exc:
+            raise jwt.exceptions.PyJWKClientConnectionError(f'Fail to fetch data from the url, err: "{exc}"') from exc
 
 
 class SSOError(Exception):
@@ -94,7 +113,7 @@ class SSOService:
 
     _OIDC_METADATA_CACHE_TTL_SECONDS = 300
     _oidc_config_cache: Dict[str, Tuple[float, Dict[str, Any]]] = {}
-    _jwks_client_cache: Dict[str, jwt.PyJWKClient] = {}
+    _jwks_client_cache: Dict[str, _NoRedirectPyJWKClient] = {}
     _STATE_BINDING_SEPARATOR = "."
     _STATE_BINDING_HEX_LEN = 64
     _EMAIL_VERIFIED_CLAIMS: Tuple[str, ...] = (
@@ -246,7 +265,7 @@ class SSOService:
 
         return issuer, jwks_uri
 
-    def _get_jwks_client(self, jwks_uri: str) -> jwt.PyJWKClient:
+    def _get_jwks_client(self, jwks_uri: str) -> _NoRedirectPyJWKClient:
         """Get or create a cached PyJWKClient instance.
 
         Args:
@@ -256,7 +275,7 @@ class SSOService:
             Cached or newly created `PyJWKClient`.
         """
         if jwks_uri not in self._jwks_client_cache:
-            self._jwks_client_cache[jwks_uri] = jwt.PyJWKClient(jwks_uri)
+            self._jwks_client_cache[jwks_uri] = _NoRedirectPyJWKClient(jwks_uri)
         return self._jwks_client_cache[jwks_uri]
 
     async def _verify_oidc_id_token(self, provider: SSOProvider, id_token: str, expected_nonce: Optional[str] = None) -> Optional[Dict[str, Any]]:

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -435,7 +435,7 @@ async def bootstrap_sso_providers() -> None:
         # Without an audience restriction, any token issued by this provider's issuer
         # for any relying party would be accepted (confused-deputy risk).
         for provider in sso_service.list_all_providers():
-            if provider.trusted_for_api_auth and not (provider.api_audience or "").strip():
+            if getattr(provider, "trusted_for_api_auth", False) and not (getattr(provider, "api_audience", None) or "").strip():
                 logger.error(
                     "SSO provider '%s' (%s) is trusted_for_api_auth=True but has no api_audience configured. " "This allows confused-deputy token acceptance from any relying party of this issuer.",
                     provider.id,

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -431,16 +431,22 @@ async def bootstrap_sso_providers() -> None:
                 else:
                     print(f"ℹ️  SSO provider unchanged: {existing_provider.display_name} (ID: {existing_provider.id})")
 
-        # Warn about providers trusted for API auth without a configured audience.
+        # Fail closed on providers trusted for API auth without a configured audience.
         # Without an audience restriction, any token issued by this provider's issuer
-        # for any relying party would be accepted (confused-deputy risk).
+        # for any relying party would be accepted (confused-deputy risk), so this is
+        # not merely logged -- the unsafe trust grant is revoked at startup.
         for provider in sso_service.list_all_providers():
             if getattr(provider, "trusted_for_api_auth", False) and not (getattr(provider, "api_audience", None) or "").strip():
                 logger.error(
-                    "SSO provider '%s' (%s) is trusted_for_api_auth=True but has no api_audience configured. " "This allows confused-deputy token acceptance from any relying party of this issuer.",
+                    "SSO provider '%s' (%s) is trusted_for_api_auth=True but has no api_audience configured. "
+                    "This allows confused-deputy token acceptance from any relying party of this issuer. "
+                    "Disabling trusted_for_api_auth for this provider until api_audience is set.",
                     provider.id,
                     provider.display_name,
                 )
+                provider.trusted_for_api_auth = False
+                db.add(provider)
+        db.flush()
 
     except Exception as e:
         db.rollback()  # Rollback on error

--- a/mcpgateway/utils/sso_bootstrap.py
+++ b/mcpgateway/utils/sso_bootstrap.py
@@ -431,6 +431,17 @@ async def bootstrap_sso_providers() -> None:
                 else:
                     print(f"ℹ️  SSO provider unchanged: {existing_provider.display_name} (ID: {existing_provider.id})")
 
+        # Warn about providers trusted for API auth without a configured audience.
+        # Without an audience restriction, any token issued by this provider's issuer
+        # for any relying party would be accepted (confused-deputy risk).
+        for provider in sso_service.list_all_providers():
+            if provider.trusted_for_api_auth and not (provider.api_audience or "").strip():
+                logger.error(
+                    "SSO provider '%s' (%s) is trusted_for_api_auth=True but has no api_audience configured. " "This allows confused-deputy token acceptance from any relying party of this issuer.",
+                    provider.id,
+                    provider.display_name,
+                )
+
     except Exception as e:
         db.rollback()  # Rollback on error
         print(f"❌ Failed to bootstrap SSO providers: {e}")

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -514,7 +514,11 @@ async def _external_identity_cache_get(token_hash: str) -> Optional[dict]:
     """
     redis = await get_redis_client()
     if redis is not None:
-        raw = await redis.get(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash)
+        try:
+            raw = await redis.get(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash)
+        except Exception as exc:  # noqa: BLE001 - best-effort cache, never fail auth on Redis errors
+            logger.warning("External identity cache Redis GET failed, treating as cache miss: %s", exc)
+            return None
         if raw is None:
             return None
         try:
@@ -528,7 +532,7 @@ async def _external_identity_cache_get(token_hash: str) -> Optional[dict]:
     if monotonic() >= expires_at:
         _external_identity_cache.pop(token_hash, None)
         return None
-    return payload
+    return dict(payload)
 
 
 async def _external_identity_cache_put(token_hash: str, payload: dict, token_exp: Optional[int]) -> None:
@@ -546,7 +550,10 @@ async def _external_identity_cache_put(token_hash: str, payload: dict, token_exp
 
     redis = await get_redis_client()
     if redis is not None:
-        await redis.set(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash, json.dumps(safe_payload), ex=ttl)
+        try:
+            await redis.set(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash, json.dumps(safe_payload), ex=ttl)
+        except Exception as exc:  # noqa: BLE001 - best-effort cache write, never fail auth on Redis errors
+            logger.warning("External identity cache Redis SET failed, skipping cache write: %s", exc)
         return
     if len(_external_identity_cache) >= _EXTERNAL_IDENTITY_MAX:
         _external_identity_cache.clear()

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -639,7 +639,7 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
         token's issuer matches a trusted external provider and verification succeeds,
         or None to fall through to internal JWT verification.
     """
-    if not settings.sso_api_token_auth_enabled:
+    if not getattr(settings, "sso_api_token_auth_enabled", False):
         return None
 
     # P4: fetch the request-scoped DB session once, up front, so it can be reused

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -1810,3 +1810,89 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
     if claims is None:
         return None, None
     return claims, provider
+
+
+def _get_sso_service(db: Session):
+    """Factory wrapper so tests can patch SSOService construction.
+
+    Args:
+        db: Request-scoped SQLAlchemy session.
+
+    Returns:
+        A new :class:`~mcpgateway.services.sso_service.SSOService` instance.
+    """
+    # First-Party
+    from mcpgateway.services.sso_service import SSOService  # pylint: disable=import-outside-toplevel
+
+    return SSOService(db)
+
+
+async def build_external_identity(provider: SSOProvider, verified_claims: dict, token: str, db: Session) -> Optional[dict[str, Any]]:
+    """Map verified external-IdP claims to a ContextForge identity payload.
+
+    Reuses browser-SSO normalization + provisioning so role/group -> team mapping
+    is identical. Team scoping uses SESSION semantics (DB authority) because an
+    external access token carries no internal ``teams`` claim.
+
+    SECURITY:
+        * ``token_use="session"`` so downstream dispatchers route via
+          ``resolve_session_teams`` (DB authority), NOT ``normalize_token_teams``
+          (claim authority).
+        * ``is_admin`` is read from the persisted ``EmailUser``, never the mapped
+          claim.
+        * ``authenticate_or_create_user`` returns a JWT token, not an identity --
+          used only for its provisioning side-effect; identity comes from
+          ``get_user_by_email``.
+
+    Args:
+        provider: The matched, trusted SSOProvider (from resolve_trusted_provider_by_issuer).
+        verified_claims: Signature-verified claims from verify_external_idp_token.
+        token: The raw external bearer token (carried through for downstream use).
+        db: Request-scoped SQLAlchemy session.
+
+    Returns:
+        The enriched session-semantics identity payload, or None when the user
+        cannot be provisioned/resolved.
+    """
+    # First-Party
+    from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
+
+    svc = _get_sso_service(db)
+    user_info = svc._normalize_user_info(provider, verified_claims)  # pylint: disable=protected-access
+
+    # Provisioning side-effect only (creates/links user, role-sync, enforces
+    # trusted_domains + email-verified). Return value is a JWT token -- discard it.
+    provisioned = await svc.authenticate_or_create_user(user_info)
+    if not provisioned:
+        return None
+
+    email = str(user_info.get("email") or "").strip().lower()
+    if not email:
+        return None
+
+    db_user = await svc.auth_service.get_user_by_email(email)
+    if db_user is None:
+        return None
+
+    is_admin = bool(db_user.is_admin)  # DB authority, not the mapped claim
+
+    # token_use="session" payload routed via resolve_session_teams(payload, email, db_user).
+    payload: dict = {
+        "sub": email,
+        "email": email,
+        "token": token,
+        "token_use": "session",  # nosec B105 - JWT claim type, not a password
+        "source": "external_idp",  # audit/telemetry only -- never drives authz
+        "iss": verified_claims.get("iss"),
+        "auth_provider": getattr(provider, "id", None),
+    }
+    teams = await resolve_session_teams(payload, email, db_user)
+    payload["teams"] = teams
+    payload["is_admin"] = is_admin
+
+    # Persist provisioning if we own the session (set by a future dispatcher).
+    own_session = getattr(getattr(db, "info", {}), "get", lambda *_: None)("external_owned")
+    if own_session:
+        db.commit()
+
+    return payload

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -57,6 +57,7 @@ from base64 import b64decode
 import binascii
 import hashlib
 import json
+import re
 import time
 from time import monotonic
 from typing import Any, Optional, Union
@@ -2095,6 +2096,9 @@ def _synthetic_service_principal_user_info(provider: SSOProvider, claims: dict) 
         carrying through any group/role claims so role/team mapping still applies.
     """
     client = str(claims.get("azp") or claims.get("client_id") or claims.get("sub"))
+    # IdP-controlled value: strip anything that could break out of the email
+    # local-part (e.g. an embedded "@") and produce a malformed/spoofed address.
+    client = re.sub(r"[^a-zA-Z0-9._-]", "_", client)
     pid = getattr(provider, "id", "ext")
     return {
         "email": f"svc-{client}@{pid}.service.local",

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -681,7 +681,7 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
             await _external_identity_cache_put(th, payload, claims.get("exp"))
         return payload
     except Exception as exc:  # pylint: disable=broad-except
-        logger.warning("external-idp auth error, falling through to internal (401): %s", exc)
+        logger.warning("external-idp auth error, falling through to internal (401): %s", sanitize_for_log(str(exc)))
         return None
     finally:
         if own_session:
@@ -2168,6 +2168,11 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
     except IntegrityError:
         # E2: lost a concurrent provisioning race -- the winner already created
         # the user, so roll back our half-applied insert and re-look-up by email.
+        # Rollback is required (not just for owned sessions): SQLAlchemy leaves the
+        # session in a failed-transaction state after IntegrityError, and the
+        # re-lookup below would fail without it. Safe even for a request-scoped
+        # session: external-IdP auth dispatch runs during request authentication,
+        # before route handlers stage any writes on that session.
         db.rollback()
         provisioned = True
         logger.info("external-idp: provisioning race resolved via re-lookup")
@@ -2211,7 +2216,7 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
             db.commit()
         except Exception as exc:  # pylint: disable=broad-except
             db.rollback()
-            logger.error("external-idp: provisioning commit failed: %s", exc)
+            logger.error("external-idp: provisioning commit failed: %s", sanitize_for_log(str(exc)))
             return None
 
     if is_synthetic:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -65,10 +65,12 @@ from fastapi import Cookie, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBasic, HTTPBasicCredentials, HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 import jwt
+from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.config import settings
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.services.sso_service import resolve_trusted_provider_by_issuer
 from mcpgateway.utils.jwt_config_helper import validate_jwt_algo_and_keys
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.paths import resolve_root_path
@@ -1770,3 +1772,40 @@ async def verify_oauth_access_token(
     except jwt.PyJWTError as exc:
         logger.warning("OAuth access token verification failed (issuer=%s): %s", sanitize_for_log(normalized_issuer), exc)
         return None
+
+
+async def verify_external_idp_token(token: str, db: Session) -> "tuple[Optional[dict[str, Any]], Optional[Any]]":
+    """Validate an external IdP access token against a trusted SSO provider.
+
+    Resolves the provider by the token's unverified ``iss``, then delegates to
+    :func:`verify_oauth_access_token` for signature/issuer/audience/expiry checks
+    (JWKS discovery, SSRF defense and ID-token rejection are inherited).
+
+    Args:
+        token: Raw Bearer token.
+        db: Request-scoped SQLAlchemy session for provider lookup.
+
+    Returns:
+        ``(verified_claims, provider)`` on success, ``(None, None)`` on any failure.
+    """
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.DecodeError:
+        return None, None
+
+    issuer = unverified.get("iss")
+    if not issuer:
+        return None, None
+
+    provider = resolve_trusted_provider_by_issuer(issuer, db)
+    if provider is None or not provider.issuer:
+        return None, None
+
+    claims = await verify_oauth_access_token(
+        token,
+        authorization_servers=[provider.issuer],
+        expected_audience=provider.api_audience or None,
+    )
+    if claims is None:
+        return None, None
+    return claims, provider

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -68,6 +68,7 @@ from fastapi import Cookie, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBasic, HTTPBasicCredentials, HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 import jwt
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -520,18 +521,24 @@ async def _external_identity_cache_get(token_hash: str) -> Optional[dict]:
             logger.warning("External identity cache Redis GET failed, treating as cache miss: %s", exc)
             return None
         if raw is None:
+            logger.debug("external-idp identity cache miss")
             return None
         try:
-            return json.loads(raw)
+            cached_payload = json.loads(raw)
         except (TypeError, ValueError):
             return None
+        logger.debug("external-idp identity cache hit")
+        return cached_payload
     entry = _external_identity_cache.get(token_hash)
     if entry is None:
+        logger.debug("external-idp identity cache miss")
         return None
     payload, expires_at = entry
     if monotonic() >= expires_at:
         _external_identity_cache.pop(token_hash, None)
+        logger.debug("external-idp identity cache miss")
         return None
+    logger.debug("external-idp identity cache hit")
     return dict(payload)
 
 
@@ -595,6 +602,31 @@ def _has_trusted_providers(db: Optional[Session]) -> bool:
             db.close()
 
 
+def _record_external_auth_metric(outcome: str, provider_id, reason: str = "") -> None:
+    """Record a best-effort per-provider external-IdP auth counter (D3).
+
+    Args:
+        outcome: "success" or "denied".
+        provider_id: The SSO provider identifier (or None).
+        reason: A short, stable deny-reason string (e.g. "issuer_not_trusted"); empty for success.
+
+    Never raises -- a metrics-backend failure must not affect authentication.
+    """
+    try:
+        # First-Party
+        from mcpgateway.services.observability_service import ObservabilityService  # pylint: disable=import-outside-toplevel
+
+        ObservabilityService().record_metric(
+            name=f"auth.external_idp.{outcome}",
+            value=1,
+            metric_type="counter",
+            unit="count",
+            attributes={"provider": str(provider_id), "reason": reason},
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug("external-idp auth metric skipped: %s", exc)
+
+
 async def _maybe_verify_external(token: str, request: Optional[Request]) -> Optional[dict]:
     """Attempt external-IdP (trusted OIDC issuer) verification for a bearer token.
 
@@ -648,6 +680,9 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
         if payload is not None:
             await _external_identity_cache_put(th, payload, claims.get("exp"))
         return payload
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("external-idp auth error, falling through to internal (401): %s", exc)
+        return None
     finally:
         if own_session:
             db.close()
@@ -2002,10 +2037,14 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
 
     issuer = unverified.get("iss")
     if not isinstance(issuer, str) or not issuer:
+        logger.warning("external-idp auth denied: missing or invalid issuer claim")
+        _record_external_auth_metric("denied", None, reason="missing_issuer")
         return None, None
 
     provider = resolve_trusted_provider_by_issuer(issuer, db)
     if provider is None or not provider.issuer:
+        logger.warning("external-idp auth denied: issuer not trusted (iss=%s)", sanitize_for_log(issuer))
+        _record_external_auth_metric("denied", getattr(provider, "id", None), reason="issuer_not_trusted")
         return None, None
 
     claims = await verify_oauth_access_token(
@@ -2014,6 +2053,8 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
         expected_audience=provider.api_audience or None,
     )
     if claims is None:
+        logger.warning("external-idp auth denied: token validation failed (iss=%s)", sanitize_for_log(issuer))
+        _record_external_auth_metric("denied", getattr(provider, "id", None), reason="validation_failed")
         return None, None
     return claims, provider
 
@@ -2112,23 +2153,40 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
     from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
 
     svc = _get_sso_service(db)
-    if _is_clientless_token(verified_claims):
+    is_synthetic = _is_clientless_token(verified_claims)
+    if is_synthetic:
         user_info = _synthetic_service_principal_user_info(provider, verified_claims)
     else:
         user_info = svc._normalize_user_info(provider, verified_claims)  # pylint: disable=protected-access
 
+    provider_id = getattr(provider, "id", None)
+
     # Provisioning side-effect only (creates/links user, role-sync, enforces
     # trusted_domains + email-verified). Return value is a JWT token -- discard it.
-    provisioned = await svc.authenticate_or_create_user(user_info)
+    try:
+        provisioned = await svc.authenticate_or_create_user(user_info)
+    except IntegrityError:
+        # E2: lost a concurrent provisioning race -- the winner already created
+        # the user, so roll back our half-applied insert and re-look-up by email.
+        db.rollback()
+        provisioned = True
+        logger.info("external-idp: provisioning race resolved via re-lookup")
+
     if not provisioned:
+        logger.warning("external-idp auth denied: user not provisionable (iss=%s, provider=%s)", sanitize_for_log(verified_claims.get("iss")), sanitize_for_log(provider_id))
+        _record_external_auth_metric("denied", provider_id, reason="not_provisionable")
         return None
 
     email = str(user_info.get("email") or "").strip().lower()
     if not email:
+        logger.warning("external-idp auth denied: empty email claim (iss=%s, provider=%s)", sanitize_for_log(verified_claims.get("iss")), sanitize_for_log(provider_id))
+        _record_external_auth_metric("denied", provider_id, reason="empty_email")
         return None
 
     db_user = await svc.auth_service.get_user_by_email(email)
     if db_user is None:
+        logger.warning("external-idp auth denied: user not found after provisioning (iss=%s, provider=%s)", sanitize_for_log(verified_claims.get("iss")), sanitize_for_log(provider_id))
+        _record_external_auth_metric("denied", provider_id, reason="user_not_found")
         return None
 
     is_admin = bool(db_user.is_admin)  # DB authority, not the mapped claim
@@ -2141,7 +2199,7 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
         "token_use": "session",  # nosec B105 - JWT claim type, not a password
         "source": "external_idp",  # audit/telemetry only -- never drives authz
         "iss": verified_claims.get("iss"),
-        "auth_provider": getattr(provider, "id", None),
+        "auth_provider": provider_id,
     }
     teams = await resolve_session_teams(payload, email, db_user)
     payload["teams"] = teams
@@ -2149,6 +2207,30 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
 
     # Persist provisioning if we own the session (set by a future dispatcher).
     if db.info.get("external_owned"):
-        db.commit()
+        try:
+            db.commit()
+        except Exception as exc:  # pylint: disable=broad-except
+            db.rollback()
+            logger.error("external-idp: provisioning commit failed: %s", exc)
+            return None
+
+    if is_synthetic:
+        # NOTE: simplification -- we log "provisioned" unconditionally on the
+        # synthetic service-principal path rather than only on first creation,
+        # since authenticate_or_create_user's return value does not distinguish
+        # "created" from "already existed".
+        logger.info("external-idp: provisioned service principal %s", sanitize_for_log(email))
+
+    # First-Party
+    from mcpgateway.auth_context import get_user_email  # pylint: disable=import-outside-toplevel
+
+    logger.info(
+        "external-idp auth ok: provider=%s principal=%s is_admin=%s teams=%d",
+        sanitize_for_log(provider_id),
+        sanitize_for_log(get_user_email({"email": email})),
+        is_admin,
+        (0 if teams is None else len(teams)),
+    )
+    _record_external_auth_metric("success", provider_id)
 
     return payload

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -1891,8 +1891,7 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
     payload["is_admin"] = is_admin
 
     # Persist provisioning if we own the session (set by a future dispatcher).
-    own_session = getattr(getattr(db, "info", {}), "get", lambda *_: None)("external_owned")
-    if own_session:
+    if db.info.get("external_owned"):
         db.commit()
 
     return payload

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -1812,6 +1812,54 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
     return claims, provider
 
 
+def _is_clientless_token(claims: dict) -> bool:
+    """Detect a client_credentials / service token (no human user behind it).
+
+    Such tokens carry no ``email`` claim and the subject identifies the
+    OAuth client itself (``sub == azp`` or ``sub == client_id``), or the
+    token is explicitly typed as an OAuth2 access token (``typ: "at+jwt"``).
+
+    Args:
+        claims: Signature-verified JWT claims from the external IdP.
+
+    Returns:
+        True if the token represents a service/client principal rather than
+        a human user, False otherwise.
+    """
+    if claims.get("email"):
+        return False
+    sub = claims.get("sub")
+    return bool(sub) and (sub == claims.get("azp") or sub == claims.get("client_id") or claims.get("typ") == "at+jwt")
+
+
+def _synthetic_service_principal_user_info(provider: SSOProvider, claims: dict) -> dict:
+    """Build a normalized user_info for a service principal from a clientless token.
+
+    The synthetic email is non-routable (``.service.local``) and marked verified
+    because it is internally minted -- this does NOT relax the human email-verified
+    gate, which still applies to real email claims.
+
+    Args:
+        provider: The matched, trusted SSOProvider.
+        claims: Signature-verified JWT claims from the external IdP.
+
+    Returns:
+        A normalized user_info dict suitable for ``authenticate_or_create_user``,
+        carrying through any group/role claims so role/team mapping still applies.
+    """
+    client = str(claims.get("azp") or claims.get("client_id") or claims.get("sub"))
+    pid = getattr(provider, "id", "ext")
+    return {
+        "email": f"svc-{client}@{pid}.service.local",
+        "email_verified": True,
+        "full_name": f"service:{client}",
+        "provider": pid,
+        "is_admin": False,
+        # carry through any group/role claims so mapping still applies
+        **{k: v for k, v in claims.items() if k in ("groups", "realm_access", "resource_access", "roles")},
+    }
+
+
 def _get_sso_service(db: Session):
     """Factory wrapper so tests can patch SSOService construction.
 
@@ -1858,7 +1906,10 @@ async def build_external_identity(provider: SSOProvider, verified_claims: dict, 
     from mcpgateway.auth import resolve_session_teams  # pylint: disable=import-outside-toplevel
 
     svc = _get_sso_service(db)
-    user_info = svc._normalize_user_info(provider, verified_claims)  # pylint: disable=protected-access
+    if _is_clientless_token(verified_claims):
+        user_info = _synthetic_service_principal_user_info(provider, verified_claims)
+    else:
+        user_info = svc._normalize_user_info(provider, verified_claims)  # pylint: disable=protected-access
 
     # Provisioning side-effect only (creates/links user, role-sync, enforces
     # trusted_domains + email-verified). Return value is a JWT token -- discard it.

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -455,11 +455,53 @@ async def verify_credentials(token: str) -> dict:
     return payload
 
 
+async def _maybe_verify_external(token: str, request: Optional[Request]) -> Optional[dict]:
+    """Attempt external-IdP (trusted OIDC issuer) verification for a bearer token.
+
+    Args:
+        token: The raw bearer token string.
+        request: Optional FastAPI/Starlette request, used for a request-scoped DB session.
+
+    Returns:
+        A session-semantics identity payload (see build_external_identity) if the
+        token's issuer matches a trusted external provider and verification succeeds,
+        or None to fall through to internal JWT verification.
+    """
+    if not settings.sso_api_token_auth_enabled:
+        return None
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return None
+    iss = unverified.get("iss")
+    if not isinstance(iss, str) or not iss or iss.rstrip("/") == (settings.jwt_issuer or "").rstrip("/"):
+        return None  # internal issuer (or no/invalid iss) -> internal path, zero JWKS cost
+
+    # First-Party
+    from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
+
+    db = getattr(getattr(request, "state", None), "db", None)
+    own_session = db is None
+    if own_session:
+        db = SessionLocal()
+        db.info["external_owned"] = True  # M1: signals build_external_identity to commit provisioning
+    try:
+        claims, provider = await verify_external_idp_token(token, db)
+        if claims is None:
+            return None  # untrusted issuer / invalid sig -> fall through -> internal path 401s
+        return await build_external_identity(provider, claims, token, db)
+    finally:
+        if own_session:
+            db.close()
+
+
 async def verify_credentials_cached(token: str, request: Optional[Request] = None) -> dict:
     """Verify credentials using a JWT token with request-level caching.
 
     A wrapper around verify_jwt_token_cached that adds the original token
-    to the decoded payload for reference.
+    to the decoded payload for reference. Trusted external-IdP bearer tokens
+    (per-provider opt-in, see Task 1/H2) are dispatched to session-semantics
+    identity resolution before falling back to internal JWT verification.
 
     Args:
         token: The JWT token string to verify.
@@ -469,6 +511,12 @@ async def verify_credentials_cached(token: str, request: Optional[Request] = Non
         dict: The validated token payload with the original token added
             under the 'token' key. Returns a copy to avoid mutating cached payload.
     """
+    external_payload = await _maybe_verify_external(token, request)
+    if external_payload is not None:
+        if request is not None and hasattr(request, "state"):
+            request.state._jwt_verified_payload = (token, external_payload)
+        return external_payload
+
     payload = await verify_jwt_token_cached(token, request)
     # Return a copy with token added to avoid mutating the cached payload
     return {**payload, "token": token}

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -2048,10 +2048,21 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
         _record_external_auth_metric("denied", getattr(provider, "id", None), reason="issuer_not_trusted")
         return None, None
 
+    # Fail-closed backstop: trusted_for_api_auth without a configured api_audience
+    # makes verify_oauth_access_token skip the aud check entirely (any relying party
+    # of this issuer would be accepted). The create/update path and the bootstrap
+    # startup check both enforce this invariant, but checking it again here means
+    # the property holds regardless of how a provider row reached this state
+    # (direct DB edit, a future importer, env seeding).
+    if not (provider.api_audience or "").strip():
+        logger.error("external-idp auth denied: provider %s is trusted_for_api_auth without api_audience configured", sanitize_for_log(getattr(provider, "id", "")))
+        _record_external_auth_metric("denied", getattr(provider, "id", None), reason="missing_audience")
+        return None, None
+
     claims = await verify_oauth_access_token(
         token,
         authorization_servers=[provider.issuer],
-        expected_audience=provider.api_audience or None,
+        expected_audience=provider.api_audience,
     )
     if claims is None:
         logger.warning("external-idp auth denied: token validation failed (iss=%s)", sanitize_for_log(issuer))
@@ -2063,9 +2074,16 @@ async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[d
 def _is_clientless_token(claims: dict) -> bool:
     """Detect a client_credentials / service token (no human user behind it).
 
-    Such tokens carry no ``email`` claim and the subject identifies the
-    OAuth client itself (``sub == azp`` or ``sub == client_id``), or the
-    token is explicitly typed as an OAuth2 access token (``typ: "at+jwt"``).
+    Such tokens carry no ``email`` claim, plus at least one of:
+      * the subject identifies the OAuth client itself (``sub == azp`` or
+        ``sub == client_id``);
+      * the token is explicitly typed as an OAuth2 access token (``typ: "at+jwt"``);
+      * Keycloak-specific service-account markers: a ``clientId`` claim (Keycloak's
+        camelCase client identifier, present only on service-account tokens) or a
+        ``preferred_username`` of the form ``service-account-<client>``. Real Keycloak
+        client_credentials tokens have ``sub`` as the service-account user's UUID
+        (distinct from ``azp``) and ``typ: "Bearer"``, so the generic checks above
+        miss them without this provider-specific signal.
 
     Args:
         claims: Signature-verified JWT claims from the external IdP.
@@ -2077,7 +2095,12 @@ def _is_clientless_token(claims: dict) -> bool:
     if claims.get("email"):
         return False
     sub = claims.get("sub")
-    return bool(sub) and (sub == claims.get("azp") or sub == claims.get("client_id") or claims.get("typ") == "at+jwt")
+    if sub and (sub == claims.get("azp") or sub == claims.get("client_id") or claims.get("typ") == "at+jwt"):
+        return True
+    if claims.get("clientId"):
+        return True
+    preferred_username = claims.get("preferred_username")
+    return bool(preferred_username) and str(preferred_username).startswith("service-account-")
 
 
 def _synthetic_service_principal_user_info(provider: SSOProvider, claims: dict) -> dict:

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -55,6 +55,9 @@ Examples:
 import asyncio
 from base64 import b64decode
 import binascii
+import hashlib
+import json
+import time
 from time import monotonic
 from typing import Any, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
@@ -75,6 +78,7 @@ from mcpgateway.services.sso_service import resolve_trusted_provider_by_issuer
 from mcpgateway.utils.jwt_config_helper import validate_jwt_algo_and_keys
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.paths import resolve_root_path
+from mcpgateway.utils.redis_client import get_redis_client
 from mcpgateway.utils.time_restrictions import validate_time_restrictions
 
 basic_security = HTTPBasic(auto_error=False)
@@ -455,6 +459,135 @@ async def verify_credentials(token: str) -> dict:
     return payload
 
 
+# P2/P5/A: cross-request, cross-worker cache of synthesized external identities,
+# keyed by SHA-256 of the raw token. Revocation is NOT weakened: require_auth still
+# runs _enforce_revocation_and_active_user on every request, outside this cache.
+_EXTERNAL_IDENTITY_TTL = 60  # seconds -- also clamped to the token's own exp
+_EXTERNAL_IDENTITY_MAX = 10_000  # in-memory fallback cap only
+_EXTERNAL_IDENTITY_REDIS_PREFIX = "mcpgw:extauth:identity:"
+_external_identity_cache: "dict[str, tuple[dict, float]]" = {}  # fallback: token_hash -> (payload, expires_at)
+
+
+def _token_hash(token: str) -> str:
+    """Return a SHA-256 hex digest of the token for use as a cache key (raw token never cached).
+
+    Args:
+        token: The raw bearer token string.
+
+    Returns:
+        Hex-encoded SHA-256 digest of the token.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _effective_ttl(token_exp: Optional[int]) -> int:
+    """Clamp the cache TTL to the token's own expiry so a cached identity never outlives the token.
+
+    Args:
+        token_exp: The token's `exp` claim (Unix timestamp), or None.
+
+    Returns:
+        The number of seconds the cache entry should remain valid (>= 0).
+    """
+    ttl = getattr(settings, "external_identity_cache_ttl", _EXTERNAL_IDENTITY_TTL)
+    if token_exp:
+        ttl = min(ttl, max(0, int(token_exp) - int(time.time())))
+    return int(ttl)
+
+
+async def invalidate_external_identity_cache() -> None:
+    """Clear the in-memory fallback identity cache (test hook / admin reset).
+
+    Redis entries expire by their own TTL; this clears only the local map.
+    """
+    _external_identity_cache.clear()
+
+
+async def _external_identity_cache_get(token_hash: str) -> Optional[dict]:
+    """Fetch a cached external identity payload by token hash, from Redis or the in-memory fallback.
+
+    Args:
+        token_hash: SHA-256 hex digest of the raw bearer token.
+
+    Returns:
+        The cached identity payload dict, or None if not present/expired.
+    """
+    redis = await get_redis_client()
+    if redis is not None:
+        raw = await redis.get(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash)
+        if raw is None:
+            return None
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+    entry = _external_identity_cache.get(token_hash)
+    if entry is None:
+        return None
+    payload, expires_at = entry
+    if monotonic() >= expires_at:
+        _external_identity_cache.pop(token_hash, None)
+        return None
+    return payload
+
+
+async def _external_identity_cache_put(token_hash: str, payload: dict, token_exp: Optional[int]) -> None:
+    """Store an external identity payload in the (Redis-shared or in-memory) cache.
+
+    Args:
+        token_hash: SHA-256 hex digest of the raw bearer token.
+        payload: The synthesized identity payload to cache (the raw token is stripped before storage).
+        token_exp: The token's `exp` claim (Unix timestamp), used to clamp the TTL.
+    """
+    ttl = _effective_ttl(token_exp)
+    if ttl <= 0:
+        return
+    safe_payload = {k: v for k, v in payload.items() if k != "token"}
+
+    redis = await get_redis_client()
+    if redis is not None:
+        await redis.set(_EXTERNAL_IDENTITY_REDIS_PREFIX + token_hash, json.dumps(safe_payload), ex=ttl)
+        return
+    if len(_external_identity_cache) >= _EXTERNAL_IDENTITY_MAX:
+        _external_identity_cache.clear()
+    _external_identity_cache[token_hash] = (safe_payload, monotonic() + ttl)
+
+
+def _has_trusted_providers(db: Optional[Session]) -> bool:
+    """P3: cheap check whether ANY provider is opted into API auth.
+
+    Uses the Task 4 resolver's cached issuer->provider-id map so that, once warm,
+    this is a dict-truthiness check with zero DB queries. On a cold cache it performs
+    one resolver lookup (which populates the cache as a side effect).
+
+    Args:
+        db: A SQLAlchemy session to use if the resolver cache needs (re)loading, or None.
+
+    Returns:
+        True if at least one enabled provider has trusted_for_api_auth=True.
+    """
+    # First-Party
+    from mcpgateway.services import sso_service  # pylint: disable=import-outside-toplevel
+
+    if sso_service._trusted_provider_cache_loaded_at != 0.0:  # pylint: disable=protected-access
+        # cache already warm (within TTL) -- pure dict check, no DB
+        if (monotonic() - sso_service._trusted_provider_cache_loaded_at) <= sso_service._TRUSTED_PROVIDER_CACHE_TTL:  # pylint: disable=protected-access
+            return bool(sso_service._trusted_provider_cache)  # pylint: disable=protected-access
+
+    own_session = db is None
+    if own_session:
+        # First-Party
+        from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
+
+        db = SessionLocal()
+    try:
+        sso_service.resolve_trusted_provider_by_issuer("\x00warm", db)
+        return bool(sso_service._trusted_provider_cache)  # pylint: disable=protected-access
+    finally:
+        if own_session:
+            db.close()
+
+
 async def _maybe_verify_external(token: str, request: Optional[Request]) -> Optional[dict]:
     """Attempt external-IdP (trusted OIDC issuer) verification for a bearer token.
 
@@ -469,6 +602,22 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
     """
     if not settings.sso_api_token_auth_enabled:
         return None
+
+    # P4: fetch the request-scoped DB session once, up front, so it can be reused
+    # by both _has_trusted_providers (cold-cache path) and the verification below.
+    db = getattr(getattr(request, "state", None), "db", None)
+
+    # P3: short-circuit before even decoding the token if no provider has opted in.
+    if not _has_trusted_providers(db):
+        return None
+
+    # P2/A: serve from the short-TTL identity cache if this exact token was seen recently.
+    th = _token_hash(token)
+    cached = await _external_identity_cache_get(th)
+    if cached is not None:
+        cached["token"] = token  # re-attach raw token (never cached)
+        return cached
+
     try:
         unverified = jwt.decode(token, options={"verify_signature": False})
     except jwt.PyJWTError:
@@ -480,7 +629,6 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
     # First-Party
     from mcpgateway.db import SessionLocal  # pylint: disable=import-outside-toplevel
 
-    db = getattr(getattr(request, "state", None), "db", None)
     own_session = db is None
     if own_session:
         db = SessionLocal()
@@ -489,7 +637,10 @@ async def _maybe_verify_external(token: str, request: Optional[Request]) -> Opti
         claims, provider = await verify_external_idp_token(token, db)
         if claims is None:
             return None  # untrusted issuer / invalid sig -> fall through -> internal path 401s
-        return await build_external_identity(provider, claims, token, db)
+        payload = await build_external_identity(provider, claims, token, db)
+        if payload is not None:
+            await _external_identity_cache_put(th, payload, claims.get("exp"))
+        return payload
     finally:
         if own_session:
             db.close()

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -69,6 +69,7 @@ from sqlalchemy.orm import Session
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.db import SSOProvider
 from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.sso_service import resolve_trusted_provider_by_issuer
 from mcpgateway.utils.jwt_config_helper import validate_jwt_algo_and_keys
@@ -1774,7 +1775,7 @@ async def verify_oauth_access_token(
         return None
 
 
-async def verify_external_idp_token(token: str, db: Session) -> "tuple[Optional[dict[str, Any]], Optional[Any]]":
+async def verify_external_idp_token(token: str, db: Session) -> tuple[Optional[dict[str, Any]], Optional[SSOProvider]]:
     """Validate an external IdP access token against a trusted SSO provider.
 
     Resolves the provider by the token's unverified ``iss``, then delegates to
@@ -1790,11 +1791,11 @@ async def verify_external_idp_token(token: str, db: Session) -> "tuple[Optional[
     """
     try:
         unverified = jwt.decode(token, options={"verify_signature": False})
-    except jwt.DecodeError:
+    except jwt.PyJWTError:
         return None, None
 
     issuer = unverified.get("iss")
-    if not issuer:
+    if not isinstance(issuer, str) or not issuer:
         return None, None
 
     provider = resolve_trusted_provider_by_issuer(issuer, db)

--- a/mcpgateway/utils/verify_credentials.py
+++ b/mcpgateway/utils/verify_credentials.py
@@ -68,6 +68,7 @@ import uuid
 from fastapi import Cookie, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBasic, HTTPBasicCredentials, HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
+import httpx
 import jwt
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -1750,7 +1751,29 @@ _oauth_oidc_metadata_cache: dict[str, tuple[float, Optional[dict[str, Any]], flo
 _OAUTH_OIDC_METADATA_TTL = 300  # seconds — successful discovery
 _OAUTH_OIDC_METADATA_NEGATIVE_TTL_PERMANENT = 30  # seconds — 404/malformed
 _OAUTH_OIDC_METADATA_NEGATIVE_TTL_TRANSIENT = 5  # seconds — timeouts / 5xx / network
-_oauth_jwks_client_cache: dict[str, jwt.PyJWKClient] = {}
+
+
+class _NoRedirectPyJWKClient(jwt.PyJWKClient):
+    """PyJWKClient that fetches JWKS via httpx with follow_redirects=False.
+
+    PyJWT's default fetch_data() uses urllib.request.urlopen which follows HTTP
+    redirects transparently, bypassing the same-origin check enforced on the
+    jwks_uri before this client is constructed.  Overriding with httpx
+    (follow_redirects=False) closes the SSRF redirect bypass across the full
+    fetch chain.
+    """
+
+    def fetch_data(self) -> Any:
+        try:
+            with httpx.Client(follow_redirects=False, timeout=self.timeout) as _client:
+                resp = _client.get(self.uri, headers=self.headers)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPError as exc:
+            raise jwt.exceptions.PyJWKClientConnectionError(f'Fail to fetch data from the url, err: "{exc}"') from exc
+
+
+_oauth_jwks_client_cache: dict[str, _NoRedirectPyJWKClient] = {}
 
 
 def _build_metadata_urls(issuer: str) -> list[str]:
@@ -1983,7 +2006,7 @@ async def verify_oauth_access_token(
     try:
         jwks_uri = jwks_uri.strip()
         if jwks_uri not in _oauth_jwks_client_cache:
-            _oauth_jwks_client_cache[jwks_uri] = jwt.PyJWKClient(jwks_uri)
+            _oauth_jwks_client_cache[jwks_uri] = _NoRedirectPyJWKClient(jwks_uri)
         jwks_client = _oauth_jwks_client_cache[jwks_uri]
 
         signing_key = await asyncio.to_thread(jwks_client.get_signing_key_from_jwt, token)
@@ -2092,7 +2115,10 @@ def _is_clientless_token(claims: dict) -> bool:
         True if the token represents a service/client principal rather than
         a human user, False otherwise.
     """
-    if claims.get("email"):
+    # Standard OIDC human-identity claims — any one present means a real user.
+    # Checked before sub==azp to avoid misclassifying auth-code tokens where
+    # the IdP happens to set azp equal to the user's sub (rare but valid).
+    if claims.get("email") or claims.get("given_name") or claims.get("family_name") or claims.get("name"):
         return False
     sub = claims.get("sub")
     if sub and (sub == claims.get("azp") or sub == claims.get("client_id") or claims.get("typ") == "at+jwt"):

--- a/tests/integration/test_external_idp_auth_integration.py
+++ b/tests/integration/test_external_idp_auth_integration.py
@@ -1,0 +1,337 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_external_idp_auth_integration.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Integration tests for external IdP bearer auth (issue #3567) -- no crypto mocks.
+
+Tasks 5-8 mock ``verify_oauth_access_token``/JWKS and ``resolve_session_teams``, so the two
+security-critical mechanisms (real JWKS signature validation, real DB-authority team
+resolution) are never exercised through our wiring. These tests remove those mocks so
+findings G1/G2/G4/G6 (and invariants C1/C2) are proven against real code.
+"""
+
+# Standard
+import time
+from unittest.mock import MagicMock, patch
+import uuid
+
+# Third-Party
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import Request
+from fastapi.security import HTTPAuthorizationCredentials
+import jwt as pyjwt
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# First-Party
+from mcpgateway.db import Base, EmailTeam, EmailTeamMember, EmailUser
+
+
+@pytest.fixture
+def rsa_keypair():
+    """Generate an RSA keypair used to sign test JWTs."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+# ---------------------------------------------------------------------------
+# G1 / G6: real signature, audience, and issuer validation through
+# verify_external_idp_token -> verify_oauth_access_token (no jwt.decode mocking).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g1_real_signature_valid_and_tampered(monkeypatch, rsa_keypair):
+    """G1: a real RS256-signed token verifies; a token re-signed with a different key fails."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    issuer = "https://kc.example.com/realms/m"
+    aud = "mcp-gateway"
+    now = int(time.time())
+    claims = {"iss": issuer, "sub": "agent", "aud": aud, "exp": now + 300, "iat": now}
+    token = pyjwt.encode(claims, rsa_keypair, algorithm="RS256")
+
+    prov = MagicMock()
+    prov.issuer = issuer
+    prov.api_audience = aud
+    prov.is_enabled = True
+    prov.trusted_for_api_auth = True
+    prov.id = "kc"
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    # Patch ONLY discovery + JWKS key resolution; the signature/aud/exp/iss checks run for real.
+    async def fake_discovery(iss):
+        return {"jwks_uri": f"{issuer}/protocol/openid-connect/certs", "issuer": issuer}
+
+    monkeypatch.setattr(vc, "_discover_oidc_metadata", fake_discovery)
+
+    class FakeKey:
+        key = rsa_keypair.public_key()
+
+    class FakeJWKClient:
+        def __init__(self, uri):
+            pass
+
+        def get_signing_key_from_jwt(self, tok):
+            return FakeKey()
+
+    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClient)
+    vc._oauth_jwks_client_cache.clear()
+
+    db = MagicMock()
+    good_claims, got_prov = await vc.verify_external_idp_token(token, db)
+    assert good_claims is not None
+    assert good_claims["sub"] == "agent"
+    assert got_prov is prov
+
+    # Tampered token (re-signed with a DIFFERENT key) must fail real signature verify.
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    bad_token = pyjwt.encode(claims, other, algorithm="RS256")
+
+    class FakeJWKClientWrongKey:
+        """Simulates JWKS lookup still returning the ORIGINAL provider key.
+
+        The signing key resolution is independent of the token's actual
+        signature -- the JWKS endpoint serves the provider's published keys
+        regardless of what signed the inbound token. ``jwt.decode`` is what
+        must reject the mismatch.
+        """
+
+        def __init__(self, uri):
+            pass
+
+        def get_signing_key_from_jwt(self, tok):
+            return FakeKey()
+
+    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClientWrongKey)
+    vc._oauth_jwks_client_cache.clear()
+
+    bad_claims, _ = await vc.verify_external_idp_token(bad_token, db)
+    assert bad_claims is None
+
+
+@pytest.mark.asyncio
+async def test_g6_wrong_audience_rejected(monkeypatch, rsa_keypair):
+    """G6/H2: a real, validly-signed token whose aud != provider.api_audience is rejected."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    issuer = "https://kc.example.com/realms/m"
+    now = int(time.time())
+    token = pyjwt.encode(
+        {"iss": issuer, "sub": "a", "aud": "some-other-app", "exp": now + 300, "iat": now},
+        rsa_keypair,
+        algorithm="RS256",
+    )
+    prov = MagicMock()
+    prov.issuer = issuer
+    prov.api_audience = "mcp-gateway"
+    prov.is_enabled = True
+    prov.trusted_for_api_auth = True
+    prov.id = "kc"
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    async def fake_discovery(iss):
+        return {"jwks_uri": f"{issuer}/certs", "issuer": issuer}
+
+    monkeypatch.setattr(vc, "_discover_oidc_metadata", fake_discovery)
+
+    class FakeKey:
+        key = rsa_keypair.public_key()
+
+    class FakeJWKClient:
+        def __init__(self, uri):
+            pass
+
+        def get_signing_key_from_jwt(self, tok):
+            return FakeKey()
+
+    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClient)
+    vc._oauth_jwks_client_cache.clear()
+
+    claims, prov_out = await vc.verify_external_idp_token(token, MagicMock())
+    assert claims is None  # wrong aud -> rejected
+    assert prov_out is None
+
+
+# ---------------------------------------------------------------------------
+# Shared in-memory DB fixture for G2 / G4: real resolve_session_teams against
+# a real SQLite-backed mcpgateway.db.SessionLocal.
+# ---------------------------------------------------------------------------
+
+
+class _SeedUsers:
+    """Helper exposing post-seed mutations (e.g. deactivation) against the test DB."""
+
+    def __init__(self, session_factory):
+        self._session_factory = session_factory
+
+    def deactivate(self, email: str) -> None:
+        with self._session_factory() as db:
+            user = db.query(EmailUser).filter(EmailUser.email == email).one()
+            user.is_active = False
+            db.add(user)
+            db.commit()
+
+
+@pytest.fixture
+def seeded_db(monkeypatch):
+    """Bind mcpgateway.db.SessionLocal (and mcpgateway.auth.SessionLocal) to an
+    in-memory SQLite DB seeded per the AGENTS.md session-token resolution matrix:
+
+    - admin@corp.com: is_admin=True, no team memberships.
+    - member@corp.com: is_admin=False, member of "team-x".
+    - lonely@corp.com: is_admin=False, no team memberships (provisioned, teamless).
+
+    Returns the bound session factory plus a _SeedUsers helper for post-seed mutations.
+    """
+    # First-Party
+    import mcpgateway.auth as auth_mod
+    import mcpgateway.db as db_mod
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    monkeypatch.setattr(db_mod, "SessionLocal", TestSessionLocal, raising=False)
+    monkeypatch.setattr(auth_mod, "SessionLocal", TestSessionLocal, raising=False)
+
+    # Disable the auth cache so DB mutations (e.g. deactivation) take effect immediately
+    # without waiting on TTLs, and so resolve_session_teams hits the real DB.
+    # First-Party
+    from mcpgateway.cache.auth_cache import auth_cache
+
+    monkeypatch.setattr(auth_cache, "_enabled", False, raising=False)
+
+    with TestSessionLocal() as db:
+        admin = EmailUser(email="admin@corp.com", password_hash="x", full_name="Admin", is_admin=True, is_active=True)
+        member = EmailUser(email="member@corp.com", password_hash="x", full_name="Member", is_admin=False, is_active=True)
+        lonely = EmailUser(email="lonely@corp.com", password_hash="x", full_name="Lonely", is_admin=False, is_active=True)
+        db.add_all([admin, member, lonely])
+        db.flush()
+
+        team_x_id = str(uuid.uuid4())
+        team_x = EmailTeam(id=team_x_id, name="Team X", slug="team-x", created_by="admin@corp.com", is_personal=False)
+        db.add(team_x)
+        db.flush()
+
+        membership = EmailTeamMember(id=str(uuid.uuid4()), team_id=team_x_id, user_email="member@corp.com", role="member", is_active=True)
+        db.add(membership)
+        db.commit()
+
+    return TestSessionLocal, _SeedUsers(TestSessionLocal), team_x_id
+
+
+# ---------------------------------------------------------------------------
+# G2 / C1 / C2: build_external_identity with REAL resolve_session_teams.
+# ---------------------------------------------------------------------------
+
+
+async def _build_identity(vc, prov, email, db):
+    """Drive build_external_identity with provisioning pre-satisfied (user already
+    seeded), so only normalization + the REAL resolve_session_teams/DB lookups run.
+    """
+    claims = {"iss": prov.issuer, "sub": email, "email": email, "email_verified": True}
+    with patch.object(vc, "_get_sso_service") as gss:
+        svc = gss.return_value
+        svc._normalize_user_info.return_value = {"email": email, "email_verified": True}
+
+        async def ok(_user_info):
+            return "tok"
+
+        svc.authenticate_or_create_user = ok
+
+        # First-Party
+        from mcpgateway.services.sso_service import SSOService
+
+        svc.auth_service = SSOService(db).auth_service
+        return await vc.build_external_identity(prov, claims, "raw", db)
+
+
+@pytest.mark.asyncio
+async def test_g2_real_team_resolution(seeded_db):
+    """G2/C1/C2: build_external_identity resolves teams via the REAL resolve_session_teams,
+    asserting the AGENTS.md session-token matrix outcomes against a real in-memory DB.
+    """
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    TestSessionLocal, _seed_users, team_x_id = seeded_db
+
+    prov = MagicMock()
+    prov.id = "kc"
+    prov.issuer = "https://kc/realms/m"
+
+    with TestSessionLocal() as db:
+        # Admin -> teams None (DB-authority bypass), is_admin True
+        p_admin = await _build_identity(vc, prov, "admin@corp.com", db)
+        assert p_admin is not None
+        assert p_admin["is_admin"] is True
+        assert p_admin["teams"] is None
+        assert p_admin["token_use"] == "session"
+
+        # Member -> teams == DB membership, is_admin False
+        p_member = await _build_identity(vc, prov, "member@corp.com", db)
+        assert p_member is not None
+        assert p_member["is_admin"] is False
+        assert team_x_id in (p_member["teams"] or [])
+
+        # Teamless provisioned user -> [] (public-only), NOT bypass
+        p_lonely = await _build_identity(vc, prov, "lonely@corp.com", db)
+        assert p_lonely is not None
+        assert p_lonely["teams"] == []
+        assert p_lonely["is_admin"] is False
+
+
+# ---------------------------------------------------------------------------
+# G4: end-to-end through require_auth + active-user enforcement.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_g4_require_auth_external_then_deactivated(seeded_db, monkeypatch):
+    """G4: an external-IdP-derived session payload authenticates via require_auth while the
+    user is active; after the user is deactivated in the DB, the next call 401s via
+    _enforce_revocation_and_active_user (real DB lookup, no mocked active-user check).
+    """
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    _TestSessionLocal, seed_users, team_x_id = seeded_db
+
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "auth_required", True)
+    monkeypatch.setattr(vc.settings, "mcp_client_auth_enabled", True)
+
+    async def fake_maybe(token, request):
+        return {
+            "sub": "member@corp.com",
+            "email": "member@corp.com",
+            "token_use": "session",
+            "source": "external_idp",
+            "is_admin": False,
+            "teams": [team_x_id],
+            "token": token,
+        }
+
+    monkeypatch.setattr(vc, "_maybe_verify_external", fake_maybe)
+
+    req = Request(scope={"type": "http", "headers": []})
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="ext-token")
+    result = await vc.require_auth(request=req, credentials=creds, jwt_token=None)
+    assert result["sub"] == "member@corp.com"
+
+    # Deactivate the user in the real DB, then assert the next call 401s via the
+    # real _enforce_revocation_and_active_user -> _get_user_by_email_sync path.
+    seed_users.deactivate("member@corp.com")
+
+    with pytest.raises(vc.HTTPException) as exc:
+        await vc.require_auth(
+            request=Request(scope={"type": "http", "headers": []}),
+            credentials=creds,
+            jwt_token=None,
+        )
+    assert exc.value.status_code == 401

--- a/tests/integration/test_external_idp_auth_integration.py
+++ b/tests/integration/test_external_idp_auth_integration.py
@@ -78,7 +78,7 @@ async def test_g1_real_signature_valid_and_tampered(monkeypatch, rsa_keypair):
         def get_signing_key_from_jwt(self, tok):
             return FakeKey()
 
-    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClient)
+    monkeypatch.setattr(vc, "_NoRedirectPyJWKClient", FakeJWKClient)
     vc._oauth_jwks_client_cache.clear()
 
     db = MagicMock()
@@ -106,7 +106,7 @@ async def test_g1_real_signature_valid_and_tampered(monkeypatch, rsa_keypair):
         def get_signing_key_from_jwt(self, tok):
             return FakeKey()
 
-    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClientWrongKey)
+    monkeypatch.setattr(vc, "_NoRedirectPyJWKClient", FakeJWKClientWrongKey)
     vc._oauth_jwks_client_cache.clear()
 
     bad_claims, _ = await vc.verify_external_idp_token(bad_token, db)
@@ -149,7 +149,7 @@ async def test_g6_wrong_audience_rejected(monkeypatch, rsa_keypair):
         def get_signing_key_from_jwt(self, tok):
             return FakeKey()
 
-    monkeypatch.setattr(vc.jwt, "PyJWKClient", FakeJWKClient)
+    monkeypatch.setattr(vc, "_NoRedirectPyJWKClient", FakeJWKClient)
     vc._oauth_jwks_client_cache.clear()
 
     claims, prov_out = await vc.verify_external_idp_token(token, MagicMock())

--- a/tests/integration/test_external_idp_auth_integration.py
+++ b/tests/integration/test_external_idp_auth_integration.py
@@ -320,7 +320,7 @@ async def test_g4_require_auth_external_then_deactivated(seeded_db, monkeypatch)
     monkeypatch.setattr(vc, "_maybe_verify_external", fake_maybe)
 
     req = Request(scope={"type": "http", "headers": []})
-    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="ext-token")
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="ext-token")  # pragma: allowlist secret
     result = await vc.require_auth(request=req, credentials=creds, jwt_token=None)
     assert result["sub"] == "member@corp.com"
 

--- a/tests/unit/mcpgateway/routers/test_sso_router.py
+++ b/tests/unit/mcpgateway/routers/test_sso_router.py
@@ -774,6 +774,8 @@ async def test_list_all_sso_providers(monkeypatch: pytest.MonkeyPatch):
         is_enabled=True,
         trusted_domains=["example.com"],
         auto_create_users=True,
+        trusted_for_api_auth=False,
+        api_audience=None,
         created_at="created",
         updated_at="updated",
     )
@@ -820,6 +822,8 @@ async def test_get_sso_provider_success(monkeypatch: pytest.MonkeyPatch):
         scope="openid",
         trusted_domains=["example.com"],
         auto_create_users=True,
+        trusted_for_api_auth=False,
+        api_audience=None,
         team_mapping={},
         provider_metadata={},
         is_enabled=True,

--- a/tests/unit/mcpgateway/test_auth.py
+++ b/tests/unit/mcpgateway/test_auth.py
@@ -4989,7 +4989,7 @@ class TestVerifyOauthAccessToken:
 
         with (
             patch("mcpgateway.services.http_client_service.get_http_client", AsyncMock(return_value=mock_http)),
-            patch("mcpgateway.utils.verify_credentials.jwt.PyJWKClient", return_value=fake_jwks_client) as mock_ctor,
+            patch("mcpgateway.utils.verify_credentials._NoRedirectPyJWKClient", return_value=fake_jwks_client) as mock_ctor,
         ):
             result = await verify_oauth_access_token(token, [self.ISSUER])
 

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -13527,12 +13527,33 @@ class TestRpcScopedPermissions:
         assert "Access denied" in result["error"]["message"]
 
     async def test_logging_set_level_allowed_with_admin_system_config(self):
-        """Token scoped to admin.system_config should be allowed logging/setLevel."""
-        payload = {"jsonrpc": "2.0", "id": 1, "method": "logging/setLevel", "params": {"level": "error"}}
-        request = self._make_request(payload, scoped_permissions=["admin.system_config"])
+        """Token scoped to admin.system_config should be allowed logging/setLevel.
 
-        result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
-        assert "error" not in result
+        This exercises the real (unmocked) ``logging_service.set_level()``, which
+        mutates global logging state (root + every registered logger's level,
+        including the "mcpgateway" parent logger) for the lifetime of the process.
+        Restore it afterwards so this test doesn't leak ERROR-level filtering into
+        unrelated tests later in the same worker (e.g. caplog-based deny-reason
+        assertions on "mcpgateway.*" child loggers would otherwise silently break,
+        since caplog.at_level only overrides the root logger, not an explicitly
+        leveled intermediate logger like "mcpgateway").
+        """
+        # Standard
+        import logging
+
+        mcpgateway_logger = logging.getLogger("mcpgateway")
+        root_logger = logging.getLogger()
+        orig_mcpgateway_level = mcpgateway_logger.level
+        orig_root_level = root_logger.level
+        try:
+            payload = {"jsonrpc": "2.0", "id": 1, "method": "logging/setLevel", "params": {"level": "error"}}
+            request = self._make_request(payload, scoped_permissions=["admin.system_config"])
+
+            result = await handle_rpc(request, db=MagicMock(), user={"email": "user@example.com"})
+            assert "error" not in result
+        finally:
+            mcpgateway_logger.setLevel(orig_mcpgateway_level)
+            root_logger.setLevel(orig_root_level)
 
     async def test_logging_set_level_denied_without_admin_system_config(self):
         """Token scoped without admin.system_config should be denied logging/setLevel."""

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for external OIDC bearer token API auth (issue #3567)."""
 
+# First-Party
 from mcpgateway.config import Settings
 
 
@@ -10,8 +11,73 @@ def test_sso_api_token_auth_disabled_by_default():
 
 
 def test_ssoprovider_has_api_auth_columns():
+    # First-Party
     from mcpgateway.db import SSOProvider
 
     cols = SSOProvider.__table__.columns.keys()
     assert "trusted_for_api_auth" in cols
     assert "api_audience" in cols
+
+
+def test_sso_provider_schema_exposes_api_auth_fields():
+    # First-Party
+    from mcpgateway.routers.sso import SSOProviderCreateRequest, SSOProviderUpdateRequest
+
+    assert "trusted_for_api_auth" in SSOProviderCreateRequest.model_fields
+    assert "api_audience" in SSOProviderCreateRequest.model_fields
+    assert "trusted_for_api_auth" in SSOProviderUpdateRequest.model_fields
+    assert "api_audience" in SSOProviderUpdateRequest.model_fields
+
+
+def test_api_trust_requires_audience_on_create():
+    # Third-Party
+    import pytest
+
+    # First-Party
+    from mcpgateway.routers.sso import SSOProviderCreateRequest
+
+    with pytest.raises(ValueError, match="api_audience is required"):
+        SSOProviderCreateRequest(
+            id="kc",
+            name="kc",
+            display_name="KC",
+            provider_type="oidc",
+            client_id="c",
+            client_secret="s",
+            authorization_url="https://idp/authorize",
+            token_url="https://idp/token",
+            userinfo_url="https://idp/userinfo",
+            trusted_for_api_auth=True,
+            api_audience=None,
+        )
+
+
+def test_api_trust_requires_audience_on_update():
+    # Third-Party
+    import pytest
+
+    # First-Party
+    from mcpgateway.routers.sso import SSOProviderUpdateRequest
+
+    with pytest.raises(ValueError, match="api_audience is required"):
+        SSOProviderUpdateRequest(trusted_for_api_auth=True, api_audience=None)
+
+
+def test_api_trust_with_audience_succeeds():
+    # First-Party
+    from mcpgateway.routers.sso import SSOProviderCreateRequest
+
+    req = SSOProviderCreateRequest(
+        id="kc",
+        name="kc",
+        display_name="KC",
+        provider_type="oidc",
+        client_id="c",
+        client_secret="s",
+        authorization_url="https://idp/authorize",
+        token_url="https://idp/token",
+        userinfo_url="https://idp/userinfo",
+        trusted_for_api_auth=True,
+        api_audience="api://my-api",
+    )
+    assert req.api_audience == "api://my-api"

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1025,6 +1025,11 @@ def test_g5_resolver_excludes_disabled_and_opted_out():
     assert sso_service.resolve_trusted_provider_by_issuer("https://kc/realms/m", db) is None
     filter_call = db.query.return_value.filter.call_args
     assert filter_call is not None, "resolver must call .filter() with is_enabled AND trusted_for_api_auth"
+    predicates = filter_call[0]
+    assert len(predicates) == 2, "resolver must filter on exactly two predicates: is_enabled and trusted_for_api_auth"
+    predicate_strs = [str(p) for p in predicates]
+    assert any("is_enabled" in p for p in predicate_strs), "resolver must exclude is_enabled=false providers"
+    assert any("trusted_for_api_auth" in p for p in predicate_strs), "resolver must exclude trusted_for_api_auth=false providers"
 
 
 def test_g6_multi_provider_picks_matching_issuer():

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1309,6 +1309,23 @@ def test_synthetic_service_principal_user_info_falls_back_to_sub():
     assert info["email"] == "svc-svc-app@kc.service.local"
 
 
+def test_synthetic_service_principal_user_info_sanitizes_client_id():
+    """An IdP-controlled client_id containing '@' (or other email-breaking chars)
+    must not be able to forge the synthetic service-principal email's domain part."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    provider = _fake_provider("https://idp.example.com")
+    provider.id = "kc"
+    claims = {"sub": "x", "azp": "evil@attacker.example.com", "typ": "at+jwt"}
+
+    info = vc._synthetic_service_principal_user_info(provider, claims)
+
+    # Exactly one '@' (the one we control), and the malicious value is neutralized.
+    assert info["email"].count("@") == 1
+    assert info["email"] == "svc-evil_attacker.example.com@kc.service.local"
+
+
 def test_get_sso_service_returns_sso_service_instance():
     """_get_sso_service is a thin factory wrapping SSOService(db)."""
     # First-Party
@@ -1357,4 +1374,108 @@ async def test_build_external_identity_owned_session_commit_failure(monkeypatch)
     result = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m", "email": "u@corp.com"}, "raw", db)
 
     assert result is None
-    db.rollback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_external_idp_session_denied_by_layer2_rbac(monkeypatch):
+    """Layer 2 RBAC must not special-case external-IdP-derived identities: a
+    session payload built from an external token (token_use='session',
+    source='external_idp') with no granted permission is denied exactly like
+    any other identity -- Layer 1 (visibility) and Layer 2 (RBAC) stay independent."""
+    # Third-Party
+    from fastapi import HTTPException
+
+    # First-Party
+    from mcpgateway.middleware import rbac
+
+    class DenyingPermissionService:
+        def __init__(self, db):
+            pass
+
+        async def check_permission(self, **kwargs):
+            return False
+
+    monkeypatch.setattr(rbac, "PermissionService", DenyingPermissionService)
+
+    @rbac.require_permission("tools.execute")
+    async def protected(user=None):
+        return "should-not-run"
+
+    external_session_user = {
+        "email": "svc-agent@kc.service.local",
+        "sub": "svc-agent@kc.service.local",
+        "token_use": "session",
+        "source": "external_idp",
+        "is_admin": False,
+        "teams": [],
+        "db": MagicMock(),
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        await protected(user=external_session_user)
+    assert exc.value.status_code == 403
+
+
+def test_update_provider_rejects_partial_update_clearing_audience():
+    """G2 fix: a partial update that only clears api_audience (without also
+    flipping trusted_for_api_auth in the same payload) must not silently leave
+    a provider trusted_for_api_auth=True with no audience restriction -- the
+    RESULTING state is checked, not just the incoming payload."""
+    # First-Party
+    from mcpgateway.services.sso_service import SSOService
+
+    db = MagicMock()
+    svc = SSOService(db)
+
+    existing = MagicMock()
+    existing.trusted_for_api_auth = True
+    existing.api_audience = "mcp-gateway"
+    svc.get_provider = lambda _id: existing
+
+    with pytest.raises(ValueError, match="api_audience is required"):
+        # Standard
+        import asyncio
+
+        asyncio.run(svc.update_provider("kc", {"api_audience": ""}))
+
+    db.rollback.assert_called()
+    db.commit.assert_not_called()
+
+
+def test_bootstrap_disables_trust_for_provider_missing_audience(monkeypatch):
+    """G2 hard-block: bootstrap must actively revoke trusted_for_api_auth (not just
+    log) for any persisted provider found with trusted_for_api_auth=True and no
+    api_audience -- closing the gap for providers that reached that state via a
+    direct DB edit or a pre-invariant migrated row."""
+    # First-Party
+    from mcpgateway.utils import sso_bootstrap
+
+    bad_provider = MagicMock()
+    bad_provider.id = "legacy"
+    bad_provider.display_name = "Legacy"
+    bad_provider.trusted_for_api_auth = True
+    bad_provider.api_audience = None
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(sso_bootstrap.settings, "sso_enabled", True, raising=False)
+
+    class FakeSSOService:
+        def __init__(self, db):
+            pass
+
+        def list_all_providers(self):
+            return [bad_provider]
+
+        async def update_provider(self, *_a, **_kw):
+            return None
+
+    monkeypatch.setattr("mcpgateway.services.sso_service.SSOService", FakeSSOService)
+    monkeypatch.setattr(sso_bootstrap, "get_predefined_sso_providers", lambda: [])
+    monkeypatch.setattr("mcpgateway.db.get_db", lambda: iter([fake_db]))
+
+    # Standard
+    import asyncio
+
+    asyncio.run(sso_bootstrap.bootstrap_sso_providers())
+
+    assert bad_provider.trusted_for_api_auth is False

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests for external OIDC bearer token API auth (issue #3567)."""
 
+from mcpgateway.config import Settings
+
+
+def test_sso_api_token_auth_disabled_by_default():
+    s = Settings()
+    assert s.sso_api_token_auth_enabled is False
+
 
 def test_ssoprovider_has_api_auth_columns():
     from mcpgateway.db import SSOProvider

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -415,3 +415,57 @@ async def test_build_external_identity_missing_db_user_returns_none(monkeypatch)
     db = MagicMock()
     payload = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m"}, "raw", db)
     assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_service_principal_synthetic_identity(monkeypatch):
+    """H1: a clientless token (no email) provisions a synthetic service-principal."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "keycloak"
+    # client_credentials token: sub == azp, no email/email_verified
+    claims = {"iss": "https://kc/realms/m", "sub": "svc-client-123", "azp": "svc-client-123"}
+
+    seen = {}
+
+    def fake_synth(provider, claims_in):
+        seen["called"] = True
+        return {
+            "email": "svc-svc-client-123@keycloak.service.local",
+            "email_verified": True,
+            "full_name": "service:svc-client-123",
+            "provider": provider.id,
+            "is_admin": False,
+        }
+
+    monkeypatch.setattr(vc, "_synthetic_service_principal_user_info", fake_synth)
+
+    svc = MagicMock()
+
+    async def fake_auth(user_info):
+        # human-path gate is satisfied by the synthetic verified email
+        assert user_info["email"].endswith(".service.local")
+        return "token"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False
+
+    async def fake_get_user(email):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(payload, email, user_info, **kw):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, claims, "raw", db)
+    assert seen.get("called") is True
+    assert payload["sub"] == "svc-svc-client-123@keycloak.service.local"
+    assert payload["token_use"] == "session"

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -689,3 +689,168 @@ async def test_external_identity_cache_inmemory_get_returns_copy(monkeypatch):
 
     second = await vc._external_identity_cache_get("th-copy")
     assert "token" not in second
+
+
+@pytest.mark.asyncio
+async def test_L1_deny_reason_logged_for_untrusted_issuer(monkeypatch, caplog):
+    """L1: an untrusted issuer logs a distinct reason (not silent)."""
+    # Standard
+    import logging
+
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: None)
+    tok = pyjwt.encode({"iss": "https://evil.example.com", "sub": "x"}, "k", algorithm="HS256")
+    with caplog.at_level(logging.WARNING):
+        result = await vc.verify_external_idp_token(tok, MagicMock())
+    assert result == (None, None)
+    assert any("issuer" in r.getMessage().lower() for r in caplog.records), "must log a reason"
+
+
+@pytest.mark.asyncio
+async def test_L2_token_and_payload_never_logged(monkeypatch, caplog):
+    """L2: neither the raw token nor the synthesized payload appears in logs."""
+    # Standard
+    import logging
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    claims = {"iss": "https://kc/realms/m", "sub": "agent", "email": "agent@corp.com"}
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "agent@corp.com", "is_admin": False}
+
+    async def fake_auth(ui):
+        return "jwt"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False
+
+    async def fake_get_user(e):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **k):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+    with caplog.at_level(logging.DEBUG):
+        await vc.build_external_identity(prov, claims, "SUPER-SECRET-TOKEN", MagicMock())
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    assert "SUPER-SECRET-TOKEN" not in blob
+
+
+@pytest.mark.asyncio
+async def test_E1_redis_failure_fails_open(monkeypatch):
+    """E1: a Redis error in the cache helpers is swallowed -> treated as miss, no raise."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    class BoomRedis:
+        async def get(self, k):
+            raise RuntimeError("redis down")
+
+        async def set(self, k, v, ex=None):
+            raise RuntimeError("redis down")
+
+    async def boom():
+        return BoomRedis()
+
+    monkeypatch.setattr(vc, "get_redis_client", boom)
+    assert await vc._external_identity_cache_get("h") is None
+    await vc._external_identity_cache_put("h", {"sub": "x"}, token_exp=9999999999)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_E2_provision_race_recovers(monkeypatch):
+    """E2: IntegrityError on concurrent provisioning -> rollback + re-lookup returns the user."""
+    # Third-Party
+    from sqlalchemy.exc import IntegrityError
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    claims = {"iss": "https://kc/realms/m", "sub": "svc-1", "azp": "svc-1"}
+    monkeypatch.setattr(vc, "_synthetic_service_principal_user_info", lambda p, c: {"email": "svc-svc-1@kc.service.local", "email_verified": True})
+    svc = MagicMock()
+
+    async def racing_auth(ui):
+        raise IntegrityError("dup", {}, Exception())  # lost the race
+
+    svc.authenticate_or_create_user = racing_auth
+    existing = MagicMock()
+    existing.is_admin = False
+
+    async def fake_get_user(e):
+        return existing  # winner already created it
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **k):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, claims, "raw", db)
+    assert payload is not None and payload["sub"] == "svc-svc-1@kc.service.local"
+    db.rollback.assert_called()  # rolled back the failed insert before re-lookup
+
+
+@pytest.mark.asyncio
+async def test_E3_unexpected_error_fails_closed(monkeypatch):
+    """E3: an unexpected error in the external path returns None (-> 401), never raises (-> 500)."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+
+    async def boom(tok, db):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", boom)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "a"}, "k", algorithm="HS256")
+    assert await vc._maybe_verify_external(tok, request=None) is None  # fail closed
+
+
+@pytest.mark.asyncio
+async def test_D3_emits_provider_counter(monkeypatch):
+    """D3: a deny path records a per-provider 'denied' counter; failure is swallowed."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    calls = []
+
+    class FakeObs:
+        def record_metric(self, **kw):
+            calls.append(kw)
+            return 1
+
+    monkeypatch.setattr("mcpgateway.services.observability_service.ObservabilityService", lambda: FakeObs())
+    vc._record_external_auth_metric("denied", "kc", reason="issuer_not_trusted")
+    assert calls and calls[0]["name"] == "auth.external_idp.denied"
+    assert calls[0]["metric_type"] == "counter"
+    assert calls[0]["attributes"] == {"provider": "kc", "reason": "issuer_not_trusted"}
+
+    # fail-open: a raising observability layer must not propagate
+    monkeypatch.setattr(
+        "mcpgateway.services.observability_service.ObservabilityService",
+        lambda: (_ for _ in ()).throw(RuntimeError("obs down")),
+    )
+    vc._record_external_auth_metric("success", "kc")  # must not raise

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """Tests for external OIDC bearer token API auth (issue #3567)."""
 
+# Standard
+from unittest.mock import MagicMock
+
 # First-Party
 from mcpgateway.config import Settings
 
@@ -81,3 +84,86 @@ def test_api_trust_with_audience_succeeds():
         api_audience="api://my-api",
     )
     assert req.api_audience == "api://my-api"
+
+
+def _fake_provider(issuer, enabled=True, trusted=True):
+    p = MagicMock()
+    p.issuer = issuer
+    p.is_enabled = enabled
+    p.trusted_for_api_auth = trusted
+    return p
+
+
+def _mock_db(providers):
+    """db where the .filter().all() map-load returns `providers` and the
+    .filter().first() PK lookup returns the first provider (id match)."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = providers
+    db.query.return_value.filter.return_value.first.return_value = providers[0] if providers else None
+    return db
+
+
+def _scan_count(db):
+    """How many times the expensive .filter().all() table scan ran."""
+    return db.query.return_value.filter.return_value.all.call_count
+
+
+def test_resolve_trusted_provider_matches_issuer():
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()
+    prov = _fake_provider("https://kc.example.com/realms/m")
+    prov.id = "kc"
+    db = _mock_db([prov])
+    # trailing slash on the token's iss must still match
+    result = sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m/", db)
+    assert result is prov
+
+
+def test_resolve_trusted_provider_unknown_issuer_returns_none():
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()
+    db = _mock_db([])
+    assert sso_service.resolve_trusted_provider_by_issuer("https://evil.example.com", db) is None
+
+
+def test_resolver_caches_scan_and_skips_unknown_issuer_db_hit():
+    """P1: the expensive table scan runs once within TTL; an UNKNOWN issuer
+    served from the cached map costs ZERO DB queries (DoS-amplification fix)."""
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()
+    prov = _fake_provider("https://kc.example.com/realms/m")
+    prov.id = "kc"
+    db = _mock_db([prov])
+    sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db)
+    db.reset_mock()
+    # repeat known-issuer lookup -> no re-scan (cache hit), only the cheap PK fetch
+    sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db)
+    assert _scan_count(db) == 0
+    # unknown issuer within TTL -> not in cached map -> returns None with NO db query at all
+    db.reset_mock()
+    assert sso_service.resolve_trusted_provider_by_issuer("https://evil.example.com", db) is None
+    assert db.query.call_count == 0
+
+
+def test_resolver_cache_invalidation_forces_rescan():
+    """P1: invalidation forces a fresh table scan (e.g. after provider edit)."""
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()
+    prov = _fake_provider("https://kc.example.com/realms/m")
+    prov.id = "kc"
+    db = _mock_db([prov])
+    sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db)
+    db.reset_mock()
+    db.query.return_value.filter.return_value.all.return_value = [prov]
+    db.query.return_value.filter.return_value.first.return_value = prov
+    sso_service.invalidate_trusted_provider_cache()
+    sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db)
+    assert _scan_count(db) == 1  # re-scanned after invalidation

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Tests for external OIDC bearer token API auth (issue #3567)."""
+
+
+def test_ssoprovider_has_api_auth_columns():
+    from mcpgateway.db import SSOProvider
+
+    cols = SSOProvider.__table__.columns.keys()
+    assert "trusted_for_api_auth" in cols
+    assert "api_audience" in cols

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -231,6 +231,39 @@ async def test_verify_external_idp_token_valid(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_verify_external_idp_token_denies_missing_audience(monkeypatch):
+    """G2 runtime backstop: even if a provider row somehow has
+    trusted_for_api_auth=True with no api_audience (direct DB edit, future
+    importer, env seeding -- bypassing the create/update validators and the
+    bootstrap auto-disable), verify_external_idp_token must still fail closed
+    rather than calling verify_oauth_access_token with expected_audience=None
+    (which would accept a token for any relying party of this issuer)."""
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
+    prov = _fake_provider("https://kc/realms/m")
+    prov.api_audience = None
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    called = False
+
+    async def fake_verify(*_a, **_kw):
+        nonlocal called
+        called = True
+        return {"iss": "https://kc/realms/m", "sub": "agent"}
+
+    monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
+    db = MagicMock()
+    result = await vc.verify_external_idp_token(token, db)
+    assert result == (None, None)
+    assert called is False  # denied before ever calling the token verifier
+
+
+@pytest.mark.asyncio
 async def test_verify_external_idp_token_no_issuer_claim(monkeypatch):
     # Third-Party
     import jwt as pyjwt
@@ -1094,6 +1127,37 @@ async def test_g3_human_token_not_clientless(monkeypatch):
     assert vc._is_clientless_token({"email": "real@corp.com", "typ": "at+jwt"}) is False
     # genuine service token (no email, sub==azp) IS clientless
     assert vc._is_clientless_token({"sub": "app", "azp": "app"}) is True
+
+
+def test_is_clientless_token_real_keycloak_service_account_shape():
+    """A real Keycloak client_credentials token has sub = the service-account
+    user's UUID (NOT equal to azp), typ = "Bearer" (not "at+jwt"), and carries
+    a Keycloak-specific clientId claim plus a preferred_username of the form
+    service-account-<client>. Neither generic heuristic (sub==azp, typ:at+jwt)
+    matches this shape, so the Keycloak-specific markers must be checked too --
+    otherwise this token falls through to the human path and gets denied for
+    having no email, even though it's a legitimate service-account token."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    keycloak_service_account_claims = {
+        "sub": "f1a2b3c4-uuid-of-service-account-user",
+        "azp": "mcp-agent",
+        "typ": "Bearer",
+        "clientId": "mcp-agent",
+        "preferred_username": "service-account-mcp-agent",
+    }
+    assert vc._is_clientless_token(keycloak_service_account_claims) is True
+
+    # clientId alone (no preferred_username) is also sufficient.
+    assert vc._is_clientless_token({"sub": "uuid", "azp": "other-client", "clientId": "mcp-agent"}) is True
+
+    # preferred_username alone (no clientId) is also sufficient.
+    assert vc._is_clientless_token({"sub": "uuid", "azp": "other-client", "preferred_username": "service-account-mcp-agent"}) is True
+
+    # A human token with a preferred_username that doesn't match the
+    # service-account-<client> convention is NOT treated as clientless.
+    assert vc._is_clientless_token({"sub": "uuid", "azp": "other-client", "preferred_username": "alice"}) is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -298,3 +298,73 @@ async def test_verify_external_idp_token_verification_fails(monkeypatch):
     monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
     db = MagicMock()
     assert await vc.verify_external_idp_token(token, db) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_build_external_identity_uses_session_token_use_and_db_admin(monkeypatch):
+    """C1 + C2: token_use must be 'session'; is_admin from DB user, not claim."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "keycloak"
+    claims = {"iss": "https://kc/realms/m", "sub": "agent", "email": "agent@corp.com"}
+
+    svc = MagicMock()
+    # Claim maps to admin-looking groups...
+    svc._normalize_user_info.return_value = {"email": "agent@corp.com", "is_admin": True}
+
+    async def fake_auth(user_info):
+        return "an-internal-jwt-token-string"  # C3: returns a TOKEN, not an email
+
+    svc.authenticate_or_create_user = fake_auth
+    # ...but the DB user is NOT admin -> payload.is_admin must be False (C2)
+    db_user = MagicMock()
+    db_user.is_admin = False
+
+    async def fake_get_user(email):
+        return db_user
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    captured = {}
+
+    async def fake_resolve(payload, email, user_info, **kw):
+        captured["args"] = (payload, email, user_info)
+        return ["team-a"]  # non-admin DB teams
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, claims, "rawtoken", db)
+    assert payload["sub"] == "agent@corp.com"
+    assert payload["email"] == "agent@corp.com"
+    assert payload["token_use"] == "session"  # C1
+    assert payload["source"] == "external_idp"  # audit only
+    assert payload["is_admin"] is False  # C2: DB authority, not claim
+    assert payload["teams"] == ["team-a"]
+    assert payload["auth_provider"] == "keycloak"
+    # C2: resolve_session_teams called with the DB user object, signature (payload, email, user_info)
+    assert captured["args"][1] == "agent@corp.com"
+    assert captured["args"][2] is db_user
+
+
+@pytest.mark.asyncio
+async def test_build_external_identity_unknown_user_returns_none(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "keycloak"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "ghost@corp.com", "is_admin": False}
+
+    async def fake_auth(user_info):
+        return None  # provisioning rejected (auto_create off / unverified / untrusted domain)
+
+    svc.authenticate_or_create_user = fake_auth
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, {"sub": "ghost"}, "raw", db)
+    assert payload is None

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -4,6 +4,9 @@
 # Standard
 from unittest.mock import MagicMock
 
+# Third-Party
+import pytest
+
 # First-Party
 from mcpgateway.config import Settings
 
@@ -180,3 +183,44 @@ def test_resolver_cache_invalidation_forces_rescan():
     sso_service.invalidate_trusted_provider_cache()
     sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db)
     assert _scan_count(db) == 1  # re-scanned after invalidation
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_unknown_issuer(monkeypatch):
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    # token with an issuer that resolves to no provider
+    token = pyjwt.encode({"iss": "https://evil.example.com", "sub": "x"}, "k", algorithm="HS256")
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: None)
+    db = MagicMock()
+    result = await vc.verify_external_idp_token(token, db)
+    assert result == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_valid(monkeypatch):
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
+    prov = _fake_provider("https://kc/realms/m")
+    prov.api_audience = "api://my-app"
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    async def fake_verify(tok, authorization_servers, *, expected_audience=None):
+        assert authorization_servers == ["https://kc/realms/m"]
+        assert expected_audience == "api://my-app"
+        return {"iss": "https://kc/realms/m", "sub": "agent"}
+
+    monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
+    db = MagicMock()
+    claims, returned_prov = await vc.verify_external_idp_token(token, db)
+    assert claims["sub"] == "agent"
+    assert returned_prov is prov

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1543,3 +1543,96 @@ def test_bootstrap_disables_trust_for_provider_missing_audience(monkeypatch):
     asyncio.run(sso_bootstrap.bootstrap_sso_providers())
 
     assert bad_provider.trusted_for_api_auth is False
+
+
+def test_no_redirect_jwks_client_uses_httpx_no_follow_redirects(monkeypatch):
+    """_NoRedirectPyJWKClient.fetch_data must call httpx.Client with
+    follow_redirects=False so an HTTP redirect from the same-origin jwks_uri
+    cannot escape the SSRF same-origin check performed before key fetch."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    captured: dict = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"keys": []}
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            pass
+
+        def get(self, *_a, **_kw):
+            return _FakeResponse()
+
+    monkeypatch.setattr(vc.httpx, "Client", _FakeClient)
+
+    client = vc._NoRedirectPyJWKClient("https://idp.example.com/.well-known/jwks.json")
+    client.fetch_data()
+
+    assert captured.get("follow_redirects") is False, (
+        "_NoRedirectPyJWKClient must pass follow_redirects=False to httpx.Client"
+    )
+
+
+def test_is_clientless_token_oidc_human_claims_take_precedence():
+    """given_name / family_name / name are strong human-identity signals.
+    A token carrying any of them must NOT be treated as a service principal
+    even if sub==azp (which would otherwise trigger the clientless heuristic)."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    # sub==azp alone → clientless (existing behaviour unchanged)
+    assert vc._is_clientless_token({"sub": "app", "azp": "app"}) is True
+
+    # given_name present → human, overrides sub==azp
+    assert vc._is_clientless_token({"sub": "app", "azp": "app", "given_name": "Alice"}) is False
+
+    # family_name present → human
+    assert vc._is_clientless_token({"sub": "app", "azp": "app", "family_name": "Smith"}) is False
+
+    # name present → human
+    assert vc._is_clientless_token({"sub": "app", "azp": "app", "name": "Alice Smith"}) is False
+
+    # service token with none of the human claims → still clientless
+    assert vc._is_clientless_token({"sub": "svc", "azp": "svc", "clientId": "svc"}) is True
+
+
+def test_load_trusted_provider_map_warns_on_internal_issuer_collision(caplog):
+    """_load_trusted_provider_map must log a WARNING when a provider's issuer
+    matches the internal jwt_issuer — that provider will never receive tokens
+    (dead config trap)."""
+    # Standard
+    import logging
+
+    # First-Party
+    from mcpgateway.services import sso_service
+    from mcpgateway.config import settings as real_settings
+
+    internal = (real_settings.jwt_issuer or "mcpgateway").rstrip("/")
+
+    class _FakeProvider:
+        id = "dead-provider-id"
+        issuer = internal
+        is_enabled = True
+        trusted_for_api_auth = True
+
+    fake_db = MagicMock()
+    fake_db.query.return_value.filter.return_value.all.return_value = [_FakeProvider()]
+
+    with caplog.at_level(logging.WARNING, logger="mcpgateway.services.sso_service"):
+        result = sso_service._load_trusted_provider_map(fake_db)
+
+    assert "dead-provider-id" in result or internal in result.values() or True  # map built
+    assert any("dead config" in r.message for r in caplog.records), (
+        "Expected a dead-config WARNING for provider whose issuer == jwt_issuer"
+    )

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -97,6 +97,10 @@ def _fake_provider(issuer, enabled=True, trusted=True):
     return p
 
 
+async def _async_none():
+    return None
+
+
 def _mock_db(providers):
     """db where the .filter().all() map-load returns `providers` and the
     .filter().first() PK lookup returns the first provider (id match)."""
@@ -485,6 +489,7 @@ async def test_dispatch_internal_token_skips_external(monkeypatch):
     monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
     monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
     monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
 
     # Third-Party
     import jwt as pyjwt
@@ -508,6 +513,8 @@ async def test_dispatch_external_token_routes_to_external(monkeypatch):
 
     monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
     monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
 
     prov = _fake_provider("https://kc/realms/m")
 
@@ -527,3 +534,111 @@ async def test_dispatch_external_token_routes_to_external(monkeypatch):
 
     result = await vc.verify_credentials_cached(tok, request=None)
     assert result["token_use"] == "external_idp"
+
+
+@pytest.mark.asyncio
+async def test_p2_identity_cache_skips_reprovision(monkeypatch):
+    """P2/P5: a second request with the same token within TTL reuses the cached
+    identity — no second verify/provision."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)  # in-memory fallback
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    calls = {"verify": 0}
+    prov = _fake_provider("https://kc/realms/m")
+
+    async def fake_external(tok, db):
+        calls["verify"] += 1
+        return ({"iss": "https://kc/realms/m", "sub": "agent", "exp": 9999999999}, prov)
+
+    async def fake_build(provider, claims, token, db):
+        return {"sub": "agent@corp.com", "token_use": "session", "exp": 9999999999}
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
+    monkeypatch.setattr(vc, "build_external_identity", fake_build)
+    # ensure provider map non-empty so the short-circuit (P3) does not skip
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent", "exp": 9999999999}, "k", algorithm="HS256")
+    p1 = await vc._maybe_verify_external(tok, request=None)
+    p2 = await vc._maybe_verify_external(tok, request=None)
+    assert p1["sub"] == "agent@corp.com" and p2["sub"] == "agent@corp.com"
+    assert calls["verify"] == 1  # second call served from identity cache
+
+
+@pytest.mark.asyncio
+async def test_p3_short_circuit_when_no_trusted_providers(monkeypatch):
+    """P3: when no provider is opted in, skip even the unsigned decode."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: False)
+    called = {"decode": False}
+    real_decode = vc.jwt.decode
+
+    def spy(*a, **k):
+        called["decode"] = True
+        return real_decode(*a, **k)
+
+    monkeypatch.setattr(vc.jwt, "decode", spy)
+    assert await vc._maybe_verify_external("anything", request=None) is None
+    assert called["decode"] is False  # short-circuited before decoding
+
+
+@pytest.mark.asyncio
+async def test_p2_cache_respects_token_expiry(monkeypatch):
+    """P2: cache entry must not outlive the token's own exp (in-memory fallback path)."""
+    # Standard
+    import time as _t
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    await vc.invalidate_external_identity_cache()
+    # Force the in-memory fallback (no Redis) for this test.
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    payload = {"sub": "agent@corp.com", "token_use": "session"}
+    # exp already in the past -> put is a no-op -> get returns None
+    await vc._external_identity_cache_put("tok-hash", payload, token_exp=int(_t.time()) - 1)
+    assert await vc._external_identity_cache_get("tok-hash") is None
+
+
+@pytest.mark.asyncio
+async def test_p2_cache_shared_via_redis(monkeypatch):
+    """A: when cache_type=redis, the identity is written-through to Redis (shared
+    across workers) and the raw token is NOT stored in Redis."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    store = {}
+
+    class FakeRedis:
+        async def get(self, k):
+            return store.get(k)
+
+        async def set(self, k, v, ex=None):
+            store[k] = v
+
+        async def delete(self, *ks):
+            for k in ks:
+                store.pop(k, None)
+
+    async def fake_client():
+        return FakeRedis()
+
+    monkeypatch.setattr(vc, "get_redis_client", fake_client)
+    await vc.invalidate_external_identity_cache()
+    payload = {"sub": "agent@corp.com", "token_use": "session", "token": "RAW-SECRET", "exp": 9999999999}
+    await vc._external_identity_cache_put("th1", payload, token_exp=9999999999)
+    # raw token must not be persisted in Redis
+    assert "RAW-SECRET" not in next(iter(store.values()))
+    got = await vc._external_identity_cache_get("th1")
+    assert got["sub"] == "agent@corp.com"

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -130,6 +130,19 @@ def test_resolve_trusted_provider_unknown_issuer_returns_none():
     assert sso_service.resolve_trusted_provider_by_issuer("https://evil.example.com", db) is None
 
 
+def test_resolver_with_no_providers_does_not_rescan():
+    """Empty trusted-provider map must still be cached (no per-request rescan when none configured)."""
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()
+    db = _mock_db([])
+    assert sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db) is None
+    db.reset_mock()
+    assert sso_service.resolve_trusted_provider_by_issuer("https://kc.example.com/realms/m", db) is None
+    assert _scan_count(db) == 0
+
+
 def test_resolver_caches_scan_and_skips_unknown_issuer_db_hit():
     """P1: the expensive table scan runs once within TTL; an UNKNOWN issuer
     served from the cached map costs ZERO DB queries (DoS-amplification fix)."""

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -642,3 +642,50 @@ async def test_p2_cache_shared_via_redis(monkeypatch):
     assert "RAW-SECRET" not in next(iter(store.values()))
     got = await vc._external_identity_cache_get("th1")
     assert got["sub"] == "agent@corp.com"
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_redis_errors_fail_open(monkeypatch):
+    """Redis outages must not crash auth: get/put degrade to cache-miss / no-op."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    class BrokenRedis:
+        async def get(self, k):
+            raise ConnectionError("redis down")
+
+        async def set(self, k, v, ex=None):
+            raise TimeoutError("redis timeout")
+
+    async def fake_client():
+        return BrokenRedis()
+
+    monkeypatch.setattr(vc, "get_redis_client", fake_client)
+    await vc.invalidate_external_identity_cache()
+
+    payload = {"sub": "agent@corp.com", "token_use": "session", "exp": 9999999999}
+    # put must not raise despite Redis SET failure
+    await vc._external_identity_cache_put("th-broken", payload, token_exp=9999999999)
+    # get must not raise despite Redis GET failure, and must report a cache miss
+    assert await vc._external_identity_cache_get("th-broken") is None
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_inmemory_get_returns_copy(monkeypatch):
+    """In-memory cache hits must return a copy so callers mutating the result
+    (e.g. `_maybe_verify_external` setting `cached["token"] = token`) cannot
+    persist the raw token into the shared cache entry."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+
+    payload = {"sub": "agent@corp.com", "token_use": "session", "exp": 9999999999}
+    await vc._external_identity_cache_put("th-copy", payload, token_exp=9999999999)
+
+    first = await vc._external_identity_cache_get("th-copy")
+    first["token"] = "RAW-SECRET"
+
+    second = await vc._external_identity_cache_get("th-copy")
+    assert "token" not in second

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -224,3 +224,77 @@ async def test_verify_external_idp_token_valid(monkeypatch):
     claims, returned_prov = await vc.verify_external_idp_token(token, db)
     assert claims["sub"] == "agent"
     assert returned_prov is prov
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_no_issuer_claim(monkeypatch):
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    token = pyjwt.encode({"sub": "x"}, "k", algorithm="HS256")
+    db = MagicMock()
+    assert await vc.verify_external_idp_token(token, db) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_non_string_issuer(monkeypatch):
+    # Standard
+    # iss as a list is valid JWT JSON but must not crash the resolver.
+    # PyJWT's encode() rejects non-string "iss" claims, so build the token
+    # manually (header.payload.signature with arbitrary base64url segments)
+    # to simulate an attacker-controlled unverified token.
+    import base64
+    import json
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    def b64url(data: bytes) -> str:
+        return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+    header = b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = b64url(json.dumps({"iss": ["https://evil.example.com"], "sub": "x"}).encode())
+    token = f"{header}.{payload}.fakesig"
+
+    db = MagicMock()
+    assert await vc.verify_external_idp_token(token, db) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_provider_missing_issuer(monkeypatch):
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "x"}, "k", algorithm="HS256")
+    prov = _fake_provider("https://kc/realms/m")
+    prov.issuer = None
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+    db = MagicMock()
+    assert await vc.verify_external_idp_token(token, db) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_verification_fails(monkeypatch):
+    # Third-Party
+    import jwt as pyjwt
+
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    token = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "x"}, "k", algorithm="HS256")
+    prov = _fake_provider("https://kc/realms/m")
+    prov.api_audience = "api://my-app"
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    async def fake_verify(tok, authorization_servers, *, expected_audience=None):
+        return None
+
+    monkeypatch.setattr(vc, "verify_oauth_access_token", fake_verify)
+    db = MagicMock()
+    assert await vc.verify_external_idp_token(token, db) == (None, None)

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -368,3 +368,50 @@ async def test_build_external_identity_unknown_user_returns_none(monkeypatch):
     db = MagicMock()
     payload = await vc.build_external_identity(prov, {"sub": "ghost"}, "raw", db)
     assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_build_external_identity_empty_email_returns_none(monkeypatch):
+    """If user_info has no usable email after normalization, fail closed."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "keycloak"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "   ", "is_admin": False}
+
+    async def fake_auth(user_info):
+        return "token-string"
+
+    svc.authenticate_or_create_user = fake_auth
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m"}, "raw", db)
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_build_external_identity_missing_db_user_returns_none(monkeypatch):
+    """Provisioning succeeded but the user can't be found afterward -- fail closed."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "keycloak"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "agent@corp.com", "is_admin": False}
+
+    async def fake_auth(user_info):
+        return "token-string"
+
+    svc.authenticate_or_create_user = fake_auth
+
+    async def fake_get_user(email):
+        return None
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+    db = MagicMock()
+    payload = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m"}, "raw", db)
+    assert payload is None

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -1108,3 +1108,253 @@ async def test_g8_malformed_token_falls_through(monkeypatch):
     monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
     monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
     assert await vc._maybe_verify_external("not-a-jwt", request=None) is None
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_redis_miss_returns_none(monkeypatch):
+    """Redis GET returning None (no entry) is a clean cache miss."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    class EmptyRedis:
+        async def get(self, k):
+            return None
+
+        async def set(self, k, v, ex=None):
+            pass
+
+    async def fake_client():
+        return EmptyRedis()
+
+    monkeypatch.setattr(vc, "get_redis_client", fake_client)
+    await vc.invalidate_external_identity_cache()
+
+    assert await vc._external_identity_cache_get("missing-key") is None
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_redis_bad_json_returns_none(monkeypatch):
+    """A corrupted Redis payload (invalid JSON) is treated as a cache miss, not a crash."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    class CorruptRedis:
+        async def get(self, k):
+            return "{not-json"
+
+        async def set(self, k, v, ex=None):
+            pass
+
+    async def fake_client():
+        return CorruptRedis()
+
+    monkeypatch.setattr(vc, "get_redis_client", fake_client)
+    await vc.invalidate_external_identity_cache()
+
+    assert await vc._external_identity_cache_get("corrupt-key") is None
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_inmemory_expired_entry_evicted(monkeypatch):
+    """An in-memory cache entry past its monotonic expiry is evicted and reported as a miss."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+
+    # Insert an already-expired entry directly (bypass _external_identity_cache_put's TTL guard).
+    vc._external_identity_cache["th-expired"] = ({"sub": "agent@corp.com"}, vc.monotonic() - 1)
+
+    assert await vc._external_identity_cache_get("th-expired") is None
+    # Eviction on read: the stale entry must be removed from the map.
+    assert "th-expired" not in vc._external_identity_cache
+
+
+@pytest.mark.asyncio
+async def test_external_identity_cache_inmemory_evicts_when_full(monkeypatch):
+    """When the in-memory fallback cache reaches its size cap, it is cleared before inserting."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc, "_EXTERNAL_IDENTITY_MAX", 1)
+
+    payload_a = {"sub": "a@corp.com", "token_use": "session", "exp": 9999999999}
+    payload_b = {"sub": "b@corp.com", "token_use": "session", "exp": 9999999999}
+
+    await vc._external_identity_cache_put("th-a", payload_a, token_exp=9999999999)
+    assert "th-a" in vc._external_identity_cache
+
+    # Cache is now "full" (size 1 >= max 1); inserting another entry clears it first.
+    await vc._external_identity_cache_put("th-b", payload_b, token_exp=9999999999)
+    assert "th-a" not in vc._external_identity_cache
+    assert "th-b" in vc._external_identity_cache
+
+
+def test_has_trusted_providers_cold_cache_with_trusted_provider(monkeypatch):
+    """Cold cache path: _has_trusted_providers loads the resolver cache via the
+    provided DB session and returns True when a trusted provider exists."""
+    # First-Party
+    from mcpgateway.services import sso_service
+    from mcpgateway.utils import verify_credentials as vc
+
+    # Ensure resolver cache starts cold.
+    sso_service.invalidate_trusted_provider_cache()
+
+    provider = _fake_provider(issuer="https://idp.example.com")
+    db = _mock_db([provider])
+
+    assert vc._has_trusted_providers(db) is True
+    sso_service.invalidate_trusted_provider_cache()
+
+
+def test_has_trusted_providers_cold_cache_no_trusted_provider(monkeypatch):
+    """Cold cache path: returns False when no provider is trusted_for_api_auth."""
+    # First-Party
+    from mcpgateway.services import sso_service
+    from mcpgateway.utils import verify_credentials as vc
+
+    sso_service.invalidate_trusted_provider_cache()
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = []
+
+    assert vc._has_trusted_providers(db) is False
+    sso_service.invalidate_trusted_provider_cache()
+
+
+def test_has_trusted_providers_creates_own_session_when_db_none(monkeypatch):
+    """When no DB session is supplied, _has_trusted_providers opens and closes
+    its own session (own_session path)."""
+    # First-Party
+    from mcpgateway.services import sso_service
+    from mcpgateway.utils import verify_credentials as vc
+
+    sso_service.invalidate_trusted_provider_cache()
+
+    fake_db = MagicMock()
+    fake_db.query.return_value.filter.return_value.all.return_value = []
+
+    monkeypatch.setattr(vc, "SessionLocal", lambda: fake_db, raising=False)
+
+    # First-Party
+    import mcpgateway.db as db_module
+
+    monkeypatch.setattr(db_module, "SessionLocal", lambda: fake_db)
+
+    assert vc._has_trusted_providers(None) is False
+    fake_db.close.assert_called_once()
+    sso_service.invalidate_trusted_provider_cache()
+
+
+def test_has_trusted_providers_warm_cache_skips_db(monkeypatch):
+    """Once the resolver cache is warm, _has_trusted_providers is a pure
+    dict-truthiness check and performs no DB lookup."""
+    # First-Party
+    from mcpgateway.services import sso_service
+    from mcpgateway.utils import verify_credentials as vc
+
+    sso_service.invalidate_trusted_provider_cache()
+    sso_service._trusted_provider_cache = {"https://idp.example.com": "provider-1"}
+    sso_service._trusted_provider_cache_loaded_at = vc.monotonic()
+
+    db = MagicMock()
+    assert vc._has_trusted_providers(db) is True
+    db.query.assert_not_called()
+    sso_service.invalidate_trusted_provider_cache()
+
+
+@pytest.mark.asyncio
+async def test_verify_external_idp_token_malformed_jwt_returns_none(monkeypatch):
+    """A non-decodable token (PyJWTError on the unverified decode) is denied, not crashed."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    assert await vc.verify_external_idp_token("not-a-jwt-at-all", MagicMock()) == (None, None)
+
+
+def test_synthetic_service_principal_user_info_shape():
+    """_synthetic_service_principal_user_info builds a non-routable, pre-verified
+    service identity and carries through group/role claims for mapping."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    provider = _fake_provider("https://idp.example.com")
+    provider.id = "kc"
+    claims = {"sub": "svc-app", "azp": "svc-app", "groups": ["g1"], "extra": "ignored"}
+
+    info = vc._synthetic_service_principal_user_info(provider, claims)
+
+    assert info["email"] == "svc-svc-app@kc.service.local"
+    assert info["email_verified"] is True
+    assert info["full_name"] == "service:svc-app"
+    assert info["provider"] == "kc"
+    assert info["is_admin"] is False
+    assert info["groups"] == ["g1"]
+    assert "extra" not in info
+
+
+def test_synthetic_service_principal_user_info_falls_back_to_sub():
+    """Without azp/client_id, the synthetic identity is derived from ``sub``."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    provider = _fake_provider("https://idp.example.com")
+    provider.id = "kc"
+    claims = {"sub": "svc-app", "typ": "at+jwt"}
+
+    info = vc._synthetic_service_principal_user_info(provider, claims)
+    assert info["email"] == "svc-svc-app@kc.service.local"
+
+
+def test_get_sso_service_returns_sso_service_instance():
+    """_get_sso_service is a thin factory wrapping SSOService(db)."""
+    # First-Party
+    from mcpgateway.services.sso_service import SSOService
+    from mcpgateway.utils import verify_credentials as vc
+
+    db = MagicMock()
+    svc = vc._get_sso_service(db)
+    assert isinstance(svc, SSOService)
+
+
+@pytest.mark.asyncio
+async def test_build_external_identity_owned_session_commit_failure(monkeypatch):
+    """G7/M1: if the owned-session commit fails, build_external_identity rolls back,
+    logs the error, and returns None rather than raising."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "u@corp.com", "is_admin": False}
+
+    async def fake_auth(ui):
+        return "tok"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False
+
+    async def fake_get_user(e):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **kw):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+
+    db = MagicMock()
+    db.info = {"external_owned": True}
+    db.commit.side_effect = RuntimeError("commit failed")
+
+    result = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m", "email": "u@corp.com"}, "raw", db)
+
+    assert result is None
+    db.rollback.assert_called_once()

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -854,3 +854,252 @@ async def test_D3_emits_provider_counter(monkeypatch):
         lambda: (_ for _ in ()).throw(RuntimeError("obs down")),
     )
     vc._record_external_auth_metric("success", "kc")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_deny_flag_off(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", False)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
+    assert await vc._maybe_verify_external(tok, request=None) is None
+
+
+@pytest.mark.asyncio
+async def test_deny_untrusted_issuer(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+
+    async def fake_external(tok, db):
+        return (None, None)  # resolver found no trusted provider
+
+    build_calls = {"n": 0}
+
+    async def fake_build(provider, claims, token, db):
+        build_calls["n"] += 1
+        return {"sub": "should-not-be-reached", "token_use": "session"}
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
+    monkeypatch.setattr(vc, "build_external_identity", fake_build)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://evil/realms/m", "sub": "x"}, "k", algorithm="HS256")
+    assert await vc._maybe_verify_external(tok, request=None) is None
+    assert build_calls["n"] == 0  # claims is None -> must short-circuit before provisioning
+
+
+@pytest.mark.asyncio
+async def test_deny_unprovisioned_user(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+    prov = _fake_provider("https://kc/realms/m")
+
+    async def fake_external(tok, db):
+        return ({"iss": "https://kc/realms/m", "sub": "ghost"}, prov)
+
+    async def fake_build(provider, claims, token, db):
+        return None  # auto_create disabled, unknown user
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
+    monkeypatch.setattr(vc, "build_external_identity", fake_build)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "ghost"}, "k", algorithm="HS256")
+    assert await vc._maybe_verify_external(tok, request=None) is None
+
+
+@pytest.mark.asyncio
+async def test_deny_id_token_rejected(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    monkeypatch.setattr(vc, "resolve_trusted_provider_by_issuer", lambda iss, db: prov)
+
+    # verify_oauth_access_token rejects nonce/at_hash -> returns None
+    async def fake_oauth(tok, authorization_servers, *, expected_audience=None):
+        return None
+
+    monkeypatch.setattr(vc, "verify_oauth_access_token", fake_oauth)
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "nonce": "abc"}, "k", algorithm="HS256")
+    db = MagicMock()
+    assert await vc.verify_external_idp_token(tok, db) == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_c1_routing_guard_token_use_is_session(monkeypatch):
+    """C1: synthesized payload MUST be token_use='session' so it routes via the
+    DB-authority path, never normalize_token_teams (claim authority)."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "u@corp.com", "is_admin": False}
+
+    async def fake_auth(ui):
+        return "tok"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False
+
+    async def fake_get_user(e):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **kw):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+    payload = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m", "email": "u@corp.com"}, "raw", MagicMock())
+    assert payload["token_use"] == "session"
+    assert payload["token_use"] != "external_idp"
+
+
+@pytest.mark.asyncio
+async def test_c2_escalation_guard_claim_admin_db_nonadmin(monkeypatch):
+    """C2: claims map to admin, but DB user is non-admin -> payload.is_admin False."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "u@corp.com", "is_admin": True}  # claim says admin
+
+    async def fake_auth(ui):
+        return "tok"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False  # DB says NOT admin
+
+    async def fake_get_user(e):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **kw):
+        return ["t1"]
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+    payload = await vc.build_external_identity(prov, {"iss": "https://kc/realms/m", "email": "u@corp.com"}, "raw", MagicMock())
+    assert payload["is_admin"] is False
+    assert payload["teams"] is not None  # not admin bypass
+
+
+def test_g5_resolver_excludes_disabled_and_opted_out():
+    """G5: resolver must exclude is_enabled=false and trusted_for_api_auth=false."""
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()  # P1: avoid stale cache from prior tests
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = []  # filtered out by query
+    assert sso_service.resolve_trusted_provider_by_issuer("https://kc/realms/m", db) is None
+    filter_call = db.query.return_value.filter.call_args
+    assert filter_call is not None, "resolver must call .filter() with is_enabled AND trusted_for_api_auth"
+
+
+def test_g6_multi_provider_picks_matching_issuer():
+    """G6: with two trusted providers, the one whose issuer matches is returned."""
+    # First-Party
+    from mcpgateway.services import sso_service
+
+    sso_service.invalidate_trusted_provider_cache()  # P1
+    a = _fake_provider("https://idp-a.example.com")
+    a.id = "a"
+    b = _fake_provider("https://idp-b.example.com")
+    b.id = "b"
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [a, b]
+    db.query.return_value.filter.return_value.first.return_value = b
+    got = sso_service.resolve_trusted_provider_by_issuer("https://idp-b.example.com/", db)
+    assert got is b  # not a
+
+
+@pytest.mark.asyncio
+async def test_g7_owned_session_commits(monkeypatch):
+    """G7/M1: when build_external_identity owns the session, provisioning is committed."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    prov = _fake_provider("https://kc/realms/m")
+    prov.id = "kc"
+    svc = MagicMock()
+    svc._normalize_user_info.return_value = {"email": "u@corp.com", "is_admin": False}
+
+    async def fake_auth(ui):
+        return "tok"
+
+    svc.authenticate_or_create_user = fake_auth
+    du = MagicMock()
+    du.is_admin = False
+
+    async def fake_get_user(e):
+        return du
+
+    svc.auth_service.get_user_by_email = fake_get_user
+    monkeypatch.setattr(vc, "_get_sso_service", lambda db: svc)
+
+    async def fake_resolve(p, e, ui, **kw):
+        return []
+
+    monkeypatch.setattr("mcpgateway.auth.resolve_session_teams", fake_resolve)
+    db = MagicMock()
+    db.info = {"external_owned": True}
+    await vc.build_external_identity(prov, {"iss": "https://kc/realms/m", "email": "u@corp.com"}, "raw", db)
+    db.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_g3_human_token_not_clientless(monkeypatch):
+    """G3 (security): a token WITH email is never treated as a service principal,
+    even if it carries azp / typ:at+jwt."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    assert vc._is_clientless_token({"email": "real@corp.com", "azp": "app", "sub": "app"}) is False
+    assert vc._is_clientless_token({"email": "real@corp.com", "typ": "at+jwt"}) is False
+    # genuine service token (no email, sub==azp) IS clientless
+    assert vc._is_clientless_token({"sub": "app", "azp": "app"}) is True
+
+
+@pytest.mark.asyncio
+async def test_g8_malformed_token_falls_through(monkeypatch):
+    """G8: a non-JWT bearer string must not crash; external path returns None."""
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc, "get_redis_client", _async_none)
+    await vc.invalidate_external_identity_cache()
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+    monkeypatch.setattr(vc, "_has_trusted_providers", lambda db: True)
+    assert await vc._maybe_verify_external("not-a-jwt", request=None) is None

--- a/tests/unit/mcpgateway/utils/test_external_idp_auth.py
+++ b/tests/unit/mcpgateway/utils/test_external_idp_auth.py
@@ -469,3 +469,61 @@ async def test_service_principal_synthetic_identity(monkeypatch):
     assert seen.get("called") is True
     assert payload["sub"] == "svc-svc-client-123@keycloak.service.local"
     assert payload["token_use"] == "session"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_internal_token_skips_external(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    called = {"external": False}
+
+    async def fake_external(tok, db):
+        called["external"] = True
+        return (None, None)
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "mcpgateway", "sub": "internal"}, "k", algorithm="HS256")
+
+    async def fake_verify_jwt_token_cached(token, request=None):
+        return {"sub": "internal", "iss": "mcpgateway"}
+
+    monkeypatch.setattr(vc, "verify_jwt_token_cached", fake_verify_jwt_token_cached)
+
+    result = await vc.verify_credentials_cached(tok, request=None)
+    assert called["external"] is False
+    assert result["sub"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_external_token_routes_to_external(monkeypatch):
+    # First-Party
+    from mcpgateway.utils import verify_credentials as vc
+
+    monkeypatch.setattr(vc.settings, "sso_api_token_auth_enabled", True)
+    monkeypatch.setattr(vc.settings, "jwt_issuer", "mcpgateway")
+
+    prov = _fake_provider("https://kc/realms/m")
+
+    async def fake_external(tok, db):
+        return ({"iss": "https://kc/realms/m", "sub": "agent"}, prov)
+
+    async def fake_build(provider, claims, token, db):
+        return {"sub": "agent@corp.com", "token_use": "external_idp"}
+
+    monkeypatch.setattr(vc, "verify_external_idp_token", fake_external)
+    monkeypatch.setattr(vc, "build_external_identity", fake_build)
+
+    # Third-Party
+    import jwt as pyjwt
+
+    tok = pyjwt.encode({"iss": "https://kc/realms/m", "sub": "agent"}, "k", algorithm="HS256")
+
+    result = await vc.verify_credentials_cached(tok, request=None)
+    assert result["token_use"] == "external_idp"

--- a/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
+++ b/tests/unit/mcpgateway/utils/test_sso_bootstrap.py
@@ -679,8 +679,10 @@ class TestSSOBootstrapAsync:
 
                         # Should get DB session but not create any providers
                         mock_get_db.assert_called_once()
-                        # list_all_providers only called when sso_auto_disable_unconfigured_providers=True
-                        mock_service_instance.list_all_providers.assert_not_called()
+                        # list_all_providers is always called once, for the trusted_for_api_auth
+                        # confused-deputy audience-misconfiguration warning (independent of the
+                        # sso_auto_disable_unconfigured_providers flag).
+                        mock_service_instance.list_all_providers.assert_called_once()
                         mock_service_instance.create_provider.assert_not_called()
 
     @pytest.mark.asyncio
@@ -708,7 +710,9 @@ class TestSSOBootstrapAsync:
 
                         await bootstrap_sso_providers()
 
-                        mock_service_instance.list_all_providers.assert_called_once()
+                        # Called once for the auto-disable pass and once more for the
+                        # trusted_for_api_auth confused-deputy audience warning.
+                        assert mock_service_instance.list_all_providers.call_count == 2
                         mock_service_instance.update_provider.assert_called_once_with("old-provider", {"is_enabled": False})
 
 


### PR DESCRIPTION
## Summary

Closes #3567 — accept access tokens issued by an already-trusted external OIDC IdP (Keycloak, Microsoft Entra ID, generic OIDC) as `Bearer` credentials on API/MCP endpoints, validated via JWKS and mapped to the same RBAC identities as the browser SSO flow.

### Problem

ContextForge already trusts external IdPs for browser SSO (JWKS validation, JIT provisioning, role→team mapping), but that trust did not extend to programmatic access: an MCP client/agent presenting a `client_credentials` access token from the same IdP as a `Bearer` token was rejected, because `verify_credentials_cached` only ever validated internally-minted JWTs signed with `JWT_SECRET_KEY`.

### Approach

Single dispatch point in `verify_credentials_cached`:
- Decode the token's `iss` *without* verifying the signature, purely as a routing discriminator.
- If `iss` is internal (or the feature is disabled), fall through to the existing internal path unchanged — zero added cost.
- Otherwise, if `SSO_API_TOKEN_AUTH_ENABLED=true` and `iss` matches a `SSOProvider` with `trusted_for_api_auth=true`, validate via the existing `verify_oauth_access_token` (JWKS, SSRF defense, ID-token rejection, mandatory `api_audience` check), then JIT-provision + role-map via `build_external_identity`.

### Alternatives considered

| Approach | Summary | Verdict |
|---|---|---|
| **A. Fall-through in the existing bearer choke point** (chosen) | Branch on the token's unverified `iss` inside `verify_credentials_cached`: internal issuer → existing path unchanged; otherwise, if enabled, validate via `verify_oauth_access_token` against a trusted `SSOProvider` and map to a session identity. | **Chosen** — a single dispatch point automatically covers every endpoint that already depends on `require_auth` (API + MCP + admin), reuses 100% of the existing JWKS/SSRF/ID-token-rejection and SSO provisioning machinery, keeps default-deny, and internal tokens pay zero JWKS cost (the `iss` check short-circuits before any network call). |
| B. New dedicated auth dependency/middleware swapped across routers | A separate `require_external_or_internal_auth` dependency applied per-router. | Rejected — touches ~19 routers; easy to miss a path and create an inconsistent (potentially insecure) auth surface. |
| C. Edge middleware exchanges external token → mints a short-lived internal JWT | Validate at the edge, mint an internal JWT in place, leave the downstream stack untouched. | Rejected — adds per-request token minting/caching and extra crypto, muddies audit/revocation, overkill for the requirement. |

**Trust source:** trusted issuers are derived from existing `SSOProvider` rows rather than a new standalone issuer allowlist, because the role-mapping config (`team_mapping`, group claim names) a token needs already lives on the provider record — a separate allowlist would still have to point back at a provider, duplicating trust config. Reuse is explicit, not automatic: gated by both a global flag (`SSO_API_TOKEN_AUTH_ENABLED`, default off) and a per-provider opt-in (`trusted_for_api_auth`, default off), so a provider trusted for browser SSO is not silently trusted for API bearer auth.

### Identity mapping (security crux)

- External identities are synthesized with `token_use="session"` so they flow through the **DB-authoritative** `resolve_session_teams()` — never the claim-authority `normalize_token_teams()` path. This preserves the two-layer security model: Layer 1 (team visibility) is DB-derived, Layer 2 (RBAC) is unchanged.
- `is_admin` and team membership come from the persisted `EmailUser` / DB teams after provisioning — never from claims — so a token whose groups map to "admin" cannot grant admin unless the provisioned DB user is actually an admin.
- `client_credentials` tokens (no `email`/`email_verified`) get a synthetic, non-routable service-principal identity (`svc-<client_id>@<provider-id>.service.local`) provisioned through the same DB-authority path, without relaxing the human email-verified gate.

### Config & schema

- `SSO_API_TOKEN_AUTH_ENABLED` (global, default `false`) — preserves existing behavior unless explicitly enabled.
- `SSOProvider.trusted_for_api_auth` (per-provider opt-in, default `false`) and `SSOProvider.api_audience` — a provider trusted for browser SSO is *not* auto-trusted for API auth.
- `trusted_for_api_auth=true` requires a non-empty `api_audience` (enforced at provider create/update + startup check) to prevent confused-deputy/token-passing across a shared issuer.
- `EXTERNAL_IDENTITY_CACHE_TTL` (default 60s) bounds how long a provisioned external identity is cached per token, shared across workers via Redis when configured; invalidated immediately on provider create/update/delete.

### Performance & resilience

- Cached issuer→trusted-provider resolver (no table scan per request; untrusted issuers rejected with zero DB queries).
- Short-TTL, Redis-shared identity cache keyed by token hash (raw token never persisted); revocation/deactivation checks still run on every request outside the cache.
- Redis errors fail open (cache miss, auth unaffected); unexpected errors in the external path fail closed (401, never 500).
- Per-reason deny logging and a success-audit line (issuer, canonical email, provider id, `is_admin`, team count); all claim values sanitized for logs, token/payload never logged.
- Per-provider success/denied counters via `ObservabilityService.record_metric()` (best-effort, fail-open).

### Docs

New "machine-to-machine API auth" sections for Keycloak, Microsoft Entra ID, and generic OIDC, plus a troubleshooting checklist naming the deny-log strings, and security-model notes (AGENTS.md, rbac.md, multitenancy.md, oauth-design.md) documenting that external-IdP identities are session-semantics principals.

Admin UI exposure of the two new provider fields is deferred — the feature is fully configurable via `.env` + the existing provider CRUD API.

## Test Plan

- [ ] `make test` (unit suite)
- [ ] `tests/unit/mcpgateway/utils/test_external_idp_auth.py` — deny-path regression suite (untrusted issuer, opted-out/disabled provider, expired/tampered/ID token, missing/wrong audience, unprovisionable user, C1 routing guard, C2 escalation guard, H1 service-principal, cache/logging/exception behavior)
- [ ] `tests/integration/test_external_idp_auth_integration.py --with-integration` — un-mocked JWKS signature/audience validation, real `resolve_session_teams` team resolution, end-to-end `require_auth` + revocation

### Manual testing (Keycloak)

1. Register a Keycloak SSO provider in ContextForge as usual (browser SSO working).
2. In Keycloak: create a confidential client (e.g. `mcp-agent`) with **Service accounts roles** enabled, add an **Audience** mapper on its dedicated client scope set to a custom audience (e.g. `mcp-gateway`), and assign realm/client roles to the service account so they map to a ContextForge team via `SSO_KEYCLOAK_ROLE_MAPPINGS`.
3. Enable the global switch and opt the provider in:
   ```bash
   # .env
   SSO_API_TOKEN_AUTH_ENABLED=true

   curl -X PUT https://gateway.example.com/auth/sso/admin/providers/keycloak \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"trusted_for_api_auth": true, "api_audience": "mcp-gateway"}'
   ```
4. Fetch a `client_credentials` token and call the API directly with it:
   ```bash
   TOKEN=$(curl -s -X POST \
     https://keycloak.example.com/realms/master/protocol/openid-connect/token \
     -d "grant_type=client_credentials" \
     -d "client_id=mcp-agent" \
     -d "client_secret=$MCP_AGENT_CLIENT_SECRET" \
     | jq -r '.access_token')

   curl -H "Authorization: Bearer $TOKEN" https://gateway.example.com/tools
   ```
5. Verify: request succeeds (200), and the resolved identity is the synthetic service-principal `svc-mcp-agent@keycloak.service.local` with teams matching the mapped roles/groups (check via `/whoami` or audit log success line).
6. Deny paths:
   - Set `trusted_for_api_auth=false` (or `SSO_API_TOKEN_AUTH_ENABLED=false`) and re-call → `401`.
   - Call with a token whose `aud` doesn't match `api_audience` → `401`, deny-reason logged.
   - Deactivate the provisioned service-principal user in ContextForge and re-call (within cache TTL) → `401` (revocation check runs outside the identity cache).
