### PR TITLE
fix(gateway): propagate connection errors on gateway update

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-02T15:09:47Z",
+  "generated_at": "2026-07-02T15:27:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1604,
+        "line_number": 1599,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1692,
+        "line_number": 1687,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2042,
+        "line_number": 2037,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3408,
+        "line_number": 3403,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3499,
+        "line_number": 3494,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3542,
+        "line_number": 3537,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3547,
+        "line_number": 3542,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3552,
+        "line_number": 3547,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4284,7 +4284,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4419,
+        "line_number": 4463,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4304,7 +4304,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15016,
+        "line_number": 15004,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4314,7 +4314,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4322,7 +4322,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 193,
+        "line_number": 137,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4330,7 +4330,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 223,
+        "line_number": 167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4338,7 +4338,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 494,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-02T12:51:18Z",
+  "generated_at": "2026-07-02T15:09:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-02T14:13:52Z",
+  "generated_at": "2026-07-02T12:51:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -274,7 +274,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1599,
+        "line_number": 1604,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1687,
+        "line_number": 1692,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2037,
+        "line_number": 2042,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3403,
+        "line_number": 3408,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3494,
+        "line_number": 3499,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3537,
+        "line_number": 3542,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3542,
+        "line_number": 3547,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -330,7 +330,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3547,
+        "line_number": 3552,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4284,7 +4284,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4463,
+        "line_number": 4419,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4304,7 +4304,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15004,
+        "line_number": 15016,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4314,7 +4314,7 @@
         "hashed_secret": "6993a3fd94a012ab50fb6b9e97ec238310f0b177",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4322,7 +4322,7 @@
         "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 137,
+        "line_number": 193,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4330,7 +4330,7 @@
         "hashed_secret": "9ec4f370c96047d96f3eb3637ca9fd144ed6e21b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 167,
+        "line_number": 223,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -4338,7 +4338,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 494,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2828,7 +2828,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     logger.warning("Failed to initialize updated gateway: %s", gce)
                     reinit_succeeded = False
                 except Exception as e:
-                    logger.warning("Failed to initialize updated gateway: %s", e)
+                    logger.warning("Failed to initialize updated gateway: %s", sanitize_exception_message(str(e), auth_query_params_decrypted))
                     reinit_succeeded = False
 
                 # Update tags if provided

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2783,10 +2783,6 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                             safe_msg = sanitize_exception_message(str(init_err), auth_query_params_decrypted)
                             raise GatewayConnectionError(f"Failed to initialize gateway at {safe_url}: {safe_msg}") from init_err
                         raise
-                    new_tool_names = [tool.name for tool in tools]
-                    new_resource_uris = [resource.uri for resource in resources]
-                    new_prompt_names = [prompt.name for prompt in prompts]
-
                     if gateway_update.one_time_auth:
                         # For one-time auth, clear auth_type and auth_value after initialization
                         gateway.auth_type = "one_time_auth"

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2779,7 +2779,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         # and decide (via init_affecting_changed) whether to propagate as a 502
                         # or swallow as a best-effort cosmetic update (see visibility note ~2256).
                         if init_affecting_changed and not isinstance(init_err, GatewayConnectionError):
-                            raise GatewayConnectionError(f"Failed to initialize gateway at {gateway.url}: {init_err}") from init_err
+                            safe_url = sanitize_url_for_logging(gateway.url, auth_query_params_decrypted)
+                            safe_msg = sanitize_exception_message(str(init_err), auth_query_params_decrypted)
+                            raise GatewayConnectionError(f"Failed to initialize gateway at {safe_url}: {safe_msg}") from init_err
                         raise
                     new_tool_names = [tool.name for tool in tools]
                     new_resource_uris = [resource.uri for resource in resources]
@@ -2825,7 +2827,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         # rolls back (nothing committed) and the API returns 502, matching
                         # POST /gateways behavior.
                         raise
-                    logger.warning(f"Failed to initialize updated gateway: {gce}")
+                    logger.warning("Failed to initialize updated gateway: %s", gce)
                     reinit_succeeded = False
                 except Exception as e:
                     logger.warning("Failed to initialize updated gateway: %s", e)
@@ -2983,9 +2985,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             )
             raise gnfe
         except GatewayConnectionError as gce:
