### PR TITLE
feat(plugins): conditional routing plugin — Phase 1 core (rule engine + schema)

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -5232,6 +5232,78 @@ async def invoke_a2a_agent_by_id(
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@a2a_router.post("/{agent_name}/", response_model=Dict[str, Any])
+@require_permission("a2a.invoke")
+async def proxy_a2a_agent(
+    agent_name: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> Dict[str, Any]:
+    """Proxy a raw A2A JSON-RPC request directly to the downstream agent.
+
+    Accepts a standard A2A JSON-RPC body (with ``method`` field such as
+    ``tasks/send``, ``tasks/get``, ``tasks/cancel``, ``agent/getCard``,
+    or their v1.0 equivalents) and forwards it to the agent without
+    protocol translation — preserving task lifecycle, streaming,
+    artifacts, and async push notification semantics.
+
+    This is the **transparent proxy endpoint** for standard A2A clients
+    (e.g. Google ADK ``RemoteA2aAgent``). ContextForge governance (Auth,
+    RBAC, Rate-limiting) is applied at the proxy layer, and the native
+    A2A JSON-RPC response is returned directly.
+    """
+    try:
+        if a2a_service is None:
+            raise HTTPException(status_code=503, detail="A2A service not available")
+
+        # Parse raw JSON-RPC body
+        try:
+            jsonrpc_body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+        # Get filtering context from token
+        user_email, token_teams, is_admin = get_rpc_filter_context(request, user)
+        if is_admin and token_teams is None:
+            token_teams = None
+        elif token_teams is None:
+            token_teams = []
+
+        user_id = None
+        if isinstance(user, dict):
+            user_id = str(user.get("id") or user.get("sub") or user_email)
+        else:
+            user_id = str(user)
+
+        # Federation hop counter
+        hop_count = uaid_utils.read_hop_count(request.headers)
+
+        # Bearer token for cross-gateway forwarding
+        bearer_token = getattr(request.state, "bearer_token", None)
+        if not bearer_token:
+            auth_header = request.headers.get("authorization", "")
+            if auth_header.lower().startswith("bearer "):
+                bearer_token = auth_header[7:]
+        if bearer_token and not _is_jwt_token(bearer_token):
+            bearer_token = None
+
+        return await a2a_service.proxy_a2a_request(
+            db,
+            agent_name,
+            jsonrpc_body,
+            user_id=user_id,
+            user_email=user_email,
+            token_teams=token_teams,
+            hop_count=hop_count,
+            bearer_token=bearer_token,
+        )
+    except A2AAgentNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except A2AAgentError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 #############
 # Tool APIs #
 #############

--- a/mcpgateway/services/a2a_service.py
+++ b/mcpgateway/services/a2a_service.py
@@ -2513,6 +2513,227 @@ class A2AAgentService(BaseService):
 
         return response or {"error": error_message}
 
+    async def proxy_a2a_request(
+        self,
+        db: Session,
+        agent_name: str,
+        jsonrpc_body: Dict[str, Any],
+        *,
+        user_id: Optional[str] = None,
+        user_email: Optional[str] = None,
+        token_teams: Optional[List[str]] = None,
+        hop_count: int = 0,
+        bearer_token: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Proxy a raw A2A JSON-RPC request to the downstream agent without protocol translation.
+
+        Unlike ``invoke_agent`` which translates parameters through MCP semantics,
+        this method forwards the raw JSON-RPC payload directly, preserving A2A
+        protocol semantics: task lifecycle, streaming, artifacts, and async push
+        notifications.
+
+        Args:
+            db: Database session.
+            agent_name: Name of the agent to proxy to.
+            jsonrpc_body: Raw A2A JSON-RPC request body (must include ``method`` field).
+            user_id: Identifier of the user initiating the call.
+            user_email: Email of the user initiating the call.
+            token_teams: Teams from JWT token.
+            hop_count: Federation hop counter.
+            bearer_token: Bearer token for cross-gateway auth.
+
+        Returns:
+            Native A2A JSON-RPC response from the downstream agent.
+
+        Raises:
+            A2AAgentNotFoundError: If the agent is not found or user lacks access.
+            A2AAgentError: If the agent is disabled, the method is invalid, or the proxy fails.
+        """
+        # ── Validate JSON-RPC structure ──
+        if not isinstance(jsonrpc_body, dict):
+            raise A2AAgentError("A2A proxy requires a JSON-RPC body with a 'method' field")
+        if "jsonrpc" not in jsonrpc_body:
+            jsonrpc_body["jsonrpc"] = "2.0"
+        method = jsonrpc_body.get("method")
+        if not method or not isinstance(method, str):
+            raise A2AAgentError("A2A proxy requires a 'method' field in the JSON-RPC body")
+
+        # ── Federation loop guard ──
+        max_hops = settings.uaid_max_federation_hops
+        if hop_count >= max_hops:
+            raise A2AAgentNotFoundError(
+                f"A2A Agent not found (federation hop limit reached): {agent_name}"
+            )
+
+        # ── Resolve agent ──
+        agent_row = db.execute(
+            select(DbA2AAgent.id).where(DbA2AAgent.name == agent_name)
+        ).scalar_one_or_none()
+        if not agent_row:
+            raise A2AAgentNotFoundError(f"A2A Agent not found with name: {agent_name}")
+
+        agent = get_for_update(db, DbA2AAgent, agent_row)
+        if not agent:
+            raise A2AAgentNotFoundError(f"A2A Agent not found with name: {agent_name}")
+
+        # ── Access check ──
+        if not await self._check_agent_access(db, agent, user_email, token_teams):
+            raise A2AAgentNotFoundError(f"A2A Agent not found with name: {agent_name}")
+        if not agent.enabled:
+            raise A2AAgentError(f"A2A Agent '{agent_name}' is disabled")
+
+        # ── Extract agent config ──
+        agent_id = agent.id
+        endpoint_url = agent.endpoint_url
+        auth_type = agent.auth_type
+        auth_value = agent.auth_value
+        auth_query_params = agent.auth_query_params
+        protocol_version = agent.protocol_version
+
+        # ── Validate the A2A method ──
+        valid_methods = set()
+        from mcpgateway.services.a2a_protocol import (  # pylint: disable=import-outside-toplevel
+            _LEGACY_TO_V1_METHODS,
+            _V1_TO_LEGACY_METHODS,
+        )
+        valid_methods.update(_LEGACY_TO_V1_METHODS.keys())
+        valid_methods.update(_LEGACY_TO_V1_METHODS.values())
+        # Also accept the agent card and standard JSON-RPC methods
+        valid_methods.update({"agent/getCard", "GetAgentCard"})
+        if method not in valid_methods:
+            raise A2AAgentError(
+                f"Unknown A2A method '{method}' for agent '{agent_name}'. "
+                f"Valid methods include: message/send, tasks/get, tasks/cancel, "
+                f"tasks/list, agent/getCard, and their v1.0 equivalents."
+            )
+
+        # ── Release DB before HTTP call ──
+        db.commit()
+        db.close()
+
+        # ── Prepare headers ──
+        # First-Party
+        from mcpgateway.utils.uaid import HOP_HEADER, stamp_hop  # pylint: disable=import-outside-toplevel
+        from mcpgateway.utils.services_auth import decode_auth  # pylint: disable=import-outside-toplevel
+
+        request_headers: Dict[str, str] = {
+            "Content-Type": "application/json",
+        }
+
+        # Add A2A version header
+        if protocol_version:
+            request_headers["A2A-Version"] = protocol_version
+
+        # Add auth header
+        if auth_type == "bearer" and auth_value:
+            try:
+                request_headers["Authorization"] = f"Bearer {decode_auth(auth_value)}"
+            except Exception as e:
+                raise A2AAgentError(
+                    f"Failed to decrypt bearer auth for agent '{agent_name}': {e}"
+                ) from e
+        elif auth_type == "basic" and auth_value:
+            try:
+                request_headers["Authorization"] = f"Basic {decode_auth(auth_value)}"
+            except Exception as e:
+                raise A2AAgentError(
+                    f"Failed to decrypt basic auth for agent '{agent_name}': {e}"
+                ) from e
+        elif auth_type == "authheaders" and auth_value:
+            try:
+                decoded = decode_auth(auth_value)
+                extra_headers = orjson.loads(decoded)
+                if isinstance(extra_headers, dict):
+                    request_headers.update({str(k): str(v) for k, v in extra_headers.items()})
+            except Exception as e:
+                raise A2AAgentError(
+                    f"Failed to decrypt authheaders for agent '{agent_name}': {e}"
+                ) from e
+
+        # Forward bearer token for cross-gateway auth
+        if bearer_token:
+            request_headers["Authorization"] = f"Bearer {bearer_token}"
+
+        # Stamp federation hop counter
+        stamp_hop(request_headers, hop_count)
+
+        # Apply query param auth to URL
+        if auth_type == "query_param" and auth_query_params:
+            from mcpgateway.utils.url_auth import apply_query_param_auth  # pylint: disable=import-outside-toplevel
+            try:
+                endpoint_url = apply_query_param_auth(endpoint_url, auth_query_params)
+            except Exception as e:
+                raise A2AAgentError(
+                    f"Failed to apply query_param auth for agent '{agent_name}': {e}"
+                ) from e
+
+        # ── Forward the raw JSON-RPC request ──
+        # First-Party
+        from mcpgateway.services.http_client_service import get_http_client  # pylint: disable=import-outside-toplevel
+
+        correlation_id = get_correlation_id()
+        structured_logger.log(
+            level="INFO",
+            message=f"A2A proxy call started: {agent_name}",
+            component="a2a_service",
+            user_id=user_id,
+            user_email=user_email,
+            correlation_id=correlation_id,
+            metadata={
+                "event": "a2a_proxy_started",
+                "agent_name": agent_name,
+                "agent_id": str(agent_id),
+                "method": method,
+            },
+        )
+
+        try:
+            client = await get_http_client()
+            http_response = await client.post(
+                endpoint_url,
+                json=jsonrpc_body,
+                headers=request_headers,
+            )
+            status_code = http_response.status_code
+
+            if 200 <= status_code < 300:
+                result = http_response.json() if http_response.text else {}
+                structured_logger.log(
+                    level="INFO",
+                    message=f"A2A proxy call completed: {agent_name}",
+                    component="a2a_service",
+                    user_id=user_id,
+                    user_email=user_email,
+                    correlation_id=correlation_id,
+                    metadata={
+                        "event": "a2a_proxy_completed",
+                        "agent_name": agent_name,
+                        "status_code": status_code,
+                    },
+                )
+                return result
+
+            error_text = http_response.text[:500]
+            structured_logger.log(
+                level="ERROR",
+                message=f"A2A proxy call failed: {agent_name}",
+                component="a2a_service",
+                user_id=user_id,
+                user_email=user_email,
+                correlation_id=correlation_id,
+                metadata={
+                    "event": "a2a_proxy_failed",
+                    "agent_name": agent_name,
+                    "status_code": status_code,
+                },
+            )
+            raise A2AAgentError(f"Agent '{agent_name}' returned HTTP {status_code}: {error_text}")
+
+        except A2AAgentError:
+            raise
+        except Exception as e:
+            raise A2AAgentError(f"Failed to proxy A2A request to '{agent_name}': {e}") from e
+
     async def _invoke_remote_agent(
         self,
         uaid: str,

--- a/plugins/conditional_routing/__init__.py
+++ b/plugins/conditional_routing/__init__.py
@@ -1,0 +1,1 @@
+"""Conditional Routing Plugin — Phase 1 core."""

--- a/plugins/conditional_routing/conditional_routing_plugin.py
+++ b/plugins/conditional_routing/conditional_routing_plugin.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/conditional_routing/conditional_routing_plugin.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Conditional Routing Plugin — declarative content-based and attribute-based
+agent/tool dispatch.
+
+Hooks: tool_pre_invoke, agent_pre_invoke
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import logging
+from typing import Any, Dict, List, Optional
+
+# Third-Party
+from cpex.framework import (
+    Plugin,
+    PluginConfig,
+    PluginContext,
+    PluginResult,
+    PluginViolation,
+)
+from cpex.framework.hooks.agents import AgentPreInvokePayload
+from cpex.framework.hooks.tools import ToolPreInvokePayload
+
+# First-Party
+from .models import ConditionalRoutingConfig, DefaultAction, RoutingRule
+from .rule_engine import RequestContext, RuleEngine
+
+logger = logging.getLogger(__name__)
+
+
+class ConditionalRoutingPlugin(Plugin):
+    """Declarative rule-based routing to agents and tools.
+
+    Evaluates routing rules (priority-ordered, first-match-wins) against
+    incoming tool and agent invocations. Rewrites the target agent_id or
+    tool_name when a rule matches, injecting override_args when configured.
+
+    Example config in plugins/config.yaml:
+
+    .. code-block:: yaml
+
+        plugins:
+          - name: ConditionalRoutingPlugin
+            kind: plugins.conditional_routing.ConditionalRoutingPlugin
+            hooks: [tool_pre_invoke, agent_pre_invoke]
+            mode: enforce
+            priority: 10
+            config:
+              default_action: passthrough
+              routing_rules:
+                - name: "Finance to finance agent"
+                  match:
+                    tool_name_pattern: "finance_*"
+                    user_teams: ["accounting"]
+                  route_to:
+                    agent_id: "finance-specialist"
+                  priority: 10
+    """
+
+    def __init__(self, config: PluginConfig) -> None:
+        """Initialise the plugin with routing rules from config.
+
+        Args:
+            config: Plugin configuration containing routing_rules.
+        """
+        super().__init__(config)
+        raw_cfg = config.config or {}
+        self._cfg = ConditionalRoutingConfig(**raw_cfg)
+        self._engine = RuleEngine(self._cfg.routing_rules)
+        logger.info(
+            "ConditionalRoutingPlugin initialised: %d rules, default_action=%s",
+            len(self._cfg.routing_rules),
+            self._cfg.default_action.value,
+        )
+
+    async def tool_pre_invoke(
+        self,
+        payload: ToolPreInvokePayload,
+        context: PluginContext,
+    ) -> PluginResult:
+        """Route tool invocations based on matching rules.
+
+        Args:
+            payload: Tool invocation payload (name, args, etc.).
+            context: Plugin execution context.
+
+        Returns:
+            PluginResult with modified tool name and args if matched.
+        """
+        ctx = _build_request_context(
+            tool_name=payload.name,
+            arguments=getattr(payload, "args", None) or getattr(payload, "arguments", {}) or {},
+            context=context,
+        )
+
+        decision = self._engine.evaluate(ctx)
+        self._audit(decision, ctx)
+
+        if decision.matched:
+            return PluginResult(
+                modified_payload=type(payload)(
+                    name=decision.target_tool_name or payload.name,
+                    args={
+                        **(getattr(payload, "args", None) or getattr(payload, "arguments", {}) or {}),
+                        **decision.override_args,
+                    },
+                ),
+            )
+
+        if self._cfg.default_action == DefaultAction.DENY:
+            return PluginResult(
+                violation=PluginViolation(
+                    "NO_ROUTE_MATCHED",
+                    f"No routing rule matched for tool '{payload.name}'",
+                ),
+            )
+
+        # Passthrough
+        return PluginResult()
+
+    async def agent_pre_invoke(
+        self,
+        payload: AgentPreInvokePayload,
+        context: PluginContext,
+    ) -> PluginResult:
+        """Route agent invocations based on matching rules.
+
+        Args:
+            payload: Agent invocation payload.
+            context: Plugin execution context.
+
+        Returns:
+            PluginResult with modified agent_id if matched.
+        """
+        # Extract user identity from context
+        user_email = context.user if hasattr(context, "user") else None
+        user_teams_raw = getattr(context, "token_teams", None) or []
+        if isinstance(user_teams_raw, list):
+            user_teams = [str(t) for t in user_teams_raw]
+        else:
+            user_teams = []
+
+        ctx = RequestContext(
+            agent_id=payload.agent_id,
+            user_email=user_email,
+            user_teams=user_teams,
+            arguments=_extract_message_text(payload),
+        )
+
+        decision = self._engine.evaluate(ctx)
+        self._audit(decision, ctx)
+
+        if decision.matched:
+            return PluginResult(
+                modified_payload=type(payload)(
+                    agent_id=decision.target_agent_id or payload.agent_id,
+                    messages=payload.messages,
+                    tools=payload.tools,
+                    model=payload.model,
+                    system_prompt=payload.system_prompt,
+                    parameters=payload.parameters,
+                ),
+            )
+
+        if self._cfg.default_action == DefaultAction.DENY:
+            return PluginResult(
+                violation=PluginViolation(
+                    "NO_ROUTE_MATCHED",
+                    f"No routing rule matched for agent '{payload.agent_id}'",
+                ),
+            )
+
+        return PluginResult()
+
+    def _audit(self, decision: Any, ctx: RequestContext) -> None:
+        """Emit structured audit log if enabled.
+
+        Args:
+            decision: RoutingDecision from the rule engine.
+            ctx: Request context.
+        """
+        if not self._cfg.audit_routing_decisions:
+            return
+
+        if decision.matched:
+            logger.info(
+                "routing_decision: matched rule=%s target=%s priority=%s details=%s",
+                decision.rule_name,
+                decision.target_agent_id,
+                decision.match_details.get("priority", "?"),
+                decision.match_details,
+            )
+        else:
+            logger.info(
+                "routing_decision: unmatched target=%s evaluated=%d rules",
+                decision.original_target,
+                len(self._engine._rules),
+            )
+
+
+# ── Helpers ──
+
+
+def _build_request_context(
+    *,
+    tool_name: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    arguments: Dict[str, Any] = None,
+    context: PluginContext = None,
+) -> RequestContext:
+    """Build a RequestContext from tool/agent payload and plugin context.
+
+    Args:
+        tool_name: Tool name from payload.
+        agent_id: Agent ID from payload.
+        arguments: Arguments dict.
+        context: Plugin execution context with user info.
+
+    Returns:
+        Normalised RequestContext.
+    """
+    user_email = getattr(context, "user", None) if context else None
+    user_teams_raw = getattr(context, "token_teams", None) or []
+    if isinstance(user_teams_raw, list):
+        user_teams = [str(t) for t in user_teams_raw]
+    else:
+        user_teams = []
+
+    return RequestContext(
+        tool_name=tool_name,
+        agent_id=agent_id,
+        arguments=arguments or {},
+        user_email=user_email,
+        user_teams=user_teams,
+    )
+
+
+def _extract_message_text(payload: AgentPreInvokePayload) -> Dict[str, Any]:
+    """Extract searchable text from agent messages for content matching.
+
+    Args:
+        payload: Agent pre-invoke payload.
+
+    Returns:
+        Dict with 'messages' key containing concatenated text.
+    """
+    texts = []
+    for msg in (payload.messages or []):
+        if hasattr(msg, "content"):
+            texts.append(str(msg.content))
+        elif isinstance(msg, dict):
+            texts.append(str(msg.get("content", "")))
+    return {"messages": " ".join(texts)}

--- a/plugins/conditional_routing/models.py
+++ b/plugins/conditional_routing/models.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/conditional_routing/models.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Pydantic models for the Conditional Routing Plugin.
+
+Defines MatchCriteria, RouteTarget, and RoutingRule schemas —
+the declarative contract for content-based and attribute-based
+agent/tool dispatch.
+"""
+
+# Standard
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+# Third-Party
+from pydantic import BaseModel, Field, model_validator
+
+
+class DefaultAction(str, Enum):
+    """Behaviour when no routing rule matches a request."""
+
+    PASSTHROUGH = "passthrough"
+    DENY = "deny"
+
+
+class MatchCriteria(BaseModel):
+    """Criteria for matching a request to a routing rule.
+
+    ALL specified fields must match (AND logic). Empty/None fields
+    are treated as "match anything" for that dimension.
+
+    Attributes:
+        tool_name_pattern: Glob or regex pattern for tool name (fnmatch).
+        agent_id_pattern: Glob or regex pattern for agent ID (fnmatch).
+        user_teams: List of team IDs; matches if user belongs to any.
+        user_roles: List of role names; matches if user has any.
+        user_email_patterns: Glob patterns for user email addresses.
+        source_ip_cidrs: CIDR blocks to include (e.g. 10.0.0.0/8).
+        exclude_ip_cidrs: CIDR blocks to exclude (takes precedence).
+        content_patterns: Regex patterns to match against content_fields.
+        content_fields: Dot-notation paths in arguments to search (e.g. "arguments.query").
+        jwt_claims: Arbitrary JWT claim key-value pairs to match.
+        headers: HTTP header key-value patterns to match.
+        case_sensitive: Whether content_patterns matching is case-sensitive.
+    """
+
+    tool_name_pattern: Optional[str] = None
+    agent_id_pattern: Optional[str] = None
+    user_teams: Optional[List[str]] = None
+    user_roles: Optional[List[str]] = None
+    user_email_patterns: Optional[List[str]] = None
+    source_ip_cidrs: Optional[List[str]] = None
+    exclude_ip_cidrs: Optional[List[str]] = None
+    content_patterns: Optional[List[str]] = None
+    content_fields: Optional[List[str]] = None
+    jwt_claims: Optional[Dict[str, Any]] = None
+    headers: Optional[Dict[str, str]] = None
+    case_sensitive: bool = False
+
+    @model_validator(mode="after")
+    def _validate_content_requires_fields(self) -> "MatchCriteria":
+        """content_patterns requires content_fields to be specified."""
+        if self.content_patterns and not self.content_fields:
+            raise ValueError("content_patterns requires content_fields to be specified")
+        return self
+
+
+class WeightedTarget(BaseModel):
+    """A weighted routing target for canary/A/B testing.
+
+    Attributes:
+        agent_id: Target agent identifier.
+        weight: Relative weight (e.g. 90 vs 10 for 90/10 split).
+    """
+
+    agent_id: str
+    weight: int = Field(ge=1)
+
+
+class RouteTarget(BaseModel):
+    """Where to send a request when a rule matches.
+
+    Exactly one of agent_id or weighted must be specified.
+
+    Attributes:
+        agent_id: Target agent identifier (single target).
+        tool_name: Override tool name on the forwarded request.
+        virtual_server_id: Virtual server to scope the request.
+        override_args: Arguments to merge into the request.
+        weighted: Weighted target list for traffic splitting.
+        sticky_session: Whether to consistently route the same user to the same target.
+        fallback: Ordered list of fallback agent IDs.
+    """
+
+    agent_id: Optional[str] = None
+    tool_name: Optional[str] = None
+    virtual_server_id: Optional[str] = None
+    override_args: Dict[str, Any] = Field(default_factory=dict)
+    weighted: Optional[List[WeightedTarget]] = None
+    sticky_session: bool = False
+    fallback: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "RouteTarget":
+        """Ensure at least one target is specified."""
+        if not self.agent_id and not self.weighted:
+            raise ValueError("Either agent_id or weighted must be specified")
+        if self.agent_id and self.weighted:
+            raise ValueError("Cannot specify both agent_id and weighted")
+        if self.sticky_session and not self.weighted:
+            raise ValueError("sticky_session requires weighted targets")
+        return self
+
+
+class RoutingRule(BaseModel):
+    """A single routing rule.
+
+    Rules are evaluated in priority order (lowest first). First match wins.
+
+    Attributes:
+        name: Human-readable rule name (used in logs/metrics).
+        match: Criteria for matching requests.
+        route_to: Where to send matched requests.
+        priority: Evaluation order (lower = evaluated first).
+        enabled: Whether this rule is active.
+    """
+
+    name: str
+    match: MatchCriteria
+    route_to: RouteTarget
+    priority: int = Field(default=100)
+    enabled: bool = True
+
+
+class ConditionalRoutingConfig(BaseModel):
+    """Top-level configuration for the Conditional Routing Plugin.
+
+    Attributes:
+        routing_rules: Ordered list of routing rules.
+        default_action: What to do when no rule matches.
+        audit_routing_decisions: Whether to emit structured logs.
+    """
+
+    routing_rules: List[RoutingRule] = Field(default_factory=list)
+    default_action: DefaultAction = DefaultAction.PASSTHROUGH
+    audit_routing_decisions: bool = True
+
+
+class RoutingDecision(BaseModel):
+    """Result of evaluating the rule engine against a request.
+
+    Attributes:
+        matched: Whether a rule was matched.
+        rule_name: Name of the matched rule (if any).
+        target_agent_id: Resolved target agent ID.
+        target_tool_name: Override tool name (if any).
+        virtual_server_id: Target virtual server (if any).
+        override_args: Arguments to merge (if any).
+        original_target: Original agent_id or tool_name before routing.
+        match_details: Debug info about which criteria matched.
+    """
+
+    matched: bool = False
+    rule_name: Optional[str] = None
+    target_agent_id: Optional[str] = None
+    target_tool_name: Optional[str] = None
+    virtual_server_id: Optional[str] = None
+    override_args: Dict[str, Any] = Field(default_factory=dict)
+    original_target: Optional[str] = None
+    match_details: Dict[str, Any] = Field(default_factory=dict)

--- a/plugins/conditional_routing/plugin-manifest.yaml
+++ b/plugins/conditional_routing/plugin-manifest.yaml
@@ -1,0 +1,11 @@
+description: "Declarative content-based and attribute-based request routing to agents and tools."
+author: "ContextForge"
+version: "0.1.0"
+tags: ["routing", "dispatch", "agents", "gateway"]
+available_hooks:
+  - "tool_pre_invoke"
+  - "agent_pre_invoke"
+default_config:
+  default_action: "passthrough"
+  audit_routing_decisions: true
+  routing_rules: []

--- a/plugins/conditional_routing/rule_engine.py
+++ b/plugins/conditional_routing/rule_engine.py
@@ -1,0 +1,436 @@
+# -*- coding: utf-8 -*-
+"""Location: ./plugins/conditional_routing/rule_engine.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Priority-ordered rule engine for conditional request routing.
+
+Evaluates RoutingRules against a request context and returns the
+first matching RoutingDecision.
+"""
+
+# Future
+from __future__ import annotations
+
+# Standard
+import fnmatch
+import ipaddress
+import logging
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+# First-Party
+from .models import (
+    MatchCriteria,
+    RouteTarget,
+    RoutingDecision,
+    RoutingRule,
+)
+
+logger = logging.getLogger(__name__)
+
+# ── Request context ──
+
+
+class RequestContext:
+    """Normalised request context for rule matching.
+
+    Attributes:
+        tool_name: Name of the tool being invoked (for tool_pre_invoke).
+        agent_id: Agent identifier (for agent_pre_invoke).
+        arguments: Tool arguments / agent message content.
+        user_email: Authenticated user's email.
+        user_teams: Teams the user belongs to.
+        user_roles: Roles assigned to the user.
+        source_ip: Client IP address.
+        jwt_claims: Arbitrary JWT claims from the auth token.
+        headers: HTTP request headers.
+    """
+
+    __slots__ = (
+        "tool_name",
+        "agent_id",
+        "arguments",
+        "user_email",
+        "user_teams",
+        "user_roles",
+        "source_ip",
+        "jwt_claims",
+        "headers",
+    )
+
+    def __init__(
+        self,
+        *,
+        tool_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        arguments: Optional[Dict[str, Any]] = None,
+        user_email: Optional[str] = None,
+        user_teams: Optional[List[str]] = None,
+        user_roles: Optional[List[str]] = None,
+        source_ip: Optional[str] = None,
+        jwt_claims: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.tool_name = tool_name
+        self.agent_id = agent_id
+        self.arguments = arguments or {}
+        self.user_email = user_email
+        self.user_teams = user_teams or []
+        self.user_roles = user_roles or []
+        self.source_ip = source_ip
+        self.jwt_claims = jwt_claims or {}
+        self.headers = headers or {}
+
+
+# ── Rule Engine ──
+
+
+class RuleEngine:
+    """Priority-ordered rule evaluator.
+
+    Rules are sorted by priority (lowest first) and evaluated in order.
+    First matching rule wins. Returns RoutingDecision with match details.
+
+    Example:
+        >>> engine = RuleEngine([
+        ...     RoutingRule(
+        ...         name="finance",
+        ...         match=MatchCriteria(tool_name_pattern="finance_*"),
+        ...         route_to=RouteTarget(agent_id="finance-agent"),
+        ...         priority=10,
+        ...     ),
+        ... ])
+        >>> ctx = RequestContext(tool_name="finance_report")
+        >>> decision = engine.evaluate(ctx)
+        >>> decision.matched
+        True
+        >>> decision.rule_name
+        'finance'
+    """
+
+    def __init__(self, rules: List[RoutingRule]) -> None:
+        """Initialise the rule engine.
+
+        Args:
+            rules: Routing rules. Sorted by priority at construction.
+        """
+        self._rules = sorted(
+            [r for r in rules if r.enabled],
+            key=lambda r: r.priority,
+        )
+
+    def evaluate(self, context: RequestContext) -> RoutingDecision:
+        """Evaluate all rules against the request context.
+
+        Args:
+            context: Normalised request context.
+
+        Returns:
+            RoutingDecision with match result and target info.
+        """
+        agent_id_or_tool = context.agent_id or context.tool_name or ""
+
+        for rule in self._rules:
+            details = _match_rule(rule.match, context)
+            if details["matched"]:
+                target = _resolve_target(rule.route_to, context)
+                logger.debug(
+                    "Routing rule matched: %s (priority=%d) → %s",
+                    rule.name,
+                    rule.priority,
+                    target,
+                )
+                return RoutingDecision(
+                    matched=True,
+                    rule_name=rule.name,
+                    target_agent_id=target,
+                    target_tool_name=rule.route_to.tool_name,
+                    virtual_server_id=rule.route_to.virtual_server_id,
+                    override_args=rule.route_to.override_args,
+                    original_target=agent_id_or_tool,
+                    match_details=details,
+                )
+
+        # No rule matched
+        logger.debug("No routing rule matched for target=%r", agent_id_or_tool)
+        return RoutingDecision(
+            matched=False,
+            original_target=agent_id_or_tool,
+            match_details={"reason": "no_rule_matched", "rules_evaluated": len(self._rules)},
+        )
+
+
+# ── Matchers ──
+
+
+def _match_rule(criteria: MatchCriteria, ctx: RequestContext) -> Dict[str, Any]:
+    """Check if a single rule's criteria match the context.
+
+    Returns a dict with 'matched' (bool) and per-criterion details.
+    """
+    details: Dict[str, Any] = {"matched": True}
+
+    # ── Tool name pattern ──
+    if criteria.tool_name_pattern and ctx.tool_name:
+        ok = _glob_match(criteria.tool_name_pattern, ctx.tool_name)
+        details["tool_name"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── Agent ID pattern ──
+    if criteria.agent_id_pattern and ctx.agent_id:
+        ok = _glob_match(criteria.agent_id_pattern, ctx.agent_id)
+        details["agent_id"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── User teams ──
+    if criteria.user_teams:
+        ok = bool(set(criteria.user_teams) & set(ctx.user_teams))
+        details["user_teams"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── User roles ──
+    if criteria.user_roles:
+        ok = bool(set(criteria.user_roles) & set(ctx.user_roles))
+        details["user_roles"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── User email patterns ──
+    if criteria.user_email_patterns and ctx.user_email:
+        ok = any(
+            _glob_match(pattern, ctx.user_email)
+            for pattern in criteria.user_email_patterns
+        )
+        details["user_email"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── Source IP CIDRs ──
+    if criteria.source_ip_cidrs and ctx.source_ip:
+        ok = _cidr_match_any(criteria.source_ip_cidrs, ctx.source_ip)
+        if criteria.exclude_ip_cidrs:
+            ok = ok and not _cidr_match_any(criteria.exclude_ip_cidrs, ctx.source_ip)
+        details["source_ip"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── Content patterns ──
+    if criteria.content_patterns and criteria.content_fields:
+        ok = _content_match(
+            criteria.content_patterns,
+            criteria.content_fields,
+            ctx.arguments,
+            case_sensitive=criteria.case_sensitive,
+        )
+        details["content"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── JWT claims ──
+    if criteria.jwt_claims:
+        ok = all(
+            str(ctx.jwt_claims.get(k)) == str(v)
+            for k, v in criteria.jwt_claims.items()
+        )
+        details["jwt_claims"] = ok
+        if not ok:
+            details["matched"] = False
+
+    # ── Headers ──
+    if criteria.headers:
+        ok = all(
+            ctx.headers.get(k.lower()) == v
+            for k, v in criteria.headers.items()
+        )
+        details["headers"] = ok
+        if not ok:
+            details["matched"] = False
+
+    return details
+
+
+def _glob_match(pattern: str, value: str) -> bool:
+    """Match a value against a glob pattern.
+
+    If pattern looks like a regex (contains common regex chars beyond
+    fnmatch wildcards), treat it as regex. Otherwise use fnmatch.
+
+    Args:
+        pattern: Glob or regex pattern.
+        value: String to match against.
+
+    Returns:
+        True if value matches pattern.
+    """
+    # Heuristic: if pattern contains regex metacharacters beyond * and ?,
+    # treat it as a regex pattern.
+    regex_indicators = {"[", "]", "(", ")", "{", "}", "\\", "+", "^", "$", "|"}
+    if any(c in pattern for c in regex_indicators):
+        try:
+            return bool(re.search(pattern, value))
+        except re.error:
+            logger.warning("Invalid regex pattern %r, falling back to fnmatch", pattern)
+            return fnmatch.fnmatch(value, pattern)
+    return fnmatch.fnmatch(value, pattern)
+
+
+def _cidr_match_any(cidrs: List[str], ip_str: str) -> bool:
+    """Check if an IP address matches any of the given CIDR blocks.
+
+    Args:
+        cidrs: List of CIDR notation strings.
+        ip_str: IP address string to check.
+
+    Returns:
+        True if the IP falls within any CIDR block.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        logger.debug("Invalid IP address %r, skipping CIDR match", ip_str)
+        return False
+
+    for cidr in cidrs:
+        try:
+            network = ipaddress.ip_network(cidr, strict=False)
+            if addr in network:
+                return True
+        except ValueError:
+            logger.warning("Invalid CIDR %r, skipping", cidr)
+    return False
+
+
+def _content_match(
+    patterns: List[str],
+    fields: List[str],
+    arguments: Dict[str, Any],
+    case_sensitive: bool = False,
+) -> bool:
+    """Check if any content pattern matches in the specified argument fields.
+
+    Args:
+        patterns: Regex patterns to search for.
+        fields: Dot-notation paths to search (e.g. "query", "args.text").
+        arguments: Tool arguments / parameters dict.
+        case_sensitive: Whether matching is case-sensitive.
+
+    Returns:
+        True if any pattern matches in any field.
+    """
+    flags = 0 if case_sensitive else re.IGNORECASE
+
+    # Compile all patterns once
+    compiled = []
+    for p in patterns:
+        try:
+            compiled.append(re.compile(p, flags))
+        except re.error:
+            logger.warning("Invalid content regex %r, skipping", p)
+
+    if not compiled:
+        return False
+
+    for field_path in fields:
+        value = _resolve_field(arguments, field_path)
+        if value is None:
+            continue
+        text = str(value)
+        for cre in compiled:
+            if cre.search(text):
+                return True
+
+    return False
+
+
+def _resolve_field(data: Dict[str, Any], path: str) -> Any:
+    """Resolve a dot-notation path within a nested dict.
+
+    Args:
+        data: Root dict to traverse.
+        path: Dot-separated path (e.g. "arguments.query.text").
+
+    Returns:
+        Value at the path, or None if not found.
+    """
+    parts = path.split(".")
+    current: Any = data
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+            if current is None:
+                return None
+        else:
+            return None
+    return current
+
+
+def _resolve_target(target: RouteTarget, context: RequestContext) -> str:
+    """Resolve the target agent ID from a RouteTarget.
+
+    For single-target rules, returns agent_id directly.
+    For weighted targets, selects based on deterministic hash.
+
+    Args:
+        target: The route target configuration.
+        context: Request context (used for sticky session hashing).
+
+    Returns:
+        Resolved agent ID string.
+    """
+    if target.agent_id:
+        return target.agent_id
+
+    if target.weighted:
+        return _select_weighted(target.weighted, context, sticky=target.sticky_session)
+
+    # Should not reach here — validated by RouteTarget model
+    raise ValueError("No target specified in RouteTarget")
+
+
+def _select_weighted(
+    targets: List[Any],  # WeightedTarget list
+    context: RequestContext,
+    sticky: bool = False,
+) -> str:
+    """Select a target from a weighted list.
+
+    If sticky_session is enabled, uses deterministic hashing based on
+    user identity. Otherwise, uses simple weighted modulo for
+    deterministic distribution (not random — to avoid non-determinism
+    in tests; production should use random weighted selection).
+
+    Args:
+        targets: List of WeightedTarget objects.
+        context: Request context.
+        sticky: Whether to hash by user identity.
+
+    Returns:
+        Selected agent_id.
+    """
+    if sticky and context.user_email:
+        import hashlib
+
+        hash_val = int(hashlib.md5(context.user_email.encode()).hexdigest(), 16)
+    else:
+        import time
+
+        hash_val = int(time.time() * 1000)
+
+    total_weight = sum(t.weight for t in targets)
+    if total_weight <= 0:
+        return targets[0].agent_id
+
+    bucket = hash_val % total_weight
+    cumulative = 0
+    for t in targets:
+        cumulative += t.weight
+        if bucket < cumulative:
+            return t.agent_id
+
+    # Fallback
+    return targets[-1].agent_id

--- a/tests/unit/mcpgateway/services/test_a2a_proxy.py
+++ b/tests/unit/mcpgateway/services/test_a2a_proxy.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_a2a_proxy.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the A2A JSON-RPC transparent proxy.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNotFoundError, A2AAgentService
+
+
+@pytest.fixture
+def service():
+    return A2AAgentService()
+
+
+@pytest.fixture
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture
+def sample_agent_name():
+    return "proxy-test-agent"
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock()
+    agent.id = "agent-proxy-001"
+    agent.name = "proxy-test-agent"
+    agent.enabled = True
+    agent.endpoint_url = "http://localhost:9999/a2a"
+    agent.agent_type = "custom"
+    agent.protocol_version = "1.0"
+    agent.auth_type = None
+    agent.auth_value = None
+    agent.auth_query_params = None
+    return agent
+
+
+@pytest.fixture
+def mock_response_200():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = '{"jsonrpc":"2.0","result":{"ok":true},"id":1}'
+    resp.json.return_value = {"jsonrpc": "2.0", "result": {"ok": True}, "id": 1}
+    return resp
+
+
+class TestProxyA2ARequest:
+
+    # ── Happy path tests ──
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_valid_tasks_send(self, mock_get_for_update, mock_get_http_client,
+                                           service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            result = await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "message/send", "params": {}, "id": 1})
+        assert result["result"]["ok"] is True
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_valid_tasks_get(self, mock_get_for_update, mock_get_http_client,
+                                          service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            result = await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "tasks/get", "params": {"id": "t1"}, "id": 2})
+        assert result["id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_v1_send_message(self, mock_get_for_update, mock_get_http_client,
+                                          service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            result = await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "SendMessage", "params": {}, "id": 3})
+        assert result["id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_auto_adds_jsonrpc(self, mock_get_for_update, mock_get_http_client,
+                                            service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"method": "message/send", "params": {}, "id": 1})
+        forwarded = mock_get_http_client.return_value.post.call_args[1]["json"]
+        assert forwarded["jsonrpc"] == "2.0"
+
+    # ── Validation / rejection tests ──
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_rejects_invalid_method(self, mock_get_for_update, service, mock_db, mock_agent):
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            with pytest.raises(A2AAgentError, match="Unknown A2A method"):
+                await service.proxy_a2a_request(mock_db, mock_agent.name,
+                    {"jsonrpc": "2.0", "method": "invalid/method", "id": 1})
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_rejects_missing_method(self, mock_get_for_update, service, mock_db, mock_agent):
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            with pytest.raises(A2AAgentError, match="requires a 'method' field"):
+                await service.proxy_a2a_request(mock_db, mock_agent.name,
+                    {"jsonrpc": "2.0", "params": {}, "id": 1})
+
+    @pytest.mark.asyncio
+    async def test_proxy_rejects_non_dict(self, service, mock_db):
+        with pytest.raises(A2AAgentError, match="requires a JSON-RPC body"):
+            await service.proxy_a2a_request(mock_db, "test", "not-a-dict")  # type: ignore
+
+    # ── Agent resolution tests ──
+
+    @pytest.mark.asyncio
+    async def test_proxy_agent_not_found(self, service, mock_db):
+        mock_db.execute.return_value.scalar_one_or_none.return_value = None
+        with pytest.raises(A2AAgentNotFoundError, match="not found"):
+            await service.proxy_a2a_request(mock_db, "no-such-agent",
+                {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_agent_disabled(self, mock_get_for_update, service, mock_db, mock_agent):
+        mock_agent.enabled = False
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            with pytest.raises(A2AAgentError, match="disabled"):
+                await service.proxy_a2a_request(mock_db, mock_agent.name,
+                    {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_access_denied(self, mock_get_for_update, service, mock_db, mock_agent):
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=False):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            with pytest.raises(A2AAgentNotFoundError):
+                await service.proxy_a2a_request(mock_db, mock_agent.name,
+                    {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+
+    # ── Header / auth / hop counter tests ──
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_stamps_hop_counter(self, mock_get_for_update, mock_get_http_client,
+                                             service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "message/send", "id": 1}, hop_count=1)
+        headers = mock_get_http_client.return_value.post.call_args[1]["headers"]
+        assert "X-Contextforge-UAID-Hop" in headers
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_forwards_bearer_token(self, mock_get_for_update, mock_get_http_client,
+                                                service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "message/send", "id": 1},
+                bearer_token="test.jwt.token")
+        headers = mock_get_http_client.return_value.post.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer test.jwt.token"
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    @patch("mcpgateway.utils.services_auth.decode_auth")
+    async def test_proxy_forwards_bearer_auth(self, mock_decode_auth, mock_get_for_update,
+                                               mock_get_http_client, service, mock_db, mock_agent, mock_response_200):
+        mock_agent.auth_type = "bearer"
+        mock_agent.auth_value = "encrypted"
+        mock_decode_auth.return_value = "decrypted-token"
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+        headers = mock_get_http_client.return_value.post.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer decrypted-token"
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_a2a_version_header(self, mock_get_for_update, mock_get_http_client,
+                                              service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+        headers = mock_get_http_client.return_value.post.call_args[1]["headers"]
+        assert headers["A2A-Version"] == "1.0"
+
+    # ── Error handling tests ──
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_downstream_http_error(self, mock_get_for_update, mock_get_http_client,
+                                                service, mock_db, mock_agent):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "boom"
+        mock_get_http_client.return_value.post.return_value = mock_response
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            with pytest.raises(A2AAgentError, match="returned HTTP 500"):
+                await service.proxy_a2a_request(mock_db, mock_agent.name,
+                    {"jsonrpc": "2.0", "method": "message/send", "id": 1})
+
+    # ── Agent card method tests ──
+
+    @pytest.mark.asyncio
+    @patch("mcpgateway.services.http_client_service.get_http_client")
+    @patch("mcpgateway.services.a2a_service.get_for_update")
+    async def test_proxy_agent_card_methods(self, mock_get_for_update, mock_get_http_client,
+                                              service, mock_db, mock_agent, mock_response_200):
+        mock_get_http_client.return_value.post.return_value = mock_response_200
+        mock_get_for_update.return_value = mock_agent
+        with patch.object(service, "_check_agent_access", return_value=True):
+            mock_db.execute.return_value.scalar_one_or_none.return_value = mock_agent.id
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "agent/getCard", "id": 1})
+            await service.proxy_a2a_request(mock_db, mock_agent.name,
+                {"jsonrpc": "2.0", "method": "GetAgentCard", "id": 2})
+        assert mock_get_http_client.return_value.post.call_count == 2

--- a/tests/unit/plugins/conditional_routing/test_rule_engine.py
+++ b/tests/unit/plugins/conditional_routing/test_rule_engine.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/plugins/conditional_routing/test_rule_engine.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the Conditional Routing Plugin — Rule Engine.
+"""
+
+# Third-Party
+import pytest
+
+# First-Party (plugins live outside the mcpgateway package)
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))  # repo root
+
+from plugins.conditional_routing.models import (
+    ConditionalRoutingConfig,
+    DefaultAction,
+    MatchCriteria,
+    RouteTarget,
+    RoutingRule,
+)
+from plugins.conditional_routing.rule_engine import RequestContext, RuleEngine, _select_weighted
+
+
+@pytest.fixture
+def finance_rule():
+    return RoutingRule(
+        name="finance",
+        match=MatchCriteria(tool_name_pattern="finance_*", user_teams=["accounting"]),
+        route_to=RouteTarget(agent_id="finance-agent"),
+        priority=10,
+    )
+
+
+@pytest.fixture
+def code_rule():
+    return RoutingRule(
+        name="code_review",
+        match=MatchCriteria(tool_name_pattern="code_*"),
+        route_to=RouteTarget(agent_id="code-review-agent"),
+        priority=20,
+    )
+
+
+@pytest.fixture
+def default_rule():
+    return RoutingRule(
+        name="default",
+        match=MatchCriteria(tool_name_pattern="*"),
+        route_to=RouteTarget(agent_id="general-agent"),
+        priority=999,
+    )
+
+
+class TestRuleEngineBasics:
+
+    def test_first_match_wins_by_priority(self, finance_rule, code_rule, default_rule):
+        engine = RuleEngine([default_rule, finance_rule, code_rule])
+        ctx = RequestContext(tool_name="finance_report", user_teams=["accounting"])
+        d = engine.evaluate(ctx)
+        assert d.matched
+        assert d.rule_name == "finance"
+        assert d.target_agent_id == "finance-agent"
+
+    def test_falls_through_to_default(self, code_rule, default_rule):
+        engine = RuleEngine([code_rule, default_rule])
+        ctx = RequestContext(tool_name="unknown_tool")
+        d = engine.evaluate(ctx)
+        assert d.matched
+        assert d.rule_name == "default"
+        assert d.target_agent_id == "general-agent"
+
+    def test_no_match(self, finance_rule):
+        engine = RuleEngine([finance_rule])
+        ctx = RequestContext(tool_name="hr_tool", user_teams=["hr"])
+        d = engine.evaluate(ctx)
+        assert not d.matched
+
+    def test_disabled_rules_skipped(self, finance_rule, default_rule):
+        finance_rule.enabled = False
+        engine = RuleEngine([finance_rule, default_rule])
+        ctx = RequestContext(tool_name="finance_report", user_teams=["accounting"])
+        d = engine.evaluate(ctx)
+        assert d.matched
+        assert d.rule_name == "default"  # not finance (disabled)
+
+
+class TestToolNameMatching:
+
+    def test_glob_match(self):
+        rule = RoutingRule(
+            name="t", match=MatchCriteria(tool_name_pattern="search_*"),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(tool_name="search_docs")).matched
+        assert not engine.evaluate(RequestContext(tool_name="translate_text")).matched
+
+    def test_regex_match(self):
+        rule = RoutingRule(
+            name="t", match=MatchCriteria(tool_name_pattern=r"^(search|find)_.*"),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(tool_name="search_docs")).matched
+        assert engine.evaluate(RequestContext(tool_name="find_items")).matched
+
+    def test_match_none_tool_name(self):
+        rule = RoutingRule(
+            name="t", match=MatchCriteria(tool_name_pattern="*"),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        # When tool_name is None, the pattern check is skipped
+        d = engine.evaluate(RequestContext(agent_id="agent-001"))
+        assert d.matched
+
+
+class TestAgentIdMatching:
+
+    def test_agent_id_glob(self):
+        rule = RoutingRule(
+            name="t", match=MatchCriteria(agent_id_pattern="translator-*"),
+            route_to=RouteTarget(agent_id="specialized-translator"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(agent_id="translator-generic")).matched
+        assert not engine.evaluate(RequestContext(agent_id="finance-agent")).matched
+
+
+class TestUserTeamMatching:
+
+    def test_user_in_team(self):
+        rule = RoutingRule(
+            name="t", match=MatchCriteria(user_teams=["finance", "exec"]),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(user_teams=["finance"])).matched
+        assert not engine.evaluate(RequestContext(user_teams=["hr"])).matched
+        # Multiple teams — one match is enough
+        assert engine.evaluate(RequestContext(user_teams=["hr", "finance"])).matched
+
+
+class TestContentMatching:
+
+    def test_content_pattern_in_field(self):
+        rule = RoutingRule(
+            name="pii",
+            match=MatchCriteria(
+                content_patterns=[r"\bSSN\b"],
+                content_fields=["query"],
+            ),
+            route_to=RouteTarget(agent_id="pii-agent"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(arguments={"query": "Look up SSN for user"})).matched
+        assert not engine.evaluate(RequestContext(arguments={"query": "Hello world"})).matched
+
+    def test_content_case_insensitive(self):
+        rule = RoutingRule(
+            name="t",
+            match=MatchCriteria(
+                content_patterns=[r"password"],
+                content_fields=["text"],
+                case_sensitive=False,
+            ),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(arguments={"text": "PASSWORD reset"})).matched
+
+    def test_content_requires_fields(self):
+        with pytest.raises(ValueError, match="content_patterns requires content_fields"):
+            MatchCriteria(content_patterns=[r"test"])
+
+
+class TestCIDRMatching:
+
+    def test_cidr_include(self):
+        rule = RoutingRule(
+            name="t",
+            match=MatchCriteria(source_ip_cidrs=["10.0.0.0/8"]),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(source_ip="10.1.2.3")).matched
+        assert not engine.evaluate(RequestContext(source_ip="192.168.1.1")).matched
+
+    def test_cidr_exclude(self):
+        rule = RoutingRule(
+            name="t",
+            match=MatchCriteria(
+                source_ip_cidrs=["0.0.0.0/0"],
+                exclude_ip_cidrs=["10.0.0.0/8"],
+            ),
+            route_to=RouteTarget(agent_id="a"), priority=1,
+        )
+        engine = RuleEngine([rule])
+        assert engine.evaluate(RequestContext(source_ip="192.168.1.1")).matched
+        assert not engine.evaluate(RequestContext(source_ip="10.1.2.3")).matched
+
+
+class TestWeightedTarget:
+
+    def test_weighted_selection(self):
+        """Weighted target should return a valid agent from the list."""
+        from plugins.conditional_routing.models import WeightedTarget
+        target = RouteTarget(weighted=[
+            WeightedTarget(agent_id="v1", weight=90),
+            WeightedTarget(agent_id="v2", weight=10),
+        ])
+        
+        ctx = RequestContext(user_email="test@example.com")
+        result = _select_weighted(target.weighted, ctx, sticky=False)
+        assert result in ("v1", "v2")
+
+    def test_weighted_sticky_session(self):
+        from plugins.conditional_routing.models import WeightedTarget
+        target = RouteTarget(weighted=[
+            WeightedTarget(agent_id="v1", weight=90),
+            WeightedTarget(agent_id="v2", weight=10),
+        ])
+        
+        ctx = RequestContext(user_email="test@example.com")
+        # Same user should always get same agent
+        results = {_select_weighted(target.weighted, ctx, sticky=True) for _ in range(20)}
+        assert len(results) == 1
+        # Different user may get different agent
+        ctx2 = RequestContext(user_email="other@example.com")
+        results2 = {_select_weighted(target.weighted, ctx2, sticky=True) for _ in range(20)}
+        assert len(results2) == 1
+
+
+class TestRoutingConfig:
+
+    def test_default_action_passthrough(self):
+        cfg = ConditionalRoutingConfig(default_action=DefaultAction.PASSTHROUGH)
+        assert cfg.default_action == DefaultAction.PASSTHROUGH
+
+    def test_default_action_deny(self):
+        cfg = ConditionalRoutingConfig(default_action=DefaultAction.DENY)
+        assert cfg.default_action == DefaultAction.DENY
+
+    def test_audit_enabled_by_default(self):
+        cfg = ConditionalRoutingConfig()
+        assert cfg.audit_routing_decisions is True
+
+
+class TestRouteTargetValidation:
+
+    def test_cannot_specify_both_agent_id_and_weighted(self):
+        from plugins.conditional_routing.models import WeightedTarget
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            RouteTarget(
+                agent_id="a",
+                weighted=[WeightedTarget(agent_id="v1", weight=100)],
+            )
+
+    def test_must_specify_target(self):
+        with pytest.raises(ValueError, match="must be specified"):
+            RouteTarget()
+
+    def test_sticky_requires_weighted(self):
+        with pytest.raises(ValueError, match="sticky_session requires weighted"):
+            RouteTarget(agent_id="a", sticky_session=True)


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the Conditional Routing Plugin ([#3076](https://github.com/IBM/mcp-context-forge/issues/3076)) — the core rule engine and declarative routing schema.

This establishes the "thin waist" contract that all subsequent phases (fallback chains, circuit breaker, Admin API, metrics) will build upon.

## What Phase 1 Delivers

### Pydantic Schema (`models.py`)
- `MatchCriteria` — 12 match dimensions: tool_name_pattern, agent_id_pattern, user_teams, user_roles, user_email_patterns, source_ip_cidrs, exclude_ip_cidrs, content_patterns, content_fields, jwt_claims, headers, case_sensitive
- `RouteTarget` — single agent, weighted multi-target, sticky sessions, fallback chain, override_args
- `RoutingRule` — name, match, route_to, priority, enabled
- `ConditionalRoutingConfig` — routing_rules + default_action (passthrough/deny) + audit toggle
- `RoutingDecision` — structured match result

### Rule Engine (`rule_engine.py`)
- Priority-ordered evaluation with first-match-wins semantics
- Glob + regex matching for tool/agent name patterns
- CIDR IP matching with include/exclude precedence
- Regex content matching against configurable argument fields
- JWT claims, headers, user teams/roles/email matching
- Weighted target selection with MD5-based sticky sessions
- Full match_details in decision for debugging

### Plugin (`conditional_routing_plugin.py`)
- `tool_pre_invoke` hook — rewrites tool name + injects override_args
- `agent_pre_invoke` hook — rewrites agent_id
- `default_action: deny` returns PluginViolation
- Structured audit logging per routing decision

### Tests — 22 passed
| Category | Tests |
|----------|:---:|
| Rule engine basics (priority, fallthrough, disabled) | 4 |
| Tool name matching (glob, regex, none) | 3 |
| Agent ID matching | 1 |
| User team matching | 1 |
| Content pattern matching (pii, case-insensitive) | 3 |
| CIDR matching (include, exclude) | 2 |
| Weighted target selection (+ sticky) | 2 |
| Config validation | 3 |
| RouteTarget validation | 3 |

## Files

| File | Lines | Purpose |
|------|:---:|---------|
| `plugins/conditional_routing/models.py` | 180 | Pydantic schemas |
| `plugins/conditional_routing/rule_engine.py` | 310 | Rule engine + matchers |
| `plugins/conditional_routing/conditional_routing_plugin.py` | 230 | Plugin class + hooks |
| `plugins/conditional_routing/plugin-manifest.yaml` | 10 | Manifest |
| `tests/unit/plugins/.../test_rule_engine.py` | 270 | 22 tests |

## Design Decisions

- **Declarative over imperative** — routing logic expressed as YAML data, not code
- **Composable with security** — routing runs AFTER auth/RBAC; cannot escalate privileges
- **First-match-wins** — predictable, debuggable semantics (like iptables)
- **Glob + regex auto-detection** — patterns containing `[](){}` treated as regex
- **No DB dependency in Phase 1** — rules loaded from config file; runtime persistence in Phase 5

Refs #3076