### PR TITLE
fix: Update s390x Containerfile to use rustup for latest Rust compiler

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -242,5 +242,3 @@ jobs:
           else
             exit 1
           fi
-
-

--- a/infra/s390x/Containerfile
+++ b/infra/s390x/Containerfile
@@ -32,8 +32,6 @@ RUN microdnf update -y && \
         cmake \
         openssl-devel \
         libffi-devel \
-        rust \
-        cargo \
         jq \
         autoconf \
         automake \
@@ -41,7 +39,11 @@ RUN microdnf update -y && \
         postgresql-devel && \
     microdnf clean all && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
-    python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel
+    python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o ./rustup.sh && \
+    bash ./rustup.sh -y
+
+ENV PATH="~/.cargo/bin:$PATH"
 
 # s390x does not support BoringSSL — force grpcio to build against OpenSSL
 ENV GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True


### PR DESCRIPTION
## Problem

The s390x wheel build job has been failing because the system-provided Rust compiler (1.92.0) is too old for the `granian` dependency, which requires Rust 1.95+.

Error from failed build:
```
error: rustc 1.92.0 is not supported by the following package:
  sysinfo@0.39.3 requires rustc 1.95
```

## Solution

This PR updates `infra/s390x/Containerfile` to:
1. Remove the system `rust` and `cargo` packages from microdnf
2. Install Rust via rustup to get the latest stable toolchain
3. Set PATH to include `~/.cargo/bin`

This ensures the s390x build environment has a current Rust compiler that meets the requirements of all dependencies.

## Testing

- [ ] s390x wheel build workflow completes successfully
- [ ] All wheels build without Rust version errors

Signed-off-by: Jonathan Springer <jps@s390x.com>