### PR TITLE
fix(docker): make UI build hook importable during FIPS venv install

### DIFF
--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -255,8 +255,13 @@ RUN if [ "$(uname -m)" = "s390x" ] || [ "$(uname -m)" = "ppc64le" ]; then \
 #   2. Native extension wheels from rust-builder (consumed by venv install)
 # Everything else (rust binaries, frontend static, app code) is copied AFTER
 # the heavy venv install so those changes don't invalidate the dep layer.
+#
+# build_hooks.py is the setuptools build_py cmdclass referenced by
+# pyproject.toml; it must be importable during `uv pip install` even though the
+# mcpgateway source tree is copied later, so it is staged here alongside
+# pyproject.toml.
 # ----------------------------------------------------------------------------
-COPY pyproject.toml /app/
+COPY pyproject.toml build_hooks.py /app/
 COPY --from=rust-builder /build/native-extension-wheels/ /tmp/local-native-extension-wheels/
 COPY --from=s390x-wheels /wheels /tmp/s390x-wheels
 COPY --chmod=0755 scripts/verify-native-extensions.py /tmp/verify-native-extensions.py

--- a/build_hooks.py
+++ b/build_hooks.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
-"""Location: ./mcpgateway/tools/builder/build_hooks.py
+"""Location: ./build_hooks.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 
 Custom setuptools build hook to generate UI assets before packaging.
+
+Kept as a top-level module (not inside the ``mcpgateway`` package) so that
+setuptools can import it during ``uv pip install``/``python -m build`` without
+requiring the ``mcpgateway`` source tree to be present. The container build
+installs dependencies with only ``pyproject.toml`` (and this file) copied in,
+ahead of the application source, to preserve dependency-layer caching.
 
 This hook runs during `python -m build` to ensure bundle-*.js and tailwind.min.css
 are generated and included in the wheel/sdist, without requiring them to be committed to git.

--- a/docs/docs/development/packaging.md
+++ b/docs/docs/development/packaging.md
@@ -65,7 +65,7 @@ You can bump the version manually or automate it via Git tags or CI/CD.
 
 ### Building PyPI Packages
 
