### PR TITLE
fix(playwright): test_should_handle_object_parameter_validation by resolving HTMX race condition and async evaluate error

### DIFF
--- a/tests/playwright/test_api_integration.py
+++ b/tests/playwright/test_api_integration.py
@@ -153,14 +153,32 @@ class TestAPIIntegration:
         Uses the json_param_tool fixture to guarantee a tool with an object
         parameter exists before the test runs.
         """
+        import json
+
         page.click('[data-testid="tools-tab"]')
         page.wait_for_selector("#tools-panel:not(.hidden)")
+        # The admin_page fixture only waits for domcontentloaded; the tools table's
+        # hx-trigger="load" initial HTMX request may still be in-flight.  Both the
+        # initial load and the search target #tools-table with outerHTML swap, so if
+        # the search fires before the initial load completes there is no #tools-table-body
+        # for HTMX to target — the swap goes nowhere and the table stays empty.
+        # Waiting for #tools-table-body to be attached (= initial load done) first
+        # eliminates this race entirely, for both fresh-page and pre-loaded cases.
+        page.wait_for_selector("#tools-table-body", state="attached", timeout=15000)
 
-        # Search for the fixture-created tool by name to avoid pagination issues
+        # Search for the fixture-created tool.  Wrap fill in expect_response so we
+        # explicitly wait for the HTMX partial response — and any synchronous
+        # history.replaceState fired by updatePanelSearchStateInUrl before the request —
+        # to fully settle before calling page.evaluate(), preventing "execution context
+        # was destroyed" errors from navigation events racing with evaluate.
         search_input = page.locator("#tools-search-input")
         search_input.wait_for(state="visible", timeout=10000)
-        search_input.fill(json_param_tool)
-        search_input.press("Enter")
+        with page.expect_response(
+            lambda r: "/admin/tools/partial" in r.url and r.request.method == "GET",
+            timeout=10000,
+        ):
+            search_input.fill(json_param_tool)
+            search_input.press("Enter")
 
         tool_row = page.locator(f'#tools-table-body tr:has-text("{json_param_tool}")')
         tool_row.wait_for(state="visible", timeout=10000)
@@ -168,24 +186,16 @@ class TestAPIIntegration:
         tool_row.locator("button[aria-expanded]").click()
         tool_row.locator('[role="menu"]').wait_for(state="visible", timeout=5000)
 
-        # HTMX may swap the tools-table-body, detaching the button during click.
-        # Extract tool ID and call testTool() directly via page.evaluate() to avoid DOM detachment.
+        # The expect_response above guarantees the search HTMX response has settled and
+        # no swap is in-flight, so clicking the Test button directly is safe (no DOM
+        # detachment risk).  Using evaluate("Admin.testTool(...)") is avoided here
+        # because testTool is async: awaiting it inside page.evaluate() while a fetch
+        # is in-flight can race with a navigation and produce "execution context
+        # was destroyed" errors.  Direct click fires the async function without blocking.
         test_btn = tool_row.locator('button:has-text("Test")')
-        tool_id = tool_row.evaluate("el => el.querySelector('button[data-test-tool-id]')?.getAttribute('data-test-tool-id')")
-        if tool_id:
-            # Call testTool directly to avoid HTMX DOM detachment race condition
-            # Tool IDs are UUID strings, not integers - pass as quoted string
-            import json
-
-            # HTMX pushes the search query into the URL via hx-push-url; Playwright
-            # treats that pushState as an in-flight navigation.  Waiting for
-            # domcontentloaded ensures the navigation event has settled before we
-            # evaluate JS, preventing "execution context was destroyed" errors.
-            page.wait_for_load_state("domcontentloaded", timeout=5000)
-            page.evaluate(f"Admin.testTool({json.dumps(tool_id)})")
-        else:
-            # Fallback if data attribute is missing
-            test_btn.click()
+        # get_attribute reads the DOM directly without a JS evaluate call.
+        tool_id = test_btn.get_attribute("data-test-tool-id")
+        test_btn.click()
 
         expect(page.locator("#tool-test-modal")).to_be_visible(timeout=10000)
         page.wait_for_selector("#tool-test-form-fields", state="visible", timeout=10000)


### PR DESCRIPTION
Relates https://github.ibm.com/contextforge-org/internal_issues/issues/297

---

## 📝 Summary

The test was consistently failing with `"Execution context was destroyed, most likely because of a navigation"` at `page.evaluate("Admin.testTool(...)")`.

---

### Steps to reproduce

1. Run `make serve`
2. Run `TEST_BASE_URL=http://localhost:4444 make test-ui-headless`
3. Failure 
```sh
FAILED tests/playwright/test_api_integration.py::TestAPIIntegration::test_should_handle_object_parameter_validation[chromium]
```
---

### Root causes

  **1. HTMX race between initial table load and search**

  `admin_page` only waits for `domcontentloaded`, so the tools table's `hx-trigger="load"` HTMX
  request may still be in-flight when the test fills the search input. Both the initial load and
  the search target `#tools-table` with `outerHTML` swap. If the search fires before the initial
  load completes, `#tools-table-body` doesn't exist yet, the search swap has no target, and the
  table stays empty.

  Fix: `wait_for_selector("#tools-table-body", state="attached")` before triggering the search.
  `state="attached"` (not `"visible"`) is required because an empty `<tbody>` has zero height and
  is considered hidden by Playwright.

  **2. Execution context destroyed by async evaluate**

  `Admin.testTool` is an `async` function that calls `await fetchWithTimeout(...)`. When invoked
  via `page.evaluate()`, Playwright blocks waiting for the returned Promise to resolve. Any
  navigation-like event during that await destroys the execution context. The previous workaround
  (`wait_for_load_state("networkidle")`) never resolved because the SSE connection keeps the page
  permanently non-idle.

  Fix: use `test_btn.click()` instead — this fires the async function without Playwright blocking
  on it. Use `get_attribute("data-test-tool-id")` to read the tool ID without a JS evaluate.

  **3. No synchronisation on search response**

  Without waiting for the HTMX search response to land, subsequent DOM operations could race with
  HTMX/Alpine's synchronous `history.replaceState` URL update.

  Fix: wrap `fill()`/`press()` in `page.expect_response(lambda r: "/admin/tools/partial" in r.url)`
  to guarantee the response and any associated URL state change has settled before proceeding.