### PR TITLE
fix(llmchat): add /llmchat to csrf_exempt_paths and apply enforce_admin_csrf dependency

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -449,6 +449,7 @@ class Settings(BaseSettings):
             "/admin/login",
             "/admin/forgot-password",
             "/admin/reset-password",
+            "/llmchat",  # Exempt: LLM Chat routes use per-route enforce_admin_csrf dependency (Admin UI feature)
             "/oauth/fetch-tools",  # Exempt: OAuth callback uses enforce_fetch_tools_csrf with origin+double-submit
             "/docs",
             "/redoc",

--- a/mcpgateway/routers/llmchat_router.py
+++ b/mcpgateway/routers/llmchat_router.py
@@ -37,6 +37,7 @@ except ImportError:
     REDIS_AVAILABLE = False
 
 # First-Party
+from mcpgateway.admin import enforce_admin_csrf
 from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
@@ -52,8 +53,8 @@ from mcpgateway.services.mcp_client_chat_service import (
 from mcpgateway.utils.redis_client import get_redis_client
 from mcpgateway.utils.services_auth import decode_auth, encode_auth
 
-# Initialize router
-llmchat_router = APIRouter(prefix="/llmchat", tags=["llmchat"])
+# Initialize router with admin CSRF protection (consistent with /admin routes)
+llmchat_router = APIRouter(prefix="/llmchat", tags=["llmchat"], dependencies=[Depends(enforce_admin_csrf)])
 
 # Redis client (initialized via init_redis() during app startup)
 redis_client = None

--- a/tests/unit/mcpgateway/routers/test_llmchat_csrf_fix.py
+++ b/tests/unit/mcpgateway/routers/test_llmchat_csrf_fix.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_llmchat_csrf_fix.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit Tests for LLM Chat CSRF Protection Fix
+
+This test suite verifies the fix for issue #5214:
+"LLM Chat Connect fails with 403 CSRF validation failed"
+
+The fix ensures /llmchat routes use admin CSRF protection (consistent with /admin).
+"""
+
+import pytest
+
+
+class TestLLMChatCSRFConfiguration:
+    """Test CSRF configuration for llmchat routes."""
+
+    def test_llmchat_in_csrf_exempt_paths(self):
+        """
+        Test that /llmchat is in csrf_exempt_paths.
+
+        This is part of the fix for #5214. /llmchat must be exempt from
+        global CSRF middleware so it can use per-route admin CSRF instead.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+
+        csrf_exempt = settings.csrf_exempt_paths
+
+        # Verify /llmchat is in the exempt list
+        assert "/llmchat" in csrf_exempt, "/llmchat must be in csrf_exempt_paths to use admin CSRF protection"
+
+    def test_llmchat_router_has_enforce_admin_csrf_dependency(self):
+        """
+        Test that llmchat_router has enforce_admin_csrf as a dependency.
+
+        This is the second part of the fix for #5214. The router must
+        apply admin CSRF protection to all routes.
+        """
+        # First-Party
+        from mcpgateway.routers.llmchat_router import llmchat_router
+
+        # Check that the router has dependencies
+        assert hasattr(llmchat_router, "dependencies"), "llmchat_router should have dependencies attribute"
+        assert llmchat_router.dependencies is not None, "llmchat_router dependencies should not be None"
+        assert len(llmchat_router.dependencies) > 0, "llmchat_router should have at least one dependency"
+
+        # Verify one of the dependencies is enforce_admin_csrf
+        # Dependencies are Depends objects, so we check the dependency attribute
+        dependency_callables = [dep.dependency for dep in llmchat_router.dependencies if hasattr(dep, "dependency")]
+
+        # Import enforce_admin_csrf to compare
+        # First-Party
+        from mcpgateway.admin import enforce_admin_csrf
+
+        assert enforce_admin_csrf in dependency_callables, "llmchat_router must have enforce_admin_csrf as a dependency"
+
+    def test_csrf_exempt_paths_comment_mentions_llmchat(self):
+        """
+        Test that the csrf_exempt_paths includes proper documentation for /llmchat.
+
+        This ensures the exemption is well-documented for future maintainers.
+        """
+        # Read the config.py file to verify the comment
+        # First-Party
+        import mcpgateway.config
+
+        import inspect
+
+        source = inspect.getsource(mcpgateway.config)
+
+        # Check that /llmchat has a comment explaining the exemption
+        assert '"/llmchat"' in source, "/llmchat should be in config.py source"
+        # The comment should mention admin CSRF or be similar to /admin comment
+        assert "llmchat" in source.lower(), "config.py should document llmchat CSRF handling"
+
+    def test_admin_routes_also_exempt_for_consistency(self):
+        """
+        Test that /admin is also exempt (sanity check for consistency).
+
+        This verifies that /llmchat follows the same pattern as /admin.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+
+        csrf_exempt = settings.csrf_exempt_paths
+
+        # Verify /admin is exempt (sanity check)
+        assert "/admin" in csrf_exempt, "/admin should be exempt (existing behavior)"
+
+    def test_llmchat_router_import_does_not_fail(self):
+        """
+        Test that importing llmchat_router with enforce_admin_csrf doesn't raise errors.
+
+        This is a basic smoke test to ensure the imports are correct.
+        """
+        try:
+            # First-Party
+            from mcpgateway.routers.llmchat_router import llmchat_router  # noqa: F401
+            from mcpgateway.admin import enforce_admin_csrf  # noqa: F401
+        except ImportError as e:
+            pytest.fail(f"Failed to import llmchat_router or enforce_admin_csrf: {e}")
+
+
+class TestLLMChatCSRFRegression:
+    """Regression tests to ensure the bug is fixed."""
+
+    def test_config_has_llmchat_exempt_after_admin(self):
+        """
+        Test that /llmchat appears in the exempt list (after or near /admin).
+
+        This is a specific regression test for the fix.
+        """
+        # First-Party
+        from mcpgateway.config import settings
+
+        csrf_exempt = settings.csrf_exempt_paths
+
+        # Find indices
+        admin_idx = csrf_exempt.index("/admin") if "/admin" in csrf_exempt else -1
+        llmchat_idx = csrf_exempt.index("/llmchat") if "/llmchat" in csrf_exempt else -1
+
+        assert admin_idx >= 0, "/admin should be in csrf_exempt_paths"
+        assert llmchat_idx >= 0, "/llmchat should be in csrf_exempt_paths (fix for #5214)"
+
+        # /llmchat should be near /admin for logical grouping
+        # (within 5 positions is reasonable)
+        distance = abs(llmchat_idx - admin_idx)
+        assert distance <= 5, f"/llmchat and /admin should be grouped together in csrf_exempt_paths (distance: {distance})"


### PR DESCRIPTION
## 🔗 Related Issue
Closes #5214

---

## 📝 Summary

This PR fixes a bug where LLM Chat → Connect from the Admin UI always fails with **403 "CSRF validation failed"** under the default configuration.

### Root Cause
The Admin UI authenticates via `/admin/login` and sets `mcpgateway_csrf_token` to a **random token** (admin CSRF scheme). However, `/llmchat` routes were **not exempt** from the global CSRF middleware, which expects **HMAC-signed session tokens**. The admin token failed HMAC validation, causing all `/llmchat/connect` requests to return 403.

### Solution
1. **Add `/llmchat` to `csrf_exempt_paths`** - Exempts llmchat routes from global CSRF middleware (consistent with `/admin`)
2. **Apply `enforce_admin_csrf` dependency** - Adds per-route admin CSRF validation to the llmchat router (same pattern as `/admin` routes)

This aligns `/llmchat` with the existing admin CSRF pattern, allowing the Admin UI's random token to be validated by `enforce_admin_csrf` instead of being rejected by the global middleware.

### Impact
- **Before**: LLM Chat feature unusable from Admin UI with default config (CSRF enabled)
- **After**: LLM Chat Connect works correctly with admin CSRF tokens

---

## 🏷️ Type of Change
- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ✅ Pass |
| Unit tests                | `make test`     | ✅ Pass |
| Coverage ≥ 80%            | `make coverage` | ✅ Pass |

### Test Results (Manual Run)
```bash
# New regression tests (6 tests)
pytest tests/unit/mcpgateway/routers/test_llmchat_csrf_fix.py -v
✅ 6 passed

# Existing llmchat router tests (90 tests)
pytest tests/unit/mcpgateway/routers/test_llmchat_router.py -v
✅ 90 passed

# CSRF middleware tests (24 tests)
pytest tests/unit/mcpgateway/middleware/test_csrf_middleware.py -v
✅ 24 passed

# Admin CSRF tests (39 tests)
pytest tests/unit/mcpgateway/test_admin.py -v -k csrf
✅ 39 passed

Total: ✅ 159 tests passed, 0 failed
```

---

## ✅ Checklist
- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes

### Technical Details

**Two CSRF Protection Mechanisms:**
1. **Admin CSRF** (`enforce_admin_csrf`): Per-route validation using random tokens, applied to `/admin` and now `/llmchat`
2. **Global CSRF Middleware**: HMAC-signed session tokens, applied to all other routes

**Admin UI Token Flow:**
```
/admin/login → sets mcpgateway_csrf_token (random)
       ↓
Admin UI JavaScript (utils.js:155-157)
       ↓
fetchWithTimeout() → adds X-CSRF-Token header
       ↓
/llmchat/connect ← validates with enforce_admin_csrf ✅
```

**Files Changed:**
- `mcpgateway/config.py` - Added `/llmchat` to `csrf_exempt_paths` with documentation
- `mcpgateway/routers/llmchat_router.py` - Added `enforce_admin_csrf` dependency to router
- `tests/unit/mcpgateway/routers/test_llmchat_csrf_fix.py` - New regression tests (6 tests)

**Consistency with Existing Patterns:**
This fix follows the **exact same pattern** used for `/admin` routes:
```python
# admin.py:1718
admin_router = APIRouter(
    prefix="/admin",
    tags=["Admin UI"],
    dependencies=[Depends(enforce_admin_csrf)],
)

# llmchat_router.py:57 (after fix)
llmchat_router = APIRouter(
    prefix="/llmchat",
    tags=["llmchat"],
    dependencies=[Depends(enforce_admin_csrf)]
)
```

**Why This Approach:**
- ✅ Consistent with existing `/admin` CSRF handling
- ✅ No changes needed to Admin UI JavaScript
- ✅ No new token fetch endpoint required
- ✅ Minimal code changes (3 lines + tests)
- ✅ Backward compatible (no breaking changes)

**Security Considerations:**
- CSRF protection remains enabled (not bypassed)
- Admin CSRF validates double-submit cookie + origin
- Bearer token requests still bypass CSRF (not vulnerable)
- GET requests remain exempt (safe methods)