### PR TITLE
bugfix/5213-admin-session-team-visibility-404

### DIFF
--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -417,6 +417,12 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
     if token_teams is not None and len(token_teams) == 0:
         is_admin = False
 
+    # Session tokens do not embed is_admin in the JWT payload; resolve_session_teams()
+    # queries the DB and sets token_teams=None only when the user is a confirmed DB
+    # admin. Trust that DB-backed resolution to set is_admin correctly here.
+    if not is_admin and token_teams is None and getattr(request.state, "token_use", None) == "session":
+        is_admin = True
+
     return user_email, token_teams, is_admin
 
 
@@ -496,6 +502,12 @@ def get_scoped_resource_access_context(request: Request, user) -> tuple[Optional
 
     if is_admin and token_teams is None:
         return user_email, None  # Keep user_email for owner matching (PR #4341 / issue #4694)
+    # Session tokens do not embed is_admin in the JWT payload; instead,
+    # resolve_session_teams() queries the DB and stores token_teams=None when
+    # the user is confirmed as admin. Trust that DB-backed resolution here so
+    # that admin session-cookie users can see team-visibility resources.
+    if token_teams is None and getattr(request.state, "token_use", None) == "session":
+        return user_email, None
     if token_teams is None:
         return user_email, []
     return user_email, token_teams

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -2371,7 +2371,6 @@ class TestRootEndpoints:
         assert response.status_code == 500
         assert "Internal error" in response.json()["detail"]
 
-
     @patch("mcpgateway.main.root_service.subscribe_changes")
     def test_subscribe_root_changes(self, mock_subscribe, test_client, auth_headers):
         """Test subscribing to root directory changes via SSE."""
@@ -2613,6 +2612,7 @@ class TestRPCEndpoints:
         assert body["error"]["code"] == -32002
         assert "Resource not found" in body["error"]["message"]
         assert body["error"]["message"] != "Internal error"
+
     @patch("mcpgateway.main.resource_service.read_resource", new_callable=AsyncMock)
     def test_rpc_resources_read_resource_error(self, mock_read, test_client, auth_headers):
         """Test resources/read returns -32000 when ResourceError is raised."""
@@ -2652,7 +2652,6 @@ class TestRPCEndpoints:
         assert "error" in body
         assert body["error"]["code"] == -32603
         assert "Internal error" in body["error"]["message"]
-
 
     @patch("mcpgateway.main.get_user_email", return_value="user_1")
     @patch("mcpgateway.main.resource_service.subscribe_resource", new_callable=AsyncMock)
@@ -2744,6 +2743,7 @@ class TestRPCEndpoints:
         body = response.json()["result"]
         assert body["nextCursor"] == "next-cursor"
         assert body["prompts"][0]["name"] == "prompt-1"
+
     @patch("mcpgateway.main.prompt_service.get_prompt", new_callable=AsyncMock)
     def test_rpc_prompts_get_not_found_error(self, mock_get, test_client, auth_headers):
         """Test prompts/get returns -32002 when PromptNotFoundError is raised."""
@@ -2804,7 +2804,6 @@ class TestRPCEndpoints:
         assert "error" in body
         assert body["error"]["code"] == -32603
         assert "Internal error" in body["error"]["message"]
-
 
     @patch("mcpgateway.main.gateway_service.list_gateways", new_callable=AsyncMock)
     def test_rpc_list_gateways(self, mock_list_gateways, test_client, auth_headers):
@@ -5238,6 +5237,50 @@ class TestGetRpcFilterContext:
         assert teams == ["t1"]
         assert is_admin is False
         assert any("internal_auth_context email non-string type" in record.message for record in caplog.records)
+
+    def test_get_rpc_filter_context_session_admin_token(self):
+        """Test that session admin token (token_teams=None, token_use=session) returns is_admin=True.
+
+        Session tokens do not embed is_admin in the JWT payload; resolve_session_teams()
+        queries the DB and sets token_teams=None for confirmed admins. get_rpc_filter_context
+        must recognize this as admin bypass and return is_admin=True.
+        """
+        # First-Party
+        from mcpgateway.main import get_rpc_filter_context
+
+        mock_request = MagicMock()
+        # Session token: no is_admin in JWT, token_teams=None from DB, token_use="session"
+        mock_request.state._jwt_verified_payload = ("token", {"sub": "admin@example.com"})
+        mock_request.state.token_teams = None
+        mock_request.state.token_use = "session"
+        user = {"email": "admin@example.com"}
+
+        email, teams, is_admin = get_rpc_filter_context(mock_request, user)
+
+        assert email == "admin@example.com"
+        assert teams is None
+        assert is_admin is True
+
+    def test_get_rpc_filter_context_session_non_admin_keeps_is_admin_false(self):
+        """Test that session non-admin token keeps is_admin=False.
+
+        A non-admin session user has token_teams set to a list (not None),
+        so is_admin should remain False.
+        """
+        # First-Party
+        from mcpgateway.main import get_rpc_filter_context
+
+        mock_request = MagicMock()
+        mock_request.state._jwt_verified_payload = ("token", {"sub": "user@example.com"})
+        mock_request.state.token_teams = ["team-a"]
+        mock_request.state.token_use = "session"
+        user = {"email": "user@example.com"}
+
+        email, teams, is_admin = get_rpc_filter_context(mock_request, user)
+
+        assert email == "user@example.com"
+        assert teams == ["team-a"]
+        assert is_admin is False
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -13114,6 +13114,45 @@ class TestHardeningHelperCoverage:
         with patch("mcpgateway.auth_context.get_rpc_filter_context", return_value=("user@example.com", None, False)):
             assert main_mod.get_scoped_resource_access_context(request, {"email": "user@example.com"}) == ("user@example.com", [])
 
+    def test_get_scoped_resource_access_context_session_admin_bypass(self):
+        """Test that session admin token gets admin bypass (email, None) from get_scoped_resource_access_context.
+
+        Session tokens do not embed is_admin in the JWT payload; resolve_session_teams()
+        sets token_teams=None via DB lookup. Both guards in auth_context.py (get_rpc_filter_context
+        and get_scoped_resource_access_context) must recognize this as admin bypass.
+        """
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = MagicMock()
+        request.state._jwt_verified_payload = ("tok", {"sub": "admin@example.com"})
+        request.state.token_teams = None
+        request.state.token_use = "session"
+
+        result = main_mod.get_scoped_resource_access_context(request, {"email": "admin@example.com"})
+        assert result == ("admin@example.com", None), f"Expected admin bypass, got {result}"
+
+    def test_get_scoped_resource_access_context_session_admin_guard_directly(self):
+        """Test the defense-in-depth session admin guard in get_scoped_resource_access_context directly.
+
+        This mocks get_rpc_filter_context to simulate the pre-fix behavior
+        (is_admin=False despite token_teams=None) to verify that the session-token
+        guard at lines 509-510 still catches the case.
+        """
+        # First-Party
+        import mcpgateway.main as main_mod
+
+        request = MagicMock(spec=Request)
+        request.state = MagicMock()
+        request.state._jwt_verified_payload = ("tok", {"sub": "admin@example.com"})
+        request.state.token_teams = None
+        request.state.token_use = "session"
+
+        with patch("mcpgateway.auth_context.get_rpc_filter_context", return_value=("admin@example.com", None, False)):
+            result = main_mod.get_scoped_resource_access_context(request, {"email": "admin@example.com"})
+        assert result == ("admin@example.com", None), f"Expected admin bypass, got {result}"
+
     @pytest.mark.asyncio
     async def test_assert_session_owner_or_admin_returns_404_for_missing_session(self):
         # First-Party


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
closes #5213 

**Two changes in mcpgateway/auth_context.py:**

**Change 1** — Root cause fix in get_rpc_filter_context() (line 420-424): Session tokens don't embed is_admin in the JWT payload, so payload.get("is_admin") returns False even for DB admin users. Added a guard that checks: if is_admin is still False but token_teams is None (the admin bypass sentinel, only set by resolve_session_teams() for DB-confirmed admins) and token_use is "session", then set is_admin = True. This fixes all ~20+ callers in main.py that use get_rpc_filter_context directly, plus _assert_session_owner_or_admin via get_request_identity.


**Change 2** — Defense-in-depth in get_scoped_resource_access_context() (line 499-504): Additional session-token guard at the scope resolution layer. Even if get_rpc_filter_context returns is_admin=False, a session token with token_teams=None is treated as admin bypass. This is the fix described in the issue.
