### PR TITLE
fix(session-affinity): carry the edge-validated auth context across cross-worker forwards

### DIFF
--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -221,6 +221,27 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
     return None
 
 
+def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
+    """Encode a trusted internal MCP auth context for forwarding.
+
+    Mirror of :func:`decode_internal_mcp_auth_context`. Used to package the
+    StreamableHTTP auth result (whatever ``streamable_http_auth()`` already
+    established at the edge) so it can be propagated to a trusted internal
+    dispatcher (e.g. ``/_internal/mcp/rpc``) without that dispatcher re-running
+    authentication. The unpadded base64url shape keeps the value header-safe.
+
+    Args:
+        auth_context: Auth-context dict (typically the return value of
+            :func:`mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context`).
+
+    Returns:
+        Unpadded base64url-encoded JSON payload suitable for the
+        ``x-contextforge-auth-context`` header.
+    """
+    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
+    return encoded.rstrip("=")
+
+
 def decode_internal_mcp_auth_context(header_value: str) -> Dict[str, Any]:
     """Decode the trusted internal MCP auth header payload.
 

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -222,20 +222,18 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
 
 
 def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
-    """Encode a trusted internal MCP auth context for forwarding.
+    """Encode an edge-validated auth context for forwarding to a trusted internal dispatcher.
 
-    Mirror of :func:`decode_internal_mcp_auth_context`. Used to package the
-    StreamableHTTP auth result (whatever ``streamable_http_auth()`` already
-    established at the edge) so it can be propagated to a trusted internal
-    dispatcher (e.g. ``/_internal/mcp/rpc``) without that dispatcher re-running
-    authentication. The unpadded base64url shape keeps the value header-safe.
+    Mirror of :func:`decode_internal_mcp_auth_context`. Packages the auth context
+    so a trusted internal dispatcher (e.g. ``/_internal/mcp/rpc``) can use it
+    without re-running authentication. The unpadded base64url shape keeps the
+    value header-safe.
 
     Args:
-        auth_context: Auth-context dict (typically the return value of
-            :func:`mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context`).
+        auth_context: Auth-context dict to encode.
 
     Returns:
-        Unpadded base64url-encoded JSON payload suitable for the
+        Unpadded base64url-encoded JSON payload for the
         ``x-contextforge-auth-context`` header.
     """
     encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -458,6 +458,7 @@ class Settings(BaseSettings):
             "/sse",  # Exempt: SSE is a server-sent event stream, not vulnerable to CSRF
             "/message",  # Exempt: MCP SSE message endpoint
             "/rpc",  # Exempt: JSON-RPC is a programmatic protocol, not browser-based
+            "/_internal/mcp/",  # Exempt: loopback-only, HMAC-gated internal dispatch (affinity/Rust forwards); not browser-reachable
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -277,18 +277,30 @@ _INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
 
 
 def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
-    """Return whether the request came from the local Rust runtime sidecar.
+    """Return whether the request came from a trusted local internal source.
+
+    Two callers are trusted today:
+
+    - ``"rust"`` — the local Rust runtime sidecar (over loopback).
+    - ``"affinity"`` — the in-process ASGITransport dispatch used by
+      session-affinity forwarding to propagate a request to the owner worker
+      after the originating worker already ran ``streamable_http_auth()``.
+
+    Both share the same defense-in-depth gates: a shared-secret-derived auth
+    header (``has_valid_internal_mcp_runtime_auth_header``) AND a loopback
+    client address. Only the ``x-contextforge-mcp-runtime`` marker value
+    differs.
 
     Args:
         request: Incoming request to inspect.
 
     Returns:
-        ``True`` when the request carries the trusted Rust runtime marker from
-        loopback, otherwise ``False``.
+        ``True`` when the request carries a trusted internal-runtime marker
+        from loopback, otherwise ``False``.
     """
     runtime_marker = request.headers.get("x-contextforge-mcp-runtime")
     client_host = getattr(getattr(request, "client", None), "host", None)
-    if runtime_marker != "rust" or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
+    if runtime_marker not in ("rust", "affinity") or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
         return False
     # Defense-in-depth: /_internal/a2a/* endpoints must refuse requests when
     # A2A support is disabled, even from an otherwise-trusted local sidecar.

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -282,14 +282,12 @@ def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
     Two callers are trusted today:
 
     - ``"rust"`` — the local Rust runtime sidecar (over loopback).
-    - ``"affinity"`` — the in-process ASGITransport dispatch used by
-      session-affinity forwarding to propagate a request to the owner worker
-      after the originating worker already ran ``streamable_http_auth()``.
+    - ``"affinity"`` — the in-process dispatch used by session-affinity
+      forwarding to reach the owner worker, carrying the identity the edge
+      already validated.
 
-    Both share the same defense-in-depth gates: a shared-secret-derived auth
-    header (``has_valid_internal_mcp_runtime_auth_header``) AND a loopback
-    client address. Only the ``x-contextforge-mcp-runtime`` marker value
-    differs.
+    Both share the same gates: a shared-secret HMAC header AND a loopback client
+    address. Only the ``x-contextforge-mcp-runtime`` marker value differs.
 
     Args:
         request: Incoming request to inspect.

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -49,6 +49,7 @@ from mcpgateway.services.upstream_session_registry import (  # re-exported as th
     MessageHandlerFactory,
 )
 from mcpgateway.utils.internal_http import (
+    internal_loopback_base_url,
     post_rpc_in_process,
 )
 
@@ -1021,27 +1022,42 @@ class SessionAffinity:
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
         """Execute a forwarded Streamable HTTP request in-process and reply via Redis.
 
-        A forwarded request always lands here on the worker that OWNS the
-        downstream session (its ``WORKER_ID`` matched the Redis owner key), so the
-        bound upstream session in this process's ``UpstreamSessionRegistry`` can
-        serve it. We therefore dispatch the JSON-RPC call to the local ``/rpc``
-        route via an **in-process ASGI transport** instead of a network loopback
-        to ``127.0.0.1``: a real loopback hits the shared gunicorn socket and the
-        kernel routes it to an arbitrary worker that does not hold this session,
-        which breaks upstream-session reuse and fails the request. The
-        ``x-forwarded-internally`` header stops the re-entered handler from
-        forwarding again.
+        A forwarded request lands here on the worker that OWNS the downstream
+        session, so the bound upstream session in this process's
+        ``UpstreamSessionRegistry`` can serve it. We dispatch to the **trusted
+        internal** ``/_internal/mcp/rpc`` endpoint via an in-process ASGI
+        transport.
+
+        Why the trusted internal endpoint (not public ``/rpc``):
+
+        - The originating worker already ran ``streamable_http_auth()``, which
+          for ``/servers/{id}/mcp`` paths handles virtual-server OAuth verifiers
+          and ``MCP_REQUIRE_AUTH=false`` public-only mode. Public ``/rpc`` only
+          knows ContextForge JWTs / cookies, so re-authenticating an OAuth
+          bearer or an unauthenticated public-only request through ``/rpc``
+          would 401.
+        - The originating worker packages its already-validated identity into
+          ``auth_context`` (the encoded ``x-contextforge-auth-context`` value)
+          and forwards it here. Combined with the
+          ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret
+          HMAC header, and the loopback client address synthesised by
+          ASGITransport, the trusted endpoint's
+          ``_is_trusted_internal_mcp_runtime_request`` gate accepts the
+          request and ``_build_internal_mcp_forwarded_user`` reconstructs the
+          same user the edge saw.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
                 - type: "http_forward"
                 - response_channel: Redis channel to publish response to
                 - mcp_session_id: Session identifier