-The project uses a custom build hook (`build_hooks/__init__.py`) that automatically generates UI assets during packaging:
+The project uses a custom build hook (`build_hooks.py`) that automatically generates UI assets during packaging:
 
 ```bash
 make dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,12 @@
 requires = ["setuptools>=78.1.1", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
-# Custom build hook to generate UI assets before packaging
+# Custom build hook to generate UI assets before packaging.
+# Defined as a top-level module (build_hooks.py) rather than inside the
+# mcpgateway package so setuptools can import it during dependency installs
+# before the application source is present (preserves Docker layer caching).
 [tool.setuptools.cmdclass]
-build_py = "mcpgateway.tools.builder.build_hooks.BuildPyWithUI"
+build_py = "build_hooks.BuildPyWithUI"
 
 [tool.uv]
 exclude-newer = "10 days"

--- a/tests/unit/mcpgateway/tools/builder/test_build_hooks.py
+++ b/tests/unit/mcpgateway/tools/builder/test_build_hooks.py
@@ -3,7 +3,7 @@
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
 
-Unit tests for mcpgateway/tools/builder/build_hooks.py.
+Unit tests for build_hooks.py.
 """
 
 # Standard
@@ -17,8 +17,8 @@ from unittest.mock import MagicMock, patch
 # Third-Party
 import pytest
 
-import mcpgateway.tools.builder.build_hooks as bh_module
-from mcpgateway.tools.builder.build_hooks import BuildPyWithUI
+import build_hooks as bh_module
+from build_hooks import BuildPyWithUI
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,23 +65,23 @@ def anchored(project, monkeypatch):
 class TestBuildUIAssetsFlag:
     def test_skips_when_flag_unset(self, hook, monkeypatch):
         monkeypatch.delenv("BUILD_UI_ASSETS", raising=False)
-        with patch("mcpgateway.tools.builder.build_hooks.build_py.run") as super_run:
+        with patch("build_hooks.build_py.run") as super_run:
             hook.run()
         super_run.assert_called_once()
 
     @pytest.mark.parametrize("value", ["1", "0", "false", "FALSE", "yes", ""])
     def test_skips_for_non_true_values(self, hook, monkeypatch, value):
         monkeypatch.setenv("BUILD_UI_ASSETS", value)
-        with patch("mcpgateway.tools.builder.build_hooks.build_py.run") as super_run:
+        with patch("build_hooks.build_py.run") as super_run:
             hook.run()
         super_run.assert_called_once()
 
     @pytest.mark.parametrize("value", ["true", "True", "TRUE"])
     def test_proceeds_for_true_values(self, hook, anchored, monkeypatch, value):
         monkeypatch.setenv("BUILD_UI_ASSETS", value)
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
         assert mock_run.called
 
@@ -124,9 +124,9 @@ class TestProjectRootDiscovery:
 
     def test_finds_root_within_depth_limit(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()  # must not sys.exit
         assert mock_run.called
 
@@ -145,7 +145,7 @@ class TestStaticDirValidation:
         monkeypatch.setattr(bh_module, "__file__", str(fake_file))
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run"):
+        with patch("build_hooks.subprocess.run"):
             with pytest.raises(SystemExit) as exc_info:
                 hook.run()
         assert exc_info.value.code == 1
@@ -158,9 +158,9 @@ class TestStaticDirValidation:
         b2.write_text("old")
 
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
 
         assert not b1.exists()
@@ -172,9 +172,9 @@ class TestStaticDirValidation:
         keeper.write_text("keep me")
 
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
 
         assert keeper.exists()
@@ -188,7 +188,7 @@ class TestStaticDirValidation:
 class TestNpmChecks:
     def test_exits_when_npm_not_found(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run", side_effect=FileNotFoundError):
+        with patch("build_hooks.subprocess.run", side_effect=FileNotFoundError):
             with pytest.raises(SystemExit) as exc_info:
                 hook.run()
         assert exc_info.value.code == 1
@@ -196,7 +196,7 @@ class TestNpmChecks:
     def test_exits_when_npm_version_check_fails(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
         with patch(
-            "mcpgateway.tools.builder.build_hooks.subprocess.run",
+            "build_hooks.subprocess.run",
             side_effect=subprocess.CalledProcessError(1, "npm"),
         ):
             with pytest.raises(SystemExit) as exc_info:
@@ -211,9 +211,9 @@ class TestNpmChecks:
         monkeypatch.setattr(bh_module, "__file__", str(fake_file))
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
 
         calls = [c.args[0] for c in mock_run.call_args_list]
@@ -221,9 +221,9 @@ class TestNpmChecks:
 
     def test_skips_npm_install_when_node_modules_present(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
 
         calls = [c.args[0] for c in mock_run.call_args_list]
@@ -244,7 +244,7 @@ class TestNpmChecks:
                 raise subprocess.CalledProcessError(1, "npm install")
             return MagicMock(returncode=0)
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run", side_effect=_side_effect):
+        with patch("build_hooks.subprocess.run", side_effect=_side_effect):
             with pytest.raises(SystemExit) as exc_info:
                 hook.run()
         assert exc_info.value.code == 1
@@ -264,7 +264,7 @@ class TestBuildSteps:
                 raise subprocess.CalledProcessError(1, "vite:build")
             return MagicMock(returncode=0)
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run", side_effect=_side_effect):
+        with patch("build_hooks.subprocess.run", side_effect=_side_effect):
             with pytest.raises(SystemExit) as exc_info:
                 hook.run()
         assert exc_info.value.code == 1
@@ -277,7 +277,7 @@ class TestBuildSteps:
                 raise subprocess.CalledProcessError(1, "build:css")
             return MagicMock(returncode=0)
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run", side_effect=_side_effect):
+        with patch("build_hooks.subprocess.run", side_effect=_side_effect):
             with pytest.raises(SystemExit) as exc_info:
                 hook.run()
         assert exc_info.value.code == 1
@@ -285,9 +285,9 @@ class TestBuildSteps:
     def test_happy_path_runs_all_npm_commands_and_calls_super(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run") as super_run:
+            with patch("build_hooks.build_py.run") as super_run:
                 hook.run()
 
         calls = [c.args[0] for c in mock_run.call_args_list]
@@ -299,9 +299,9 @@ class TestBuildSteps:
     def test_happy_path_npm_commands_use_project_root_as_cwd(self, hook, anchored, monkeypatch):
         monkeypatch.setenv("BUILD_UI_ASSETS", "true")
 
-        with patch("mcpgateway.tools.builder.build_hooks.subprocess.run") as mock_run:
+        with patch("build_hooks.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            with patch("mcpgateway.tools.builder.build_hooks.build_py.run"):
+            with patch("build_hooks.build_py.run"):
                 hook.run()
 
         cwd_values = {tuple(c.args[0]): c.kwargs.get("cwd") or c.args[1] if len(c.args) > 1 else c.kwargs.get("cwd") for c in mock_run.call_args_list if c.args[0] != ["npm", "--version"]}


### PR DESCRIPTION
## 🔗 Related Issue

Closes

---

## 📝 Summary

The FIPS container build was producing a virtual environment that contained
**only build tools** (`pip`, `setuptools`, `wheel`, `uv`) — no `mcpgateway`,
`gunicorn`, `uvicorn`, or any application dependency. This surfaced in the
Docker Security Scan as the FedRAMP post-build compliance failure:

```
FAIL: runtime python3 can import gunicorn from the venv (regression: #68373)
=== Results: 21 passed, 1 failed ===
```

**Root cause:** The custom setuptools `build_py` cmdclass `BuildPyWithUI` (added
to generate UI assets at packaging time) lived **inside** the `mcpgateway`
package at `mcpgateway/tools/builder/build_hooks.py`, and `pyproject.toml`
referenced it as `mcpgateway.tools.builder.build_hooks.BuildPyWithUI`.

`Containerfile.lite` intentionally copies **only `pyproject.toml`** into the
builder before running `uv pip install`, and copies the `mcpgateway/` source
tree **after** the heavy dependency layer (to preserve dependency-layer
caching — source edits shouldn't invalidate the install layer). As a result,
when setuptools tried to resolve the cmdclass during the install, it attempted
to `import mcpgateway`, which was not yet present in the build context, and
aborted:

```
ModuleNotFoundError: No module named 'mcpgateway'
```

`uv pip install` exited non-zero and installed nothing. The only FedRAMP check
that exercises a Python import (gunicorn) failed; the other 21 checks pass
because they only validate file permissions / crypto policy.

**Fix:** Move the build hook to a top-level `build_hooks.py` at the repo root so
it is importable during `uv pip install` **without** requiring the `mcpgateway`
source tree. `pyproject.toml` now references `build_hooks.BuildPyWithUI`, and the
Containerfile stages `build_hooks.py` alongside `pyproject.toml` before the venv
install. This fixes the install **while preserving** the existing
dependency-layer caching design.

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation._

**Root-cause reproduction (before fix):** in a directory containing only
`pyproject.toml`:
```
$ uv pip install .
  ...
  ModuleNotFoundError: No module named 'mcpgateway'
  EXIT 1   # venv ends up with only pip/setuptools/wheel/uv
```

**After fix (directory with only `pyproject.toml` + `build_hooks.py`):**
```
$ uv pip install .
  ...
  EXIT 0
$ uv pip list | grep -iE 'gunicorn|uvicorn|fastapi'
  fastapi    0.137.x
  gunicorn   26.0.0
  uvicorn    0.47.0
```

**Clean container build + FedRAMP validation:**
```
$ docker build --no-cache -f Containerfile.lite \
    --build-arg ENABLE_FIPS=true \
    --build-arg PYTHON_VERSION=3.11 \
    --build-arg UBI_BASE=registry.access.redhat.com/ubi9/ubi:latest \
    --build-arg NODEJS_IMAGE=registry.access.redhat.com/ubi9/nodejs-20:latest \
    --build-arg UBI_MINIMAL=registry.access.redhat.com/ubi9/ubi-minimal@sha256:6ea809... \
    -t mcp-context-forge-scan:fedramp-validate .

$ docker run --rm --user root --entrypoint /bin/bash \
    mcp-context-forge-scan:fedramp-validate -c "$(cat scripts/fedramp-validate.sh)"
  ...
  PASS: runtime python3 can import gunicorn from the venv (regression: #68373)
  === Results: 22 passed, 0 failed ===
```

**Build-hook unit tests (import path / patch targets updated for the move):**
```
$ pytest tests/unit/mcpgateway/tools/builder/test_build_hooks.py
  28 passed   # 25 unit + 3 slow wheel-build tests
```

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     | ⬜ pending CI |
| Unit tests                | `make test`     | ✅ build_hooks suite 28/28; full suite via CI |
| Coverage ≥ 80%            | `make coverage` | ⬜ pending CI |
| FedRAMP validation        | `scripts/fedramp-validate.sh` (FIPS image) | ✅ 22 passed, 0 failed |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)