-            logger.error(f"GatewayConnectionError during gateway update: {gce}")
+            logger.error("GatewayConnectionError during gateway update: %s", gce)
             db.rollback()
-            raise gce
+            raise
         except IntegrityError as ie:
             logger.error("IntegrityErrors in group: %s", ie)
             db.rollback()

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2444,6 +2444,32 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 original_client_cert = getattr(gateway, "client_cert", None)
                 original_client_key = getattr(gateway, "client_key", None)
 
+                def _connection_field_pairs(include_signing: bool = True) -> tuple:
+                    """(new, old) pairs for connect-affecting fields, read at call time.
+
+                    Fields are re-read from `gateway` on every call (not cached) because
+                    callers invoke this at different points in the update flow, after
+                    `gateway` attributes may have been mutated in between (e.g. one_time_auth
+                    clearing auth_type/auth_value, query_param auth switching).
+                    """
+                    pairs = (
+                        (gateway.url, original_url),
+                        (gateway.transport, original_transport),
+                        (gateway.auth_type, original_auth_type),
+                        (gateway.auth_value, original_auth_value),
+                        (gateway.auth_query_params, original_auth_query_params),
+                        (gateway.oauth_config, original_oauth_config),
+                        (gateway.ca_certificate, original_ca_certificate),
+                        (getattr(gateway, "client_cert", None), original_client_cert),
+                        (getattr(gateway, "client_key", None), original_client_key),
+                    )
+                    if include_signing:
+                        pairs += (
+                            (gateway.ca_certificate_sig, original_ca_certificate_sig),
+                            (gateway.signing_algorithm, original_signing_algorithm),
+                        )
+                    return pairs
+
                 # Update fields if provided
                 if gateway_update.name is not None:
                     gateway.name = gateway_update.name
@@ -2653,20 +2679,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     db.commit()
                     db.refresh(gateway)
 
-                    _connect_field_changes = (
-                        (gateway.url, original_url),
-                        (gateway.transport, original_transport),
-                        (gateway.auth_type, original_auth_type),
-                        (gateway.auth_value, original_auth_value),
-                        (gateway.auth_query_params, original_auth_query_params),
-                        (gateway.oauth_config, original_oauth_config),
-                        (gateway.ca_certificate, original_ca_certificate),
-                        (gateway.ca_certificate_sig, original_ca_certificate_sig),
-                        (gateway.signing_algorithm, original_signing_algorithm),
-                        (getattr(gateway, "client_cert", None), original_client_cert),
-                        (getattr(gateway, "client_key", None), original_client_key),
-                    )
-                    if any(new_value != old_value for new_value, old_value in _connect_field_changes):
+                    if any(new_value != old_value for new_value, old_value in _connection_field_pairs()):
                         await _evict_upstream_sessions_for_gateway(str(gateway.id))
 
                     cache = _get_registry_cache()
@@ -2737,20 +2750,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 # Connection-affecting fields already written to `gateway` above; compare
                 # against the pre-update snapshot to decide whether a failed re-init must
                 # block the commit (vs. a cosmetic update tolerating an unreachable upstream).
-                init_affecting_changed = any(
-                    new != old
-                    for new, old in (
-                        (gateway.url, original_url),
-                        (gateway.transport, original_transport),
-                        (gateway.auth_type, original_auth_type),
-                        (gateway.auth_value, original_auth_value),
-                        (gateway.auth_query_params, original_auth_query_params),
-                        (gateway.oauth_config, original_oauth_config),
-                        (gateway.ca_certificate, original_ca_certificate),
-                        (getattr(gateway, "client_cert", None), original_client_cert),
-                        (getattr(gateway, "client_key", None), original_client_key),
-                    )
-                )
+                # ca_certificate_sig/signing_algorithm excluded: not passed to _initialize_gateway,
+                # so they can't affect connection re-init success/failure.
+                init_affecting_changed = any(new != old for new, old in _connection_field_pairs(include_signing=False))
 
                 try:
                     ca_certificate = getattr(gateway, "ca_certificate", None)
@@ -2863,20 +2865,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 # (name, description, tags, passthrough_headers, visibility, etc.)
                 # leave sessions alone to preserve the 1:1 downstream-session
                 # connection-reuse benefit.