-                - method: HTTP method (GET, POST, DELETE)
-                - path: Request path (e.g., /servers/{id}/mcp)
-                - headers: Request headers dict (lowercased keys)
-                - body: Hex-encoded request body
-            redis: Redis client for publishing response
+                - method: HTTP method (POST primarily)
+                - path: Original request path (e.g., /servers/{id}/mcp)
+                - headers: Original request headers (lowercased keys)
+                - body: Hex-encoded JSON-RPC request body
+                - auth_context: base64url-encoded auth context from the
+                  originating worker's ``streamable_http_auth()`` result
+            redis: Redis client for publishing the response
         """
         response_channel = request.get("response_channel")
 
@@ -1057,6 +1073,7 @@ class SessionAffinity:
             headers = request.get("headers", {})
             body_hex = request.get("body", "")
             mcp_session_id = request.get("mcp_session_id")
+            auth_context_header = request.get("auth_context") or ""
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
@@ -1079,7 +1096,8 @@ class SessionAffinity:
                 await _publish(202, b"")
                 return
 
-            # Inject the virtual server id (from the path) into params so /rpc routes correctly.
+            # Inject the virtual server id (from the path) into params so the
+            # dispatcher routes to the right virtual server.
             server_match = _SERVER_ID_RE.search(path)
             if server_match and isinstance(json_body, dict):
                 if not isinstance(json_body.get("params"), dict):
@@ -1088,31 +1106,62 @@ class SessionAffinity:
                 body = orjson.dumps(json_body)
 
             # First-Party - lazy imports avoid a circular dependency with main/transport.
-            # First-Party
+            from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+            from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel
+            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel,protected-access
 
+            # Old / mixed-version forwarded payloads (e.g. a worker still on a
+            # pre-auth-context build during a rolling deploy) may omit the auth
+            # context. Fall back to an encoded public-only ({}) context so the
+            # trusted-internal endpoint applies default visibility instead of
+            # rejecting the dispatch with 400 (it requires a non-empty context).
+            if not auth_context_header:
+                auth_context_header = encode_internal_mcp_auth_context({})
+
+            # Build headers for the TRUSTED internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" marker that identifies us
+            #   to _is_trusted_internal_mcp_runtime_request.
+            # - x-contextforge-mcp-runtime-auth: shared-secret-derived HMAC
+            #   matched by has_valid_internal_mcp_runtime_auth_header.
+            # - x-contextforge-auth-context: the encoded auth context from the
+            #   originating worker; decoded server-side via
+            #   _build_internal_mcp_forwarded_user so the dispatcher uses the
+            #   same user identity streamable_http_auth() established.
             rpc_headers = {
                 "content-type": "application/json",
                 "x-mcp-session-id": mcp_session_id or "",
-                "x-forwarded-internally": "true",
+                "x-contextforge-mcp-runtime": "affinity",
+                "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                "x-contextforge-auth-context": auth_context_header,
             }
-            auth_header = _resolve_auth_header_name(settings).lower()
-            if auth_header in headers:
-                rpc_headers[auth_header] = headers[auth_header]
+            # Preserve the originating bearer under the CONFIGURED auth header
+            # (AUTH_HEADER_NAME), not a hardcoded "authorization". /_internal/mcp/
+            # is CSRF-exempt so this is defense-in-depth, but the CSRF bearer
+            # short-circuit keys on the configured header via get_auth_header_value,
+            # so hardcoding "authorization" would drop the bearer on custom-header
+            # deployments. The endpoint trusts the encoded auth-context above and
+            # does not re-authenticate from the bearer.
+            auth_header_name = _resolve_auth_header_name(settings).lower()
+            original_auth = headers.get(auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+            if original_auth:
+                rpc_headers[auth_header_name] = original_auth
             # Preserve passthrough headers destined for upstream MCP servers (#3640).
             rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
-            # Dispatch IN-PROCESS so /rpc resolves the bound upstream session from
-            # this worker's registry instead of bouncing back through the shared
-            # socket to a random worker (see post_rpc_in_process).
-            response = await post_rpc_in_process(
-                content=body,
-                headers=rpc_headers,
-                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
-            )
+            # Dispatch IN-PROCESS to the trusted internal endpoint. The explicit
+            # client=("127.0.0.1", 0) tells ASGITransport to set scope["client"]
+            # to a loopback address so the trust check accepts the request.
+            transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+            async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+                response = await client.post(
+                    "/_internal/mcp/rpc",
+                    content=body,
+                    headers=rpc_headers,
+                    timeout=settings.mcpgateway_pool_rpc_forward_timeout,
+                )
 
-            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process: {response.status_code}")
+            logger.debug(f"[HTTP_AFFINITY] Worker {WORKER_ID} | Session {session_short}... | Executed in-process via /_internal/mcp/rpc: {response.status_code}")
 
             resp_headers = {"content-type": "application/json"}
             if mcp_session_id:
@@ -1149,6 +1198,7 @@ class SessionAffinity:
         headers: Dict[str, str],
         body: bytes,
         query_string: str = "",
+        auth_context: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Forward a Streamable HTTP request to the worker that owns the session via Redis Pub/Sub.
 
@@ -1165,6 +1215,12 @@ class SessionAffinity:
             headers: Request headers.
             body: Request body bytes.
             query_string: Query string if any.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying
+                the result of ``streamable_http_auth()`` from the originating
+                worker. Lets the owner dispatch via the trusted internal
+                ``/_internal/mcp/rpc`` endpoint without re-authenticating, so
+                OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only modes
+                survive forwarding.
 
         Returns:
             Dict with 'status', 'headers', and 'body' from the owner worker's response,
@@ -1206,6 +1262,11 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
+                # Encoded auth context from the originating worker's
+                # streamable_http_auth() result; the owner uses this to
+                # dispatch via the trusted internal /_internal/mcp/rpc
+                # endpoint without re-authenticating.
+                "auth_context": auth_context,
             }
 
             # Subscribe to response channel BEFORE publishing request (prevent race)

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -1119,13 +1119,10 @@ class SessionAffinity:
                 "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
                 "x-contextforge-auth-context": auth_context_header,
             }
-            # Preserve the originating bearer under the CONFIGURED auth header
-            # (AUTH_HEADER_NAME), not a hardcoded "authorization". /_internal/mcp/
-            # is CSRF-exempt so this is defense-in-depth, but the CSRF bearer
-            # short-circuit keys on the configured header via get_auth_header_value,
-            # so hardcoding "authorization" would drop the bearer on custom-header
-            # deployments. The endpoint trusts the encoded auth-context above and
-            # does not re-authenticate from the bearer.
+            # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+            # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+            # the configured header, so a custom header would otherwise be dropped.
+            # This is defense-in-depth; the endpoint trusts the auth-context above.
             auth_header_name = _resolve_auth_header_name(settings).lower()
             original_auth = headers.get(auth_header_name) or headers.get(_resolve_auth_header_name(settings))
             if original_auth:
@@ -1199,12 +1196,10 @@ class SessionAffinity:
             headers: Request headers.
             body: Request body bytes.
             query_string: Query string if any.
-            auth_context: Encoded ``x-contextforge-auth-context`` value carrying
-                the result of ``streamable_http_auth()`` from the originating
-                worker. Lets the owner dispatch via the trusted internal
-                ``/_internal/mcp/rpc`` endpoint without re-authenticating, so
-                OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only modes
-                survive forwarding.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying the
+                originating worker's already-validated identity, so the owner can
+                dispatch to the trusted internal endpoint without re-authenticating
+                (OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only survive).
 
         Returns:
             Dict with 'status', 'headers', and 'body' from the owner worker's response,
@@ -1246,10 +1241,7 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
-                # Encoded auth context from the originating worker's
-                # streamable_http_auth() result; the owner uses this to
-                # dispatch via the trusted internal /_internal/mcp/rpc
-                # endpoint without re-authenticating.
+                # Encoded edge identity; lets the owner dispatch without re-authenticating.
                 "auth_context": auth_context,
             }
 

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -1022,29 +1022,19 @@ class SessionAffinity:
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
         """Execute a forwarded Streamable HTTP request in-process and reply via Redis.
 
-        A forwarded request lands here on the worker that OWNS the downstream
-        session, so the bound upstream session in this process's
-        ``UpstreamSessionRegistry`` can serve it. We dispatch to the **trusted
-        internal** ``/_internal/mcp/rpc`` endpoint via an in-process ASGI
-        transport.
+        The request lands on the worker that owns the downstream session, so the
+        bound upstream session in this process can serve it. It is dispatched
+        in-process to the trusted-internal ``/_internal/mcp/rpc`` endpoint rather
+        than the public ``/rpc``.
 
