### PR TITLE
feat: add Xquik to MCP catalog

### DIFF
--- a/mcp-catalog.yml
+++ b/mcp-catalog.yml
@@ -993,6 +993,18 @@ catalog_servers:
     requires_api_key: false
     tags: ["twitter", "social-media", "archive"]
 
+  - id: xquik
+    name: "Xquik"
+    category: "Social Media"
+    url: "https://xquik.com/mcp"
+    auth_type: "API Key"
+    provider: "Xquik"
+    transport: "STREAMABLEHTTP"
+    secure: true
+    description: "X/Twitter data workflows, API exploration, monitoring, webhooks, and confirmation-gated actions"
+    requires_api_key: true
+    tags: ["twitter", "x", "social-media", "data", "monitoring", "webhooks"]
+
   # Parallel AI
   - id: parallel-task
     name: "Parallel Task"


### PR DESCRIPTION
## Related Issue
No related issue. Small catalog entry update.

## Summary
Adds Xquik to `mcp-catalog.yml` as an API-key protected Streamable HTTP MCP server in the Social Media category.

## Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

## Verification

| Check | Command | Status |
| --- | --- | --- |
| Catalog YAML parse | `python3 -c "import yaml; data=yaml.safe_load(open('mcp-catalog.yml')); ..."` | Passed |
| Whitespace | `git diff --check` | Passed |
| Public MCP endpoint | `curl -sS -o /dev/null -w "%{http_code}" https://xquik.com/mcp` | Returned `401` without API key, consistent with API Key auth |

## Checklist
- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed
- [x] DCO signed commit

## Notes
No full suite run for this catalog-only change.