-                _connect_field_changes = (
-                    (gateway.url, original_url),
-                    (gateway.transport, original_transport),
-                    (gateway.auth_type, original_auth_type),
-                    (gateway.auth_value, original_auth_value),
-                    (gateway.auth_query_params, original_auth_query_params),
-                    (gateway.oauth_config, original_oauth_config),
-                    (gateway.ca_certificate, original_ca_certificate),
-                    (gateway.ca_certificate_sig, original_ca_certificate_sig),
-                    (gateway.signing_algorithm, original_signing_algorithm),
-                    (getattr(gateway, "client_cert", None), original_client_cert),
-                    (getattr(gateway, "client_key", None), original_client_key),
-                )
-                if any(new_value != old_value for new_value, old_value in _connect_field_changes):
+                if any(new_value != old_value for new_value, old_value in _connection_field_pairs()):
                     await _evict_upstream_sessions_for_gateway(str(gateway.id))
 
                 # Invalidate cache after successful update

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -2734,6 +2734,24 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 # Initialize empty lists in case initialization fails
                 reinit_succeeded = False
 
+                # Connection-affecting fields already written to `gateway` above; compare
+                # against the pre-update snapshot to decide whether a failed re-init must
+                # block the commit (vs. a cosmetic update tolerating an unreachable upstream).
+                init_affecting_changed = any(
+                    new != old
+                    for new, old in (
+                        (gateway.url, original_url),
+                        (gateway.transport, original_transport),
+                        (gateway.auth_type, original_auth_type),
+                        (gateway.auth_value, original_auth_value),
+                        (gateway.auth_query_params, original_auth_query_params),
+                        (gateway.oauth_config, original_oauth_config),
+                        (gateway.ca_certificate, original_ca_certificate),
+                        (getattr(gateway, "client_cert", None), original_client_cert),
+                        (getattr(gateway, "client_key", None), original_client_key),
+                    )
+                )
+
                 try:
                     ca_certificate = getattr(gateway, "ca_certificate", None)
                     connection_material = await self._prepare_gateway_connection_material(
@@ -2743,17 +2761,30 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                         decrypt_client_key=True,
                         log_context="gateway re-init",
                     )
-                    capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
-                        connection_material.url,
-                        gateway.auth_value,
-                        gateway.transport,
-                        gateway.auth_type,
-                        gateway.oauth_config,
-                        ca_certificate,
-                        auth_query_params=auth_query_params_decrypted,
-                        client_cert=connection_material.client_cert,
-                        client_key=connection_material.client_key,
-                    )
+                    try:
+                        capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
+                            connection_material.url,
+                            gateway.auth_value,
+                            gateway.transport,
+                            gateway.auth_type,
+                            gateway.oauth_config,
+                            ca_certificate,
+                            auth_query_params=auth_query_params_decrypted,
+                            client_cert=connection_material.client_cert,
+                            client_key=connection_material.client_key,
+                        )
+                    except Exception as init_err:
+                        # New URL/auth/TLS config is unreachable or invalid. Wrap non-connection
+                        # errors so the outer handler can recognize this as a connection failure
+                        # and decide (via init_affecting_changed) whether to propagate as a 502
+                        # or swallow as a best-effort cosmetic update (see visibility note ~2256).
+                        if init_affecting_changed and not isinstance(init_err, GatewayConnectionError):
+                            raise GatewayConnectionError(f"Failed to initialize gateway at {gateway.url}: {init_err}") from init_err
+                        raise
+                    new_tool_names = [tool.name for tool in tools]
+                    new_resource_uris = [resource.uri for resource in resources]
+                    new_prompt_names = [prompt.name for prompt in prompts]
+
                     if gateway_update.one_time_auth:
                         # For one-time auth, clear auth_type and auth_value after initialization
                         gateway.auth_type = "one_time_auth"
@@ -2788,6 +2819,14 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     self._active_gateways.discard(gateway.url)
                     self._active_gateways.add(gateway.url)
                     reinit_succeeded = True
+                except GatewayConnectionError as gce:
+                    if init_affecting_changed:
+                        # Do NOT persist the broken update — propagate so the outer handler
+                        # rolls back (nothing committed) and the API returns 502, matching
+                        # POST /gateways behavior.
+                        raise
+                    logger.warning(f"Failed to initialize updated gateway: {gce}")
+                    reinit_succeeded = False
                 except Exception as e:
                     logger.warning("Failed to initialize updated gateway: %s", e)
                     reinit_succeeded = False
