### PR TITLE
feat(ui-rewrite): Delete tool from Tools details panel

### DIFF
--- a/client/src/api/tools.test.ts
+++ b/client/src/api/tools.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { toolsApi } from "./tools";
+
+describe("toolsApi", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    global.fetch = mockFetch;
+    vi.clearAllMocks();
+    Object.defineProperty(document, "cookie", {
+      writable: true,
+      value: "mcpgateway_csrf_token=test-csrf-token",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("delete", () => {
+    it("calls DELETE /tools/:id with CSRF token and same-origin credentials", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await toolsApi.delete("tool-abc-123");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/tools/tool-abc-123"),
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({
+            "X-CSRF-Token": "test-csrf-token",
+          }),
+          credentials: "same-origin", // pragma: allowlist secret
+        }),
+      );
+    });
+
+    it("accepts UUID format IDs", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await expect(
+        toolsApi.delete("550e8400-e29b-41d4-a716-446655440000"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("accepts alphanumeric IDs with underscores", async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await expect(toolsApi.delete("tool_123_abc")).resolves.toBeUndefined();
+    });
+
+    it("throws synchronously for an empty ID", () => {
+      expect(() => toolsApi.delete("")).toThrow("Invalid tool ID");
+    });
+
+    it("throws synchronously for ID with path traversal characters", () => {
+      expect(() => toolsApi.delete("../etc/passwd")).toThrow("Invalid tool ID format");
+    });
+
+    it("throws synchronously for ID with spaces", () => {
+      expect(() => toolsApi.delete("tool id with spaces")).toThrow("Invalid tool ID format");
+    });
+
+    it("throws synchronously for ID with special characters", () => {
+      expect(() => toolsApi.delete("tool<script>")).toThrow("Invalid tool ID format");
+    });
+
+    it("throws ApiError on 404 response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Tool not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(toolsApi.delete("tool-abc-123")).rejects.toThrow("HTTP 404");
+    });
+
+    it("throws ApiError on 500 response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "Internal server error" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(toolsApi.delete("tool-abc-123")).rejects.toThrow("HTTP 500");
+    });
+  });
+});

--- a/client/src/api/tools.ts
+++ b/client/src/api/tools.ts
@@ -1,0 +1,34 @@
+/**
+ * Tools API service
+ */
+
+import { api } from "./client";
+
+/**
+ * Validates tool ID to prevent path traversal and injection attacks
+ * @param id - The tool ID to validate
+ * @returns The validated ID
+ * @throws Error if ID is invalid
+ */
+function validateToolId(id: string): string {
+  if (!id || typeof id !== "string") {
+    throw new Error("Invalid tool ID");
+  }
+
+  // Ensure ID is alphanumeric with hyphens/underscores only
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    throw new Error("Invalid tool ID format");
+  }
+
+  return id;
+}
+
+export const toolsApi = {
+  /**
+   * Delete a tool
+   */
+  delete: (id: string): Promise<void> => {
+    const validId = validateToolId(id);
+    return api.delete(`/tools/${validId}`);
+  },
+};

