### PR TITLE
feat: add virtual server delete flow

### DIFF
--- a/client/e2e/gateways.spec.ts
+++ b/client/e2e/gateways.spec.ts
@@ -204,7 +204,128 @@ test.describe("Gateways page", () => {
 
     await expect(page.getByRole("menuitem", { name: "Edit server" })).toHaveCount(0);
     await expect(page.getByRole("menuitem", { name: "Deactivate" })).toHaveCount(0);
-    await expect(page.getByRole("menuitem", { name: "Delete" })).toHaveCount(0);
+    const deleteItem = page.getByRole("menuitem", { name: "Delete" });
+    await expect(deleteItem).toBeVisible();
+    await expect(deleteItem).not.toHaveAttribute("data-disabled", "");
+  });
+
+  test("confirms and deletes a virtual server", async ({ page }) => {
+    let isDeleted = false;
+    let listRequestCount = 0;
+    let deleteRequestCount = 0;
+
+    await page.route("**/servers?*", async (route) => {
+      listRequestCount += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ servers: isDeleted ? [] : [MOCK_VIRTUAL_SERVER] }),
+      });
+    });
+    await page.route(`**/servers/${MOCK_VIRTUAL_SERVER.id}`, async (route) => {
+      expect(route.request().method()).toBe("DELETE");
+      deleteRequestCount += 1;
+      isDeleted = true;
+      await route.fulfill({ status: 204 });
+    });
+
+    await page.goto(APP.GATEWAYS);
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText("testVS")).toBeVisible();
+
+    await page.getByRole("button", { name: "Actions for testVS" }).click();
+    await page.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Delete virtual server" });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByText("Are you sure you want to delete testVS? This action cannot be undone."),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    await expect.poll(() => deleteRequestCount).toBe(1);
+    await expect.poll(() => listRequestCount).toBeGreaterThan(1);
+    await expect(page.getByText("testVS")).toHaveCount(0);
+    await expect(page.getByRole("status")).toContainText("testVS deleted.");
+  });
+
+  test("shows delete progress while a virtual server delete is pending", async ({ page }) => {
+    let deleteRequestCount = 0;
+    let releaseDelete: () => void;
+    const deleteCanFinish = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+
+    await page.route("**/servers?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ servers: [MOCK_VIRTUAL_SERVER] }),
+      });
+    });
+    await page.route(`**/servers/${MOCK_VIRTUAL_SERVER.id}`, async (route) => {
+      expect(route.request().method()).toBe("DELETE");
+      deleteRequestCount += 1;
+      await deleteCanFinish;
+      await route.fulfill({ status: 204 });
+    });
+
+    await page.goto(APP.GATEWAYS);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Actions for testVS" }).click();
+    await page.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Delete virtual server" });
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    const deletingButton = dialog.getByRole("button", { name: /Deleting/i });
+    await expect(deletingButton).toBeDisabled();
+    await expect(deletingButton).toHaveAttribute("aria-busy", "true");
+    await expect(dialog.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    await expect.poll(() => deleteRequestCount).toBe(1);
+
+    releaseDelete!();
+    await expect(dialog).toHaveCount(0);
+    await expect.poll(() => deleteRequestCount).toBe(1);
+  });
+
+  test("shows delete failures in a toast instead of the page content", async ({ page }) => {
+    let deleteRequestCount = 0;
+
+    await page.route("**/servers?*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ servers: [MOCK_VIRTUAL_SERVER] }),
+      });
+    });
+    await page.route(`**/servers/${MOCK_VIRTUAL_SERVER.id}`, async (route) => {
+      expect(route.request().method()).toBe("DELETE");
+      deleteRequestCount += 1;
+      await route.fulfill({
+        status: 403,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Forbidden" }),
+      });
+    });
+
+    await page.goto(APP.GATEWAYS);
+    await page.waitForLoadState("networkidle");
+
+    await page.getByRole("button", { name: "Actions for testVS" }).click();
+    await page.getByRole("menuitem", { name: "Delete" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Delete virtual server" });
+    await dialog.getByRole("button", { name: "Delete" }).click();
+
+    await expect.poll(() => deleteRequestCount).toBe(1);
+    await expect(page.getByText("Error deleting virtual server")).toBeVisible();
+    await expect(page.getByText("You don't have permission to perform this action.")).toBeVisible();
+    await expect(page.getByRole("main").getByText("Error deleting virtual server")).toHaveCount(0);
+    await expect(page.getByText("testVS")).toBeVisible();
   });
 
   test("opens virtual server details panel from row actions", async ({ page }) => {

--- a/client/src/api/virtualServers.test.ts
+++ b/client/src/api/virtualServers.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { buildCreateVirtualServerPayload } from "./virtualServers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "./client";
+import { buildCreateVirtualServerPayload, deleteVirtualServer } from "./virtualServers";
+
+vi.mock("./client", () => ({
+  api: {
+    delete: vi.fn(),
+  },
+}));
 
 describe("virtualServers API", () => {
+  beforeEach(() => {
+    vi.mocked(api.delete).mockReset();
+  });
+
   it("builds the create payload expected by POST /servers", () => {
     expect(
       buildCreateVirtualServerPayload({
@@ -212,5 +223,13 @@ describe("virtualServers API", () => {
 
     expect(payload.server.team_id).toBeNull();
     expect(payload.team_id).toBeNull();
+  });
+
+  it("deletes a virtual server by encoded id", async () => {
+    vi.mocked(api.delete).mockResolvedValue(undefined);
+
+    await deleteVirtualServer("gateway/1?mode=delete");
+
+    expect(api.delete).toHaveBeenCalledWith("/servers/gateway%2F1%3Fmode%3Ddelete");
   });
 });

--- a/client/src/api/virtualServers.ts
+++ b/client/src/api/virtualServers.ts
@@ -50,3 +50,7 @@ export function buildCreateVirtualServerPayload(
 export function createVirtualServer(details: CreateServerDetails): Promise<VirtualServer> {
   return api.post<VirtualServer>("/servers", buildCreateVirtualServerPayload(details));
 }
+
+export function deleteVirtualServer(id: string): Promise<void> {
+  return api.delete<void>(`/servers/${encodeURIComponent(id)}`);
+}

--- a/client/src/components/gateways/VirtualServerCard.tsx
+++ b/client/src/components/gateways/VirtualServerCard.tsx
@@ -26,6 +26,8 @@ export function VirtualServerCard({
   onEdit,
   onDelete,
   onToggleStatus,
+  isDeleting = false,
+  deleteDisabled = false,
   className,
 }: {
   server: VirtualServer;
@@ -34,6 +36,8 @@ export function VirtualServerCard({
   onEdit?: (server: VirtualServer) => void;
   onDelete?: (server: VirtualServer) => void;
   onToggleStatus?: (server: VirtualServer) => void;
+  isDeleting?: boolean;
+  deleteDisabled?: boolean;
   className?: string;
 }) {
   const intl = useIntl();
@@ -123,6 +127,7 @@ export function VirtualServerCard({
                   <>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
+                      disabled={isDeleting || deleteDisabled}
                       onClick={(e) => {
                         e.stopPropagation();
                         onDelete(server);

--- a/client/src/components/servers/ConfirmDialog.tsx
+++ b/client/src/components/servers/ConfirmDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from "../ui/dialog";
 import { Button } from "../ui/button";
+import { Loading } from "../ui/loading";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -17,7 +18,10 @@ interface ConfirmDialogProps {
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: "default" | "destructive";
-  onConfirm: () => void;
+  onConfirm: () => void | Promise<void>;
+  isLoading?: boolean;
+  loadingLabel?: string;
+  closeOnConfirm?: boolean;
 }
 
 export function ConfirmDialog({
@@ -29,29 +33,49 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   variant = "default",
   onConfirm,
+  isLoading = false,
+  loadingLabel,
+  closeOnConfirm = true,
 }: ConfirmDialogProps) {
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (isLoading && !nextOpen) return;
+      onOpenChange(nextOpen);
+    },
+    [isLoading, onOpenChange],
+  );
+
   const handleCancel = useCallback(() => {
+    if (isLoading) return;
     onOpenChange(false);
-  }, [onOpenChange]);
+  }, [isLoading, onOpenChange]);
 
   const handleConfirm = useCallback(() => {
-    onConfirm();
-    onOpenChange(false);
-  }, [onConfirm, onOpenChange]);
+    void onConfirm();
+    if (closeOnConfirm && !isLoading) {
+      onOpenChange(false);
+    }
+  }, [closeOnConfirm, isLoading, onConfirm, onOpenChange]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <Button variant="outline" onClick={handleCancel}>
+          <Button variant="outline" onClick={handleCancel} disabled={isLoading}>
             {cancelLabel}
           </Button>
-          <Button variant={variant} onClick={handleConfirm}>
-            {confirmLabel}
+          <Button
+            variant={variant}
+            onClick={handleConfirm}
+            disabled={isLoading}
+            aria-busy={isLoading}
+          >
+            {isLoading && <Loading variant="inline" />}
+            {isLoading ? (loadingLabel ?? confirmLabel) : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/client/src/components/ui/loading.tsx
+++ b/client/src/components/ui/loading.tsx
@@ -1,19 +1,26 @@
 import { useIntl } from "react-intl";
+import { cn } from "@/lib/utils";
 
-export function Loading() {
+export function Loading({ variant = "page" }: { variant?: "page" | "inline" }) {
   const intl = useIntl();
   const label = intl.formatMessage({ id: "common.loading" });
+  const isInline = variant === "inline";
 
   return (
-    <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
+    <div
+      className={cn(
+        "flex items-center justify-center",
+        isInline ? "size-4" : "min-h-[calc(100vh-200px)]",
+      )}
+    >
       <div
         role="status"
         aria-live="polite"
         aria-label={label}
-        className="flex flex-col items-center justify-center gap-4"
+        className={cn("flex items-center justify-center", isInline ? "size-4" : "flex-col gap-4")}
       >
         <svg
-          className="h-16 w-16"
+          className={cn(isInline ? "size-4" : "h-16 w-16")}
           xmlns="http://www.w3.org/2000/svg"
           width="22"
           height="20"
@@ -35,13 +42,15 @@ export function Loading() {
             style={{ animationDuration: "1.5s" }}
           />
         </svg>
-        <div
-          aria-hidden="true"
-          className="text-xl font-extrabold leading-none tracking-normal text-center animate-pulse"
-          style={{ animationDuration: "1.5s" }}
-        >
-          Context Forge
-        </div>
+        {!isInline && (
+          <div
+            aria-hidden="true"
+            className="text-xl font-extrabold leading-none tracking-normal text-center animate-pulse"
+            style={{ animationDuration: "1.5s" }}
+          >
+            Context Forge
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/i18n/locales/en-US/gateways.json
+++ b/client/src/i18n/locales/en-US/gateways.json
@@ -1,5 +1,6 @@
 {
   "gateways.title": "Virtual servers",
+  "gateways.notifications": "Notifications",
   "gateways.loadingVirtualServers": "Loading virtual servers, please wait...",
   "gateways.errorLoadingVirtualServers": "Error loading virtual servers",
   "gateways.action.mcpServer.title": "MCP server",
@@ -64,6 +65,11 @@
   "gateways.card.resourceCount": "{count, plural, one {# resource} other {# resources}}",
   "gateways.card.promptCount": "{count, plural, one {# prompt} other {# prompts}}",
   "gateways.card.notSyncedYet": "Not synced yet",
+  "gateways.delete.title": "Delete virtual server",
+  "gateways.delete.description": "Are you sure you want to delete {name}? This action cannot be undone.",
+  "gateways.delete.deleting": "Deleting...",
+  "gateways.delete.success": "{name} deleted.",
+  "gateways.delete.errorTitle": "Error deleting virtual server",
   "gateways.details.sheetTitle": "{name} details",
   "gateways.details.sheetDescription": "Virtual server details and activity.",
   "gateways.details.addSource": "Add source",

--- a/client/src/i18n/locales/es-ES/gateways.json
+++ b/client/src/i18n/locales/es-ES/gateways.json
@@ -1,5 +1,6 @@
 {
   "gateways.title": "Servidores virtuales",
+  "gateways.notifications": "Notificaciones",
   "gateways.loadingVirtualServers": "Cargando servidores virtuales, espere...",
   "gateways.errorLoadingVirtualServers": "Error al cargar los servidores virtuales",
   "gateways.action.mcpServer.title": "Servidor MCP",
@@ -64,6 +65,11 @@
   "gateways.card.resourceCount": "{count, plural, one {# recurso} other {# recursos}}",
   "gateways.card.promptCount": "{count, plural, one {# prompt} other {# prompts}}",
   "gateways.card.notSyncedYet": "Aún no sincronizado",
+  "gateways.delete.title": "Eliminar servidor virtual",
+  "gateways.delete.description": "¿Seguro que desea eliminar {name}? Esta acción no se puede deshacer.",
+  "gateways.delete.deleting": "Eliminando...",
+  "gateways.delete.success": "{name} eliminado.",
+  "gateways.delete.errorTitle": "Error al eliminar el servidor virtual",
   "gateways.details.sheetTitle": "Detalles de {name}",
   "gateways.details.sheetDescription": "Detalles y actividad del servidor virtual.",
   "gateways.details.addSource": "Agregar fuente",

--- a/client/src/i18n/locales/pt-BR/gateways.json
+++ b/client/src/i18n/locales/pt-BR/gateways.json
@@ -1,5 +1,6 @@
 {
   "gateways.title": "Servidores virtuais",
+  "gateways.notifications": "Notificações",
   "gateways.loadingVirtualServers": "Carregando servidores virtuais, aguarde...",
   "gateways.errorLoadingVirtualServers": "Erro ao carregar servidores virtuais",
   "gateways.action.mcpServer.title": "Servidor MCP",
@@ -64,6 +65,11 @@
   "gateways.card.resourceCount": "{count, plural, one {# recurso} other {# recursos}}",
   "gateways.card.promptCount": "{count, plural, one {# prompt} other {# prompts}}",
   "gateways.card.notSyncedYet": "Ainda não sincronizado",
+  "gateways.delete.title": "Excluir servidor virtual",
+  "gateways.delete.description": "Tem certeza de que deseja excluir {name}? Esta ação não pode ser desfeita.",
+  "gateways.delete.deleting": "Excluindo...",
+  "gateways.delete.success": "{name} excluído.",
+  "gateways.delete.errorTitle": "Erro ao excluir servidor virtual",
   "gateways.details.sheetTitle": "Detalhes de {name}",
   "gateways.details.sheetDescription": "Detalhes e atividade do servidor virtual.",
   "gateways.details.addSource": "Adicionar fonte",

--- a/client/src/pages/Gateways.test.tsx
+++ b/client/src/pages/Gateways.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { renderWithProviders } from "@/test/test-utils";
 import { Gateways } from "./Gateways";
 import { useQuery } from "@/hooks/useQuery";
+import { deleteVirtualServer } from "@/api/virtualServers";
 import type { VirtualServer } from "@/types/server";
 
 // Mock the router
@@ -20,17 +22,32 @@ vi.mock("@/hooks/useQuery", () => ({
   useQuery: vi.fn(),
 }));
 
+vi.mock("@/api/virtualServers", () => ({
+  deleteVirtualServer: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
 const mockUseQuery = vi.mocked(useQuery);
+const mockDeleteVirtualServer = vi.mocked(deleteVirtualServer);
+const mockToastError = vi.mocked(toast.error);
 
 describe("Gateways", () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockToastError.mockClear();
+    mockDeleteVirtualServer.mockReset();
+    mockDeleteVirtualServer.mockResolvedValue(undefined);
     mockUseQuery.mockReturnValue({
       data: { servers: [] },
       error: null,
       isLoading: false,
       execute: vi.fn(),
-      refetch: vi.fn(),
+      refetch: vi.fn().mockResolvedValue({ servers: [] }),
     });
   });
 
@@ -126,7 +143,7 @@ describe("Gateways", () => {
 
     expect(await screen.findByRole("menuitem", { name: "View details" })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "Deactivate" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).not.toHaveAttribute("data-disabled");
   });
 
   it("renders empty virtual servers as full-width add-components rows", () => {
@@ -383,7 +400,7 @@ describe("Gateways", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("opens virtual server details and keeps unfinished row actions disabled", async () => {
+  it("opens virtual server details from the actions menu", async () => {
     const user = userEvent.setup();
     const mockServer: VirtualServer = {
       id: "gateway/1?mode=detail",
@@ -510,6 +527,7 @@ describe("Gateways", () => {
 
     const viewDetails = await screen.findByRole("menuitem", { name: "View details" });
     expect(viewDetails).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).not.toHaveAttribute("data-disabled");
 
     await user.click(viewDetails);
 
@@ -569,6 +587,203 @@ describe("Gateways", () => {
 
     expect(screen.getAllByText("github://repo/{owner}/{repo}").length).toBeGreaterThan(0);
     expect(screen.getAllByText("summarize_pull_request").length).toBeGreaterThan(0);
+  });
+
+  it("confirms and deletes a virtual server", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn().mockResolvedValue({ servers: [] });
+    const mockServer: VirtualServer = {
+      id: "gateway/1?mode=delete",
+      name: "GH repo tasks",
+      description: "Test server",
+      icon: "",
+      createdAt: "2026-04-16T13:23:12Z",
+      updatedAt: "2026-04-16T13:23:12Z",
+      enabled: true,
+      associatedTools: [],
+      associatedToolIds: [],
+      associatedResources: [],
+      associatedPrompts: [],
+      associatedA2aAgents: [],
+      metrics: null,
+      tags: [],
+      createdBy: "admin@example.com",
+      createdFromIp: "127.0.0.1",
+      createdVia: "ui",
+      createdUserAgent: "Mozilla/5.0",
+      modifiedBy: null,
+      modifiedFromIp: null,
+      modifiedVia: null,
+      modifiedUserAgent: null,
+      importBatchId: null,
+      federationSource: null,
+      version: 1,
+      teamId: "team-1",
+      team: "Test Team",
+      ownerEmail: "admin@example.com",
+      visibility: "team",
+      oauthEnabled: false,
+      oauthConfig: null,
+    };
+
+    mockUseQuery.mockReturnValue({
+      data: { servers: [mockServer] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch,
+    });
+
+    renderWithProviders(<Gateways />);
+
+    await user.click(screen.getByRole("button", { name: "Actions for GH repo tasks" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Delete" }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Delete virtual server")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Are you sure you want to delete GH repo tasks? This action cannot be undone.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockDeleteVirtualServer).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(mockDeleteVirtualServer).toHaveBeenCalledWith("gateway/1?mode=delete");
+    await waitFor(() => expect(refetch).toHaveBeenCalledOnce());
+    expect(screen.getByRole("status")).toHaveTextContent("GH repo tasks deleted.");
+    await waitFor(() => expect(screen.queryByText("GH repo tasks")).not.toBeInTheDocument());
+  });
+
+  it("shows delete progress and blocks repeated delete requests while pending", async () => {
+    const user = userEvent.setup();
+    let resolveDelete!: () => void;
+    const deletePromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const refetch = vi.fn().mockResolvedValue({ servers: [] });
+    const mockServer: VirtualServer = {
+      id: "gateway-pending",
+      name: "Pending server",
+      description: "Test server",
+      icon: "",
+      createdAt: "2026-04-16T13:23:12Z",
+      updatedAt: "2026-04-16T13:23:12Z",
+      enabled: true,
+      associatedTools: [],
+      associatedToolIds: [],
+      associatedResources: [],
+      associatedPrompts: [],
+      associatedA2aAgents: [],
+      metrics: null,
+      tags: [],
+      createdBy: "admin@example.com",
+      createdFromIp: "127.0.0.1",
+      createdVia: "ui",
+      createdUserAgent: "Mozilla/5.0",
+      modifiedBy: null,
+      modifiedFromIp: null,
+      modifiedVia: null,
+      modifiedUserAgent: null,
+      importBatchId: null,
+      federationSource: null,
+      version: 1,
+      teamId: "team-1",
+      team: "Test Team",
+      ownerEmail: "admin@example.com",
+      visibility: "team",
+      oauthEnabled: false,
+      oauthConfig: null,
+    };
+
+    mockDeleteVirtualServer.mockReturnValue(deletePromise);
+    mockUseQuery.mockReturnValue({
+      data: { servers: [mockServer] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch,
+    });
+
+    renderWithProviders(<Gateways />);
+
+    await user.click(screen.getByRole("button", { name: "Actions for Pending server" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    const deletingButton = screen.getByRole("button", { name: /Deleting/i });
+    expect(deletingButton).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(mockDeleteVirtualServer).toHaveBeenCalledOnce();
+
+    await user.click(deletingButton);
+    expect(mockDeleteVirtualServer).toHaveBeenCalledOnce();
+
+    resolveDelete();
+    await waitFor(() => expect(refetch).toHaveBeenCalledOnce());
+  });
+
+  it("shows delete failures in a toast without rendering a page alert", async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    const mockServer: VirtualServer = {
+      id: "gateway-error",
+      name: "Error server",
+      description: "Test server",
+      icon: "",
+      createdAt: "2026-04-16T13:23:12Z",
+      updatedAt: "2026-04-16T13:23:12Z",
+      enabled: true,
+      associatedTools: [],
+      associatedToolIds: [],
+      associatedResources: [],
+      associatedPrompts: [],
+      associatedA2aAgents: [],
+      metrics: null,
+      tags: [],
+      createdBy: "admin@example.com",
+      createdFromIp: "127.0.0.1",
+      createdVia: "ui",
+      createdUserAgent: "Mozilla/5.0",
+      modifiedBy: null,
+      modifiedFromIp: null,
+      modifiedVia: null,
+      modifiedUserAgent: null,
+      importBatchId: null,
+      federationSource: null,
+      version: 1,
+      teamId: "team-1",
+      team: "Test Team",
+      ownerEmail: "admin@example.com",
+      visibility: "team",
+      oauthEnabled: false,
+      oauthConfig: null,
+    };
+
+    mockDeleteVirtualServer.mockRejectedValue(new Error("HTTP 403: Forbidden"));
+    mockUseQuery.mockReturnValue({
+      data: { servers: [mockServer] },
+      error: null,
+      isLoading: false,
+      execute: vi.fn(),
+      refetch,
+    });
+
+    renderWithProviders(<Gateways />);
+
+    await user.click(screen.getByRole("button", { name: "Actions for Error server" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith("Error deleting virtual server", {
+        description: "You don't have permission to perform this action.",
+      }),
+    );
+    expect(screen.getByText("Error server")).toBeInTheDocument();
+    expect(screen.queryByText("Error deleting virtual server")).not.toBeInTheDocument();
+    expect(refetch).not.toHaveBeenCalled();
   });
 
   it("renders virtual server card without crashing when array fields are missing", () => {

--- a/client/src/pages/Gateways.tsx
+++ b/client/src/pages/Gateways.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIntl } from "react-intl";
+import { toast } from "sonner";
 import { Blocks, Bot, Code } from "lucide-react";
 import { MCPIcon } from "@/components/icons/MCPIcon";
 import { ConnectSourceCard } from "@/components/gateways/ConnectSourceCard";
@@ -8,11 +9,14 @@ import { VirtualServerCard } from "@/components/gateways/VirtualServerCard";
 import { VirtualServerDetailsPanel } from "@/components/gateways/VirtualServerDetailsPanel";
 import type { ActionCard } from "@/components/gateways/types";
 import { hasVirtualServerComponents } from "@/components/gateways/utils";
+import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { Loading } from "@/components/ui/loading";
+import { deleteVirtualServer } from "@/api/virtualServers";
 import { useQuery } from "@/hooks/useQuery";
 import { useRouter } from "@/router";
 import type { VirtualServer, VirtualServersResponse } from "@/types/server";
 import { cn } from "@/lib/utils";
+import { sanitizeError } from "@/utils/errors";
 
 const DEFAULT_PAGE_SIZE = 12;
 const SERVERS_QUERY_PATH = `/servers?limit=${DEFAULT_PAGE_SIZE}&include_pagination=true`;
@@ -27,11 +31,91 @@ function sortServersForLayout(servers: VirtualServer[]): VirtualServer[] {
 export function Gateways() {
   const intl = useIntl();
   const { navigate } = useRouter();
-  const { data, error, isLoading } = useQuery<VirtualServersResponse>(SERVERS_QUERY_PATH);
+  const { data, error, isLoading, refetch } = useQuery<VirtualServersResponse>(SERVERS_QUERY_PATH);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const pendingDeleteServerIdRef = useRef<string | null>(null);
   const [detailsServer, setDetailsServer] = useState<VirtualServer | null>(null);
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false);
-  const servers = useMemo(() => data?.servers ?? [], [data?.servers]);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteServer, setDeleteServer] = useState<VirtualServer | null>(null);
+  const [deletedServerIds, setDeletedServerIds] = useState<Set<string>>(() => new Set());
+  const [pendingDeleteServerId, setPendingDeleteServerId] = useState<string | null>(null);
+  const [deleteStatus, setDeleteStatus] = useState<string | null>(null);
+  const servers = useMemo(
+    () => (data?.servers ?? []).filter((server) => !deletedServerIds.has(server.id)),
+    [data?.servers, deletedServerIds],
+  );
   const layoutServers = useMemo(() => sortServersForLayout(servers), [servers]);
+  const isDeletePending = pendingDeleteServerId !== null;
+
+  useEffect(() => {
+    if (!deleteStatus) return;
+    (headingRef.current ?? statusRef.current)?.focus();
+  }, [deleteStatus]);
+
+  const handleDelete = useCallback(
+    (server: VirtualServer) => {
+      if (isDeletePending) return;
+      setDeleteServer(server);
+      setDeleteStatus(null);
+      setDeleteDialogOpen(true);
+    },
+    [isDeletePending],
+  );
+
+  const handleDeleteDialogOpenChange = useCallback((open: boolean) => {
+    setDeleteDialogOpen(open);
+    if (!open) {
+      setDeleteServer(null);
+    }
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteServer || pendingDeleteServerIdRef.current) return;
+
+    const serverToDelete = deleteServer;
+    const deletedMessage = intl.formatMessage(
+      { id: "gateways.delete.success" },
+      { name: serverToDelete.name },
+    );
+
+    pendingDeleteServerIdRef.current = serverToDelete.id;
+    setPendingDeleteServerId(serverToDelete.id);
+    setDeleteStatus(null);
+
+    try {
+      await deleteVirtualServer(serverToDelete.id);
+      setDeletedServerIds((previous) => {
+        const next = new Set(previous);
+        next.add(serverToDelete.id);
+        return next;
+      });
+      setDetailsServer((current) => (current?.id === serverToDelete.id ? null : current));
+      setDeleteStatus(deletedMessage);
+      setDeleteDialogOpen(false);
+      setDeleteServer(null);
+      try {
+        await refetch();
+      } catch (refreshErr) {
+        console.error(
+          "Failed to refresh virtual servers after deletion:",
+          sanitizeError(refreshErr),
+        );
+      }
+    } catch (err) {
+      const errorMessage = sanitizeError(err);
+      toast.error(intl.formatMessage({ id: "gateways.delete.errorTitle" }), {
+        description: errorMessage,
+      });
+      setDeleteDialogOpen(false);
+      setDeleteServer(null);
+      console.error("Failed to delete virtual server:", errorMessage);
+    } finally {
+      pendingDeleteServerIdRef.current = null;
+      setPendingDeleteServerId(null);
+    }
+  }, [deleteServer, intl, refetch]);
 
   const openDetailsPanel = (server: VirtualServer) => {
     setDetailsServer(server);
@@ -110,7 +194,19 @@ export function Gateways() {
   if (servers.length > 0) {
     return (
       <div className="space-y-9 p-6">
-        <h1 className="text-base font-semibold text-foreground">
+        <div
+          ref={statusRef}
+          tabIndex={-1}
+          className="sr-only"
+          role="status"
+          aria-label={intl.formatMessage({ id: "gateways.notifications" })}
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {deleteStatus}
+        </div>
+
+        <h1 ref={headingRef} tabIndex={-1} className="text-base font-semibold text-foreground">
           {intl.formatMessage({ id: "gateways.title" })}
         </h1>
 
@@ -137,6 +233,9 @@ export function Gateways() {
                 server={server}
                 onViewDetails={openDetailsPanel}
                 onAddComponents={() => navigate(CREATE_SERVER_PATH)}
+                onDelete={handleDelete}
+                isDeleting={pendingDeleteServerId === server.id}
+                deleteDisabled={isDeletePending && pendingDeleteServerId !== server.id}
                 className={cn(!hasComponents && "col-span-full")}
               />
             );
@@ -151,11 +250,43 @@ export function Gateways() {
             onAddSources={() => navigate(CREATE_SERVER_PATH)}
           />
         )}
+
+        <ConfirmDialog
+          open={deleteDialogOpen}
+          onOpenChange={handleDeleteDialogOpenChange}
+          title={intl.formatMessage({ id: "gateways.delete.title" })}
+          description={intl.formatMessage(
+            { id: "gateways.delete.description" },
+            { name: deleteServer?.name ?? intl.formatMessage({ id: "gateways.title" }) },
+          )}
+          confirmLabel={intl.formatMessage({ id: "common.button.delete" })}
+          cancelLabel={intl.formatMessage({ id: "common.button.cancel" })}
+          variant="destructive"
+          onConfirm={confirmDelete}
+          isLoading={pendingDeleteServerId === deleteServer?.id}
+          loadingLabel={intl.formatMessage({ id: "gateways.delete.deleting" })}
+          closeOnConfirm={false}
+        />
       </div>
     );
   }
 
-  return <SourceSelection actionCards={actionCards} />;
+  return (
+    <>
+      <div
+        ref={statusRef}
+        tabIndex={-1}
+        className="sr-only"
+        role="status"
+        aria-label={intl.formatMessage({ id: "gateways.notifications" })}
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {deleteStatus}
+      </div>
+      <SourceSelection actionCards={actionCards} />
+    </>
+  );
 }
 
 function VirtualServerDetailsPanelContainer({


### PR DESCRIPTION
## 🔗 Related Issue
Closes #4181

---

## 📝 Summary
Adds a guarded delete flow for virtual servers in the React Gateways page. The flow now confirms destructive action, blocks duplicate deletes on slow networks, shows inline progress, refetches the paginated server list, and announces successful deletion for assistive technology.

---

## 🏷️ Type of Change
- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Focused unit tests | `npm run test:run -- src/api/virtualServers.test.ts src/pages/Gateways.test.tsx` | Passed |
| Client build | `npm run build` | Passed |
| E2E suite | `npm run e2e` | Passed |
| E2E typecheck | `./node_modules/.bin/tsc -p tsconfig.e2e.json --noEmit` | Passed |
| Diff whitespace | `git diff --check` | Passed |

---

## ✅ Checklist
- [x] Code formatted
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
Rebased onto the current `epic/ui-rewrite` so the PR diff contains only the virtual server delete flow changes.