### PR TITLE
feat(ui-rewrite): add input/output schema dialog with schema syntax highlighting

### DIFF
--- a/client/src/components/tools/ToolSchemaDialog.test.tsx
+++ b/client/src/components/tools/ToolSchemaDialog.test.tsx
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToolSchemaDialog } from "./ToolSchemaDialog";
+import * as gatewayUtils from "@/components/gateways/utils";
+import type { Tool } from "@/types/tool";
+
+// Helper to create mock tool
+function createMockTool(overrides?: Partial<Tool>): Tool {
+  return {
+    id: "tool-1",
+    name: "Test Tool",
+    originalName: "test_tool",
+    description: "Test description",
+    originalDescription: "Original test description",
+    title: "Test Tool Title",
+    displayName: "Test Display Name",
+    gatewayId: "gateway-id",
+    gatewaySlug: "test-gateway",
+    customName: "Test Tool",
+    customNameSlug: "test-tool",
+    enabled: true,
+    reachable: true,
+    executionCount: 0,
+    tags: ["tag1"],
+    integrationType: "MCP",
+    requestType: "http",
+    url: "https://example.com/tool",
+    version: 1,
+    visibility: "team",
+    createdAt: "2024-01-01T00:00:00",
+    updatedAt: "2024-01-02T00:00:00",
+    ...overrides,
+  };
+}
+
+describe("ToolSchemaDialog", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(gatewayUtils, "copyToClipboard").mockImplementation(() => {});
+  });
+
+  it("renders dialog when open is true", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Tool schema")).toBeInTheDocument();
+  });
+
+  it("does not render dialog when open is false", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={false} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders Input and Output section headers", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByText("Input")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
+  });
+
+  it("displays input schema when provided", () => {
+    const tool = createMockTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query" },
+        },
+      },
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getAllByText(/query/)[0]).toBeInTheDocument();
+    expect(screen.getByText(/Search query/)).toBeInTheDocument();
+  });
+
+  it("displays output schema when provided", () => {
+    const tool = createMockTool({
+      outputSchema: {
+        type: "object",
+        properties: {
+          result: { type: "string" },
+        },
+      },
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByText(/result/)).toBeInTheDocument();
+  });
+
+  it("displays empty object when schemas are undefined", () => {
+    const tool = createMockTool({
+      inputSchema: undefined,
+      outputSchema: undefined,
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // Should display "{}" for both sections
+    const preElements = screen.getAllByRole("code");
+    expect(preElements).toHaveLength(2);
+  });
+
+  it("renders copy buttons for input and output schemas", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    const copyButtons = screen.getAllByLabelText(/Copy/);
+    expect(copyButtons).toHaveLength(2);
+    expect(screen.getByLabelText("Copy input")).toBeInTheDocument();
+    expect(screen.getByLabelText("Copy output")).toBeInTheDocument();
+  });
+
+  it("copies input schema to clipboard when copy button is clicked", async () => {
+    const user = userEvent.setup();
+    const inputSchema = { type: "object", properties: { query: { type: "string" } } };
+    const tool = createMockTool({ inputSchema });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    const copyButton = screen.getByLabelText("Copy input");
+    await user.click(copyButton);
+
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith(JSON.stringify(inputSchema, null, 2));
+  });
+
+  it("copies output schema to clipboard when copy button is clicked", async () => {
+    const user = userEvent.setup();
+    const outputSchema = { type: "object", properties: { result: { type: "string" } } };
+    const tool = createMockTool({ outputSchema });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    const copyButton = screen.getByLabelText("Copy output");
+    await user.click(copyButton);
+
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith(
+      JSON.stringify(outputSchema, null, 2),
+    );
+  });
+
+  it("renders Close button", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // Both the footer button and the dialog's sr-only × share the name "Close"
+    const closeButtons = screen.getAllByRole("button", { name: /close/i });
+    expect(closeButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls onOpenChange with false when Close button is clicked", async () => {
+    const user = userEvent.setup();
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // Footer button has no SVG child; × button does — use that to distinguish them
+    const allClose = screen.getAllByRole("button", { name: /close/i });
+    const footerClose = allClose.find((btn) => !btn.querySelector("svg"))!;
+    await user.click(footerClose);
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onOpenChange when X button is clicked", async () => {
+    const user = userEvent.setup();
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // × button contains an SVG icon; footer button contains only text
+    const allClose = screen.getAllByRole("button", { name: /close/i });
+    const xButton = allClose.find((btn) => btn.querySelector("svg"))!;
+    await user.click(xButton);
+
+    expect(mockOnOpenChange).toHaveBeenCalled();
+  });
+
+  it("handles null tool gracefully and copy buttons emit empty schema", async () => {
+    const user = userEvent.setup();
+    render(<ToolSchemaDialog tool={null} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Tool schema")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Copy input"));
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith("{}");
+
+    await user.click(screen.getByLabelText("Copy output"));
+    expect(gatewayUtils.copyToClipboard).toHaveBeenCalledWith("{}");
+  });
+
+  it("formats JSON with proper indentation", () => {
+    const tool = createMockTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+      },
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // "type" appears as a key multiple times across spans; assert at least one is present
+    expect(screen.getAllByText(/type/)[0]).toBeInTheDocument();
+  });
+
+  it("applies proper styling classes to schema sections", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    const preElements = document.querySelectorAll("pre");
+    expect(preElements).toHaveLength(2);
+
+    preElements.forEach((pre) => {
+      expect(pre).toHaveClass("bg-neutral-900");
+      expect(pre).toHaveClass("rounded-md");
+      expect(pre).toHaveClass("whitespace-pre-wrap");
+      expect(pre).toHaveClass("break-words");
+    });
+  });
+
+  it("renders schema icon with correct styling", () => {
+    const tool = createMockTool();
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    // Inline style is serialised as kebab-case in the DOM attribute
+    const iconContainer = document.querySelector('[style*="background-color"]');
+    expect(iconContainer).toBeInTheDocument();
+  });
+
+  it("handles complex nested schemas", () => {
+    const tool = createMockTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          nested: {
+            type: "object",
+            properties: {
+              deep: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByText(/nested/)).toBeInTheDocument();
+    expect(screen.getByText(/deep/)).toBeInTheDocument();
+    expect(screen.getByText(/array/)).toBeInTheDocument();
+  });
+
+  it("handles schemas with long text values", () => {
+    const tool = createMockTool({
+      inputSchema: {
+        type: "object",
+        properties: {
+          description: {
+            type: "string",
+            description:
+              "This is a very long description that should wrap properly in the dialog without causing overflow issues",
+          },
+        },
+      },
+    });
+    render(<ToolSchemaDialog tool={tool} open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(
+      screen.getByText(/This is a very long description that should wrap properly/),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/tools/ToolSchemaDialog.tsx
+++ b/client/src/components/tools/ToolSchemaDialog.tsx
@@ -1,0 +1,86 @@
+import { Copy, Code } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/components/gateways/utils";
+import { JsonHighlighter } from "@/components/ui/json-highlighter";
+import type { Tool } from "@/types/tool";
+
+interface ToolSchemaDialogProps {
+  tool: Tool | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function SchemaSection({
+  title,
+  schema,
+}: {
+  title: string;
+  schema: Record<string, unknown> | undefined;
+}) {
+  const schemaText = schema ? JSON.stringify(schema, null, 2) : "{}";
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground">{title}</h3>
+      <div className="relative">
+        <pre className="max-h-[280px] overflow-auto rounded-md bg-neutral-900 p-4 text-xs leading-relaxed text-neutral-100 whitespace-pre-wrap break-words">
+          <code className="break-words">
+            <JsonHighlighter text={schemaText} />
+          </code>
+        </pre>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={`Copy ${title.toLowerCase()}`}
+          className="absolute right-2 top-2 size-6 bg-neutral-800/80 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100"
+          onClick={() => copyToClipboard(schemaText)}
+        >
+          <Copy className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ToolSchemaDialog({ tool, open, onOpenChange }: ToolSchemaDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <div
+              className="flex h-6 w-6 items-center justify-center rounded"
+              style={{ backgroundColor: "#6FFF9F" }}
+            >
+              <Code className="h-4 w-4 text-black" />
+            </div>
+            <DialogTitle>Tool schema</DialogTitle>
+          </div>
+          <DialogDescription className="sr-only">
+            View the input and output schemas for this tool
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <SchemaSection title="Input" schema={tool?.inputSchema} />
+          <SchemaSection title="Output" schema={tool?.outputSchema} />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/tools/ToolsTable.test.tsx
+++ b/client/src/components/tools/ToolsTable.test.tsx
@@ -186,6 +186,24 @@ describe("ToolsTable", () => {
     expect(schemaButton).toBeInTheDocument();
   });
 
+  it("opens schema dialog when schema button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [
+      createMockTool(1, {
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+        outputSchema: { type: "object", properties: { result: { type: "string" } } },
+      }),
+    ];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    const schemaButton = screen.getByLabelText("View schema");
+    await user.click(schemaButton);
+
+    // Dialog should be visible
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Tool schema")).toBeInTheDocument();
+  });
+
   it("does not trigger row selection when schema button is clicked", async () => {
     const user = userEvent.setup();
     const tools = [createMockTool(1)];
@@ -195,6 +213,25 @@ describe("ToolsTable", () => {
     await user.click(schemaButton);
 
     expect(mockOnSelectTool).not.toHaveBeenCalled();
+  });
+
+  it("closes schema dialog when Close button is clicked", async () => {
+    const user = userEvent.setup();
+    const tools = [createMockTool(1)];
+    render(<ToolsTable tools={tools} onSelectTool={mockOnSelectTool} />);
+
+    // Open dialog
+    const schemaButton = screen.getByLabelText("View schema");
+    await user.click(schemaButton);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Close dialog — two buttons share the name "Close" (footer button + dialog's sr-only × button);
+    // the footer button is first in DOM order since Radix appends × after children
+    const [closeButton] = screen.getAllByRole("button", { name: /close/i });
+    await user.click(closeButton);
+
+    // Dialog should be closed
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("renders more options button", () => {

--- a/client/src/components/tools/ToolsTable.tsx
+++ b/client/src/components/tools/ToolsTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Copy, MoreHorizontal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import type { Tool } from "@/types/tool";
 import { copyToClipboard, truncateMiddle } from "@/components/gateways/utils";
+import { ToolSchemaDialog } from "@/components/tools/ToolSchemaDialog";
 
 export function ToolsTable({
   tools,
@@ -20,112 +22,131 @@ export function ToolsTable({
   selectedToolId?: string | null;
   onSelectTool: (tool: Tool) => void;
 }) {
+  const [schemaDialogTool, setSchemaDialogTool] = useState<Tool | null>(null);
+  const [isSchemaDialogOpen, setIsSchemaDialogOpen] = useState(false);
+
+  const handleSchemaClick = (tool: Tool) => {
+    setSchemaDialogTool(tool);
+    setIsSchemaDialogOpen(true);
+  };
+
   return (
-    <Table>
-      <TableHeader>
-        <TableRow className="hover:bg-transparent">
-          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool</TableHead>
-          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Name</TableHead>
-          <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool ID</TableHead>
-          <TableHead className="h-9 w-[80px] px-4 py-2.5 text-xs font-medium">Schema</TableHead>
-          <TableHead className="h-9 w-[40px] px-4 py-2.5" />
-        </TableRow>
-      </TableHeader>
-      <TableBody className="[&_tr]:border-0">
-        {tools.map((tool) => (
-          <TableRow
-            key={tool.id}
-            data-state={selectedToolId === tool.id ? "selected" : undefined}
-            onClick={() => onSelectTool(tool)}
-            className="cursor-pointer"
-          >
-            <TableCell className="px-4 py-3 text-sm text-foreground">
-              <span className="line-clamp-1">{tool.displayName || tool.title || tool.name}</span>
-            </TableCell>
-
-            <TableCell className="px-4 py-3">
-              <div className="flex min-w-0 items-center">
-                <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
-                  {tool.originalName}
-                </span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={`Copy ${tool.originalName}`}
-                  className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copyToClipboard(tool.originalName);
-                  }}
-                >
-                  <Copy className="size-3" />
-                </Button>
-              </div>
-            </TableCell>
-
-            <TableCell className="px-4 py-3">
-              <div className="flex min-w-0 items-center">
-                <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
-                  {truncateMiddle(tool.id, 18)}
-                </span>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="Copy tool ID"
-                  className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    copyToClipboard(tool.id);
-                  }}
-                >
-                  <Copy className="size-3" />
-                </Button>
-              </div>
-            </TableCell>
-
-            <TableCell className="px-4 py-3 text-center">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="View schema"
-                className="size-5 text-muted-foreground hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  // TODO: Implement schema view
-                }}
-              >
-                <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                  />
-                </svg>
-              </Button>
-            </TableCell>
-
-            <TableCell className="px-4 py-3 text-center">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label="More options"
-                className="size-5 text-muted-foreground hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  // TODO: Implement more options menu
-                }}
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </TableCell>
+    <>
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool</TableHead>
+            <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Name</TableHead>
+            <TableHead className="h-9 px-4 py-2.5 text-xs font-medium">Tool ID</TableHead>
+            <TableHead className="h-9 w-[80px] px-4 py-2.5 text-xs font-medium">Schema</TableHead>
+            <TableHead className="h-9 w-[40px] px-4 py-2.5" />
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody className="[&_tr]:border-0">
+          {tools.map((tool) => (
+            <TableRow
+              key={tool.id}
+              data-state={selectedToolId === tool.id ? "selected" : undefined}
+              onClick={() => onSelectTool(tool)}
+              className="cursor-pointer"
+            >
+              <TableCell className="px-4 py-3 text-sm text-foreground">
+                <span className="line-clamp-1">{tool.displayName || tool.title || tool.name}</span>
+              </TableCell>
+
+              <TableCell className="px-4 py-3">
+                <div className="flex min-w-0 items-center">
+                  <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                    {tool.originalName}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label={`Copy ${tool.originalName}`}
+                    className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      copyToClipboard(tool.originalName);
+                    }}
+                  >
+                    <Copy className="size-3" />
+                  </Button>
+                </div>
+              </TableCell>
+
+              <TableCell className="px-4 py-3">
+                <div className="flex min-w-0 items-center">
+                  <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                    {truncateMiddle(tool.id, 18)}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Copy tool ID"
+                    className="ml-4 size-4 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      copyToClipboard(tool.id);
+                    }}
+                  >
+                    <Copy className="size-3" />
+                  </Button>
+                </div>
+              </TableCell>
+
+              <TableCell className="px-4 py-3 text-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="View schema"
+                  className="size-5 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleSchemaClick(tool);
+                  }}
+                >
+                  <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                    />
+                  </svg>
+                </Button>
+              </TableCell>
+
+              <TableCell className="px-4 py-3 text-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="More options"
+                  className="size-5 text-muted-foreground hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    // TODO: Implement more options menu
+                  }}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <ToolSchemaDialog
+        tool={schemaDialogTool}
+        open={isSchemaDialogOpen}
+        onOpenChange={(open) => {
+          setIsSchemaDialogOpen(open);
+          if (!open) setSchemaDialogTool(null);
+        }}
+      />
+    </>
   );
 }

--- a/client/src/components/ui/json-highlighter.test.tsx
+++ b/client/src/components/ui/json-highlighter.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { JsonHighlighter } from "./json-highlighter";
+
+describe("JsonHighlighter", () => {
+  it("renders simple JSON string", () => {
+    const json = '{"key": "value"}';
+    const { container } = render(<JsonHighlighter text={json} />);
+    expect(container.textContent).toBe(json);
+  });
+
+  it("highlights string values", () => {
+    const json = '{"name": "test"}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const stringSpan = Array.from(spans).find((span) => span.textContent === '"test"');
+    expect(stringSpan).toHaveStyle({ color: "#AE69FF" });
+  });
+
+  it("highlights object keys", () => {
+    const json = '{"key": "value"}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const keySpan = Array.from(spans).find((span) => span.textContent === '"key"');
+    expect(keySpan).toHaveStyle({ color: "#6FFF9F" });
+  });
+
+  it("highlights numbers", () => {
+    const json = '{"count": 42}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const numberSpan = Array.from(spans).find((span) => span.textContent === "42");
+    expect(numberSpan).toHaveStyle({ color: "#FFB86F" });
+  });
+
+  it("highlights boolean values", () => {
+    const json = '{"enabled": true, "disabled": false}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const trueSpan = Array.from(spans).find((span) => span.textContent === "true");
+    const falseSpan = Array.from(spans).find((span) => span.textContent === "false");
+
+    expect(trueSpan).toHaveStyle({ color: "#6FC8FF" });
+    expect(falseSpan).toHaveStyle({ color: "#6FC8FF" });
+  });
+
+  it("highlights null values", () => {
+    const json = '{"value": null}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const nullSpan = Array.from(spans).find((span) => span.textContent === "null");
+    expect(nullSpan).toHaveStyle({ color: "#6FC8FF" });
+  });
+
+  it("does not highlight punctuation", () => {
+    const json = '{"key": "value"}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    // Punctuation should be rendered as plain text (not in colored spans)
+    expect(container.textContent).toContain("{");
+    expect(container.textContent).toContain("}");
+    expect(container.textContent).toContain(":");
+  });
+
+  it("preserves whitespace", () => {
+    const json = '{\n  "key": "value"\n}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    expect(container.textContent).toBe(json);
+  });
+
+  it("handles nested objects", () => {
+    const json = '{"outer": {"inner": "value"}}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const outerKey = Array.from(spans).find((span) => span.textContent === '"outer"');
+    const innerKey = Array.from(spans).find((span) => span.textContent === '"inner"');
+
+    expect(outerKey).toHaveStyle({ color: "#6FFF9F" });
+    expect(innerKey).toHaveStyle({ color: "#6FFF9F" });
+  });
+
+  it("handles arrays", () => {
+    const json = '{"items": [1, 2, 3]}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const numbers = Array.from(spans).filter((span) =>
+      ["1", "2", "3"].includes(span.textContent || ""),
+    );
+
+    expect(numbers).toHaveLength(3);
+    numbers.forEach((span) => {
+      expect(span).toHaveStyle({ color: "#FFB86F" });
+    });
+  });
+
+  it("handles escaped characters in strings", () => {
+    const json = '{"text": "line1\\nline2"}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    expect(container.textContent).toContain("line1\\nline2");
+  });
+
+  it("handles negative numbers", () => {
+    const json = '{"value": -42}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const numberSpan = Array.from(spans).find((span) => span.textContent === "-42");
+    expect(numberSpan).toHaveStyle({ color: "#FFB86F" });
+  });
+
+  it("handles decimal numbers", () => {
+    const json = '{"value": 3.14}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const numberSpan = Array.from(spans).find((span) => span.textContent === "3.14");
+    expect(numberSpan).toHaveStyle({ color: "#FFB86F" });
+  });
+
+  it("handles scientific notation", () => {
+    const json = '{"value": 1.5e10}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    const spans = container.querySelectorAll("span");
+    const numberSpan = Array.from(spans).find((span) => span.textContent === "1.5e10");
+    expect(numberSpan).toHaveStyle({ color: "#FFB86F" });
+  });
+
+  it("handles empty object", () => {
+    const json = "{}";
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    expect(container.textContent).toBe("{}");
+  });
+
+  it("handles empty array", () => {
+    const json = "[]";
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    expect(container.textContent).toBe("[]");
+  });
+
+  it("handles complex nested structure", () => {
+    const json = JSON.stringify(
+      {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query",
+          },
+          limit: {
+            type: "number",
+            default: 10,
+          },
+        },
+      },
+      null,
+      2,
+    );
+
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    expect(container.textContent).toBe(json);
+
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBeGreaterThan(0);
+  });
+
+  it("renders each token with correct key", () => {
+    const json = '{"a": 1, "b": 2}';
+    const { container } = render(<JsonHighlighter text={json} />);
+
+    // Each token should have a unique key (idx)
+    const spans = container.querySelectorAll("span");
+    expect(spans.length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/components/ui/json-highlighter.tsx
+++ b/client/src/components/ui/json-highlighter.tsx
@@ -1,0 +1,100 @@
+import { useMemo } from "react";
+
+type TokenType = "key" | "string" | "number" | "boolean" | "null" | "punctuation" | "whitespace";
+
+interface TokenStyle {
+  color?: string;
+  fontWeight?: string;
+  fontStyle?: string;
+}
+
+const TOKEN_STYLES: Record<TokenType, TokenStyle> = {
+  key: { color: "#6FFF9F", fontWeight: "bold" },
+  string: { color: "#AE69FF" },
+  number: { color: "#FFB86F", fontStyle: "italic" },
+  boolean: { color: "#6FC8FF", fontStyle: "italic" },
+  null: { color: "#6FC8FF", fontStyle: "italic" },
+  punctuation: {},
+  whitespace: {},
+};
+
+function tokenizeJson(json: string): Array<{ type: TokenType; value: string }> {
+  const tokens: Array<{ type: TokenType; value: string }> = [];
+  let i = 0;
+
+  while (i < json.length) {
+    const ch = json[i];
+
+    if (ch === '"') {
+      let j = i + 1;
+      while (j < json.length) {
+        if (json[j] === "\\") {
+          j += 2;
+        } else if (json[j] === '"') {
+          j++;
+          break;
+        } else {
+          j++;
+        }
+      }
+      const str = json.slice(i, j);
+      let k = j;
+      while (k < json.length && /\s/.test(json[k])) k++;
+      tokens.push({ type: json[k] === ":" ? "key" : "string", value: str });
+      i = j;
+    } else if (/\s/.test(ch)) {
+      let j = i;
+      while (j < json.length && /\s/.test(json[j])) j++;
+      tokens.push({ type: "whitespace", value: json.slice(i, j) });
+      i = j;
+    } else if (json.slice(i, i + 4) === "true") {
+      tokens.push({ type: "boolean", value: "true" });
+      i += 4;
+    } else if (json.slice(i, i + 5) === "false") {
+      tokens.push({ type: "boolean", value: "false" });
+      i += 5;
+    } else if (json.slice(i, i + 4) === "null") {
+      tokens.push({ type: "null", value: "null" });
+      i += 4;
+    } else if (ch === "-" || /\d/.test(ch)) {
+      let j = i;
+      if (json[j] === "-") j++;
+      while (j < json.length && /\d/.test(json[j])) j++;
+      if (json[j] === ".") {
+        j++;
+        while (j < json.length && /\d/.test(json[j])) j++;
+      }
+      if (json[j] === "e" || json[j] === "E") {
+        j++;
+        if (json[j] === "+" || json[j] === "-") j++;
+        while (j < json.length && /\d/.test(json[j])) j++;
+      }
+      tokens.push({ type: "number", value: json.slice(i, j) });
+      i = j;
+    } else {
+      tokens.push({ type: "punctuation", value: ch });
+      i++;
+    }
+  }
+
+  return tokens;
+}
+
+export function JsonHighlighter({ text }: { text: string }) {
+  const tokens = useMemo(() => tokenizeJson(text), [text]);
+  return (
+    <>
+      {tokens.map((token, idx) => {
+        const style = TOKEN_STYLES[token.type];
+        const hasStyle = style.color || style.fontWeight || style.fontStyle;
+        return hasStyle ? (
+          <span key={`${token.type}-${idx}`} style={style}>
+            {token.value}
+          </span>
+        ) : (
+          token.value
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #5195 

### Summary 

Implements the previously stubbed "View schema" button in the Tools table. Clicking it opens a dialog showing a tool's input and output JSON schemas. Introduces a reusable `JsonHighlighter` component that tokenises JSON and applies per-token colour and weight styling.

<img width="1684" height="877" alt="Screenshot 2026-06-15 at 17 22 56" src="https://github.com/user-attachments/assets/bc6d675b-1552-4dc3-a0e2-33816e3e41e3" />

<img width="1685" height="876" alt="Screenshot 2026-06-15 at 17 23 11" src="https://github.com/user-attachments/assets/b97194c4-8fd0-49e5-a89b-f376a2624b6f" />


### What's included

  - **`ToolSchemaDialog`** — modal displaying input and output schemas in scrollable pre blocks, each with a copy-to-clipboard button
  - **`JsonHighlighter`** (`client/src/components/ui/json-highlighter`) — standalone syntax highlighter using token colours from the design system (`#6FFF9F` keys bold, `#AE69FF` strings, `#FFB86F` numbers italic, `#6FC8FF` booleans/null italic); secondary visual cues (bold, italic) satisfy WCAG 1.4.1 so structure is readable without colour perception; tokenisation is memoised per `text` prop
  - **`ToolsTable`** — "View schema" button wired to open the dialog with event isolation so it does not trigger row selection; stale `schemaDialogTool` reference cleared on close to prevent wrong schema showing during the close animation
 
### Tests

  `ToolSchemaDialog.test.tsx` (19 cases) and `json-highlighter.test.tsx` (18 cases) cover rendering, copy interactions, null-tool safety, button disambiguation, and tokeniser edge cases. `ToolsTable.test.tsx` extended with schema dialog open/close and selection isolation scenarios.
