### PR TITLE
fix(playwright): user deletion FK cascade, team selector delegation, …

### DIFF
--- a/mcpgateway/admin_ui/eventDelegation.js
+++ b/mcpgateway/admin_ui/eventDelegation.js
@@ -116,6 +116,17 @@ function executeAction(action, args, event, eventFirst = false) {
  * @param {Event} event - The click event
  */
 function handleDelegatedClick(event) {
+  // Handle team selector item clicks (data-action="select-team" on buttons injected
+  // via innerHTML, where onclick attributes are stripped by the innerHTML guard).
+  const selectTeamTarget = event.target.closest('[data-action="select-team"]');
+  if (selectTeamTarget) {
+    event.preventDefault();
+    if (window.Admin && typeof window.Admin.selectTeamFromSelector === 'function') {
+      window.Admin.selectTeamFromSelector(selectTeamTarget);
+    }
+    return;
+  }
+
   const target = event.target.closest('[data-action-click]');
   if (!target) return;
 

--- a/mcpgateway/services/email_auth_service.py
+++ b/mcpgateway/services/email_auth_service.py
@@ -2077,10 +2077,16 @@ class EmailAuthService:
 
                         if len(all_members) == 1 and all_members[0].user_email == email:
                             # This is a single-user personal team - cascade delete it
-                            logger.info("Deleting personal team '%s' (single member: %s)", SecurityValidator.sanitize_log_message(team.name), SecurityValidator.sanitize_log_message(email))
-                            # Delete team members first (should be just the owner)
-                            delete_team_members_stmt = delete(EmailTeamMember).where(EmailTeamMember.team_id == team.id)
-                            self.db.execute(delete_team_members_stmt)
+                            logger.info(f"Deleting personal team '{SecurityValidator.sanitize_log_message(team.name)}' (single member: {SecurityValidator.sanitize_log_message(email)})")
+                            # Delete history records first: team_id FK has no ON DELETE CASCADE,
+                            # so history must be removed before the team is deleted.
+                            self.db.execute(delete(EmailTeamMemberHistory).where(EmailTeamMemberHistory.team_id == team.id))
+                            # Delete team members via raw SQL.
+                            self.db.execute(delete(EmailTeamMember).where(EmailTeamMember.team_id == team.id))
+                            # Expire the members collection so the ORM cascade re-queries the DB
+                            # (finding nothing) instead of re-deleting already-gone objects,
+                            # which would raise StaleDataError at commit time.
+                            self.db.expire(team, ["members"])
                             # Delete the team
                             self.db.delete(team)
                         else:

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -4447,6 +4447,7 @@ class ToolService(BaseService):
         # ═══════════════════════════════════════════════════════════════════════════
         # First-Party
         from mcpgateway.transports.context import request_headers_var  # pylint: disable=import-outside-toplevel
+
         if request_headers:
             request_headers_var.set(request_headers)
         # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/playwright/test_api_integration.py
+++ b/tests/playwright/test_api_integration.py
@@ -177,6 +177,11 @@ class TestAPIIntegration:
             # Tool IDs are UUID strings, not integers - pass as quoted string
             import json
 
+            # HTMX pushes the search query into the URL via hx-push-url; Playwright
+            # treats that pushState as an in-flight navigation.  Waiting for
+            # domcontentloaded ensures the navigation event has settled before we
+            # evaluate JS, preventing "execution context was destroyed" errors.
+            page.wait_for_load_state("domcontentloaded", timeout=5000)
             page.evaluate(f"Admin.testTool({json.dumps(tool_id)})")
         else:
             # Fallback if data attribute is missing

--- a/tests/unit/mcpgateway/services/test_email_auth_basic.py
+++ b/tests/unit/mcpgateway/services/test_email_auth_basic.py
@@ -2717,6 +2717,7 @@ class TestEmailAuthServiceUserDeletion:
             mock_teams_result,
             mock_no_owners,  # No other owners
             mock_single_member,  # Just the user as member
+            mock_empty,  # Delete team member history records
             mock_empty,  # Delete team members
             mock_empty,  # Delete auth events
             mock_empty,  # Delete user team members

--- a/tests/unit/mcpgateway/validation/test_tags.py
+++ b/tests/unit/mcpgateway/validation/test_tags.py
@@ -241,7 +241,9 @@ class TestConfigurableTagLimits:
         assert TagValidator.validate(system_tag) is True
 
         # Very long descriptive tag (186 chars - adjusted)
-        long_tag = "machine-learning-natural-language-processing-transformer-based-sentiment-analysis-production-deployment-version-2-team-ai-research-department-engineering-organization-enterprise-customer"
+        long_tag = (
+            "machine-learning-natural-language-processing-transformer-based-sentiment-analysis-production-deployment-version-2-team-ai-research-department-engineering-organization-enterprise-customer"
+        )
         assert len(long_tag) == 186
         assert TagValidator.validate(long_tag) is True
 


### PR DESCRIPTION
Closes https://github.ibm.com/contextforge-org/internal_issues/issues/297/

Three Playwright tests are improved.

1. `test_delete_user` - HTTP 400 on `DELETE /admin/users/<email>`

`delete_user` in `EmailAuthService `was raising a SQLAlchemy `StaleDataError` at commit time when deleting a user who owned a single-member personal team. The original code bulk-deleted team members via raw SQL, then called `session.delete(team)`. At flush, the ORM's `cascade="all, delete-orphan"` on `EmailTeam.members` tried to re-DELETE the same objects (still in the session identity map) - 0 rows affected → StaleDataError → HTTP 400.

The fix:
  1. Explicitly deletes `EmailTeamMemberHistory` rows by `team_id` first — that FK has no `ON DELETE CASCADE` so it must be removed before the team row is.
  2. Keeps the raw SQL member delete to clear the rows from the DB.
  3. Calls `session.expire(team, ["members"])` so the ORM cascade re-queries the (now-empty) collection at flush instead of attempting to re-delete already-gone objects.

The corresponding unit test mock's side_effect list is updated to expect the additional `execute()` call.

2. `test_iframe_team_selector_onclick_stripped_but_delegation_works` - `team_id` absent from iframe URL after clicking team

Team selector buttons injected via innerHTML (and processed by the innerHTML guard that strips on* attributes) carry `data-action="select-team"` but had no event listener. The `handleDelegatedClick` function in `eventDelegation.js` only handled `[data-action-click]`, so clicking a team item did nothing and `updateTeamContext` was never called.

The fix adds a `[data-action="select-team"]` check at the top of `handleDelegatedClick` that calls `window.Admin.selectTeamFromSelector(target)` — the same function already used for direct-onclick paths. The JS bundle is rebuilt.

3. `test_should_handle_object_parameter_validation` - "Execution context was destroyed" on `page.evaluate`

After `search_input.press("Enter")`, HTMX pushes the search query into the URL via `hx-push-url`. Playwright treats the resulting `history.pushState` as an in-flight navigation. If `page.evaluate("Admin.testTool(...)")` is called before that navigation event settles, Playwright destroys the execution context mid-call. A `page.wait_for_load_state("domcontentloaded")` before the evaluate ensures the navigation has completed before
  JavaScript is injected.
