### PR TITLE
fix(ui-rewrite): team visibility always tracks current sidebar team on submit form

### DIFF
--- a/client/src/components/mcp-servers/AdvancedSettings.test.tsx
+++ b/client/src/components/mcp-servers/AdvancedSettings.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import * as AuthContextModule from "@/auth/AuthContext";
+import { AdvancedSettings } from "./AdvancedSettings";
+
+vi.mock("@/auth/AuthContext", () => ({
+  useAuthContext: vi.fn(),
+}));
+
+const mockUseAuthContext = vi.mocked(AuthContextModule.useAuthContext);
+
+type AdvancedSettingsProps = Parameters<typeof AdvancedSettings>[0];
+
+const makeAuthContext = (selectedTeamId: string | null = null) =>
+  ({
+    selectedTeamId,
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    setSelectedTeamId: vi.fn(),
+  }) as ReturnType<typeof AuthContextModule.useAuthContext>;
+
+const makeProps = (overrides: Partial<AdvancedSettingsProps> = {}): AdvancedSettingsProps => ({
+  visibility: "public",
+  onVisibilityChange: vi.fn(),
+  teamId: "",
+  onTeamIdChange: vi.fn(),
+  authType: "none",
+  onAuthTypeChange: vi.fn(),
+  basicAuthUsername: "",
+  basicAuthPassword: "",
+  onBasicAuthUsernameChange: vi.fn(),
+  onBasicAuthPasswordChange: vi.fn(),
+  bearerToken: "",
+  onBearerTokenChange: vi.fn(),
+  customHeaders: [],
+  onCustomHeadersChange: vi.fn(),
+  oauthClientId: "",
+  oauthClientSecret: "",
+  oauthTokenUrl: "",
+  oauthGrantType: "client_credentials",
+  oauthIssuerUrl: "",
+  oauthRedirectUri: "",
+  oauthAuthorizationUrl: "",
+  oauthScopes: "",
+  oauthStoreTokens: false,
+  oauthAutoRefresh: false,
+  oauthUsername: "",
+  oauthPassword: "",
+  onOAuthClientIdChange: vi.fn(),
+  onOAuthClientSecretChange: vi.fn(),
+  onOAuthTokenUrlChange: vi.fn(),
+  onOAuthGrantTypeChange: vi.fn(),
+  onOAuthIssuerUrlChange: vi.fn(),
+  onOAuthRedirectUriChange: vi.fn(),
+  onOAuthAuthorizationUrlChange: vi.fn(),
+  onOAuthScopesChange: vi.fn(),
+  onOAuthStoreTokensChange: vi.fn(),
+  onOAuthAutoRefreshChange: vi.fn(),
+  onOAuthUsernameChange: vi.fn(),
+  onOAuthPasswordChange: vi.fn(),
+  queryParamName: "",
+  queryParamApiKey: "",
+  onQueryParamNameChange: vi.fn(),
+  onQueryParamApiKeyChange: vi.fn(),
+  oneTimeAuth: false,
+  onOneTimeAuthChange: vi.fn(),
+  passthroughHeaders: "",
+  onPassthroughHeadersChange: vi.fn(),
+  onCACertificateFilesSelected: vi.fn(),
+  ...overrides,
+});
+
+describe("AdvancedSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuthContext.mockReturnValue(makeAuthContext());
+  });
+
+  describe("team visibility — teamId sync (issue #5077)", () => {
+    it("syncs teamId with selectedTeamId on mount when visibility is team and teamId is unset", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+
+      render(
+        <AdvancedSettings {...makeProps({ visibility: "team", teamId: "", onTeamIdChange })} />,
+      );
+
+      expect(onTeamIdChange).toHaveBeenCalledWith("team-A");
+    });
+
+    it("propagates selectedTeamId change after teamId is already set (regression: was ignored by !teamId guard)", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+      const { rerender } = render(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+      onTeamIdChange.mockClear();
+
+      // User switches the sidebar team switcher to team-B before submitting
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-B"));
+      rerender(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+
+      expect(onTeamIdChange).toHaveBeenCalledWith("team-B");
+    });
+
+    it("does not call onTeamIdChange when selectedTeamId already matches teamId", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+
+      render(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+
+      expect(onTeamIdChange).not.toHaveBeenCalled();
+    });
+
+    it("clears teamId when visibility changes away from team", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+      const { rerender } = render(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+      onTeamIdChange.mockClear();
+
+      rerender(
+        <AdvancedSettings
+          {...makeProps({ visibility: "public", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+
+      expect(onTeamIdChange).toHaveBeenCalledWith("");
+    });
+
+    it("clears teamId when selectedTeamId becomes null while visibility is team", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext(null));
+      const onTeamIdChange = vi.fn();
+
+      render(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+
+      expect(onTeamIdChange).toHaveBeenCalledWith("");
+    });
+
+    it("does not call onTeamIdChange when visibility is not team and teamId is already empty", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+
+      render(
+        <AdvancedSettings {...makeProps({ visibility: "public", teamId: "", onTeamIdChange })} />,
+      );
+
+      expect(onTeamIdChange).not.toHaveBeenCalled();
+    });
+
+    it("tracks each subsequent sidebar team switch while visibility stays team", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+      const onTeamIdChange = vi.fn();
+      const { rerender } = render(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+      onTeamIdChange.mockClear();
+
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-B"));
+      rerender(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-A", onTeamIdChange })}
+        />,
+      );
+      expect(onTeamIdChange).toHaveBeenCalledWith("team-B");
+      onTeamIdChange.mockClear();
+
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-C"));
+      rerender(
+        <AdvancedSettings
+          {...makeProps({ visibility: "team", teamId: "team-B", onTeamIdChange })}
+        />,
+      );
+      expect(onTeamIdChange).toHaveBeenCalledWith("team-C");
+    });
+  });
+
+  describe("team visibility — hint message", () => {
+    it("shows 'scoped to currently selected team' when visibility is team and a team is selected", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+
+      render(<AdvancedSettings {...makeProps({ visibility: "team", teamId: "team-A" })} />);
+
+      expect(screen.getByText(/scoped to your currently selected team/i)).toBeInTheDocument();
+    });
+
+    it("shows 'please select a team' when visibility is team but no team is selected", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext(null));
+
+      render(<AdvancedSettings {...makeProps({ visibility: "team", teamId: "" })} />);
+
+      expect(screen.getByText(/please select a team using the team switcher/i)).toBeInTheDocument();
+    });
+
+    it("does not show either team hint when visibility is not team", () => {
+      mockUseAuthContext.mockReturnValue(makeAuthContext("team-A"));
+
+      render(<AdvancedSettings {...makeProps({ visibility: "public" })} />);
+
+      expect(screen.queryByText(/scoped to your currently selected team/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/please select a team using the team switcher/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/mcp-servers/AdvancedSettings.tsx
+++ b/client/src/components/mcp-servers/AdvancedSettings.tsx
@@ -128,8 +128,8 @@ export function AdvancedSettings({
 
   useEffect(() => {
     if (visibility === "team") {
-      if (selectedTeamId && !teamId) {
-        onTeamIdChange(selectedTeamId);
+      if ((selectedTeamId ?? "") !== teamId) {
+        onTeamIdChange(selectedTeamId ?? "");
       }
     } else if (teamId) {
       onTeamIdChange("");
@@ -210,7 +210,10 @@ export function AdvancedSettings({
           Visibility
         </label>
         <Select value={visibility} onValueChange={onVisibilityChange}>
-          <SelectTrigger className="h-10 w-full border-neutral-300 bg-white dark:border-neutral-700 dark:bg-neutral-950">
+          <SelectTrigger
+            id="visibility"
+            className="h-10 w-full border-neutral-300 bg-white dark:border-neutral-700 dark:bg-neutral-950"
+          >
             <SelectValue placeholder="Select visibility" />
           </SelectTrigger>
           <SelectContent>

--- a/client/src/components/mcp-servers/MCPServerForm.test.tsx
+++ b/client/src/components/mcp-servers/MCPServerForm.test.tsx
@@ -198,6 +198,20 @@ describe("MCPServerForm", () => {
       expect(screen.getByText("Passthrough headers")).toBeInTheDocument();
       expect(screen.getByText("CA certificate")).toBeInTheDocument();
     });
+
+    it("shows team-switcher hint when Team visibility is selected and no team is active", async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<MCPServerForm {...defaultProps} />);
+
+      await user.click(screen.getByRole("button", { name: /Advanced settings/i }));
+      await user.click(screen.getByRole("combobox", { name: /visibility/i }));
+      await user.click(screen.getByRole("option", { name: /^Team$/i }));
+
+      // AuthProvider returns selectedTeamId: null (unauthenticated), so the sidebar prompt appears
+      expect(
+        screen.getByText(/please select a team using the team switcher in the sidebar/i),
+      ).toBeInTheDocument();
+    });
   });
 
   describe("Authentication Type Selection", () => {


### PR DESCRIPTION
### Summary

  Fixes [#5077](https://github.com/IBM/mcp-context-forge/issues/5077): when creating or editing an MCP server with **Team** visibility, switching the sidebar team switcher after the form is already open was silently ignored — the server was always scoped to whichever team was active when visibility was first set to `team`.

  **Root cause:** `AdvancedSettings.tsx` had a `!teamId` guard in the `useEffect` that syncs `teamId` from `selectedTeamId`. Once `teamId` was set on first selection, subsequent `selectedTeamId` changes were never propagated.

 ### Changes

#### `AdvancedSettings.tsx`

  Replace the `!teamId` guard with a divergence check so `teamId` always tracks the current sidebar selection while visibility is `team`:

  ```tsx
  // Before (buggy)
  if (selectedTeamId && !teamId) {
    onTeamIdChange(selectedTeamId);
  }

  // After (fixed)
  if ((selectedTeamId ?? "") !== teamId) {
    onTeamIdChange(selectedTeamId ?? "");
  }
  ```

  Also adds `id="visibility"` to the `SelectTrigger` so the `<label htmlFor="visibility">` creates a proper accessible association (matches the pattern used by the OAuth grant-type select).

#### `AdvancedSettings.test.tsx` *(new)*

  10 unit tests covering the `teamId` sync behaviour:

  - Initial sync on mount when `teamId` is unset
  - Propagation after `teamId` is already set (the regression case)
  - No spurious calls when `selectedTeamId` already matches `teamId`
  - Clearing `teamId` when visibility changes away from `team`
  - Clearing `teamId` when `selectedTeamId` becomes `null`
  - Multi-switch tracking across consecutive sidebar changes
  - Hint message rendering (`scoped to team` vs `please select a team` vs hidden)

#### `MCPServerForm.test.tsx`

  Adds one integration test confirming the "please select a team" hint appears when Team visibility is selected with no active team.
