### PR TITLE
ugfix/5044-jsonpath-filter-jq-mismatch

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -242,5 +242,3 @@ jobs:
           else
             exit 1
           fi
-
-

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-15T06:32:35Z",
+  "generated_at": "2026-06-15T06:46:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4244,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15019,
+        "line_number": 15021,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-11T09:41:14Z",
+  "generated_at": "2026-06-15T06:32:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4244,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15017,
+        "line_number": 15019,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -16929,12 +16929,7 @@ async def get_resources_section(
         LOGGER.debug(f"User {user_email} requesting resources section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all resources with token_teams for proper scoping
-        resources_result = await local_resource_service.list_resources(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        resources_result = await local_resource_service.list_resources(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(resources_result, tuple):
             resources_list = resources_result[0]
         else:
@@ -16995,12 +16990,7 @@ async def get_prompts_section(
         LOGGER.debug(f"User {user_email} requesting prompts section with team_id={team_id}, token_teams={token_teams}")
 
         # Get all prompts with token_teams for proper scoping
-        prompts_result = await local_prompt_service.list_prompts(
-            db,
-            include_inactive=True,
-            user_email=user_email,
-            token_teams=token_teams
-        )
+        prompts_result = await local_prompt_service.list_prompts(db, include_inactive=True, user_email=user_email, token_teams=token_teams)
         if isinstance(prompts_result, tuple):
             prompts_list = prompts_result[0]
         else:

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -559,7 +559,7 @@ class ToolCreate(BaseModel):
         input_schema (Optional[Dict[str, Any]]): JSON Schema for validating tool parameters. Alias 'inputSchema'.
         output_schema (Optional[Dict[str, Any]]): JSON Schema for validating tool output. Alias 'outputSchema'.
         annotations (Optional[Dict[str, Any]]): Tool annotations for behavior hints such as title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint.
-        jsonpath_filter (Optional[str]): JSON modification filter.
+        jsonpath_filter (Optional[str]): Filter expression to extract a subset of the JSON response. Supports JSONPath (e.g., `$.data`) and jq (e.g., `.data`) syntax.
         auth (Optional[AuthenticationValues]): Authentication credentials (Basic or Bearer Token or custom headers) if required.
         gateway_id (Optional[str]): ID of the gateway for the tool.
     """
@@ -581,7 +581,7 @@ class ToolCreate(BaseModel):
         default_factory=dict,
         description="Tool annotations for behavior hints (title, readOnlyHint, destructiveHint, idempotentHint, openWorldHint)",
     )
-    jsonpath_filter: Optional[str] = Field(default="", description="JSON modification filter")
+    jsonpath_filter: Optional[str] = Field(default="", description="Filter expression to extract a subset of the JSON response. Supports JSONPath (e.g., `$.data`) and jq (e.g., `.data`) syntax.")
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the tool")
@@ -1147,7 +1147,7 @@ class ToolUpdate(BaseModelWithConfigDict):
     input_schema: Optional[Dict[str, Any]] = Field(None, description="JSON Schema for validating tool parameters")
     output_schema: Optional[Dict[str, Any]] = Field(None, description="JSON Schema for validating tool output")
     annotations: Optional[Dict[str, Any]] = Field(None, description="Tool annotations for behavior hints")
-    jsonpath_filter: Optional[str] = Field(None, description="JSON path filter for rpc tool calls")
+    jsonpath_filter: Optional[str] = Field(None, description="Filter expression to extract a subset of the JSON response. Supports JSONPath (e.g., `$.data`) and jq (e.g., `.data`) syntax.")
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -47,6 +47,7 @@ from cpex.framework import (
 from cpex.framework.constants import GATEWAY_METADATA, TOOL_METADATA
 import httpx
 import jq
+from jsonpath_ng.ext import parse as jsonpath_parse
 import jsonschema
 from jsonschema import Draft4Validator, Draft6Validator, Draft7Validator, validators
 from mcp import ClientSession, types
@@ -724,6 +725,20 @@ def extract_using_jq(data, jq_filter=""):
     elif not isinstance(data, (dict, list)):
         # If the input is not a string, dict, or list, raise an error
         return ["Input data must be a JSON string, dictionary, or list."]
+
+    # Check if the filter is a JSONPath expression (starts with $)
+    if jq_filter_str.startswith("$"):
+        try:
+            jsonpath_expr = jsonpath_parse(jq_filter_str)
+            matches = [m.value for m in jsonpath_expr.find(data)]
+            if not matches:
+                return [TextContent(type="text", text="Error applying jsonpath filter")]
+            if len(matches) == 1:
+                return matches[0]
+            return matches
+        except Exception as e:
+            message = "Error applying jsonpath filter: " + str(e)
+            return [TextContent(type="text", text=message)]
 
     # Apply the jq filter to the data using cached compiled program
     try:
@@ -4447,6 +4462,7 @@ class ToolService(BaseService):
         # ═══════════════════════════════════════════════════════════════════════════
         # First-Party
         from mcpgateway.transports.context import request_headers_var  # pylint: disable=import-outside-toplevel
+
         if request_headers:
             request_headers_var.set(request_headers)
         # ═══════════════════════════════════════════════════════════════════════════

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -3890,8 +3890,12 @@
                 <input
                   type="text"
                   name="jsonpath_filter"
+                  placeholder="$.main"
                   class="mt-1 px-3 py-2 block w-full rounded-md border border-gray-300 dark:border-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-900 dark:placeholder-gray-300 dark:text-gray-300"
                 />
+                <p class="mt-1 text-xs text-gray-500 dark:text-indigo-300">
+                  Filter to extract a subset of the JSON response. Supports JSONPath (e.g., <code>$.main</code>) and jq (e.g., <code>.main</code>) syntax.
+                </p>
               </div>
               <!-- Authentication Section -->
               <div>

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -224,6 +224,47 @@ class TestToolServiceHelpersExtended:
         result = extract_using_jq({"a": 1}, ".a")
         assert result == [TextContent(type="text", text="Error applying jsonpath filter: boom")]
 
+    def test_extract_using_jq_jsonpath_simple(self):
+        """JSONPath expression ($.data) should extract nested value."""
+        data = {"data": {"temperature": 25}, "meta": {"source": "api"}}
+        result = extract_using_jq(data, "$.data")
+        assert result == {"temperature": 25}
+
+    def test_extract_using_jq_jsonpath_deep(self):
+        """Deep JSONPath ($.store.book[0].title) should extract nested value."""
+        data = {"store": {"book": [{"title": "The Name of the Wind"}, {"title": "A Game of Thrones"}]}}
+        result = extract_using_jq(data, "$.store.book[0].title")
+        assert result == "The Name of the Wind"
+
+    def test_extract_using_jq_jsonpath_string_input(self):
+        """JSONPath expression should work with string JSON input."""
+        result = extract_using_jq('{"data": {"temperature": 25}, "meta": {"source": "api"}}', "$.data")
+        assert result == {"temperature": 25}
+
+    def test_extract_using_jq_jsonpath_no_match(self):
+        """JSONPath expression with no match should return TextContent error."""
+        result = extract_using_jq({"a": 1}, "$.b")
+        assert result == [TextContent(type="text", text="Error applying jsonpath filter")]
+
+    def test_extract_using_jq_jsonpath_invalid_expression(self):
+        """Invalid JSONPath expression should return TextContent error."""
+        result = extract_using_jq({"a": 1}, "$.[invalid")
+        assert len(result) == 1
+        assert result[0].type == "text"
+        assert result[0].text.startswith("Error applying jsonpath filter")
+
+    def test_extract_using_jq_jsonpath_multiple_matches(self):
+        """JSONPath expression with multiple matches should return list of values."""
+        data = {"items": [{"id": 1}, {"id": 2}, {"id": 3}]}
+        result = extract_using_jq(data, "$.items[*].id")
+        assert result == [1, 2, 3]
+
+    def test_extract_using_jq_jsonpath_root(self):
+        """JSONPath expression ($) should return the full data."""
+        data = {"a": 1}
+        result = extract_using_jq(data, "$")
+        assert result == {"a": 1}
+
     def test_tool_service_plugin_env_override(self, monkeypatch):
         """PLUGINS_ENABLED env flag controls whether the plugin factory is available."""
         # First-Party


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #5044
 Dual-Syntax Support

1. Core Fix (mcpgateway/services/tool_service.py)

# Added JSONPath library import
from jsonpath_ng.ext import parse as jsonpath_parse

# New logic in extract_using_jq():
if jq_filter_str.startswith("$"):
    # Route to JSONPath evaluation
    jsonpath_expr = jsonpath_parse(jq_filter_str)
    matches = [m.value for m in jsonpath_expr.find(data)]
    return matches[0] if len(matches) == 1 else matches
else:
    # Keep existing jq evaluation (backward compatible)

What it does:
- Detects if filter starts with $ → uses JSONPath
- Otherwise → uses jq (existing behavior)
- No breaking changes for existing users

2. Documentation Updates (mcpgateway/schemas.py)

Before:
- ToolCreate: "JSON modification filter" ❌
- ToolUpdate: "JSON path filter for rpc tool calls" ❌

After:
"Filter expression to extract a subset of the JSON response.
Supports JSONPath (e.g., `$.data`) and jq (e.g., `.data`) syntax."

What it does: Clear documentation showing both syntaxes work

3. Admin UI Improvements (mcpgateway/templates/admin.html

Added:
- Placeholder: $.main
- Help text: "Supports JSONPath (e.g., $.main) and jq (e.g., .main) syntax"
4 Test Coverage (tests/unit/mcpgateway/services/test_tool_service.py



Changes made (option "a" from the issue — honor JSONPath while keeping jq backward compatibility):
1. mcpgateway/services/tool_service.py (lines 50, 729-743):
- Added from jsonpath_ng.ext import parse as jsonpath_parse import
- In extract_using_jq(), added a detection branch: if the filter starts with $, it's evaluated as JSONPath via jsonpath_ng.ext.parse().find() instead of jq.compile(). Non-$ filters continue to use jq as before, preserving full backward compatibility.
2. mcpgateway/schemas.py (lines 562, 584, 1150):
- Updated ToolCreate docstring, ToolCreate.jsonpath_filter, and ToolUpdate.jsonpath_filter descriptions to: "Filter expression to extract a subset of the JSON response. Supports JSONPath (e.g., $.data) and jq (e.g., .data) syntax."
3. mcpgateway/templates/admin.html (lines 3895, 3897-3900):
- Added placeholder="$.main" to the input field
- Added a help text paragraph explaining both JSONPath and jq syntax
4. tests/unit/mcpgateway/services/test_tool_service.py (lines 227-273):
- Added 7 new tests covering: simple JSONPath ($.data), deep JSONPath ($.store.book[0].title), string JSON input, no-match error, invalid expression error, multiple matches ($.items[*].id), and root expression ($)
