### PR TITLE
fix: include workspace members in a2a image build

### DIFF
--- a/a2a-agents/rust/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/rust/a2a-echo-agent/Dockerfile
@@ -4,6 +4,8 @@ FROM docker.io/library/rust:1.86-slim AS builder
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
+COPY mcp-servers/rust/benchmark-server ./mcp-servers/rust/benchmark-server
+COPY mcp-servers/rust/slow-time-server ./mcp-servers/rust/slow-time-server
 COPY a2a-agents/rust/a2a-echo-agent ./a2a-agents/rust/a2a-echo-agent
 RUN cargo build --release -p a2a-echo-agent
 


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Fixes the `a2a-echo-agent` container smoke build by copying all Rust workspace members declared in the root `Cargo.toml` into the Docker build context.

## 🔁 Reproduction Steps

Merge-queue Docker Security Scan failed in `Container Smoke (a2a-echo-agent)`:

https://github.com/IBM/mcp-context-forge/actions/runs/27633199347/job/81713600593

The failing Dockerfile path:

```bash
docker buildx build --platform linux/amd64 --load -f a2a-agents/rust/a2a-echo-agent/Dockerfile -t mcp-context-forge-a2a-echo-agent:scan .
```

Before this fix, Cargo stopped while loading the root workspace because `mcp-servers/rust/benchmark-server/Cargo.toml` was missing inside the image build context.

## 🐞 Root Cause

`a2a-agents/rust/a2a-echo-agent/Dockerfile` copies the root `Cargo.toml`, which declares these workspace members:

- `mcp-servers/rust/benchmark-server`
- `mcp-servers/rust/slow-time-server`
- `a2a-agents/rust/a2a-echo-agent`

The Dockerfile only copied `crates/` and `a2a-agents/rust/a2a-echo-agent/`. Cargo validates workspace members before building the selected package, so the missing MCP server manifests made the build fail before compiling the echo agent.

## 💡 Fix Description

Copy the missing Rust MCP server workspace members into the builder stage before running:

```bash
cargo build --release -p a2a-echo-agent
```

This keeps the root workspace manifest complete inside the container build context while preserving the existing single-package build.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          | Not run; Dockerfile-only change |
| Unit tests                            | `make test`          | Not run; Dockerfile-only change |
| Coverage ≥ 80 %                       | `make coverage`      | Not run; Dockerfile-only change |
| Manual regression no longer fails     | `docker buildx build --no-cache --platform linux/amd64 --load -f a2a-agents/rust/a2a-echo-agent/Dockerfile -t mcp-context-forge-a2a-echo-agent:verify-nocache .` | Passed |
| Container health                      | `docker run --rm --platform linux/amd64 -p 127.0.0.1:19100:9100 mcp-context-forge-a2a-echo-agent:verify-nocache` then `curl -fsS http://127.0.0.1:19100/health` | Passed: `{"name":"a2a-echo-agent","status":"healthy","version":"0.1.0"}` |

## 📐 MCP Compliance (if relevant)

Not applicable. This only changes the Docker build context for the Rust A2A echo agent image.

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