@@ -2943,6 +2982,10 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 error=gnfe,
             )
             raise gnfe
+        except GatewayConnectionError as gce:
+            logger.error(f"GatewayConnectionError during gateway update: {gce}")
+            db.rollback()
+            raise gce
         except IntegrityError as ie:
             logger.error("IntegrityErrors in group: %s", ie)
             db.rollback()

--- a/tests/e2e/test_gateway_async_lifecycle.py
+++ b/tests/e2e/test_gateway_async_lifecycle.py
@@ -301,6 +301,69 @@ async def test_sqlite_async_gateway_lifecycle_happy_path(lifecycle_client):
 
 
 @pytest.mark.asyncio
+async def test_sqlite_async_gateway_update_bad_url_defers_failure_to_worker(lifecycle_client, monkeypatch):
+    client, live_gateway_service = lifecycle_client
+
+    create_response = await client.post(
+        "/gateways",
+        json={"name": "bad-update-gateway", "url": "http://example.com/original", "transport": "SSE"},
+        headers=TEST_AUTH_HEADER,
+    )
+    assert create_response.status_code == 202
+    gateway_id = create_response.json()["id"]
+
+    live_gateway_service._initialize_gateway = AsyncMock(
+        return_value=(
+            {"tools": {"listChanged": True}},
+            [_make_tool("initial_tool", "Initial tool")],
+            [],
+            [],
+            [],
+        )
+    )
+    await live_gateway_service._run_gateway_lifecycle_pass()
+
+    active_response = await client.get(f"/gateways/{gateway_id}", headers=TEST_AUTH_HEADER)
+    assert active_response.status_code == 200
+    assert active_response.json()["status"] == "active"
+
+    bad_url = "http://example.com/bad-update"
+    update_response = await client.put(
+        f"/gateways/{gateway_id}",
+        json={"url": bad_url},
+        headers=TEST_AUTH_HEADER,
+    )
+    assert update_response.status_code == 202
+    updated_pending = update_response.json()
+    assert updated_pending["status"] == "pending"
+    assert updated_pending["reachable"] is False
+    assert updated_pending["url"] == bad_url
+    assert _response_value(updated_pending, "registration_attempts") == 0
+    assert _response_value(updated_pending, "next_retry_at") is None
+    assert _response_value(updated_pending, "last_error") is None
+
+    persisted_pending_response = await client.get("/admin/gateways/bad-update-gateway", headers=TEST_ADMIN_AUTH_HEADER)
+    assert persisted_pending_response.status_code == 200
+    persisted_pending = persisted_pending_response.json()
+    assert persisted_pending["status"] == "pending"
+    assert persisted_pending["url"] == bad_url
+
+    failure_message = "Connection refused: http://example.com/bad-update"
+    monkeypatch.setattr(live_gateway_service, "_initialize_gateway_with_timeout", AsyncMock(side_effect=RuntimeError(failure_message)))
+    await live_gateway_service._run_gateway_lifecycle_pass()
+
+    retry_response = await client.get("/admin/gateways/bad-update-gateway", headers=TEST_ADMIN_AUTH_HEADER)
+    assert retry_response.status_code == 200
+    retry_gateway = retry_response.json()
+    assert retry_gateway["status"] == "pending"
+    assert retry_gateway["reachable"] is False
+    assert _response_value(retry_gateway, "registration_attempts") == 1
+    assert _response_value(retry_gateway, "next_retry_at") is not None
+    assert _response_value(retry_gateway, "last_error") == failure_message
+    assert _response_value(retry_gateway, "status_message") == failure_message
+
+
+@pytest.mark.asyncio
 async def test_sqlite_async_gateway_lifecycle_retry_and_delete_stop_flow(lifecycle_client):
     client, live_gateway_service = lifecycle_client
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1549,6 +1549,35 @@ class TestGatewayService:
         test_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_update_gateway_url_generic_exception_wraps_and_sanitizes(self, gateway_service, mock_gateway, test_db):