-        Why the trusted internal endpoint (not public ``/rpc``):
-
-        - The originating worker already ran ``streamable_http_auth()``, which
-          for ``/servers/{id}/mcp`` paths handles virtual-server OAuth verifiers
-          and ``MCP_REQUIRE_AUTH=false`` public-only mode. Public ``/rpc`` only
-          knows ContextForge JWTs / cookies, so re-authenticating an OAuth
-          bearer or an unauthenticated public-only request through ``/rpc``
-          would 401.
-        - The originating worker packages its already-validated identity into
-          ``auth_context`` (the encoded ``x-contextforge-auth-context`` value)
-          and forwards it here. Combined with the
-          ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret
-          HMAC header, and the loopback client address synthesised by
-          ASGITransport, the trusted endpoint's
-          ``_is_trusted_internal_mcp_runtime_request`` gate accepts the
-          request and ``_build_internal_mcp_forwarded_user`` reconstructs the
-          same user the edge saw.
+        Public ``/rpc`` only understands ContextForge JWTs and cookies, so an
+        OAuth bearer or an ``MCP_REQUIRE_AUTH=false`` public-only request would
+        401 if re-authenticated there. Instead, the originating worker's
+        already-validated identity rides in ``auth_context`` (the encoded
+        ``x-contextforge-auth-context`` header); with the
+        ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret HMAC,
+        and the loopback client address, the trusted endpoint accepts the request
+        and reconstructs the same user the edge established.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
@@ -1111,23 +1101,17 @@ class SessionAffinity:
             from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
             from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel,protected-access
 
-            # Old / mixed-version forwarded payloads (e.g. a worker still on a
-            # pre-auth-context build during a rolling deploy) may omit the auth
-            # context. Fall back to an encoded public-only ({}) context so the
-            # trusted-internal endpoint applies default visibility instead of
-            # rejecting the dispatch with 400 (it requires a non-empty context).
+            # A forwarded payload may omit the auth context; fall back to an
+            # encoded public-only ({}) context so the endpoint applies default
+            # visibility instead of rejecting the dispatch with 400.
             if not auth_context_header:
                 auth_context_header = encode_internal_mcp_auth_context({})
 
-            # Build headers for the TRUSTED internal /_internal/mcp/rpc endpoint:
-            # - x-contextforge-mcp-runtime: "affinity" marker that identifies us
-            #   to _is_trusted_internal_mcp_runtime_request.
-            # - x-contextforge-mcp-runtime-auth: shared-secret-derived HMAC
-            #   matched by has_valid_internal_mcp_runtime_auth_header.
-            # - x-contextforge-auth-context: the encoded auth context from the
-            #   originating worker; decoded server-side via
-            #   _build_internal_mcp_forwarded_user so the dispatcher uses the
-            #   same user identity streamable_http_auth() established.
+            # Trust headers for the internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" caller marker
+            # - x-contextforge-mcp-runtime-auth: shared-secret HMAC
+            # - x-contextforge-auth-context: the encoded edge auth context, so the
+            #   endpoint reconstructs the same user without re-authenticating.
             rpc_headers = {
                 "content-type": "application/json",
                 "x-mcp-session-id": mcp_session_id or "",

--- a/mcpgateway/transports/rust_mcp_runtime_proxy.py
+++ b/mcpgateway/transports/rust_mcp_runtime_proxy.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 # Standard
 import asyncio
-import base64
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 import httpx
-import orjson
 from sqlalchemy import exists as sa_exists
 from starlette.types import Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import encode_internal_mcp_auth_context
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session
 from mcpgateway.db import Server as DbServer
@@ -338,5 +337,4 @@ def _build_forwarded_auth_context_header() -> str | None:
     auth_context = get_streamable_http_auth_context()
     if not auth_context:
         return None
-    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
-    return encoded.rstrip("=")
+    return encode_internal_mcp_auth_context(auth_context)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4209,12 +4209,9 @@ class SessionManagerWrapper:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
 
-                    # Package the authenticated identity that streamable_http_auth()
-                    # established for this request so the owner worker can dispatch
-                    # via the trusted internal /_internal/mcp/rpc endpoint without
-                    # re-authenticating. This is what makes virtual-server OAuth
-                    # tokens and MCP_REQUIRE_AUTH=false public-only mode survive a
-                    # cross-worker forward.
+                    # Package the edge-validated identity so the owner can dispatch via
+                    # the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating, letting OAuth and public-only sessions survive.
                     # First-Party
                     from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
 

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4322,12 +4322,10 @@ class SessionManagerWrapper:
                             body = orjson.dumps(json_body)
                             logger.debug("[HTTP_AFFINITY_LOCAL] Injected server_id %s into /rpc params", server_id)
 
-                        # Owner-direct path: dispatch to the TRUSTED internal
-                        # /_internal/mcp/rpc endpoint carrying the auth context that
-                        # streamable_http_auth() already validated for this request, so
-                        # virtual-server OAuth and MCP_REQUIRE_AUTH=false public-only
-                        # sessions are honored without re-authenticating against public
-                        # /rpc (which only understands ContextForge JWTs/cookies).
+                        # Owner-direct path: dispatch to the trusted internal
+                        # /_internal/mcp/rpc endpoint carrying the edge-validated auth
+                        # context, so OAuth and public-only sessions are honored without
+                        # re-authenticating against public /rpc (JWTs/cookies only).
                         # First-Party
                         from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
                         from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
@@ -4341,10 +4339,10 @@ class SessionManagerWrapper:
                             "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
                             "x-contextforge-auth-context": encode_internal_mcp_auth_context(get_streamable_http_auth_context()),
                         }
-                        # Preserve the originating bearer under the CONFIGURED auth
-                        # header (AUTH_HEADER_NAME), not a hardcoded "authorization":
-                        # /_internal/mcp/ is CSRF-exempt so this is defense-in-depth, but
-                        # the CSRF bearer short-circuit keys on the configured header.
+                        # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+                        # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+                        # the configured header, so a custom header would otherwise be dropped.
+                        # This is defense-in-depth; the endpoint trusts the auth-context above.
                         _auth_header_name = _resolve_auth_header_name(settings).lower()
                         _original_auth = headers.get(_auth_header_name) or headers.get(_resolve_auth_header_name(settings))
                         if _original_auth:
@@ -4352,9 +4350,9 @@ class SessionManagerWrapper:
                         # Forward passthrough headers for upstream MCP servers (see #3640).
                         rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
-                        # Dispatch IN-PROCESS so the request runs on this worker — the
-                        # session owner that holds the bound upstream session — instead of
-                        # looping back over the shared socket to a random worker (#4205).
+                        # Dispatch in-process so the request runs on this worker, the
+                        # session owner that holds the bound upstream session, instead of
+                        # looping back over the shared socket to a random worker.
                         transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
                         async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                             response = await client.post(

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -4209,6 +4209,17 @@ class SessionManagerWrapper:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
 
+                    # Package the authenticated identity that streamable_http_auth()
+                    # established for this request so the owner worker can dispatch
+                    # via the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating. This is what makes virtual-server OAuth
+                    # tokens and MCP_REQUIRE_AUTH=false public-only mode survive a
+                    # cross-worker forward.
+                    # First-Party
+                    from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+                    encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
+
                     # Read request body
                     body_parts = []
                     while True:
@@ -4230,6 +4241,7 @@ class SessionManagerWrapper:
                         headers=headers,
                         body=body,
                         query_string=query_string,
+                        auth_context=encoded_auth_context,
                     )
 
                     if response:
@@ -4313,24 +4325,47 @@ class SessionManagerWrapper:
                             body = orjson.dumps(json_body)
                             logger.debug("[HTTP_AFFINITY_LOCAL] Injected server_id %s into /rpc params", server_id)
 