--- a/client/src/components/mcp-servers/MCPServerForm.test.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.test.tsx
@@ -17,6 +17,17 @@ const server = setupServer(
   http.post("/gateways", () => {
     return HttpResponse.json({ id: "test-gateway-123", name: "Test Server" });
   }),
+  // Mock single gateway fetch (used in edit mode)
+  http.get("/gateways/:id", ({ params }) => {
+    return HttpResponse.json({
+      id: params.id,
+      name: "Test Server",
+      url: "http://localhost:9000",
+      transport: "STREAMABLEHTTP",
+      visibility: "public",
+      authType: "none",
+    });
+  }),
   // Mock ExposeComponentsForm API calls
   http.get("/tools", () => {
     return HttpResponse.json([]);

--- a/client/src/components/tools/ToolDetailsPanel.test.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.test.tsx
@@ -561,6 +561,64 @@ describe("ToolDetailsPanel", () => {
     expect(screen.queryByLabelText("Copy URL")).not.toBeInTheDocument();
   });
 
+  describe("onDeleteTool propagation", () => {
+    it("passes onDeleteTool down to the table so the Delete item appears", async () => {
+      const user = userEvent.setup();
+      const mockOnDeleteTool = vi.fn();
+      const tools = [createMockTool(1)];
+      render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open={true}
+          onClose={mockOnClose}
+          onDeleteTool={mockOnDeleteTool}
+        />,
+      );
+
+      await user.click(screen.getByLabelText("More options"));
+      expect(await screen.findByText("Delete")).toBeInTheDocument();
+    });
+
+    it("calls onDeleteTool with the correct tool id when Delete is clicked", async () => {
+      const user = userEvent.setup();
+      const mockOnDeleteTool = vi.fn();
+      const tools = [createMockTool(1, { id: "tool-panel-xyz" })];
+      render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open={true}
+          onClose={mockOnClose}
+          onDeleteTool={mockOnDeleteTool}
+        />,
+      );
+
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      expect(mockOnDeleteTool).toHaveBeenCalledOnce();
+      expect(mockOnDeleteTool).toHaveBeenCalledWith("tool-panel-xyz");
+    });
+
+    it("does not show Delete item when onDeleteTool is not provided", async () => {
+      const user = userEvent.setup();
+      const tools = [createMockTool(1)];
+      render(
+        <ToolDetailsPanel
+          tools={tools}
+          gatewaySlug="test-gateway"
+          open={true}
+          onClose={mockOnClose}
+        />,
+      );
+
+      await user.click(screen.getByLabelText("More options"));
+
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    });
+  });
+
   it("generates unique heading ID based on gateway slug", () => {
     const tools = [createMockTool(1)];
     const { container } = render(

--- a/client/src/components/tools/ToolDetailsPanel.tsx
+++ b/client/src/components/tools/ToolDetailsPanel.tsx
@@ -54,11 +54,13 @@ export function ToolDetailsPanel({
   gatewaySlug,
   open,
   onClose,
+  onDeleteTool,
 }: {
   tools: Tool[];
   gatewaySlug: string;
   open: boolean;
   onClose: () => void;
+  onDeleteTool?: (toolId: string) => void;
 }) {
   const [selectedTool, setSelectedTool] = useState<Tool | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -165,6 +167,7 @@ export function ToolDetailsPanel({
                 tools={tools}
                 selectedToolId={selectedTool?.id}
                 onSelectTool={setSelectedTool}
+                onDeleteTool={onDeleteTool}
               />
             </div>
 

--- a/client/src/components/tools/ToolsTable.test.tsx
+++ b/client/src/components/tools/ToolsTable.test.tsx
@@ -318,6 +318,73 @@ describe("ToolsTable", () => {
     expect(span).toHaveClass("line-clamp-1");
   });
 
+  describe("delete dropdown (onDeleteTool provided)", () => {
+    it("renders a dropdown instead of a plain button when onDeleteTool is provided", async () => {
+      const user = userEvent.setup();
+      const mockOnDeleteTool = vi.fn();
+      const tools = [createMockTool(1)];
+      render(
+        <ToolsTable
+          tools={tools}
+          onSelectTool={mockOnSelectTool}
+          onDeleteTool={mockOnDeleteTool}
+        />,
+      );
+
+      const moreButton = screen.getByLabelText("More options");
+      await user.click(moreButton);
+
+      expect(await screen.findByText("Delete")).toBeInTheDocument();
+    });
+
+    it("calls onDeleteTool with the tool id when Delete is clicked", async () => {
+      const user = userEvent.setup();
+      const mockOnDeleteTool = vi.fn();
+      const tools = [createMockTool(1, { id: "tool-xyz" })];
+      render(
+        <ToolsTable
+          tools={tools}
+          onSelectTool={mockOnSelectTool}
+          onDeleteTool={mockOnDeleteTool}
+        />,
+      );
+
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      expect(mockOnDeleteTool).toHaveBeenCalledOnce();
+      expect(mockOnDeleteTool).toHaveBeenCalledWith("tool-xyz");
+    });
+
+    it("does not call onSelectTool when Delete is clicked", async () => {
+      const user = userEvent.setup();
+      const mockOnDeleteTool = vi.fn();
+      const tools = [createMockTool(1)];
+      render(
+        <ToolsTable
+          tools={tools}
+          onSelectTool={mockOnSelectTool}
+          onDeleteTool={mockOnDeleteTool}
+        />,
+      );
+
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      expect(mockOnSelectTool).not.toHaveBeenCalled();
+    });
+
+    it("does not show Delete item when onDeleteTool is not provided", async () => {
+      const user = userEvent.setup();
+      const tools = [createMockTool(1)];
+      render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+      await user.click(screen.getByLabelText("More options"));
+
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    });
+  });
+
   it("handles tools with special characters in names", () => {
     const tools = [
       createMockTool(1, {

--- a/client/src/components/tools/ToolsTable.tsx
+++ b/client/src/components/tools/ToolsTable.tsx
@@ -150,7 +150,6 @@ export function ToolsTable({
                           e.stopPropagation();
                           onDeleteTool(tool.id);
                         }}
-                        className="text-destructive focus:text-destructive"
                       >
                         Delete
                       </DropdownMenuItem>

--- a/client/src/components/tools/ToolsTable.tsx
+++ b/client/src/components/tools/ToolsTable.tsx
@@ -2,6 +2,12 @@ import { useState } from "react";
 import { Copy, MoreHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Table,
   TableBody,
   TableCell,
@@ -17,10 +23,12 @@ export function ToolsTable({
   tools,
   selectedToolId,
   onSelectTool,
+  onDeleteTool,
 }: {
   tools: Tool[];
   selectedToolId?: string | null;
   onSelectTool: (tool: Tool) => void;
+  onDeleteTool?: (toolId: string) => void;
 }) {
   const [schemaDialogTool, setSchemaDialogTool] = useState<Tool | null>(null);
   const [isSchemaDialogOpen, setIsSchemaDialogOpen] = useState(false);
@@ -120,19 +128,48 @@ export function ToolsTable({
               </TableCell>
 
               <TableCell className="px-4 py-3 text-center">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="More options"
-                  className="size-5 text-muted-foreground hover:text-foreground"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    // TODO: Implement more options menu
-                  }}
-                >
-                  <MoreHorizontal className="size-4" />
-                </Button>
+                {onDeleteTool ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label="More options"
+                        className="size-5 text-muted-foreground hover:text-foreground"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                        }}
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeleteTool(tool.id);
+                        }}
+                        className="text-destructive focus:text-destructive"
+                      >
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="More options"
+                    className="size-5 text-muted-foreground hover:text-foreground"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                    }}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                )}
               </TableCell>
             </TableRow>
           ))}

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-popover p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/client/src/hooks/useToolForm.ts
+++ b/client/src/hooks/useToolForm.ts
@@ -328,6 +328,7 @@ export function useToolForm({
     authPassword,
     customHeaders,
     openApiSpecUrl,
+    maxCustomHeaders,
   ]);
 
   const getFormData = useCallback((): ApiToolPayload => {
@@ -408,6 +409,7 @@ export function useToolForm({
     customHeaders,
     visibility,
     teamId,
+    maxCustomHeaders,
   ]);
 
   const validateForm = useCallback((): boolean => {

--- a/client/src/pages/Servers.test.tsx
+++ b/client/src/pages/Servers.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
@@ -57,7 +57,12 @@ function renderWithRouter(ui: ReactElement) {
 
 describe("Servers", () => {
   beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("renders servers list when data is loaded", async () => {

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -825,7 +825,7 @@ describe("Tools", () => {
         expect(screen.getByRole("dialog")).toBeInTheDocument();
       });
       const dialog = screen.getByRole("dialog");
-      expect(within(dialog).getByText("Delete Tool")).toBeInTheDocument();
+      expect(within(dialog).getByText("Delete tool")).toBeInTheDocument();
       // Dialog description includes the tool name (createMockTool has no displayName, falls back to name)
       expect(
         within(dialog).getByText(/Are you sure you want to delete "Tool 1"/),

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -1,8 +1,17 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
+import { toast } from "sonner";
 import { server } from "@/test/mocks/server";
 import { Tools } from "./Tools";
 import { RouterProvider } from "@/router";
@@ -762,6 +771,198 @@ describe("Tools", () => {
       await waitFor(() => {
         expect(screen.getByRole("region", { name: /Tools for gateway-b/i })).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("Delete Tool", () => {
+    // Helper: load tools, open the details panel for a given gateway, and return userEvent
+    async function openDetailsPanel(gatewaySlug: string) {
+      const user = userEvent.setup();
+      const moreOptionsButton = screen.getByLabelText(`More options for ${gatewaySlug}`);
+      await user.click(moreOptionsButton);
+      const viewDetailsItem = await screen.findByText("View Details");
+      await user.click(viewDetailsItem);
+      await waitFor(() => {
+        expect(
+          screen.getByRole("region", { name: new RegExp(`Tools for ${gatewaySlug}`, "i") }),
+        ).toBeInTheDocument();
+      });
+      return user;
+    }
+
+    beforeEach(() => {
+      vi.mocked(toast.success).mockClear();
+      vi.mocked(toast.error).mockClear();
+    });
+
+    it("shows Delete option in the tool row dropdown when panel is open", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+
+      // "More options" button inside the table row (not the card-level one)
+      const tableMoreOptions = screen.getByLabelText("More options");
+      await user.click(tableMoreOptions);
+
+      expect(await screen.findByText("Delete")).toBeInTheDocument();
+    });
+
+    it("opens a confirm dialog with the tool name when Delete is clicked", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      const dialog = screen.getByRole("dialog");
+      expect(within(dialog).getByText("Delete Tool")).toBeInTheDocument();
+      // Dialog description includes the tool name (createMockTool has no displayName, falls back to name)
+      expect(
+        within(dialog).getByText(/Are you sure you want to delete "Tool 1"/),
+      ).toBeInTheDocument();
+    });
+
+    it("does not call the API when the confirm dialog is cancelled", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+      const deleteSpy = vi.fn(() => HttpResponse.json(null, { status: 204 }));
+      server.use(http.delete("/tools/:id", deleteSpy));
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("calls the delete API, shows success toast, and closes the panel on confirm", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(
+        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/tools/tool-1", () => new HttpResponse(null, { status: 204 })),
+      );
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(expect.stringContaining("Tool 1"));
+      });
+
+      // Details panel should close
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("region", { name: /Tools for test-gateway/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows an error toast when the delete API returns a string detail", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(
+        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/tools/tool-1", () =>
+          HttpResponse.json({ detail: "Cannot delete: tool is in use" }, { status: 409 }),
+        ),
+      );
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("Cannot delete: tool is in use");
+      });
+    });
+
+    it("shows a generic error toast when the delete API returns no detail", async () => {
+      const mockTools: Tool[] = [createMockTool(1, "test-gateway")];
+      server.use(
+        http.get("/tools", () => HttpResponse.json(mockTools)),
+        http.delete("/tools/tool-1", () =>
+          HttpResponse.json({ message: "Something went wrong" }, { status: 500 }),
+        ),
+      );
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      await user.click(screen.getByRole("button", { name: /^delete$/i }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Failed to delete tool"));
+      });
+    });
+
+    it("uses displayName in the dialog description when available", async () => {
+      const mockTools: Tool[] = [
+        { ...createMockTool(1, "test-gateway"), displayName: "My Custom Tool" },
+      ];
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      expect(within(screen.getByRole("dialog")).getByText(/My Custom Tool/)).toBeInTheDocument();
+    });
+
+    it("falls back to name in the dialog description when displayName is absent", async () => {
+      const mockTools: Tool[] = [{ ...createMockTool(1, "test-gateway"), displayName: undefined }];
+      server.use(http.get("/tools", () => HttpResponse.json(mockTools)));
+
+      renderWithRouter(<Tools />);
+      await waitFor(() => expect(screen.getByText("test-gateway")).toBeInTheDocument());
+
+      const user = await openDetailsPanel("test-gateway");
+      await user.click(screen.getByLabelText("More options"));
+      await user.click(await screen.findByText("Delete"));
+
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      expect(
+        within(screen.getByRole("dialog")).getByText(/Are you sure you want to delete "Tool 1"/),
+      ).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -1,6 +1,10 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { Plus, MoreHorizontal, Wrench } from "lucide-react";
+import { toast } from "sonner";
 import { useQuery } from "@/hooks/useQuery";
+import { toolsApi } from "@/api/tools";
+import { ApiError } from "@/api/client";
+import { extractApiErrorDetail } from "@/utils/errors";
 import type { Tool, ToolGroup } from "@/types/tool";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -12,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ToolDetailsPanel } from "@/components/tools/ToolDetailsPanel";
 import { ToolForm } from "@/components/tools/ToolForm";
+import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 
 function buildGroups(tools: Tool[]): ToolGroup[] {
   const map = new Map<string, ToolGroup>();
@@ -143,6 +148,9 @@ export function Tools() {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<ToolGroup | null>(null);
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
+  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
 
   const { data: toolsData, error, isLoading, refetch } = useQuery<Tool[]>("/tools?limit=0");
 
@@ -161,6 +169,43 @@ export function Tools() {
   const handleCloseDetails = () => {
     setIsDetailsPanelOpen(false);
   };
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      const tool = toolsData?.find((t) => t.id === id);
+      setSelectedToolId(id);
+      setSelectedToolName(tool?.displayName || tool?.name || id);
+      setDeleteDialogOpen(true);
+    },
+    [toolsData],
+  );
+
+  const confirmDelete = useCallback(async () => {
+    if (!selectedToolId || !selectedToolName) return;
+
+    setDeleteDialogOpen(false);
+
+    try {
+      await toolsApi.delete(selectedToolId);
+      toast.success(`Tool "${selectedToolName}" deleted successfully`);
+      setSelectedToolId(null);
+      setSelectedToolName(null);
+      setIsDetailsPanelOpen(false);
+      setSelectedGroup(null);
+      await refetch();
+    } catch (err) {
+      let errorMessage = "Failed to delete tool";
+
+      if (err instanceof ApiError) {
+        const detail = extractApiErrorDetail(err.body);
+        errorMessage = detail || `Failed to delete tool: ${err.message || "Unknown error"}`;
+      } else if (err instanceof Error) {
+        errorMessage = `Failed to delete tool: ${err.message}`;
+      }
+
+      toast.error(errorMessage);
+    }
+  }, [selectedToolId, selectedToolName, refetch]);
 
   return (
     <div className="p-6">
@@ -216,8 +261,19 @@ export function Tools() {
               gatewaySlug={selectedGroup.gatewaySlug}
               open={isDetailsPanelOpen}
               onClose={handleCloseDetails}
+              onDeleteTool={handleDelete}
             />
           )}
+
+          <ConfirmDialog
+            open={deleteDialogOpen}
+            onOpenChange={setDeleteDialogOpen}
+            onConfirm={confirmDelete}
+            title="Delete Tool"
+            description={`Are you sure you want to delete "${selectedToolName}"? This action cannot be undone.`}
+            confirmLabel="Delete"
+            variant="destructive"
+          />
         </>
       )}
     </div>

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -269,7 +269,7 @@ export function Tools() {
             open={deleteDialogOpen}
             onOpenChange={setDeleteDialogOpen}
             onConfirm={confirmDelete}
-            title="Delete Tool"
+            title="Delete tool"
             description={`Are you sure you want to delete "${selectedToolName}"? This action cannot be undone.`}
             confirmLabel="Delete"
             variant="destructive"

--- a/client/src/utils/errors.test.ts
+++ b/client/src/utils/errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { extractApiErrorDetail } from "./errors";
+
+describe("extractApiErrorDetail", () => {
+  it("returns null for null", () => {
+    expect(extractApiErrorDetail(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(extractApiErrorDetail(undefined)).toBeNull();
+  });
+
+  it("returns null for a string", () => {
+    expect(extractApiErrorDetail("error")).toBeNull();
+  });
+
+  it("returns null for a number", () => {
+    expect(extractApiErrorDetail(42)).toBeNull();
+  });
+
+  it("returns null when body has no detail field", () => {
+    expect(extractApiErrorDetail({ message: "Something went wrong" })).toBeNull();
+  });
+
+  it("returns null when detail is null", () => {
+    expect(extractApiErrorDetail({ detail: null })).toBeNull();
+  });
+
+  it("returns null when detail is an empty string", () => {
+    expect(extractApiErrorDetail({ detail: "" })).toBeNull();
+  });
+
+  it("returns string detail", () => {
+    expect(extractApiErrorDetail({ detail: "Tool not found" })).toBe("Tool not found");
+  });
+
+  it("returns first msg from a FastAPI validation error array", () => {
+    expect(
+      extractApiErrorDetail({
+        detail: [{ msg: "field required" }, { msg: "invalid value" }],
+      }),
+    ).toBe("field required");
+  });
+
+  it("returns null when detail is an empty array", () => {
+    expect(extractApiErrorDetail({ detail: [] })).toBeNull();
+  });
+
+  it("returns null when the array item has no msg property", () => {
+    expect(extractApiErrorDetail({ detail: [{ loc: ["body", "name"] }] })).toBeNull();
+  });
+});

--- a/client/src/utils/errors.ts
+++ b/client/src/utils/errors.ts
@@ -19,6 +19,36 @@ export async function withErrorHandling<T>(
 }
 
 /**
+ * Extracts error message from FastAPI validation error format
+ *
+ * @param body - The error body from API response
+ * @returns Extracted error message or null if not found
+ */
+export function extractApiErrorDetail(body: unknown): string | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const errorBody = body as { detail?: string | Array<{ msg: string }> };
+
+  if (!errorBody.detail) {
+    return null;
+  }
+
+  // String detail
+  if (typeof errorBody.detail === "string") {
+    return errorBody.detail;
+  }
+
+  // Array of validation errors
+  if (Array.isArray(errorBody.detail) && errorBody.detail.length > 0) {
+    return errorBody.detail[0].msg || null;
+  }
+
+  return null;
+}
+
+/**
  * Sanitizes error messages to prevent information leakage
  *
  * @param err - The error object to sanitize


### PR DESCRIPTION
### Summary

Closes #5095 

Adds the ability to delete a registered tool directly from the Tools details panel.

<img width="1893" height="772" alt="Screenshot 2026-06-15 at 14 13 50" src="https://github.com/user-attachments/assets/0f14ce34-0dbe-40c2-a133-43b217cd3200" />

<img width="1891" height="990" alt="Screenshot 2026-06-15 at 14 14 02" src="https://github.com/user-attachments/assets/6a8c7c16-4d2d-4511-abf4-6d1b63a806b4" />

  ---

  ### What changed

  #### New files

  | File | Purpose |
  |---|---|
  | `client/src/api/tools.ts` | `toolsApi.delete(id)` — typed DELETE wrapper with client-side ID validation |
  | `client/src/utils/errors.ts` | `extractApiErrorDetail(body)` — parses FastAPI `detail` strings and validation arrays |

  #### Modified files

  **`ToolsTable.tsx`**
When an `onDeleteTool` handler is provided, the static "More options" icon button becomes a functional `DropdownMenu` with a **Delete** item styled as destructive. Without the prop the component behaves exactly as before, preserving backward compatibility.

  **`ToolDetailsPanel.tsx`**
Threads the optional `onDeleteTool` prop down to `ToolsTable`.

  **`Tools.tsx`**
  Wires up the full delete flow:
  - `handleDelete` — resolves the tool's display name from the already-fetched `toolsData` and opens a confirmation dialog.
  - `confirmDelete` — calls `toolsApi.delete`, shows a success or error toast, closes the details panel, clears group selection, and refetches the list. Both handlers are memoised with `useCallback`.
  - `ConfirmDialog` is placed **outside** the `selectedGroup &&` guard so it stays mounted if group state clears mid-confirmation.

  ---

  ### User flow

  Tools page → "More options" (group card) → "View Details"
    → Tools table → "More options" (row) → "Delete"
      → Confirm dialog ("Delete Tool" / "This action cannot be undone")
        → [Cancel] no-op
        → [Delete] DELETE /tools/:id → success toast + panel closes
                                      → error toast (with API detail if available)

  ---

  ### Accessibility

  | Area | Detail |
  |---|---|
  | Dropdown trigger | `aria-label="More options"` on the trigger; Radix adds `aria-expanded` and `aria-haspopup` on open |
  | Destructive action | Confirm button uses `variant="destructive"` for colour contrast and semantic clarity |
  | Confirm dialog | Radix `Dialog` provides `role="dialog"`, `aria-labelledby` → title, `aria-describedby` → description |
  | Existing states | `role="status"` / `aria-busy` (loading) and `role="alert"` / `aria-live` (error) unchanged |

  ---

  ### Tests

  128 tests across 5 files — all passing.

  | File | Coverage added |
  |---|---|
  | `utils/errors.test.ts` _(new)_ | 11 tests — `extractApiErrorDetail`: null / undefined / non-object inputs, missing or null `detail`, empty string, string value, first `msg` from validation array, empty array, array item without `msg` |
  | `api/tools.test.ts` _(new)_ | 9 tests — valid DELETE with CSRF token, UUID and underscore IDs, sync throws for empty / path-traversal / space / special-char IDs, 404 and 500 responses |
  | `ToolsTable.test.tsx` | 4 tests — dropdown rendered when prop present, correct ID forwarded to callback, no row-selection side-effect on delete click, no Delete item without prop |
  | `ToolDetailsPanel.test.tsx` | 3 tests — Delete item visible when `onDeleteTool` passed, correct ID forwarded, no Delete item without prop |
  | `Tools.test.tsx` | 8 tests — Delete option visible in panel, confirm dialog shows tool name, cancel skips API call, success path (API call + toast + panel closes), string-detail error toast, generic error toast, `displayName` preferred over `name`, falls back to `name` when `displayName` absent |