+        """Generic Exception on re-init with connection-affecting change wraps into GatewayConnectionError.
+
+        Covers sanitize_url_for_logging / sanitize_exception_message path (#5188).
+        """
+        test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
+        test_db.commit = Mock()
+        test_db.rollback = Mock()
+        test_db.refresh = Mock()
+        test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
+
+        gateway_service._initialize_gateway = AsyncMock(
+            side_effect=Exception("Connection refused: http://example.com?api_key=secret123")  # pragma: allowlist secret
+        )
+        gateway_service._notify_gateway_updated = AsyncMock()
+        url = GatewayService.normalize_url("http://example.com/new-url")
+        gateway_update = GatewayUpdate(url=url)
+
+        mock_gateway_read = MagicMock()
+        mock_gateway_read.masked.return_value = mock_gateway_read
+
+        with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
+            with pytest.raises(GatewayConnectionError):
+                await gateway_service.update_gateway(test_db, 1, gateway_update)
+
+        test_db.commit.assert_not_called()
+        test_db.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_update_gateway_visibility_propagates_when_init_fails(self, gateway_service, mock_gateway, test_db):
         """Visibility change must propagate to linked tools/prompts/resources even when gateway init fails."""
         # Set up linked items with old visibility

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -1571,9 +1571,11 @@ class TestGatewayService:
         mock_gateway_read.masked.return_value = mock_gateway_read
 
         with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
-            with pytest.raises(GatewayConnectionError):
+            with pytest.raises(GatewayConnectionError) as exc_info:
                 await gateway_service.update_gateway(test_db, 1, gateway_update)
 
+        # Secret query-param value must be sanitized out of the propagated message
+        assert "secret123" not in str(exc_info.value)
         test_db.commit.assert_not_called()
         test_db.rollback.assert_called_once()
 

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -835,6 +835,9 @@ class TestGatewayService:
         """update_gateway persists ca_certificate, ca_certificate_sig, signing_algorithm, client_cert, and client_key."""
         mock_gateway.team_id = 1
         execute_results = [_make_execute_result(scalar=mock_gateway), _make_execute_result(scalar=None)]
+        # Extra results for the stale-tool bulk-delete statements (ToolMetric,
+        # server_tool_association, DbTool) triggered by mock_gateway's dummy tool.
+        execute_results += [_make_execute_result(rowcount=0) for _ in range(5)]
         test_db.execute = Mock(side_effect=execute_results)
         test_db.commit = Mock()
         test_db.refresh = Mock()
@@ -1516,10 +1519,15 @@ class TestGatewayService:
 
     @pytest.mark.asyncio
     async def test_update_gateway_url_initialization_failure(self, gateway_service, mock_gateway, test_db):
-        """Test updating gateway URL when initialization fails."""
+        """Test updating gateway URL when initialization fails.
+
+        A connection-affecting change (URL) combined with a re-init failure must
+        propagate GatewayConnectionError and roll back, not silently commit (#5188).
+        """
         # Use return_value for all execute calls
         test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
         test_db.commit = Mock()
+        test_db.rollback = Mock()
         test_db.refresh = Mock()
         # Mock the query for team name lookup
         test_db.query = Mock(return_value=Mock(filter=Mock(return_value=Mock(first=Mock(return_value=None)))))
@@ -1533,12 +1541,12 @@ class TestGatewayService:
         mock_gateway_read = MagicMock()
         mock_gateway_read.masked.return_value = mock_gateway_read
 
-        # Should not raise exception, just log warning
         with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
-            await gateway_service.update_gateway(test_db, 1, gateway_update)
+            with pytest.raises(GatewayConnectionError):
+                await gateway_service.update_gateway(test_db, 1, gateway_update)
 
-        assert mock_gateway.url == url
-        test_db.commit.assert_called_once()
+        test_db.commit.assert_not_called()
+        test_db.rollback.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_update_gateway_visibility_propagates_when_init_fails(self, gateway_service, mock_gateway, test_db):

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -8405,10 +8405,21 @@ async def test_update_gateway_direct_proxy_rejected_when_disabled(gateway_servic
     existing_gateway.url = "https://existing.example.com"
     existing_gateway.enabled = True
     existing_gateway.gateway_mode = "cache"
+    existing_gateway.transport = "SSE"
+    existing_gateway.auth_type = None
+    existing_gateway.auth_value = None
+    existing_gateway.auth_query_params = None
+    existing_gateway.oauth_config = None
+    existing_gateway.ca_certificate = None
+    existing_gateway.ca_certificate_sig = None
+    existing_gateway.signing_algorithm = None
+    existing_gateway.client_cert = None
+    existing_gateway.client_key = None
     existing_gateway.tools = []
     existing_gateway.resources = []
     existing_gateway.prompts = []
     existing_gateway.email_team = None
+    existing_gateway.version = 1
 
     # get_for_update returns the existing gateway (first call) and None (slug-check)
     monkeypatch.setattr(
@@ -8436,6 +8447,7 @@ async def test_update_gateway_direct_proxy_rejected_when_disabled(gateway_servic
 
     db = MagicMock()
     db.rollback = MagicMock()
+    gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], []))
 
     with patch("mcpgateway.services.gateway_service.settings", mock_settings):
         with pytest.raises(GatewayError, match="disabled"):