+                        # Owner-direct path: dispatch to the TRUSTED internal
+                        # /_internal/mcp/rpc endpoint carrying the auth context that
+                        # streamable_http_auth() already validated for this request, so
+                        # virtual-server OAuth and MCP_REQUIRE_AUTH=false public-only
+                        # sessions are honored without re-authenticating against public
+                        # /rpc (which only understands ContextForge JWTs/cookies).
+                        # First-Party
+                        from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+                        from mcpgateway.main import app  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.internal_http import internal_loopback_base_url  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+
                         rpc_headers = {
                             "content-type": "application/json",
                             "x-mcp-session-id": mcp_session_id,
-                            "x-forwarded-internally": "true",
+                            "x-contextforge-mcp-runtime": "affinity",
+                            "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                            "x-contextforge-auth-context": encode_internal_mcp_auth_context(get_streamable_http_auth_context()),
                         }
-                        _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                        if _gw_auth_lower in headers:
-                            rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                        # Preserve the originating bearer under the CONFIGURED auth
+                        # header (AUTH_HEADER_NAME), not a hardcoded "authorization":
+                        # /_internal/mcp/ is CSRF-exempt so this is defense-in-depth, but
+                        # the CSRF bearer short-circuit keys on the configured header.
+                        _auth_header_name = _resolve_auth_header_name(settings).lower()
+                        _original_auth = headers.get(_auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+                        if _original_auth:
+                            rpc_headers[_auth_header_name] = _original_auth
                         # Forward passthrough headers for upstream MCP servers (see #3640).
-                        # First-Party
-                        from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-
                         rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
-                        # Dispatch IN-PROCESS so /rpc runs on this worker — the session
-                        # owner that holds the bound upstream session — instead of looping
-                        # back over the shared socket to a random worker (#4205 isolation).
-                        response = await post_rpc_in_process(content=body, headers=rpc_headers, timeout=30.0)
+                        # Dispatch IN-PROCESS so the request runs on this worker — the
+                        # session owner that holds the bound upstream session — instead of
+                        # looping back over the shared socket to a random worker (#4205).
+                        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+                        async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+                            response = await client.post(
+                                "/_internal/mcp/rpc",
+                                content=body,
+                                headers=rpc_headers,
+                                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
+                            )
 
                         response_headers = [
                             (b"content-type", b"application/json"),

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -565,12 +565,10 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
         "upgrade",
         "x-mcp-session-id",
         "x-forwarded-internally",
-        # Gateway-internal trust headers for the /_internal/mcp/* dispatch.
-        # These carry the server-established auth context, runtime marker, and
-        # HMAC; a client-supplied passthrough header must never overwrite them
-        # (it would let a caller spoof the trusted identity while the server's
-        # valid HMAC still rides along). Mirrors the authorization / proxy-user
-        # protection above.
+        # Gateway-internal trust headers for the /_internal/mcp/* dispatch: the
+        # server-established auth context, runtime marker, and HMAC. A client
+        # passthrough header must never overwrite them, or a caller could spoof
+        # the trusted identity while the server's valid HMAC still rides along.
         "x-contextforge-auth-context",
         "x-contextforge-mcp-runtime",
         "x-contextforge-mcp-runtime-auth",

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -565,6 +565,16 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
         "upgrade",
         "x-mcp-session-id",
         "x-forwarded-internally",
+        # Gateway-internal trust headers for the /_internal/mcp/* dispatch.
+        # These carry the server-established auth context, runtime marker, and
+        # HMAC; a client-supplied passthrough header must never overwrite them
+        # (it would let a caller spoof the trusted identity while the server's
+        # valid HMAC still rides along). Mirrors the authorization / proxy-user
+        # protection above.
+        "x-contextforge-auth-context",
+        "x-contextforge-mcp-runtime",
+        "x-contextforge-mcp-runtime-auth",
+        "x-contextforge-session-validated",
     }
 )
 

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -234,10 +234,10 @@ async def test_exempt_path_passes_without_token():
 async def test_internal_mcp_dispatch_is_csrf_exempt_by_default():
     """``/_internal/mcp/*`` is CSRF-exempt by default (loopback-only, HMAC-gated).
 
-    Regression for the cross-worker forward 403: the affinity dispatch posts to
-    the trusted-internal endpoint, which must not require a CSRF token. Without
-    the exemption, custom AUTH_HEADER_NAME deployments (whose bearer the CSRF
-    short-circuit can't find) would 403 on the inner dispatch.
+    The affinity dispatch posts to the trusted-internal endpoint, which must not
+    require a CSRF token. Without the exemption, custom AUTH_HEADER_NAME
+    deployments (whose bearer the CSRF short-circuit can't find) would 403 on the
+    inner dispatch.
     """
     # First-Party
     from mcpgateway.config import settings as real_settings

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -231,6 +231,39 @@ async def test_exempt_path_passes_without_token():
 
 
 @pytest.mark.asyncio