--- a/tests/unit/mcpgateway/services/test_upstream_session_registry_lifecycle.py
+++ b/tests/unit/mcpgateway/services/test_upstream_session_registry_lifecycle.py
@@ -330,7 +330,7 @@ async def test_update_gateway_with_url_change_calls_registry_evict_gateway():
     test_db.commit = Mock()
     test_db.refresh = Mock()
 
-    service._initialize_gateway = AsyncMock(return_value=({"prompts": {}, "resources": {}, "tools": {}}, [], [], []))
+    service._initialize_gateway = AsyncMock(return_value=({"prompts": {}, "resources": {}, "tools": {}}, [], [], [], []))
     service._notify_gateway_updated = AsyncMock()
     service._active_gateways = set()
     service._classification_service = None

--- a/tests/unit/mcpgateway/test_multi_auth_headers.py
+++ b/tests/unit/mcpgateway/test_multi_auth_headers.py
@@ -325,7 +325,7 @@ class TestMultiAuthHeaders:
         mock_db.refresh = MagicMock()
         mock_db.query = MagicMock(return_value=MagicMock(filter=MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))))
 
-        monkeypatch.setattr(service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], [])))
+        monkeypatch.setattr(service, "_initialize_gateway", AsyncMock(return_value=({}, [], [], [], [])))
         monkeypatch.setattr(service, "_update_or_create_tools", MagicMock(return_value=[]))
         monkeypatch.setattr(service, "_update_or_create_resources", MagicMock(return_value=[]))
         monkeypatch.setattr(service, "_update_or_create_prompts", MagicMock(return_value=[]))


### PR DESCRIPTION
## Summary
- `PUT /gateways/{id}` previously swallowed `_initialize_gateway` failures during update and committed the new (broken) config anyway, returning 200 for an unreachable/invalid gateway URL — unlike `POST /gateways`, which correctly returns 502.
- Now, when a connection-affecting field (`url`, `transport`, `auth_type`/`auth_value`/`auth_query_params`, `oauth_config`, `ca_certificate`, `client_cert`/`client_key`) changes and re-initialization fails, the error propagates as `GatewayConnectionError`, the transaction rolls back, and the API returns 502 — matching `POST` behavior.
- Cosmetic-only updates (name/description/tags/visibility) on an already-unreachable gateway still commit, preserving the existing best-effort behavior (issue #4205 / visibility propagation).
- <Extended by @ja8zyjits >
- When `GATEWAY_ASYNC_LIFECYCLE_ENABLED=true`, update failures remain deferred to the async lifecycle worker: `PUT` returns `202 pending`, persists the new config, and retry metadata is recorded by the worker.
 

Closes #5188

## Test plan
- [x] `tests/unit/mcpgateway/services/test_gateway_service.py::test_update_gateway_url_initialization_failure` updated to assert `GatewayConnectionError` propagates and commit is not called when a connection-affecting field changes and re-init fails.
- [x] `tests/unit/mcpgateway/services/test_gateway_service.py::test_update_gateway_visibility_propagates_when_init_fails` (regression guard) confirms cosmetic-only updates still commit when init fails.
- [x] `tests/unit/mcpgateway/test_main_error_handlers.py::test_update_gateway_connection_error` confirms API-level 502 mapping.
- [x] Full gateway service + main error handler suites pass (354 passed).
- <Extended by @ja8zyjits >
- [x] Added SQLite async lifecycle regression coverage for bad URL update: `PUT` returns `202 pending`, persists the new URL, and worker failure records retry metadata instead of returning route-level `502`.
- [x]  `pytest tests/e2e/test_gateway_async_lifecycle.py -v`
- [x] `pytest tests/unit/mcpgateway/services/test_gateway_service.py -v -k "async_lifecycle or url_initialization_failure"`