+async def test_internal_mcp_dispatch_is_csrf_exempt_by_default():
+    """``/_internal/mcp/*`` is CSRF-exempt by default (loopback-only, HMAC-gated).
+
+    Regression for the cross-worker forward 403: the affinity dispatch posts to
+    the trusted-internal endpoint, which must not require a CSRF token. Without
+    the exemption, custom AUTH_HEADER_NAME deployments (whose bearer the CSRF
+    short-circuit can't find) would 403 on the inner dispatch.
+    """
+    # First-Party
+    from mcpgateway.config import settings as real_settings
+
+    # The shipped default must cover the internal MCP dispatch prefix.
+    assert "/_internal/mcp/" in real_settings.csrf_exempt_paths
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/_internal/mcp/rpc"
+    request.headers = {}  # no CSRF token, no bearer
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = real_settings.csrf_exempt_paths
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
 async def test_bearer_token_request_passes_without_csrf():
     """Test that requests with Authorization: Bearer header pass without CSRF token."""
     middleware = CSRFMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1523,10 +1523,8 @@ class _FakeHttpxClient:
     async def as_post_rpc(self, *, content=None, headers=None, timeout=None):
         """Adapter so this fake can stand in for ``utils.internal_http.post_rpc_in_process``.
 
-        After PR #4987 the executor dispatches via a single helper instead of
-        constructing its own ``httpx.AsyncClient``. Patching the helper to this
-        method lets the existing fake capture ``content``/``headers``/``timeout``
-        for the call-site assertions.
+        Patching the helper to this method lets the fake capture
+        ``content``/``headers``/``timeout`` for the call-site assertions.
         """
         self.last_post_kwargs = {"content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
@@ -2422,9 +2420,8 @@ async def test_execute_forwarded_http_request_preserves_custom_auth_header():
     """Executor side: the bearer is preserved under the CONFIGURED auth header.
 
     On a deployment with ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the CSRF bearer
-    short-circuit keys on that header (``get_auth_header_value``). Hardcoding
-    ``authorization`` would drop the bearer and risk a 403 on the inner dispatch.
-    Regression for the review finding on custom auth-header deployments.
+    short-circuit keys on that header, so hardcoding ``authorization`` would drop
+    the bearer and risk a 403 on the inner dispatch.
     """
     # Third-Party
     import orjson

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -1099,6 +1099,81 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
 
 
 @pytest.mark.asyncio
+async def test_forward_to_owner_includes_auth_context_in_redis_payload():
+    """The encoded auth context from the originating worker is carried in the forwarded Redis payload.
+
+    Without this, the owner worker cannot reconstruct the StreamableHTTP user
+    that ``streamable_http_auth()`` already validated at the edge, so forwarded
+    OAuth and ``MCP_REQUIRE_AUTH=false`` requests would re-authenticate against
+    the public ``/rpc`` and fail with 401.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    # Make the pubsub wait return immediately so we focus on the published payload.
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    encoded_ctx = "base64url-encoded-auth-ctx-from-edge"
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner(
+            owner_worker_id="other-worker",
+            mcp_session_id="sess-auth",
+            method="POST",
+            path="/servers/srv-9/mcp",
+            headers={"Authorization": "Bearer x"},
+            body=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            auth_context=encoded_ctx,
+        )
+
+    # Locate the forward payload published to the owner's HTTP channel.
+    owner_channels = [(chan, payload) for chan, payload in fake.published if chan == "mcpgw:pool_http:other-worker"]
+    assert owner_channels, "forward payload was not published to the owner channel"
+    forward_data = orjson.loads(owner_channels[0][1])
+    assert forward_data["type"] == "http_forward"
+    assert forward_data["auth_context"] == encoded_ctx
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_defaults_auth_context_to_none_when_omitted():
+    """Sender side: when no auth_context is supplied, the field is present and set to None.
+
+    The executor reads ``request.get("auth_context") or ""`` and forwards an
+    empty string header — equivalent to the pre-auth-context behaviour. This
+    test pins the shape so future signature changes don't silently break the
+    contract.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner("other-worker", "sess-no-ctx", "POST", "/mcp", {}, b"")
+
+    forward_data = orjson.loads(fake.published[0][1])
+    assert "auth_context" in forward_data
+    assert forward_data["auth_context"] is None
+
+
+@pytest.mark.asyncio
 async def test_forward_to_owner_times_out_and_returns_none_with_metric_bump():
     """No message arrives → asyncio.timeout fires → metric incremented, None returned."""
     # First-Party
@@ -1433,8 +1508,8 @@ class _FakeHttpxClient:
     async def __aexit__(self, *_exc):
         return False
 
-    async def post(self, url, *, json=None, headers=None, timeout=None):
-        self.last_post_kwargs = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+    async def post(self, url, *, json=None, content=None, headers=None, timeout=None):
+        self.last_post_kwargs = {"url": url, "json": json, "content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
@@ -1574,12 +1649,7 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_response_via_redis():
-    """Happy path: dispatch in-process via ``post_rpc_in_process``, hex-encode the response body, publish to Redis.
-
-    Pins the PR #4987 contract: the executor delegates dispatch to the shared
-    helper with ``x-forwarded-internally: true`` (loop-stop) and the
-    ``server_id`` parsed from the path injected into the JSON-RPC ``params``.
-    """
+    """Happy path: dispatch in-process to the trusted internal endpoint and publish the response back."""
     # Third-Party
     import orjson
 
@@ -1598,25 +1668,31 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
         "method": "POST",
         "path": "/servers/srv-9/mcp",
         "query_string": "",
-        "headers": {"authorization": "Bearer x"},
+        "headers": {"Authorization": "Bearer x"},
         "body": jsonrpc_body.hex(),
         "original_worker": "origin-worker",
         "mcp_session_id": "sess-123456789",
+        "auth_context": "encoded-ctx",
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    # Helper invoked with loop-stop header and session-id passthrough.
+    # Dispatched to the trusted-internal endpoint, NOT the public /rpc.
     assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
     headers = client.last_post_kwargs["headers"]
-    assert headers["x-forwarded-internally"] == "true"
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == "encoded-ctx"
     assert headers["x-mcp-session-id"] == "sess-123456789"
-    # server_id parsed from the path is injected so /rpc routes to the right virtual server.
+    # server_id from the path is injected into JSON-RPC params before dispatch.
     sent_body = orjson.loads(client.last_post_kwargs["content"])
     assert sent_body["params"]["server_id"] == "srv-9"
 
@@ -1631,12 +1707,7 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_500_error_on_exception():
-    """If ``post_rpc_in_process`` raises, a 500 error envelope is still published to Redis.
-
-    The body must carry a real JSON-RPC payload so the dispatch path actually
-    runs — an empty body short-circuits to a 202 ack and the helper is never
-    invoked.
-    """
+    """If the internal HTTP call raises, a 500 error envelope is still published to Redis."""
     # Third-Party
     import orjson
 
@@ -1659,7 +1730,9 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
@@ -2242,14 +2315,160 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
 
 
 @pytest.mark.asyncio
-async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
-    """Lifecycle methods (DELETE, GET) carry no JSON-RPC body, so the owner acks 200 without invoking the helper.
+async def test_execute_forwarded_http_request_preserves_authorization_for_csrf_bypass():
+    """The originating ``Authorization`` bearer is copied onto the trusted-internal dispatch.
 
-    The pre-#4987 test asserted that a query string was appended to a synthesised
-    URL, but the new executor never rebuilds the path — it always calls
-    ``post_rpc_in_process`` with the JSON-RPC body destined for ``/rpc``.
-    Lifecycle requests short-circuit before that helper is touched.
+    The CSRF middleware short-circuits on bearer-tokened requests; without
+    preserving the original ``Authorization`` header, the affinity dispatch to
+    ``/_internal/mcp/rpc`` 403s on CSRF even though the trusted-internal gate
+    itself is satisfied. Mirrors the Rust runtime forward path.
     """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-auth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"authorization": "Bearer original-jwt"},  # lowercased like the wire
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-auth-bypass",
+        "auth_context": "ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    sent_headers = client.last_post_kwargs["headers"]
+    assert sent_headers.get("authorization") == "Bearer original-jwt"
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_synthesizes_public_context_when_missing():
+    """Executor side: a forwarded payload with no auth_context falls back to an encoded public-only ({}) context.
+
+    Old / mixed-version payloads (e.g. a worker on a pre-auth-context build
+    during a rolling deploy) may omit ``auth_context``. Rather than sending an
+    empty header — which ``_build_internal_mcp_forwarded_user`` rejects with 400
+    — the executor synthesizes an encoded public-only ({}) context so the
+    dispatch applies default visibility. The trust headers (runtime marker +
+    HMAC) are still set.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-noctx",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-ctx",
+        # No "auth_context" key on purpose.
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    # Missing context -> encoded public-only ({}) context, NOT an empty header
+    # (an empty header would 400 at _build_internal_mcp_forwarded_user).
+    # First-Party
+    from mcpgateway.auth_context import decode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+    assert headers["x-contextforge-auth-context"]
+    assert decode_internal_mcp_auth_context(headers["x-contextforge-auth-context"]) == {}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_custom_auth_header():
+    """Executor side: the bearer is preserved under the CONFIGURED auth header.
+
+    On a deployment with ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the CSRF bearer
+    short-circuit keys on that header (``get_auth_header_value``). Hardcoding
+    ``authorization`` would drop the bearer and risk a 403 on the inner dispatch.
+    Regression for the review finding on custom auth-header deployments.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-customauth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"x-mcp-gateway-auth": "Bearer custom-tok"},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-custom",
+        "auth_context": "encoded-ctx",
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    headers = client.last_post_kwargs["headers"]
+    # Configured header preserved (lowercased); hardcoded "authorization" is NOT used.
+    assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
+    """Lifecycle methods (DELETE, GET) don't carry a JSON-RPC body, so the owner just acks 200 without dispatching."""
     # Third-Party
     import orjson
 
@@ -2272,12 +2491,13 @@ async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    # Helper was never invoked.
+    # Acked without invoking the in-process dispatch.
     assert client.last_post_kwargs is None
     decoded = orjson.loads(fake.published[0][1])
     assert decoded["status"] == 200

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8832,6 +8832,147 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_local_affinity_post_dispatches_to_internal_endpoint_with_auth_context(monkeypatch):
+    """Owner-direct affinity POST dispatches to the trusted-internal /_internal/mcp/rpc.
+
+    Closes the coverage gap for the local-owner path: instead of re-authenticating
+    against public /rpc (which only understands ContextForge JWTs/cookies and would
+    401 virtual-server OAuth or MCP_REQUIRE_AUTH=false public-only sessions), the
+    owner dispatches to the trusted-internal endpoint carrying the affinity runtime
+    marker, the HMAC, and the edge-validated auth context. The originating
+    Authorization header is preserved for the CSRF bearer short-circuit.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    # Deterministic auth context regardless of request-scoped state.
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"authorization", b"Bearer tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        # Routed to the trusted-internal endpoint, NOT public /rpc.
+        assert mock_client.post.call_args.args[0] == "/_internal/mcp/rpc"
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["x-contextforge-mcp-runtime"] == "affinity"
+        assert headers["x-contextforge-mcp-runtime-auth"]
+        assert headers["x-contextforge-auth-context"]
+        # Authorization preserved for the CSRF bearer short-circuit.
+        assert headers["authorization"] == "Bearer tok"
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
+    """Owner-direct dispatch preserves the bearer under the CONFIGURED auth header.
+
+    On ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the bearer rides that header and
+    the CSRF short-circuit keys on it. Hardcoding ``authorization`` would drop it.
+    Regression for the review finding, owner-direct path.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_header_name", "X-MCP-Gateway-Auth")
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"x-mcp-gateway-auth", b"Bearer custom-tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        headers = mock_client.post.call_args.kwargs["headers"]
+        # Configured header preserved (lowercased); hardcoded "authorization" not used.
+        assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+        assert "authorization" not in headers
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "params_value,params_json",
     [
@@ -9011,6 +9152,65 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeypatch):
+    """The sender encodes the live ``get_streamable_http_auth_context()`` result and passes it through ``forward_to_owner``.
+
+    Without this, OAuth-enabled virtual servers and ``MCP_REQUIRE_AUTH=false``
+    public-only mode would 401 after a cross-worker forward, because the owner
+    would have nothing to reconstruct the edge-authenticated user from.
+    """
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    # Stand-in for the authenticated identity the edge worker already established.
+    edge_auth_ctx = {"email": "alice@example.com", "is_admin": False, "teams": ["t1"]}
+    expected_encoded = encode_internal_mcp_auth_context(edge_auth_ctx)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context", lambda: edge_auth_ctx)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-auth")])
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-2")
+    mock_pool.forward_to_owner = AsyncMock(
+        return_value={
+            "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body": b'{"jsonrpc":"2.0","result":{}}',
+        }
+    )
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+    ):
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
+
+    await wrapper.shutdown()
+    # auth_context kwarg is supplied and equals the encoded edge identity.
+    assert mock_pool.forward_to_owner.call_args.kwargs["auth_context"] == expected_encoded
+
+
+@pytest.mark.asyncio
 async def test_affinity_forward_failure_falls_through(monkeypatch):
     """Test affinity forward failure falls through to local handling (line 1525-1527)."""
 
@@ -9186,66 +9386,6 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
     assert messages[0]["status"] == 200
 
 
-@pytest.mark.asyncio
-async def test_local_affinity_post_dispatches_via_post_rpc_in_process(monkeypatch):
-    """Local-owned path goes through the shared ``post_rpc_in_process`` helper (PR #4987).
-
-    Before this PR the dispatch built its own ``httpx.AsyncClient`` and
-    looped back to ``127.0.0.1`` over the shared gunicorn socket — which the
-    kernel then routed to a random worker that did not hold the bound
-    upstream session. Routing through the helper enforces in-process dispatch
-    so ``/rpc`` resolves the session from THIS worker's
-    ``UpstreamSessionRegistry``. Pins both the helper call and the loop-stop
-    header that prevents the re-entered handler from forwarding again.
-    """
-
-    class DummySessionManager:
-        @asynccontextmanager
-        async def run(self):
-            yield self
-
-        async def handle_request(self, scope, receive, send_func):
-            raise AssertionError("Should not reach SDK")
-
-    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
-    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
-    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
-
-    wrapper = SessionManagerWrapper()
-    await wrapper.initialize()
-
-    send, _messages = _make_send_collector()
-    body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
-    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-local"), (b"authorization", b"Bearer original-jwt")])
-
-    mock_pool = MagicMock()
-    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")  # we own it → local-owned path
-
-    mock_session_class = MagicMock()
-    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.content = b'{"jsonrpc":"2.0","result":{}}'
-
-    mock_post_rpc = AsyncMock(return_value=mock_response)
-
-    with (
-        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
-        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
-        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
-        patch("mcpgateway.transports.streamablehttp_transport.post_rpc_in_process", mock_post_rpc),
-    ):
-        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
-
-    await wrapper.shutdown()
-    # Helper was invoked exactly once with the loop-stop header so the re-entered handler doesn't forward again.
-    mock_post_rpc.assert_awaited_once()
-    sent_headers = mock_post_rpc.await_args.kwargs["headers"]
-    assert sent_headers["x-forwarded-internally"] == "true"
-    assert sent_headers["x-mcp-session-id"] == "sess-local"
-    # Original Authorization is preserved so /rpc can re-authenticate the same caller.
-    assert sent_headers["authorization"] == "Bearer original-jwt"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8911,8 +8911,7 @@ async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
     """Owner-direct dispatch preserves the bearer under the CONFIGURED auth header.
 
     On ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the bearer rides that header and
-    the CSRF short-circuit keys on it. Hardcoding ``authorization`` would drop it.
-    Regression for the review finding, owner-direct path.
+    the CSRF short-circuit keys on it, so hardcoding ``authorization`` would drop it.
     """
     # Third-Party
     import orjson

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -497,3 +497,42 @@ class TestPassthroughHeaders:
 
         # Should log warning about conflict
         assert any("conflicts with pre-defined headers" in record.message for record in caplog.records)
+
+
+class TestLoopbackSkipTrustedInternalHeaders:
+    """Deny-path: client passthrough must never carry the gateway-internal trust headers.
+
+    The ``/_internal/mcp/*`` dispatch sets ``x-contextforge-auth-context`` (the
+    server-established identity), ``x-contextforge-mcp-runtime``, and the HMAC.
+    If the loopback passthrough echoed a client-supplied copy of those, a caller
+    could spoof the trusted identity while the server's valid HMAC still rode
+    along (the trusted headers are set, then passthrough is ``update()``-d over
+    them). The loopback skip set must strip them. Regression for the review
+    finding on trusted-header overwrite.
+    """
+
+    def test_filter_strips_trusted_internal_headers(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        spoofed = {
+            "x-contextforge-auth-context": "SPOOFED",
+            "x-contextforge-mcp-runtime": "affinity",
+            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",
+            "x-contextforge-session-validated": "rust",
+            "x-business-header": "kept",
+        }
+        out = filter_loopback_skip_headers(spoofed)
+        assert "x-contextforge-auth-context" not in out
+        assert "x-contextforge-mcp-runtime" not in out
+        assert "x-contextforge-mcp-runtime-auth" not in out
+        assert "x-contextforge-session-validated" not in out
+        # Non-trusted business headers are unaffected.
+        assert out.get("x-business-header") == "kept"
+
+    def test_filter_strips_trusted_headers_case_insensitively(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        out = filter_loopback_skip_headers({"X-ContextForge-Auth-Context": "SPOOFED"})
+        assert not any(k.lower() == "x-contextforge-auth-context" for k in out)

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -506,9 +506,7 @@ class TestLoopbackSkipTrustedInternalHeaders:
     server-established identity), ``x-contextforge-mcp-runtime``, and the HMAC.
     If the loopback passthrough echoed a client-supplied copy of those, a caller
     could spoof the trusted identity while the server's valid HMAC still rode
-    along (the trusted headers are set, then passthrough is ``update()``-d over
-    them). The loopback skip set must strip them. Regression for the review
-    finding on trusted-header overwrite.
+    along. The loopback skip set must strip them.
     """
 
     def test_filter_strips_trusted_internal_headers(self):


### PR DESCRIPTION
> Draft for review. Base is `fix/session-affinity-inprocess-dispatch` so the diff shows only the incremental change on top of the in-process dispatch work; retarget to the integration branch before merge.

## Summary

When a stateful MCP request lands on a worker that doesn't own the session, it gets forwarded to the owning worker. Today that forward re-enters the app through the public `/rpc`, which only understands ContextForge JWTs and cookies. So a request the edge already authenticated via virtual-server OAuth (RFC 9728) or `MCP_REQUIRE_AUTH=false` public-only mode gets re-authenticated on the inside and 401s, even though the original request was valid.

This change packages the identity that `streamable_http_auth()` already validated at the edge and ships it with the forward, so the owning worker **trusts that decision instead of re-authenticating**.

## What it does

- Forwards dispatch to the trusted-internal endpoint `/_internal/mcp/rpc` (the same one the Rust runtime uses) instead of the public `/rpc`, with the full trust-header set: the `affinity` runtime marker, the shared-secret HMAC, and the encoded auth context from the originating worker.
- The originating worker encodes `get_streamable_http_auth_context()` and attaches it to the forward payload; the owner reconstructs the same user rather than verifying a credential it can't (an OAuth bearer or, for public-only, no credential at all).
- `encode_internal_mcp_auth_context` is promoted to a public helper (mirroring the existing decode side), and the internal trust check now accepts an `affinity` caller marker alongside `rust`.

## Architecture: before & after

The cross-worker forward itself is unchanged. What changes is **which endpoint the owning worker dispatches to** and **whether the edge-validated identity travels with the forward**.

`#4987` switched the owner-side dispatch to in-process ASGI transport, but it still re-entered the app through the **public `/rpc`**, which re-authenticates from the forwarded `Authorization` header. That public path only understands ContextForge JWTs and cookies, so OAuth-bearer and `MCP_REQUIRE_AUTH=false` public-only sessions 401 the moment a request lands on a non-owner worker.

**Before this PR (state after `#4987`):**

```
Worker A (edge)            Redis            Worker B (owns session)
─────────────            ─────            ───────────────────────
streamable_http_auth                     _execute_forwarded_http_request
  validates ✓   ──forward──► pub/sub ──►        │  (forwards raw headers only;
  (result discarded)                            │   validated identity is NOT sent)
                                                ▼
                                         POST /rpc   ◄── in-process, but PUBLIC endpoint
                                                │
                                                │  RE-AUTHENTICATES from raw Authorization
                                                │  • ContextForge JWT  → ✓
                                                │  • OAuth bearer      → ✗ 401
                                                │  • public-only sess. → ✗ 401
                                                ▼
◄──────── 401 published back via Redis ─────────┘   (OAuth / public-only sessions break)
```

**After this PR:**

```
Worker A (edge)            Redis            Worker B (owns session)
─────────────            ─────            ───────────────────────
streamable_http_auth                     _execute_forwarded_http_request
  validates ✓                                   │  attaches trust headers:
  encode_internal_mcp_auth_context(             │   • x-contextforge-auth-context (the identity)
    edge identity)                              │   • x-contextforge-mcp-runtime: affinity
        └──forward + auth_context─► pub/sub ──► │   • x-contextforge-mcp-runtime-auth: HMAC
                                                ▼
                                         POST /_internal/mcp/rpc  ◄── trusted-internal endpoint
                                                │   (loopback ASGITransport, HMAC-gated)
                                                │  RECONSTRUCTS the edge user — no re-auth
                                                │  • OAuth bearer      → ✓
                                                │  • public-only sess. → ✓
                                                ▼  runs against bound upstream session
◄──────── 200 + result published back via Redis ┘
```

Net change:

```
#4987:  forward raw  →  POST /rpc                  →  re-auth   →  OAuth / public-only = 401
#5212:  forward raw + encoded identity  →  POST /_internal/mcp/rpc  →  trust, no re-auth  →  all ✓
```

Auth now happens exactly once, at Worker A's edge; the owning worker trusts that decision instead of re-running a narrower auth surface that can't validate the original credential.

## Dispatch-site coverage

| Site | Dispatch | Auth |
|---|---|---|
| `_execute_forwarded_http_request` (Redis-forwarded) | `/_internal/mcp/rpc` | edge auth context |
| `[HTTP_AFFINITY_LOCAL]` (owner-direct) | `/_internal/mcp/rpc` | edge auth context |
| `_execute_forwarded_request` (generic JSON-RPC) | public `/rpc` | forwarded `Authorization` (by design) |

The owner-direct `[HTTP_AFFINITY_LOCAL]` path previously re-authenticated against public `/rpc` via the forwarded `Authorization` header, which 401s for OAuth / public-only sessions. It now dispatches to the trusted-internal endpoint with the edge auth context, the same as the Redis-forwarded path.


## Notes for reviewers

- `_execute_forwarded_request` (the generic JSON-RPC path) intentionally stays on public `/rpc` and authenticates from the forwarded `Authorization` header.
- A legacy `[HTTP_AFFINITY_FORWARDED]` loopback branch (`is_internally_forwarded`) still routes to `/rpc`; it does not appear to be on the live Redis-pub/sub forward path, so it is left untouched pending confirmation that it is reachable.
- The passthrough-overwrite and missing-context issues also exist in the consolidated `multiworker-forwarding` branch; if that becomes the integration path, these fixes should be ported there too.

Relates to #5206.

## Benchmark (full session-affinity stack)

Built an image from this branch (which stacks #4981 + #4987 + this PR's auth-context work) and ran `make benchmark-mcp-tools` (125 users, 60s) against the `3 replicas x 24 workers` stack with `USE_STATEFUL_SESSIONS=true`, `MCPGATEWAY_SESSION_AFFINITY_ENABLED=true`, `CACHE_TYPE=redis`. Compared against an image built from `main` (no session-affinity fixes), same stack and benchmark:

| Metric | `main` (unfixed) | This branch (fixed stack) |
|---|---|---|
| Throughput | 15.1 RPS | **548-584 RPS** |
| Failures | 0.22% | **0.00%** |
| Avg latency | 6,294 ms | **~150 ms** |
| p95 / p99 | 22,000 / 25,000 ms | **~350 / ~900 ms** |
| `tools/call` p99 | 25,000 ms (pinned near the forward timeout) | **~880 ms** |

Fixed-stack numbers are consistent across three 60s runs (583.8 / 569.7 / 547.4 RPS), all 0% failures. The throughput recovery comes from the underlying forwarding fixes in #4981 (per-worker `WORKER_ID`) and #4987 (in-process dispatch); the unfixed run shows the classic #4557 signature (fast `initialize`, `tools/call` p99 pinned at the forward timeout). **This PR's auth-context propagation rides on top with no throughput regression** while ensuring virtual-server OAuth and `MCP_REQUIRE_AUTH=false` public-only sessions survive the cross-worker forward.

<details>
<summary>Sample run — <code>make benchmark-mcp-tools</code> (fixed stack)</summary>

```
📊 Running tools-only MCP benchmark...
   Host: http://localhost:8080
   Server: 9779b6698cbd4b4995ee04a4fab38737
   Users: 125, Spawn: 30/s, Duration: 60s
[2026-06-14 19:53:03,372] MAC-B3F2E0/INFO/locust.main: Starting Locust 2.44.0

==========================================================================================
MCP STREAMABLE HTTP PROTOCOL — RESULTS
==========================================================================================

                                         OVERALL
  --------------------------------------------------------------------------------------
  Total Requests:           34,942
  Total Failures:                0 (0.00%)
  Requests/sec (RPS):       583.78

  Response Times (ms):
    Average:      147.30
    Min:           11.39
    Max:         2761.67
    p50:          110.00
    p90:          240.00
    p95:          330.00
    p99:          870.00

                                    ENDPOINT BREAKDOWN
  --------------------------------------------------------------------------------------
  Name                                              Reqs    Fails      RPS  Avg(ms)  p99(ms)
  --------------------------------------------------------------------------------------
  MCP tools/call [rapid]                          33,166        0    554.1    147.6    870.0
  MCP tools/list [rapid]                           1,651        0     27.6    143.8    900.0
  MCP initialize                                     125        0      2.1    124.9    420.0

==========================================================================================
```


</details>

_Indicative, not authoritative: 60s runs on a local colima VM (12 CPU / 16 GB); the before/after differ only in the gateway image._

## Manual verification — statefulness & isolation under multi-worker affinity (#4205)

Confirmed that per-session upstream state survives the multi-worker session-affinity forwarding this branch's stack performs (the #4205 invariant: one upstream session per downstream session, no scatter onto fresh upstream connections). A minimal stateful counter MCP server is registered behind the gateway; a session is incremented N times and must read back N. If forwarding scattered onto a fresh upstream session, the counter would drop.

<details>
<summary>Setup — counter server, registration, and the session driver</summary>

Minimal per-session counter (streamable HTTP); state is keyed by the upstream session, so a scatter onto a new connection would show a fresh counter:

```python
"""Minimal stateful MCP counter (streamable HTTP) for the #4205 isolation repro.

State is kept PER MCP SESSION (keyed by the ServerSession object), so if the
gateway scatters a session's calls onto a second upstream connection, that new
connection sees a fresh counter — which is exactly what the test detects.
"""

from mcp.server.fastmcp import Context, FastMCP

mcp = FastMCP("repro-counter", host="0.0.0.0", port=9400)

# per-session counters, keyed by the upstream ServerSession identity
_counters: dict[int, int] = {}


@mcp.tool()
def increment(ctx: Context) -> int:
    """Increment this session's counter and return the new value."""
    key = id(ctx.session)
    _counters[key] = _counters.get(key, 0) + 1
    return _counters[key]


@mcp.tool()
def get_value(ctx: Context) -> int:
    """Return this session's current counter value."""
    return _counters.get(id(ctx.session), 0)


if __name__ == "__main__":
    mcp.run(transport="streamable-http")
```

Register it and scope its tools into a virtual server (admin JWT):

1. `python counter_server.py` (listens on `:9400`; reachable from the gateway containers via `host.docker.internal`).
2. `POST /gateways` -> `{"name":"repro-counter","url":"http://host.docker.internal:9400/mcp","transport":"STREAMABLEHTTP"}`
3. `POST /servers` -> `{"server":{"name":"repro-counter-vs","associated_tools":[<discovered tool ids>]}}`

Each test drives one or more sessions against `/servers/{id}/mcp` with this shape (concurrent sessions run via a thread pool):

```python
def run_session(name, token, n):
    H = {"Authorization": f"Bearer {token}", "Content-Type": "application/json",
         "Accept": "application/json, text/event-stream"}
    c = httpx.Client(timeout=30, headers=H)
    r = c.post(URL, json={"jsonrpc":"2.0","id":1,"method":"initialize","params":{
        "protocolVersion":"2025-03-26","capabilities":{},
        "clientInfo":{"name":name,"version":"1.0"}}})
    H["Mcp-Session-Id"] = r.headers["mcp-session-id"]   # sessionful -> real session id
    c.post(URL, json={"jsonrpc":"2.0","method":"notifications/initialized"}, headers=H)
    inc = [call(c, "repro-counter-increment") for _ in range(n)]   # tools/call x n
    return H["Mcp-Session-Id"], inc, call(c, "repro-counter-get-value")
```

</details>

<details>
<summary>Test 1 — single session, 25 increments (PASS)</summary>

**Steps:** one session; `increment` x25, then `get_value`.

**Result:**

```
increments: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
get_value : 25
failures  : 0

mcpgw:pool_owner:4b28654b...  ->  08329f662a3d:92   (owner pid 92, not :1 -> per-worker WORKER_ID active)
```

Requests round-robin through nginx across the 3 x 24 replicas (no sticky LB), so they hit non-owner workers and forward to the owner; the monotonic counter proves the forward reused the single bound upstream session.

</details>

<details>
<summary>Test 2 — same-user multi-session, 3 concurrent sessions, one token (PASS)</summary>

**Steps:** no additional setup (reuses the counter, virtual server, and the single admin token from Setup). Drive 3 `run_session()` calls concurrently via a thread pool, each `increment` x10, then `get_value`.

**Result:**

```
S1  sid=ac2a7b3ffe78...  increments=[1,2,3,4,5,6,7,8,9,10]  get_value=10
S2  sid=51d2e450c732...  increments=[1,2,3,4,5,6,7,8,9,10]  get_value=10
S3  sid=df1bc836512f...  increments=[1,2,3,4,5,6,7,8,9,10]  get_value=10
distinct sids: 3

mcpgw:pool_owner:51d2e450c7324d74b04b370ace4f480e
mcpgw:pool_owner:ac2a7b3ffe784f2b9e5ce1b0a3ea4a6d
mcpgw:pool_owner:df1bc836512f4d158ffaf96ced247e98
```

3 sids -> 3 distinct `pool_owner` keys; each counter independent and correct -> no cross-session leakage.

</details>

<details>
<summary>Test 3 — two concurrent tokens (PASS)</summary>

**Steps (additional setup):** mint two distinct tokens for the same admin identity (different `--exp` produces different token strings, mirroring #4987), then drive two sessions in parallel, each `increment` x10, then `get_value`:

```
TOK_A=$(python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 900 --secret "$JWT_SECRET_KEY")
TOK_B=$(python -m mcpgateway.utils.create_jwt_token --username admin@example.com --exp 600 --secret "$JWT_SECRET_KEY")
```

**Result:**

```
UserA  sid=4714ca3d42ab...  increments=[1,2,3,4,5,6,7,8,9,10]  get_value=10
UserB  sid=c71af3958f68...  increments=[1,2,3,4,5,6,7,8,9,10]  get_value=10
distinct sids: 2
```

Each session reaches 10 with no cross-talk; isolation holds when the discriminator is the downstream session id.

</details>

<details>
<summary>Test 4 — multi-upstream isolation, one session across two counters (PASS)</summary>

**Steps (additional setup):** run a second counter on `:9401`, register it as a second gateway, and create a virtual server scoping tools from both gateways:

```
python counter_server.py     # counter A on :9400  (gateway repro-counter)
python counter_server_b.py   # counter B on :9401  (gateway repro-counter-b; same script, port=9401)
```

- `POST /gateways` -> `{"name":"repro-counter-b","url":"http://host.docker.internal:9401/mcp","transport":"STREAMABLEHTTP"}`
- `POST /servers` -> `{"server":{"name":"repro-counter-multi","associated_tools":[<all 4 tool ids>]}}`

Then in **one** session, interleave: A x5, B x3, A x2, then `get_value` on each.

**Result:**

```
session: 9e92f8a3...
A increments: [1, 2, 3, 4, 5]  then  [6, 7]
B increments: [1, 2, 3]
A get_value: 7     B get_value: 3
```

One downstream `Mcp-Session-Id` (one `pool_owner` key) binds **two independent upstream sessions**, one per gateway, keyed by `(downstream_session_id, gateway_id)`. Counter A continues across the interleaved B calls and B stays independent -> no cross-upstream leakage.

</details>

<details>
<summary>Test 5 — owner-worker kill / failover recovery contract (PASS)</summary>

**Steps (no new servers):** bind a session and `increment` x5; read its owner from Redis (`mcpgw:pool_owner:<sid>` = `host:pid`); map `host` to its gateway container and `kill -9` the owning gunicorn worker; then hit the now-stale session id, and finally `initialize` a fresh session.

**Result:**

```
[1] bound session 14160152... | increments [1, 2, 3, 4, 5]
[2] pool_owner -> 08329f662a3d:37
[3] owner worker pid 37 in container mcp-context-forge-gateway-2
[4] kill -9 37 -> worker dead (gunicorn master respawns a replacement)
[5] stale-sid request -> HTTP 404 in 30.0s | {"error":{"code":-32600,"message":"Session not found"}}
[6] fresh initialize 0282a5ab... | increments [1, 2, 3]
```

When the owning worker dies, the session's in-memory upstream is gone (by design). A request on the stale id forwards to the dead owner, times out at `mcpgateway_pool_rpc_forward_timeout` (~30s), and returns a clean structured `404` / JSON-RPC `-32600 "Session not found"` -> not a hang or 5xx. The killed worker is auto-respawned and a fresh `initialize` binds and works. This is the failure-mode recovery contract; #4987 notes the fix does not change it (documented here for completeness).

</details>

_Exercises the JWT-authenticated forwarding path. This PR's OAuth / `MCP_REQUIRE_AUTH=false` public-only auth-context handling is covered by the unit and deny-path tests above. Indicative runs on the local stack._




