### PR TITLE
fix(schemas): persist auth_headers array in POST /tools and PUT /tools/{tool_id}

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T12:34:13Z",
+  "generated_at": "2026-07-15T15:18:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5928,
+        "line_number": 5948,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6425,
+        "line_number": 6445,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6437,
+        "line_number": 6457,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6509,
+        "line_number": 6529,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7576,
+        "line_number": 7596,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1078,16 +1078,6 @@
         "is_verified": false,
         "line_number": 173,
         "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "docs/docs/architecture/mcp-apps.md": [
-      {
-        "hashed_secret": "7f89c5fe5f113485339383ac7cca52e698544052",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 245,
-        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -4058,7 +4048,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 750,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4089,16 +4079,6 @@
         "verified_result": null
       }
     ],
-    "mcpgateway/routers/oauth_router.py": [
-      {
-        "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 739,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "mcpgateway/schemas.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
@@ -4106,16 +4086,6 @@
         "is_verified": false,
         "line_number": 4577,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "mcpgateway/services/mcp_client_chat_service.py": [
-      {
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 590,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4218,6 +4188,14 @@
       }
     ],
     "mcpgateway/utils/url_auth.py": [
+      {
+        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -4545,26 +4523,6 @@
         "verified_result": null
       }
     ],
-    "scripts/test_email_auth_api.py": [
-      {
-        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 341,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/integration/test_concurrency_row_locking.py": [
-      {
-        "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/js/admin-ui.test.js": [
       {
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
@@ -4869,58 +4827,22 @@
         "verified_result": null
       }
     ],
-    "tests/playwright/security/test_team_selector_e2e.py": [
-      {
-        "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 283,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1412,
+        "line_number": 1397,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_oauth_audience.py": [
       {
-        "hashed_secret": "e360adbe2fa9bb945b9afc993ea1306cb976e947",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 213,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "50e8361b5726f72eed9dffaec824570b635147b6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 246,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 319,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
-      {
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 679,
+        "line_number": 160,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4930,25 +4852,17 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 970,
+        "line_number": 461,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
-        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 11800,
-        "type": "Hex High Entropy String",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18217,
+        "line_number": 17941,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4958,7 +4872,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 235,
+        "line_number": 129,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4968,7 +4882,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2830,
+        "line_number": 2805,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4978,7 +4892,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1484,
+        "line_number": 1464,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-14T16:15:49Z",
+  "generated_at": "2026-07-14T16:29:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4104,7 +4104,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4561,
+        "line_number": 4577,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -266,7 +266,7 @@
         "hashed_secret": "b4673e578b9b30fe8bba1b555b7b59883444c697",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1736,
+        "line_number": 1746,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -274,7 +274,7 @@
         "hashed_secret": "4a0a2df96d4c9a13a282268cab33ac4b8cbb2c72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1824,
+        "line_number": 1834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +282,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2174,
+        "line_number": 2184,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -290,7 +290,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3539,
+        "line_number": 3549,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -298,7 +298,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3630,
+        "line_number": 3640,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -306,7 +306,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3673,
+        "line_number": 3683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -314,7 +314,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3678,
+        "line_number": 3688,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -322,7 +322,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3683,
+        "line_number": 3693,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T15:18:26Z",
+  "generated_at": "2026-07-15T15:37:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 56,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1360,
+        "line_number": 1365,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1455,
+        "line_number": 1460,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1831,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2148,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1304,
+        "line_number": 1317,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1308,
+        "line_number": 1321,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2980,7 +2980,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 825,
+        "line_number": 827,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-14T16:29:16Z",
+  "generated_at": "2026-07-15T12:34:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4940,7 +4940,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11788,
+        "line_number": 11800,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -4948,7 +4948,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18205,
+        "line_number": 18217,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T13:42:55Z",
+  "generated_at": "2026-07-14T16:15:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5948,
+        "line_number": 5928,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6445,
+        "line_number": 6425,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6457,
+        "line_number": 6437,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6529,
+        "line_number": 6509,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7596,
+        "line_number": 7576,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -590,7 +590,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 56,
+        "line_number": 54,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -674,7 +674,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1365,
+        "line_number": 1360,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1460,
+        "line_number": 1455,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1831,
+        "line_number": 1826,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1078,6 +1078,16 @@
         "is_verified": false,
         "line_number": 173,
         "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/docs/architecture/mcp-apps.md": [
+      {
+        "hashed_secret": "7f89c5fe5f113485339383ac7cca52e698544052",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 245,
+        "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
@@ -2148,7 +2158,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1317,
+        "line_number": 1304,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +2166,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1321,
+        "line_number": 1308,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2980,7 +2990,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 827,
+        "line_number": 825,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4048,7 +4058,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 750,
+        "line_number": 751,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4079,13 +4089,33 @@
         "verified_result": null
       }
     ],
+    "mcpgateway/routers/oauth_router.py": [
+      {
+        "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 739,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "mcpgateway/schemas.py": [
       {
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4469,
+        "line_number": 4561,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "mcpgateway/services/mcp_client_chat_service.py": [
+      {
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 590,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -4188,14 +4218,6 @@
       }
     ],
     "mcpgateway/utils/url_auth.py": [
-      {
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 118,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
       {
         "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
         "is_secret": false,
@@ -4523,6 +4545,26 @@
         "verified_result": null
       }
     ],
+    "scripts/test_email_auth_api.py": [
+      {
+        "hashed_secret": "42d7bc4801cb72f2559bd9f6c9af9a2707ca321e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 341,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/integration/test_concurrency_row_locking.py": [
+      {
+        "hashed_secret": "03aca59f05abb8e7b8ceb737167b6cd48dfa0a3f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/js/admin-ui.test.js": [
       {
         "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
@@ -4827,22 +4869,58 @@
         "verified_result": null
       }
     ],
+    "tests/playwright/security/test_team_selector_e2e.py": [
+      {
+        "hashed_secret": "b4e44716dbbf57be3dae2f819d96795a85d06652",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 283,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1397,
+        "line_number": 1412,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/services/test_oauth_audience.py": [
       {
+        "hashed_secret": "e360adbe2fa9bb945b9afc993ea1306cb976e947",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 213,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "50e8361b5726f72eed9dffaec824570b635147b6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 246,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 319,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/unit/mcpgateway/services/test_oauth_manager.py": [
+      {
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 679,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4852,17 +4930,25 @@
         "hashed_secret": "718cbcc5a4207c0d5f38e3a309bdba17cb0074b7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 461,
+        "line_number": 970,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
     ],
     "tests/unit/mcpgateway/test_admin.py": [
       {
+        "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 11788,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17877,
+        "line_number": 18205,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4872,7 +4958,7 @@
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 235,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }
@@ -4882,7 +4968,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2805,
+        "line_number": 2830,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4892,7 +4978,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1464,
+        "line_number": 1484,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 - Rust MCP runtime sidecar, Rust A2A runtime sidecar, and ValidationMiddleware are deprecated as of 2026-06-11 and will sunset on 2026-07-07. Use the Python MCP transport path, the Python A2A invocation path, and endpoint-level Pydantic or protocol-specific validation instead. See [Deprecations](docs/docs/deprecations.md).
 
+## [Unreleased]
+
+### Fixed
+
+- **Custom Auth Headers on Tools** ([#5314](https://github.com/IBM/mcp-context-forge/pull/5314), [#5201](https://github.com/IBM/mcp-context-forge/issues/5201)) - `POST /tools` and `PUT /tools/{tool_id}` now persist the `auth_headers` array instead of silently storing `auth_value: null`. Invalid header keys/values are rejected with a 422 rather than an unhandled 500.
+
+### Changed
+
+- **Stricter `authheaders` Key Validation (Gateways, Tools, A2A Agents)** ([#5314](https://github.com/IBM/mcp-context-forge/pull/5314)) - Header-key validation is now shared across all create/update schemas and the admin form. Keys with embedded whitespace (e.g. `X Api Key`) were previously accepted and stored as invalid HTTP header names that failed at invocation time; they are now rejected with a 422 at config time, and surrounding whitespace is trimmed before storage. Gateway or A2A configs relying on the old behavior will need their header keys corrected on the next update.
+
 ## [1.0.5] - 2026-07-07 - API Versioning, Auth Hardening, A2A Compatibility, and Build Consolidation
 
 ### Overview

--- a/docs/docs/using/multi-auth-headers.md
+++ b/docs/docs/using/multi-auth-headers.md
@@ -114,8 +114,9 @@ Gateways, tools and A2A agents share a single validator, so the same rules apply
 - Header keys may contain only alphanumeric characters, hyphens and underscores — anything else (including embedded spaces) is rejected with a 422
 - Surrounding whitespace on a header key is trimmed before storage
 - Duplicate header keys will use the last provided value
+- Header keys and values must be strings; any other JSON type is rejected with a 422
 - Header values can be empty strings if required by your authentication scheme, and may contain special characters
-- A maximum of 100 headers may be supplied
+- A maximum of 100 header entries may be submitted. The cap applies to the entries you send, before duplicates collapse — so 101 entries are rejected even if they resolve to fewer unique keys
 
 ### Best Practices
 1. **Use HTTPS**: Always use HTTPS URLs for your MCP servers to prevent header interception

--- a/docs/docs/using/multi-auth-headers.md
+++ b/docs/docs/using/multi-auth-headers.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-ContextForge now supports multiple custom authentication headers for gateway connections. This feature allows you to configure multiple header key-value pairs that will be sent with every request to your MCP servers.
+ContextForge supports multiple custom authentication headers for both **gateway** connections and **REST tools**. This feature allows you to configure multiple header key-value pairs that will be sent with every request to your MCP servers or REST endpoints.
 
 !!! tip "Admin UI URL"
     - Direct installs (`uvx`, pip, or `docker run`): `http://localhost:4444/admin/`
@@ -66,9 +66,29 @@ gateway = GatewayCreate(
 )
 ```
 
+## Tools
+
+REST tools accept the same `auth_headers` array on `POST /tools` and `PUT /tools/{tool_id}`, with identical
+validation and precedence rules:
+
+```json
+{
+  "name": "my-tool",
+  "url": "https://api.example.com/endpoint",
+  "request_type": "POST",
+  "auth_type": "authheaders",
+  "auth_headers": [
+    {"key": "X-API-Key", "value": "secret"},
+    {"key": "X-Tenant", "value": "acme"}
+  ]
+}
+```
+
+The same array is used by the "Custom Headers" authentication type in the Tools tab of the Admin UI.
+
 ## Backward Compatibility
 
-The gateway still supports the legacy single-header format for backward compatibility:
+Gateways and tools still support the legacy single-header format for backward compatibility:
 
 ```json
 {
@@ -88,10 +108,14 @@ If both `auth_headers` (multi) and `auth_header_key`/`auth_header_value` (single
 All authentication headers are encrypted before being stored in the database using AES-256-GCM encryption. The encryption key is derived from the `AUTH_ENCRYPTION_SECRET` environment variable.
 
 ### Header Validation
-- Empty header keys are ignored
+Gateways, tools and A2A agents share a single validator, so the same rules apply everywhere:
+
+- Empty header keys are ignored; if no entry has a key, the request is rejected with a 422
+- Header keys may contain only alphanumeric characters, hyphens and underscores — anything else (including embedded spaces) is rejected with a 422
+- Surrounding whitespace on a header key is trimmed before storage
 - Duplicate header keys will use the last provided value
-- Header values can be empty strings if required by your authentication scheme
-- Special characters in header keys and values are supported
+- Header values can be empty strings if required by your authentication scheme, and may contain special characters
+- A maximum of 100 headers may be supplied
 
 ### Best Practices
 1. **Use HTTPS**: Always use HTTPS URLs for your MCP servers to prevent header interception
@@ -183,6 +207,19 @@ The system will automatically convert your configuration to the multi-header for
 ### GatewayUpdate Schema
 ```python
 {
+    "auth_type": "authheaders",
+    "auth_headers": [
+        {"key": str, "value": str},
+        ...
+    ]
+}
+```
+
+### ToolCreate / ToolUpdate Schema
+```python
+{
+    "name": str,           # ToolCreate only
+    "url": str,            # ToolCreate only
     "auth_type": "authheaders",
     "auth_headers": [
         {"key": str, "value": str},

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -146,6 +146,7 @@ from mcpgateway.schemas import (
     ToolMetrics,
     ToolRead,
     ToolUpdate,
+    _encode_auth_headers_list,
 )
 from mcpgateway.services.a2a_agent_plugin_binding_service import A2AAgentPluginBindingForbiddenError, A2AAgentPluginBindingNotFoundError, A2AAgentPluginBindingService
 from mcpgateway.services.a2a_service import A2AAgentError, A2AAgentNameConflictError, A2AAgentNotFoundError, A2AAgentService
@@ -11780,11 +11781,21 @@ async def admin_get_tool(tool_id: str, request: Request, db: Session = Depends(g
 def _build_auth_obj_from_form(form: Any) -> Optional[dict[str, Any]]:
     """Parse auth fields from a form and return a serialized auth object, or None.
 
+    Custom headers are validated by the same ``_encode_auth_headers_list`` helper the JSON
+    tool/gateway schemas use, so malformed header keys and oversized header sets are rejected
+    here with a 422 instead of being persisted and failing later at tool-invocation time.
+    Rows with a blank key are dropped first: the admin form submits empty rows for headers the
+    user never filled in, and those must keep meaning "no headers" rather than 422.
+
     Args:
         form: Multipart form data containing auth_type and credential fields.
 
     Returns:
         A dict with auth_type and encrypted auth_value, or None if no valid auth provided.
+
+    Raises:
+        HTTPException: 422 if auth_type is 'oauth' (unsupported on tools) or if the supplied
+            custom headers fail validation.
     """
     auth_headers_json = form.get("auth_headers") or ""
     auth_headers: list[dict[str, Any]] = []
@@ -11812,12 +11823,14 @@ def _build_auth_obj_from_form(form: Any) -> Optional[dict[str, Any]]:
                 auth_value = encode_auth({"Authorization": f"Bearer {token}"})
                 auth_obj = {"auth_type": auth_type, "auth_value": auth_value}
         elif auth_type == "authheaders":
-            if auth_headers:
-                header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if h.get("key")}
-                if header_dict:
-                    auth_value = encode_auth(header_dict)
-                    auth_obj = {"auth_type": auth_type, "auth_value": auth_value}
-            else:
+            populated_headers = [h for h in auth_headers if isinstance(h, dict) and h.get("key")]
+            if populated_headers:
+                try:
+                    auth_value = _encode_auth_headers_list(populated_headers)
+                except ValueError as exc:
+                    raise HTTPException(status_code=422, detail=str(exc)) from exc
+                auth_obj = {"auth_type": auth_type, "auth_value": auth_value}
+            elif not auth_headers:
                 header_key = form.get("auth_header_key", "")
                 header_value = form.get("auth_header_value", "")
                 if header_key and header_value:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -11801,9 +11801,13 @@ def _build_auth_obj_from_form(form: Any) -> Optional[dict[str, Any]]:
     auth_headers: list[dict[str, Any]] = []
     if auth_headers_json:
         try:
-            auth_headers = orjson.loads(auth_headers_json)
+            parsed_headers = orjson.loads(auth_headers_json)
         except (orjson.JSONDecodeError, ValueError):
-            auth_headers = []
+            parsed_headers = []
+        # orjson.loads accepts any JSON scalar (e.g. "5", "null", "true"), so guard against a
+        # non-list value here rather than letting it reach the list comprehension below and raise
+        # an uncaught TypeError (500). A non-list body simply means "no custom headers".
+        auth_headers = parsed_headers if isinstance(parsed_headers, list) else []
 
     auth_type = form.get("auth_type", "")
     if auth_type and auth_type.lower() == "oauth":

--- a/mcpgateway/admin_ui/auth.js
+++ b/mcpgateway/admin_ui/auth.js
@@ -321,7 +321,7 @@ export function updateAuthHeadersJSON(containerId) {
 
   // Check for excessive headers
   if (headers.length > 100) {
-    console.error("Maximum of 100 headers allowed per gateway");
+    console.error("Maximum of 100 headers allowed.");
     return;
   }
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -553,34 +553,88 @@ def _extract_rest_url_components(values: dict) -> dict:
 
 
 def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
-    """Encode a multi-header ``auth_headers`` list into a stored auth value.
+    """Validate and encode a multi-header ``auth_headers`` list into a stored auth value.
 
-    Shared by :class:`ToolCreate` and :class:`ToolUpdate` so the ``authheaders``
-    multi-header encoding stays consistent across the create and update paths.
-    Each element is expected to be a ``{"key": ..., "value": ...}`` dict; non-dict
-    elements and entries without a key are skipped (last value wins on duplicate
-    keys).
+    Canonical ``authheaders`` array encoder shared by :class:`ToolCreate`,
+    :class:`ToolUpdate`, :class:`GatewayCreate`, :class:`GatewayUpdate`,
+    :class:`A2AAgentCreate` and :class:`A2AAgentUpdate` so the multi-header
+    validation and encoding stay identical across every create/update path.
+
+    Each element is expected to be a ``{"key": ..., "value": ...}`` dict. Non-dict
+    elements and entries without a key are skipped, empty values are allowed, and the
+    last value wins on duplicate keys (a warning is logged). Validation raises
+    ``ValueError`` (surfaced as a 422 through the schemas) when a key has an invalid
+    format, when no entry carries a usable key, or when more than 100 headers remain.
+
+    Note:
+        The non-dict skip above only applies when this helper is called directly. Each
+        schema declares ``auth_headers`` as ``Optional[List[Dict[str, str]]]``, so
+        Pydantic rejects non-dict entries (e.g. ``["not-a-dict"]``) at field validation
+        before they could reach this helper.
 
     Args:
-        auth_headers: List of header dicts to encode.
+        auth_headers: Non-empty list of header dicts to validate and encode.
 
     Returns:
-        Optional[str]: The encoded auth value, or ``None`` when no entry carries a
-        usable key.
+        Optional[str]: The encoded auth value (``encode_auth`` returns ``None`` only when
+        encoding is unavailable; this helper otherwise raises on invalid input).
+
+    Raises:
+        ValueError: If a header key has an invalid format, no valid header with a key is
+            present, or more than 100 headers are supplied.
 
     Examples:
         >>> from mcpgateway.utils.services_auth import decode_auth
         >>> decode_auth(_encode_auth_headers_list([{'key': 'X-API-Key', 'value': 'secret'}]))
         {'X-API-Key': 'secret'}
-        >>> _encode_auth_headers_list([{'value': 'no-key'}]) is None
-        True
-        >>> _encode_auth_headers_list(['not-a-dict']) is None
-        True
+        >>> _encode_auth_headers_list([{'value': 'no-key'}])
+        Traceback (most recent call last):
+            ...
+        ValueError: For 'authheaders' auth, at least one valid header with a key must be provided.
+        >>> _encode_auth_headers_list([{'key': 'Bad@Key!', 'value': 'x'}])
+        Traceback (most recent call last):
+            ...
+        ValueError: Invalid header key format: 'Bad@Key!'. Header keys should contain only alphanumeric characters, hyphens, and underscores.
     """
-    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if isinstance(h, dict) and h.get("key")}
-    if header_dict:
-        return encode_auth(header_dict)
-    return None
+    header_dict = {}
+    duplicate_keys = set()
+
+    for header in auth_headers:
+        # Non-dict entries are skipped here; schema field validation rejects them earlier.
+        if not isinstance(header, dict):
+            continue
+
+        key = header.get("key")
+        value = header.get("value", "")
+
+        # Skip headers without a key.
+        if not key:
+            continue
+
+        # Track duplicate keys (last value wins).
+        if key in header_dict:
+            duplicate_keys.add(key)
+
+        # Validate header key format (basic HTTP header validation).
+        if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
+            raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
+
+        # Store header (empty values are allowed).
+        header_dict[key] = value
+
+    # Ensure at least one valid header.
+    if not header_dict:
+        raise ValueError("For 'authheaders' auth, at least one valid header with a key must be provided.")
+
+    # Warn about duplicate keys (last value used).
+    if duplicate_keys:
+        logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
+
+    # Check for excessive headers (prevent abuse).
+    if len(header_dict) > 100:
+        raise ValueError("Maximum of 100 headers allowed.")
+
+    return encode_auth(header_dict)
 
 
 class ToolCreate(BaseModel):
@@ -970,9 +1024,12 @@ class ToolCreate(BaseModel):
             elif auth_type.lower() == "authheaders":
                 auth_headers = values.get("auth_headers")
                 if auth_headers and isinstance(auth_headers, list):
-                    # New multi-header array format takes precedence over the legacy pair.
+                    # A non-empty multi-header array takes precedence over the legacy pair and is
+                    # validated/encoded by the shared helper (raises on invalid input, matching gateways).
                     values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
                 else:
+                    # An empty/absent array falls through to the legacy single-header pair; when that is
+                    # also absent we intentionally store a null auth_value rather than raising.
                     header_key = values.get("auth_header_key", "")
                     header_value = values.get("auth_header_value", "")
                     if header_key and header_value:
@@ -1424,9 +1481,12 @@ class ToolUpdate(BaseModelWithConfigDict):
             elif auth_type.lower() == "authheaders":
                 auth_headers = values.get("auth_headers")
                 if auth_headers and isinstance(auth_headers, list):
-                    # New multi-header array format takes precedence over the legacy pair.
+                    # A non-empty multi-header array takes precedence over the legacy pair and is
+                    # validated/encoded by the shared helper (raises on invalid input, matching gateways).
                     values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
                 else:
+                    # An empty/absent array falls through to the legacy single-header pair; when that is
+                    # also absent we intentionally store a null auth_value rather than raising.
                     header_key = values.get("auth_header_key", "")
                     header_value = values.get("auth_header_value", "")
                     if header_key and header_value:
@@ -3218,45 +3278,8 @@ class GatewayCreate(BaseModelWithConfigDict):
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
             if auth_headers and isinstance(auth_headers, list):
-                # New multi-headers format with enhanced validation
-                header_dict = {}
-                duplicate_keys = set()
-
-                for header in auth_headers:
-                    if not isinstance(header, dict):
-                        continue
-
-                    key = header.get("key")
-                    value = header.get("value", "")
-
-                    # Skip headers without keys
-                    if not key:
-                        continue
-
-                    # Track duplicate keys (last value wins)
-                    if key in header_dict:
-                        duplicate_keys.add(key)
-
-                    # Validate header key format (basic HTTP header validation)
-                    if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
-                        raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
-
-                    # Store header (empty values are allowed)
-                    header_dict[key] = value
-
-                # Ensure at least one valid header
-                if not header_dict:
-                    raise ValueError("For 'authheaders' auth, at least one valid header with a key must be provided.")
-
-                # Warn about duplicate keys (optional - could log this instead)
-                if duplicate_keys:
-                    logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
-
-                # Check for excessive headers (prevent abuse)
-                if len(header_dict) > 100:
-                    raise ValueError("Maximum of 100 headers allowed per gateway.")
-
-                return encode_auth(header_dict)
+                # New multi-headers format (validated and encoded by the shared helper)
+                return _encode_auth_headers_list(auth_headers)
 
             # Legacy single header format (backward compatibility)
             header_key = data.get("auth_header_key")
@@ -3598,45 +3621,8 @@ class GatewayUpdate(BaseModelWithConfigDict):
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
             if auth_headers and isinstance(auth_headers, list):
-                # New multi-headers format with enhanced validation
-                header_dict = {}
-                duplicate_keys = set()
-
-                for header in auth_headers:
-                    if not isinstance(header, dict):
-                        continue
-
-                    key = header.get("key")
-                    value = header.get("value", "")
-
-                    # Skip headers without keys
-                    if not key:
-                        continue
-
-                    # Track duplicate keys (last value wins)
-                    if key in header_dict:
-                        duplicate_keys.add(key)
-
-                    # Validate header key format (basic HTTP header validation)
-                    if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
-                        raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
-
-                    # Store header (empty values are allowed)
-                    header_dict[key] = value
-
-                # Ensure at least one valid header
-                if not header_dict:
-                    raise ValueError("For 'authheaders' auth, at least one valid header with a key must be provided.")
-
-                # Warn about duplicate keys (optional - could log this instead)
-                if duplicate_keys:
-                    logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
-
-                # Check for excessive headers (prevent abuse)
-                if len(header_dict) > 100:
-                    raise ValueError("Maximum of 100 headers allowed per gateway.")
-
-                return encode_auth(header_dict)
+                # New multi-headers format (validated and encoded by the shared helper)
+                return _encode_auth_headers_list(auth_headers)
 
             # Legacy single header format (backward compatibility)
             header_key = data.get("auth_header_key")
@@ -5101,45 +5087,8 @@ class A2AAgentCreate(BaseModel):
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
             if auth_headers and isinstance(auth_headers, list):
-                # New multi-headers format with enhanced validation
-                header_dict = {}
-                duplicate_keys = set()
-
-                for header in auth_headers:
-                    if not isinstance(header, dict):
-                        continue
-
-                    key = header.get("key")
-                    value = header.get("value", "")
-
-                    # Skip headers without keys
-                    if not key:
-                        continue
-
-                    # Track duplicate keys (last value wins)
-                    if key in header_dict:
-                        duplicate_keys.add(key)
-
-                    # Validate header key format (basic HTTP header validation)
-                    if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
-                        raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
-
-                    # Store header (empty values are allowed)
-                    header_dict[key] = value
-
-                # Ensure at least one valid header
-                if not header_dict:
-                    raise ValueError("For 'authheaders' auth, at least one valid header with a key must be provided.")
-
-                # Warn about duplicate keys (optional - could log this instead)
-                if duplicate_keys:
-                    logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
-
-                # Check for excessive headers (prevent abuse)
-                if len(header_dict) > 100:
-                    raise ValueError("Maximum of 100 headers allowed per gateway.")
-
-                return encode_auth(header_dict)
+                # New multi-headers format (validated and encoded by the shared helper)
+                return _encode_auth_headers_list(auth_headers)
 
             # Legacy single header format (backward compatibility)
             header_key = data.get("auth_header_key")
@@ -5477,45 +5426,8 @@ class A2AAgentUpdate(BaseModelWithConfigDict):
             # Support both new multi-headers format and legacy single header format
             auth_headers = data.get("auth_headers")
             if auth_headers and isinstance(auth_headers, list):
-                # New multi-headers format with enhanced validation
-                header_dict = {}
-                duplicate_keys = set()
-
-                for header in auth_headers:
-                    if not isinstance(header, dict):
-                        continue
-
-                    key = header.get("key")
-                    value = header.get("value", "")
-
-                    # Skip headers without keys
-                    if not key:
-                        continue
-
-                    # Track duplicate keys (last value wins)
-                    if key in header_dict:
-                        duplicate_keys.add(key)
-
-                    # Validate header key format (basic HTTP header validation)
-                    if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
-                        raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
-
-                    # Store header (empty values are allowed)
-                    header_dict[key] = value
-
-                # Ensure at least one valid header
-                if not header_dict:
-                    raise ValueError("For 'authheaders' auth, at least one valid header with a key must be provided.")
-
-                # Warn about duplicate keys (optional - could log this instead)
-                if duplicate_keys:
-                    logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
-
-                # Check for excessive headers (prevent abuse)
-                if len(header_dict) > 100:
-                    raise ValueError("Maximum of 100 headers allowed per gateway.")
-
-                return encode_auth(header_dict)
+                # New multi-headers format (validated and encoded by the shared helper)
+                return _encode_auth_headers_list(auth_headers)
 
             # Legacy single header format (backward compatibility)
             header_key = data.get("auth_header_key")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -552,6 +552,37 @@ def _extract_rest_url_components(values: dict) -> dict:
     return values
 
 
+def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
+    """Encode a multi-header ``auth_headers`` list into a stored auth value.
+
+    Shared by :class:`ToolCreate` and :class:`ToolUpdate` so the ``authheaders``
+    multi-header encoding stays consistent across the create and update paths.
+    Each element is expected to be a ``{"key": ..., "value": ...}`` dict; non-dict
+    elements and entries without a key are skipped (last value wins on duplicate
+    keys).
+
+    Args:
+        auth_headers: List of header dicts to encode.
+
+    Returns:
+        Optional[str]: The encoded auth value, or ``None`` when no entry carries a
+        usable key.
+
+    Examples:
+        >>> from mcpgateway.utils.services_auth import decode_auth
+        >>> decode_auth(_encode_auth_headers_list([{'key': 'X-API-Key', 'value': 'secret'}]))
+        {'X-API-Key': 'secret'}
+        >>> _encode_auth_headers_list([{'value': 'no-key'}]) is None
+        True
+        >>> _encode_auth_headers_list(['not-a-dict']) is None
+        True
+    """
+    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if isinstance(h, dict) and h.get("key")}
+    if header_dict:
+        return encode_auth(header_dict)
+    return None
+
+
 class ToolCreate(BaseModel):
     """
     Represents the configuration for creating a tool with various attributes and settings.
@@ -592,6 +623,8 @@ class ToolCreate(BaseModel):
     extension_metadata: Optional[Dict[str, Any]] = Field(default=None, alias="extensionMetadata", description="Extension-specific metadata keyed by extension identifier")
     jsonpath_filter: Optional[str] = Field(default="", description="JSON modification filter")
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
+    # Declared for OpenAPI discoverability; consumed by the ``assemble_auth`` validator to build ``auth`` for the "authheaders" type.
+    auth_headers: Optional[List[Dict[str, str]]] = Field(None, description="List of custom headers for 'authheaders' authentication (array of {'key': ..., 'value': ...} entries)")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(default_factory=list, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(default=False, description="Whether the tool is deprecated (visible but non-executable)")
@@ -900,6 +933,8 @@ class ToolCreate(BaseModel):
             >>> result = ToolCreate.assemble_auth(values)
             >>> result['auth']['auth_type']
             'authheaders'
+            >>> result['auth']['auth_value'] is not None
+            True
 
             >>> # Test authheaders with legacy single-header fallback
             >>> values = {'auth_type': 'authheaders', 'auth_header_key': 'X-API-Key', 'auth_header_value': 'secret'}
@@ -935,12 +970,8 @@ class ToolCreate(BaseModel):
             elif auth_type.lower() == "authheaders":
                 auth_headers = values.get("auth_headers")
                 if auth_headers and isinstance(auth_headers, list):
-                    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if h.get("key")}
-                    if header_dict:
-                        encoded_auth = encode_auth(header_dict)
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
-                    else:
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                    # New multi-header array format takes precedence over the legacy pair.
+                    values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
                 else:
                     header_key = values.get("auth_header_key", "")
                     header_value = values.get("auth_header_value", "")
@@ -948,6 +979,7 @@ class ToolCreate(BaseModel):
                         encoded_auth = encode_auth({header_key: header_value})
                         values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
                     else:
+                        # Don't encode empty headers - leave auth empty
                         values["auth"] = {"auth_type": "authheaders", "auth_value": None}
         return values
 
@@ -1177,6 +1209,8 @@ class ToolUpdate(BaseModelWithConfigDict):
     extension_metadata: Optional[Dict[str, Any]] = Field(default=None, alias="extensionMetadata", description="Extension-specific metadata keyed by extension identifier")
     jsonpath_filter: Optional[str] = Field(None, description="JSON path filter for rpc tool calls")
     auth: Optional[AuthenticationValues] = Field(None, description="Authentication credentials (Basic or Bearer Token or custom headers) if required")
+    # Declared for OpenAPI discoverability; consumed by the ``assemble_auth`` validator to build ``auth`` for the "authheaders" type.
+    auth_headers: Optional[List[Dict[str, str]]] = Field(None, description="List of custom headers for 'authheaders' authentication (array of {'key': ..., 'value': ...} entries)")
     gateway_id: Optional[str] = Field(None, description="id of gateway for the tool")
     tags: Optional[List[str]] = Field(None, description="Tags for categorizing the tool")
     deprecated: Optional[bool] = Field(None, description="Whether the tool is deprecated (visible but non-executable)")
@@ -1390,12 +1424,8 @@ class ToolUpdate(BaseModelWithConfigDict):
             elif auth_type.lower() == "authheaders":
                 auth_headers = values.get("auth_headers")
                 if auth_headers and isinstance(auth_headers, list):
-                    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if h.get("key")}
-                    if header_dict:
-                        encoded_auth = encode_auth(header_dict)
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
-                    else:
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                    # New multi-header array format takes precedence over the legacy pair.
+                    values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
                 else:
                     header_key = values.get("auth_header_key", "")
                     header_value = values.get("auth_header_value", "")
@@ -1403,6 +1433,7 @@ class ToolUpdate(BaseModelWithConfigDict):
                         encoded_auth = encode_auth({header_key: header_value})
                         values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
                     else:
+                        # Don't encode empty headers - leave auth empty
                         values["auth"] = {"auth_type": "authheaders", "auth_value": None}
         return values
 

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -552,7 +552,7 @@ def _extract_rest_url_components(values: dict) -> dict:
     return values
 
 
-def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
+def _encode_auth_headers_list(auth_headers: List[Any]) -> Optional[str]:
     """Validate and encode a multi-header ``auth_headers`` list into a stored auth value.
 
     Canonical ``authheaders`` array encoder shared by :class:`ToolCreate`,
@@ -561,16 +561,19 @@ def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
     validation and encoding stay identical across every create/update path.
 
     Each element is expected to be a ``{"key": ..., "value": ...}`` dict. Non-dict
-    elements and entries without a key are skipped, empty values are allowed, and the
-    last value wins on duplicate keys (a warning is logged). Validation raises
-    ``ValueError`` (surfaced as a 422 through the schemas) when a key has an invalid
-    format, when no entry carries a usable key, or when more than 100 headers remain.
+    elements and entries without a key are skipped, empty values are allowed, surrounding
+    whitespace on a key is trimmed, and the last value wins on duplicate keys (a warning is
+    logged). Validation raises ``ValueError`` (surfaced as a 422 through the schemas) when a
+    key or value is not a string, when a key has an invalid format, when no entry carries a
+    usable key, or when more than 100 headers remain.
 
     Note:
-        The non-dict skip above only applies when this helper is called directly. Each
-        schema declares ``auth_headers`` as ``Optional[List[Dict[str, str]]]``, so
-        Pydantic rejects non-dict entries (e.g. ``["not-a-dict"]``) at field validation
-        before they could reach this helper.
+        ``ToolCreate``/``ToolUpdate`` assemble auth in a ``mode="before"`` validator, so this
+        helper sees the raw, uncoerced client JSON on those paths and must do its own type
+        checking. ``GatewayCreate``/``GatewayUpdate`` and the A2A schemas are ``mode="after"``,
+        where Pydantic has already coerced ``auth_headers`` to ``List[Dict[str, str]]`` against
+        the declared field — which is also why a non-dict entry (e.g. ``["not-a-dict"]``) is
+        rejected at field validation there and only reaches the skip below on a direct call.
 
     Args:
         auth_headers: Non-empty list of header dicts to validate and encode.
@@ -580,12 +583,15 @@ def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
         encoding is unavailable; this helper otherwise raises on invalid input).
 
     Raises:
-        ValueError: If a header key has an invalid format, no valid header with a key is
-            present, or more than 100 headers are supplied.
+        ValueError: If a header key or value is not a string, a header key has an invalid
+            format, no valid header with a key is present, or more than 100 headers are
+            supplied.
 
     Examples:
         >>> from mcpgateway.utils.services_auth import decode_auth
         >>> decode_auth(_encode_auth_headers_list([{'key': 'X-API-Key', 'value': 'secret'}]))
+        {'X-API-Key': 'secret'}
+        >>> decode_auth(_encode_auth_headers_list([{'key': '  X-API-Key  ', 'value': 'secret'}]))
         {'X-API-Key': 'secret'}
         >>> _encode_auth_headers_list([{'value': 'no-key'}])
         Traceback (most recent call last):
@@ -595,6 +601,14 @@ def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
         Traceback (most recent call last):
             ...
         ValueError: Invalid header key format: 'Bad@Key!'. Header keys should contain only alphanumeric characters, hyphens, and underscores.
+        >>> _encode_auth_headers_list([{'key': 'X Api Key', 'value': 'x'}])
+        Traceback (most recent call last):
+            ...
+        ValueError: Invalid header key format: 'X Api Key'. Header keys should contain only alphanumeric characters, hyphens, and underscores.
+        >>> _encode_auth_headers_list([{'key': 123, 'value': 'x'}])
+        Traceback (most recent call last):
+            ...
+        ValueError: Invalid header key type: 'int'. Header keys must be strings.
     """
     header_dict = {}
     duplicate_keys = set()
@@ -611,12 +625,29 @@ def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
         if not key:
             continue
 
+        # Raw client JSON reaches here through the tool schemas' mode="before" validators, so
+        # reject non-string keys/values as ValueError (422) instead of letting them blow up on
+        # str operations or dict insertion (an unhandled AttributeError/TypeError -> 500).
+        if not isinstance(key, str):
+            raise ValueError(f"Invalid header key type: '{type(key).__name__}'. Header keys must be strings.")
+        if value is None:
+            value = ""
+        if not isinstance(value, str):
+            raise ValueError(f"Invalid header value type for '{key}': '{type(value).__name__}'. Header values must be strings.")
+
+        # Surrounding whitespace is a common copy/paste artifact and is trimmed. Embedded
+        # whitespace is not: it produces an invalid HTTP header name that would otherwise be
+        # stored and only fail later, at tool-invocation time.
+        key = key.strip()
+        if not key:
+            continue
+
         # Track duplicate keys (last value wins).
         if key in header_dict:
             duplicate_keys.add(key)
 
         # Validate header key format (basic HTTP header validation).
-        if not all(c.isalnum() or c in "-_" for c in key.replace(" ", "")):
+        if not all(c.isalnum() or c in "-_" for c in key):
             raise ValueError(f"Invalid header key format: '{key}'. Header keys should contain only alphanumeric characters, hyphens, and underscores.")
 
         # Store header (empty values are allowed).
@@ -635,6 +666,50 @@ def _encode_auth_headers_list(auth_headers: list) -> Optional[str]:
         raise ValueError("Maximum of 100 headers allowed.")
 
     return encode_auth(header_dict)
+
+
+def _assemble_tool_authheaders(values: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the ``authheaders`` auth object for the tool create/update schemas.
+
+    Shared by :meth:`ToolCreate.assemble_auth` and :meth:`ToolUpdate.assemble_auth` so both
+    paths resolve the multi-header array, the legacy single-header pair and the "nothing
+    supplied" case identically.
+
+    Precedence:
+        1. A non-empty ``auth_headers`` array wins and is validated/encoded by
+           :func:`_encode_auth_headers_list` (raises on invalid input, matching gateways).
+        2. Otherwise the legacy ``auth_header_key``/``auth_header_value`` pair is encoded.
+        3. An absent array **and** an empty/absent legacy pair — which includes the explicit
+           ``auth_headers=[]`` case, e.g. the admin UI clearing every header row — stores a
+           null ``auth_value`` rather than raising, so callers can unset headers.
+
+    Args:
+        values: Raw (pre-validation) input values for a tool create/update.
+
+    Returns:
+        Dict[str, Any]: The assembled ``{"auth_type": "authheaders", "auth_value": ...}`` object.
+
+    Examples:
+        >>> from mcpgateway.utils.services_auth import decode_auth
+        >>> auth = _assemble_tool_authheaders({'auth_headers': [{'key': 'X-API-Key', 'value': 'secret'}]})
+        >>> decode_auth(auth['auth_value'])
+        {'X-API-Key': 'secret'}
+        >>> auth = _assemble_tool_authheaders({'auth_header_key': 'X-API-Key', 'auth_header_value': 'legacy'})
+        >>> decode_auth(auth['auth_value'])['X-API-Key']
+        'legacy'
+        >>> _assemble_tool_authheaders({'auth_headers': []})
+        {'auth_type': 'authheaders', 'auth_value': None}
+    """
+    auth_headers = values.get("auth_headers")
+    if auth_headers and isinstance(auth_headers, list):
+        return {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
+
+    header_key = values.get("auth_header_key", "")
+    header_value = values.get("auth_header_value", "")
+    if header_key and header_value:
+        return {"auth_type": "authheaders", "auth_value": encode_auth({header_key: header_value})}
+
+    return {"auth_type": "authheaders", "auth_value": None}
 
 
 class ToolCreate(BaseModel):
@@ -1022,22 +1097,7 @@ class ToolCreate(BaseModel):
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
                 values["auth"] = {"auth_type": "bearer", "auth_value": encoded_auth}
             elif auth_type.lower() == "authheaders":
-                auth_headers = values.get("auth_headers")
-                if auth_headers and isinstance(auth_headers, list):
-                    # A non-empty multi-header array takes precedence over the legacy pair and is
-                    # validated/encoded by the shared helper (raises on invalid input, matching gateways).
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
-                else:
-                    # An empty/absent array falls through to the legacy single-header pair; when that is
-                    # also absent we intentionally store a null auth_value rather than raising.
-                    header_key = values.get("auth_header_key", "")
-                    header_value = values.get("auth_header_value", "")
-                    if header_key and header_value:
-                        encoded_auth = encode_auth({header_key: header_value})
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
-                    else:
-                        # Don't encode empty headers - leave auth empty
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                values["auth"] = _assemble_tool_authheaders(values)
         return values
 
     @model_validator(mode="before")
@@ -1479,22 +1539,7 @@ class ToolUpdate(BaseModelWithConfigDict):
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
                 values["auth"] = {"auth_type": "bearer", "auth_value": encoded_auth}
             elif auth_type.lower() == "authheaders":
-                auth_headers = values.get("auth_headers")
-                if auth_headers and isinstance(auth_headers, list):
-                    # A non-empty multi-header array takes precedence over the legacy pair and is
-                    # validated/encoded by the shared helper (raises on invalid input, matching gateways).
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": _encode_auth_headers_list(auth_headers)}
-                else:
-                    # An empty/absent array falls through to the legacy single-header pair; when that is
-                    # also absent we intentionally store a null auth_value rather than raising.
-                    header_key = values.get("auth_header_key", "")
-                    header_value = values.get("auth_header_value", "")
-                    if header_key and header_value:
-                        encoded_auth = encode_auth({header_key: header_value})
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
-                    else:
-                        # Don't encode empty headers - leave auth empty
-                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                values["auth"] = _assemble_tool_authheaders(values)
         return values
 
     @model_validator(mode="before")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -867,8 +867,12 @@ class ToolCreate(BaseModel):
         """
         Assemble authentication information from separate keys if provided.
 
-        Looks for keys "auth_type", "auth_username", "auth_password", "auth_token", "auth_header_key" and "auth_header_value".
+        Looks for keys "auth_type", "auth_username", "auth_password", "auth_token", "auth_headers",
+        "auth_header_key" and "auth_header_value".
         Constructs the "auth" field as a dictionary suitable for BasicAuth or BearerTokenAuth or HeadersAuth.
+
+        For "authheaders" type, the "auth_headers" list (array of {"key": ..., "value": ...} dicts)
+        takes precedence over the legacy "auth_header_key"/"auth_header_value" single-header pair.
 
         Args:
             values: Dict with authentication information
@@ -891,7 +895,13 @@ class ToolCreate(BaseModel):
             >>> result['auth']['auth_type']
             'bearer'
 
-            >>> # Test authheaders
+            >>> # Test authheaders with array (multi-header)
+            >>> values = {'auth_type': 'authheaders', 'auth_headers': [{'key': 'X-API-Key', 'value': 'secret'}, {'key': 'X-Tenant', 'value': 'acme'}]}
+            >>> result = ToolCreate.assemble_auth(values)
+            >>> result['auth']['auth_type']
+            'authheaders'
+
+            >>> # Test authheaders with legacy single-header fallback
             >>> values = {'auth_type': 'authheaders', 'auth_header_key': 'X-API-Key', 'auth_header_value': 'secret'}
             >>> result = ToolCreate.assemble_auth(values)
             >>> result['auth']['auth_type']
@@ -923,14 +933,22 @@ class ToolCreate(BaseModel):
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
                 values["auth"] = {"auth_type": "bearer", "auth_value": encoded_auth}
             elif auth_type.lower() == "authheaders":
-                header_key = values.get("auth_header_key", "")
-                header_value = values.get("auth_header_value", "")
-                if header_key and header_value:
-                    encoded_auth = encode_auth({header_key: header_value})
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                auth_headers = values.get("auth_headers")
+                if auth_headers and isinstance(auth_headers, list):
+                    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if h.get("key")}
+                    if header_dict:
+                        encoded_auth = encode_auth(header_dict)
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                    else:
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
                 else:
-                    # Don't encode empty headers - leave auth empty
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                    header_key = values.get("auth_header_key", "")
+                    header_value = values.get("auth_header_value", "")
+                    if header_key and header_value:
+                        encoded_auth = encode_auth({header_key: header_value})
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                    else:
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
         return values
 
     @model_validator(mode="before")
@@ -1337,8 +1355,12 @@ class ToolUpdate(BaseModelWithConfigDict):
         """
         Assemble authentication information from separate keys if provided.
 
-        Looks for keys "auth_type", "auth_username", "auth_password", "auth_token", "auth_header_key" and "auth_header_value".
+        Looks for keys "auth_type", "auth_username", "auth_password", "auth_token", "auth_headers",
+        "auth_header_key" and "auth_header_value".
         Constructs the "auth" field as a dictionary suitable for BasicAuth or BearerTokenAuth or HeadersAuth.
+
+        For "authheaders" type, the "auth_headers" list (array of {"key": ..., "value": ...} dicts)
+        takes precedence over the legacy "auth_header_key"/"auth_header_value" single-header pair.
 
         Args:
             values: Dict with authentication information
@@ -1347,7 +1369,7 @@ class ToolUpdate(BaseModelWithConfigDict):
             Dict: Reformatedd values dict
         """
         logger.debug(
-            "Assembling auth in ToolCreate with raw values",
+            "Assembling auth in ToolUpdate with raw values",
             extra={
                 "auth_type": values.get("auth_type"),
                 "auth_username": values.get("auth_username"),
@@ -1366,14 +1388,22 @@ class ToolUpdate(BaseModelWithConfigDict):
                 encoded_auth = encode_auth({"Authorization": f"Bearer {values.get('auth_token', '')}"})
                 values["auth"] = {"auth_type": "bearer", "auth_value": encoded_auth}
             elif auth_type.lower() == "authheaders":
-                header_key = values.get("auth_header_key", "")
-                header_value = values.get("auth_header_value", "")
-                if header_key and header_value:
-                    encoded_auth = encode_auth({header_key: header_value})
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                auth_headers = values.get("auth_headers")
+                if auth_headers and isinstance(auth_headers, list):
+                    header_dict = {h.get("key"): h.get("value", "") for h in auth_headers if h.get("key")}
+                    if header_dict:
+                        encoded_auth = encode_auth(header_dict)
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                    else:
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
                 else:
-                    # Don't encode empty headers - leave auth empty
-                    values["auth"] = {"auth_type": "authheaders", "auth_value": None}
+                    header_key = values.get("auth_header_key", "")
+                    header_value = values.get("auth_header_value", "")
+                    if header_key and header_value:
+                        encoded_auth = encode_auth({header_key: header_value})
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": encoded_auth}
+                    else:
+                        values["auth"] = {"auth_type": "authheaders", "auth_value": None}
         return values
 
     @model_validator(mode="before")

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -560,12 +560,16 @@ def _encode_auth_headers_list(auth_headers: List[Any]) -> Optional[str]:
     :class:`A2AAgentCreate` and :class:`A2AAgentUpdate` so the multi-header
     validation and encoding stay identical across every create/update path.
 
+    At most 100 entries may be supplied; the cap is enforced against the submitted list, before
+    any iteration, so an oversized payload is rejected without being walked (duplicate keys still
+    collapse to a single stored header, but they count towards the cap).
+
     Each element is expected to be a ``{"key": ..., "value": ...}`` dict. Non-dict
     elements and entries without a key are skipped, empty values are allowed, surrounding
     whitespace on a key is trimmed, and the last value wins on duplicate keys (a warning is
-    logged). Validation raises ``ValueError`` (surfaced as a 422 through the schemas) when a
-    key or value is not a string, when a key has an invalid format, when no entry carries a
-    usable key, or when more than 100 headers remain.
+    logged). Validation raises ``ValueError`` (surfaced as a 422 through the schemas) when more
+    than 100 entries are supplied, when a key or value is not a string, when a key has an invalid
+    format, or when no entry carries a usable key.
 
     Note:
         ``ToolCreate``/``ToolUpdate`` assemble auth in a ``mode="before"`` validator, so this
@@ -583,9 +587,8 @@ def _encode_auth_headers_list(auth_headers: List[Any]) -> Optional[str]:
         encoding is unavailable; this helper otherwise raises on invalid input).
 
     Raises:
-        ValueError: If a header key or value is not a string, a header key has an invalid
-            format, no valid header with a key is present, or more than 100 headers are
-            supplied.
+        ValueError: If more than 100 header entries are supplied, a header key or value is not a
+            string, a header key has an invalid format, or no valid header with a key is present.
 
     Examples:
         >>> from mcpgateway.utils.services_auth import decode_auth
@@ -609,7 +612,17 @@ def _encode_auth_headers_list(auth_headers: List[Any]) -> Optional[str]:
         Traceback (most recent call last):
             ...
         ValueError: Invalid header key type: 'int'. Header keys must be strings.
+        >>> _encode_auth_headers_list([{'key': f'X-H-{i}', 'value': 'v'} for i in range(101)])
+        Traceback (most recent call last):
+            ...
+        ValueError: Maximum of 100 headers allowed.
     """
+    # Enforce the cap on the submitted list before iterating: the tool schemas run this from a
+    # mode="before" validator on raw client JSON, so an arbitrarily long array would otherwise be
+    # walked in full before being rejected (CWE-770).
+    if len(auth_headers) > 100:
+        raise ValueError("Maximum of 100 headers allowed.")
+
     header_dict = {}
     duplicate_keys = set()
 
@@ -661,10 +674,6 @@ def _encode_auth_headers_list(auth_headers: List[Any]) -> Optional[str]:
     if duplicate_keys:
         logger.warning(f"Duplicate header keys detected (last value used): {', '.join(duplicate_keys)}")
 
-    # Check for excessive headers (prevent abuse).
-    if len(header_dict) > 100:
-        raise ValueError("Maximum of 100 headers allowed.")
-
     return encode_auth(header_dict)
 
 
@@ -680,8 +689,15 @@ def _assemble_tool_authheaders(values: Dict[str, Any]) -> Dict[str, Any]:
            :func:`_encode_auth_headers_list` (raises on invalid input, matching gateways).
         2. Otherwise the legacy ``auth_header_key``/``auth_header_value`` pair is encoded.
         3. An absent array **and** an empty/absent legacy pair — which includes the explicit
-           ``auth_headers=[]`` case, e.g. the admin UI clearing every header row — stores a
-           null ``auth_value`` rather than raising, so callers can unset headers.
+           ``auth_headers=[]`` case, e.g. the admin UI submitting only blank header rows —
+           yields a null ``auth_value`` rather than raising.
+
+    Note:
+        A null ``auth_value`` is not an "unset" instruction. On update,
+        :meth:`ToolService.update_tool` only writes ``auth_value`` when it is non-null, so a tool's
+        stored credentials survive a partial update that omits them (which is what keeps masked
+        values from wiping real secrets). Clearing headers on an existing tool is therefore not
+        supported through this path.
 
     Args:
         values: Raw (pre-validation) input values for a tool create/update.

--- a/tests/integration/test_tool_auth_headers_api.py
+++ b/tests/integration/test_tool_auth_headers_api.py
@@ -110,3 +110,41 @@ def test_post_tools_non_string_header_key_returns_422(client):
     """
     response = client.post("/tools/", json=_create_payload("bad_key_type_tool", auth_type="authheaders", auth_headers=[{"key": 123, "value": "x"}]))
     assert response.status_code == 422, response.text
+
+
+def test_post_tools_excessive_headers_returns_422(client):
+    """More than 100 header entries is rejected through the real route, not persisted."""
+    headers = [{"key": f"X-Header-{i}", "value": f"v{i}"} for i in range(101)]
+    response = client.post("/tools/", json=_create_payload("too_many_headers_tool", auth_type="authheaders", auth_headers=headers))
+    assert response.status_code == 422, response.text
+
+
+def test_post_tools_persists_legacy_single_header_pair(client):
+    """The legacy auth_header_key/auth_header_value pair still persists through POST /tools."""
+    response = client.post(
+        "/tools/",
+        json=_create_payload("legacy_tool", auth_type="authheaders", auth_header_key="X-API-Key", auth_header_value="legacy-secret"),
+    )
+    assert response.status_code == 200, response.text
+
+    _, auth_value = _stored_auth("legacy_tool")
+    assert decode_auth(auth_value) == {"X-API-Key": "legacy-secret"}  # pragma: allowlist secret
+
+
+def test_put_tools_empty_array_preserves_stored_headers(client):
+    """PUT /tools/{id} with an empty auth_headers array leaves existing credentials intact.
+
+    The schema resolves an empty array to ``auth_value=None``, but ToolService.update_tool only
+    writes auth_value when it is non-null, so a partial update never wipes stored secrets. This
+    pins that behavior: an empty array is not an "unset headers" instruction, and clearing
+    credentials is not supported through this path.
+    """
+    created = client.post("/tools/", json=_create_payload("clear_tool", auth_type="authheaders", auth_headers=REPRO_HEADERS))
+    assert created.status_code == 200, created.text
+    tool_id = created.json()["id"]
+
+    response = client.put(f"/tools/{tool_id}", json={"auth_type": "authheaders", "auth_headers": []})
+    assert response.status_code == 200, response.text
+
+    _, auth_value = _stored_auth("clear_tool")
+    assert decode_auth(auth_value) == {"X-API-Key": "secret", "X-Tenant": "acme"}

--- a/tests/integration/test_tool_auth_headers_api.py
+++ b/tests/integration/test_tool_auth_headers_api.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/integration/test_tool_auth_headers_api.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+End-to-end coverage for the ``auth_headers`` array on the JSON tool API (issue #5201).
+
+Unlike the schema-level unit tests, these drive the real ``POST /tools`` / ``PUT /tools/{id}``
+routes through ToolService and assert what actually lands in the database, so the originally
+reported bug (headers silently dropped, ``auth_value`` stored as ``NULL``) stays closed.
+"""
+
+# Standard
+from unittest.mock import AsyncMock, patch
+
+# Third-Party
+from fastapi.testclient import TestClient
+import pytest
+
+# First-Party
+import mcpgateway.db as db_mod
+from mcpgateway.db import Tool as DbTool
+from mcpgateway.middleware.rbac import get_current_user_with_permissions
+from mcpgateway.utils.services_auth import decode_auth
+
+REPRO_HEADERS = [
+    {"key": "X-API-Key", "value": "secret"},
+    {"key": "X-Tenant", "value": "acme"},
+]
+
+
+@pytest.fixture
+def client(app_with_temp_db):
+    """TestClient with authentication and RBAC bypassed."""
+
+    def _current_user(_request=None, _credentials=None, _jwt_token=None):
+        return {"email": "test_user@example.com", "full_name": "Test User", "is_admin": True, "ip_address": "127.0.0.1", "user_agent": "test"}
+
+    app_with_temp_db.dependency_overrides[get_current_user_with_permissions] = _current_user
+    with patch("mcpgateway.middleware.rbac.PermissionService.check_permission", new=AsyncMock(return_value=True)):
+        yield TestClient(app_with_temp_db)
+    app_with_temp_db.dependency_overrides.pop(get_current_user_with_permissions, None)
+
+
+def _stored_auth(tool_name: str):
+    """Read the persisted auth_type/auth_value for a tool straight from the database.
+
+    Args:
+        tool_name: Name of the tool to look up.
+
+    Returns:
+        tuple: The stored ``(auth_type, auth_value)`` pair.
+    """
+    # Resolved lazily: the app_with_temp_db fixture swaps db_mod.SessionLocal for the temp DB.
+    with db_mod.SessionLocal() as session:
+        tool = session.query(DbTool).filter(DbTool.original_name == tool_name).one()
+        return tool.auth_type, tool.auth_value
+
+
+def _create_payload(name: str, **tool_fields):
+    """Build a POST /tools request body.
+
+    Args:
+        name: Tool name.
+        **tool_fields: Extra fields merged into the nested tool object.
+
+    Returns:
+        dict: The request body.
+    """
+    tool = {"name": name, "url": "https://api.example.com/endpoint", "request_type": "POST", "integration_type": "REST"}
+    tool.update(tool_fields)
+    return {"tool": tool, "team_id": None, "visibility": "private"}
+
+
+def test_post_tools_persists_auth_headers_array(client):
+    """POST /tools stores every entry of the auth_headers array (issue #5201 repro)."""
+    response = client.post("/tools/", json=_create_payload("repro_tool", auth_type="authheaders", auth_headers=REPRO_HEADERS))
+    assert response.status_code == 200, response.text
+
+    auth_type, auth_value = _stored_auth("repro_tool")
+    assert auth_type == "authheaders"
+    assert auth_value is not None, "auth_value was stored as NULL - headers were dropped"
+    assert decode_auth(auth_value) == {"X-API-Key": "secret", "X-Tenant": "acme"}
+
+
+def test_put_tools_persists_auth_headers_array(client):
+    """PUT /tools/{id} replaces stored headers with the full auth_headers array."""
+    created = client.post("/tools/", json=_create_payload("update_tool", auth_type="authheaders", auth_headers=[{"key": "X-Old", "value": "old"}]))
+    assert created.status_code == 200, created.text
+    tool_id = created.json()["id"]
+
+    response = client.put(f"/tools/{tool_id}", json={"auth_type": "authheaders", "auth_headers": REPRO_HEADERS})
+    assert response.status_code == 200, response.text
+
+    _, auth_value = _stored_auth("update_tool")
+    assert decode_auth(auth_value) == {"X-API-Key": "secret", "X-Tenant": "acme"}
+
+
+def test_post_tools_malformed_header_key_returns_422(client):
+    """A malformed header key is a client error, not an unhandled 500."""
+    response = client.post("/tools/", json=_create_payload("bad_key_tool", auth_type="authheaders", auth_headers=[{"key": "Bad@Key!", "value": "x"}]))
+    assert response.status_code == 422, response.text
+
+
+def test_post_tools_non_string_header_key_returns_422(client):
+    """A non-string header key is a client error, not an unhandled 500.
+
+    ToolCreate assembles auth in a ``mode="before"`` validator, so this value reaches the
+    encoder uncoerced; it previously raised AttributeError/TypeError and surfaced as a 500.
+    """
+    response = client.post("/tools/", json=_create_payload("bad_key_type_tool", auth_type="authheaders", auth_headers=[{"key": 123, "value": "x"}]))
+    assert response.status_code == 422, response.text

--- a/tests/unit/js/auth.test.js
+++ b/tests/unit/js/auth.test.js
@@ -745,7 +745,7 @@ describe("updateAuthHeadersJSON - extended", () => {
 
     updateAuthHeadersJSON("auth-headers-container");
 
-    expect(errorSpy).toHaveBeenCalledWith("Maximum of 100 headers allowed per gateway");
+    expect(errorSpy).toHaveBeenCalledWith("Maximum of 100 headers allowed.");
   });
 
   test("maps auth-headers-container-a2a to auth-headers-json-a2a", () => {

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1991,6 +1991,18 @@ class TestAdminToolRoutes:
         result = _build_auth_obj_from_form(form)
         assert result is None
 
+    @pytest.mark.parametrize("scalar_json", ["5", "null", "true", "3.14", '"a string"', '{"key": "X-API-Key"}'])
+    def test_build_auth_obj_from_form_non_list_json(self, scalar_json, mock_request, mock_db):
+        """A non-list JSON value for auth_headers is treated as "no headers", not a 500.
+
+        ``orjson.loads`` accepts any valid JSON scalar/object, so guarding against a non-list
+        value keeps a body like ``auth_headers=5`` from raising an uncaught TypeError when the
+        header list is iterated.
+        """
+        form = FakeForm({"auth_type": "authheaders", "auth_headers": scalar_json})
+        # No usable headers and no legacy key/value pair -> None (never raises).
+        assert _build_auth_obj_from_form(form) is None
+
     def test_build_auth_obj_from_form_basic_missing_password(self, mock_request, mock_db):
         """_build_auth_obj_from_form returns None for basic auth with missing password."""
         form = FakeForm({"auth_type": "basic", "auth_username": "user"})

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -2021,6 +2021,58 @@ class TestAdminToolRoutes:
         assert exc_info.value.status_code == 422
         assert "oauth" in exc_info.value.detail.lower()
 
+    def test_build_auth_obj_from_form_authheaders_multi(self, mock_request, mock_db):
+        """_build_auth_obj_from_form encodes every populated header row."""
+        form = FakeForm(
+            {
+                "auth_type": "authheaders",
+                "auth_headers": json.dumps([{"key": "X-API-Key", "value": "secret"}, {"key": "X-Tenant", "value": "acme"}]),
+            }
+        )
+        auth_obj = _build_auth_obj_from_form(form)
+        assert auth_obj["auth_type"] == "authheaders"
+        assert decode_auth(auth_obj["auth_value"]) == {"X-API-Key": "secret", "X-Tenant": "acme"}
+
+    def test_build_auth_obj_from_form_authheaders_invalid_key_raises_422(self, mock_request, mock_db):
+        """The admin form rejects malformed header keys with a 422, matching POST /tools."""
+        from fastapi import HTTPException
+
+        form = FakeForm(
+            {
+                "auth_type": "authheaders",
+                "auth_headers": json.dumps([{"key": "Bad@Key!", "value": "secret"}]),
+            }
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            _build_auth_obj_from_form(form)
+        assert exc_info.value.status_code == 422
+        assert "Invalid header key format" in exc_info.value.detail
+
+    def test_build_auth_obj_from_form_authheaders_excessive_headers_raises_422(self, mock_request, mock_db):
+        """The admin form enforces the same 100-header cap as POST /tools."""
+        from fastapi import HTTPException
+
+        form = FakeForm(
+            {
+                "auth_type": "authheaders",
+                "auth_headers": json.dumps([{"key": f"X-Header-{i}", "value": f"v{i}"} for i in range(101)]),
+            }
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            _build_auth_obj_from_form(form)
+        assert exc_info.value.status_code == 422
+        assert "Maximum of 100 headers allowed" in exc_info.value.detail
+
+    def test_build_auth_obj_from_form_authheaders_blank_rows_still_none(self, mock_request, mock_db):
+        """Blank header rows submitted by the admin form still mean 'no auth', not a 422."""
+        form = FakeForm(
+            {
+                "auth_type": "authheaders",
+                "auth_headers": json.dumps([{"key": "", "value": ""}, {"key": "", "value": ""}]),
+            }
+        )
+        assert _build_auth_obj_from_form(form) is None
+
     @patch.object(ToolService, "set_tool_state")
     async def test_admin_set_tool_state_various_activate_values(self, mock_toggle_status, mock_request, mock_db):
         """Test setting tool state with various activate values."""

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -764,3 +764,120 @@ def test_tool_update_authheaders_non_dict_entry_rejected_cleanly():
             auth_type="authheaders",
             auth_headers=["not-a-dict"],
         )
+
+
+# =========================================================================
+# ToolCreate / ToolUpdate: uncoerced header key/value types.
+#
+# The tool schemas assemble auth in a mode="before" validator, so auth_headers
+# arrives as raw client JSON rather than the coerced List[Dict[str, str]] the
+# mode="after" gateway/A2A validators see. Bad key/value types must therefore
+# surface as a 422 ValidationError, not an AttributeError/TypeError -> 500.
+# =========================================================================
+
+
+@pytest.mark.parametrize("bad_key", [123, ["X-API-Key"], {"nested": "key"}, True])
+def test_tool_create_authheaders_non_string_key_rejected_cleanly(bad_key):
+    """A non-string auth_headers key produces a clean ValidationError, not a 500."""
+    with pytest.raises(ValidationError):
+        ToolCreate(
+            name="my_tool",
+            url="https://api.example.com/endpoint",
+            request_type="POST",
+            auth_type="authheaders",
+            auth_headers=[{"key": bad_key, "value": "x"}],
+        )
+
+
+@pytest.mark.parametrize("bad_key", [123, ["X-API-Key"], {"nested": "key"}, True])
+def test_tool_update_authheaders_non_string_key_rejected_cleanly(bad_key):
+    """A non-string auth_headers key produces a clean ValidationError, not a 500 (ToolUpdate)."""
+    with pytest.raises(ValidationError):
+        ToolUpdate(
+            auth_type="authheaders",
+            auth_headers=[{"key": bad_key, "value": "x"}],
+        )
+
+
+def test_tool_create_authheaders_non_string_value_rejected_cleanly():
+    """A non-string auth_headers value produces a clean ValidationError, not a 500."""
+    with pytest.raises(ValidationError):
+        ToolCreate(
+            name="my_tool",
+            url="https://api.example.com/endpoint",
+            request_type="POST",
+            auth_type="authheaders",
+            auth_headers=[{"key": "X-API-Key", "value": {"unexpected": "object"}}],
+        )
+
+
+def test_encode_auth_headers_list_non_string_key_raises_value_error():
+    """The shared helper raises ValueError (not AttributeError/TypeError) for non-string keys."""
+    with pytest.raises(ValueError, match="Header keys must be strings"):
+        _encode_auth_headers_list([{"key": 123, "value": "x"}])
+
+    # An unhashable key would otherwise raise TypeError on dict insertion.
+    with pytest.raises(ValueError, match="Header keys must be strings"):
+        _encode_auth_headers_list([{"key": ["X-API-Key"], "value": "x"}])
+
+
+def test_encode_auth_headers_list_non_string_value_raises_value_error():
+    """The shared helper raises ValueError for non-string header values."""
+    with pytest.raises(ValueError, match="Header values must be strings"):
+        _encode_auth_headers_list([{"key": "X-API-Key", "value": 123}])
+
+
+def test_encode_auth_headers_list_none_value_treated_as_empty():
+    """An explicit null header value is stored as an empty string rather than rejected."""
+    encoded = _encode_auth_headers_list([{"key": "X-API-Key", "value": None}])
+    assert decode_auth(encoded) == {"X-API-Key": ""}
+
+
+# =========================================================================
+# Header key whitespace: surrounding whitespace is trimmed, embedded
+# whitespace is rejected (it would otherwise be persisted as an invalid HTTP
+# header name and only fail at tool-invocation time).
+# =========================================================================
+
+
+def test_encode_auth_headers_list_strips_surrounding_whitespace():
+    """Surrounding whitespace on a header key is trimmed before storage."""
+    encoded = _encode_auth_headers_list([{"key": "  X-API-Key  ", "value": "secret"}])
+    assert decode_auth(encoded) == {"X-API-Key": "secret"}
+
+
+def test_encode_auth_headers_list_embedded_whitespace_key_raises():
+    """A header key with embedded whitespace is rejected instead of stored."""
+    with pytest.raises(ValueError, match="Invalid header key format"):
+        _encode_auth_headers_list([{"key": "X Api Key", "value": "secret"}])
+
+
+def test_encode_auth_headers_list_whitespace_only_key_skipped():
+    """A whitespace-only key is skipped like an empty key."""
+    with pytest.raises(ValueError, match="at least one valid header with a key must be provided"):
+        _encode_auth_headers_list([{"key": "   ", "value": "secret"}])
+
+
+def test_tool_create_authheaders_embedded_whitespace_key_rejected():
+    """ToolCreate rejects a header key with embedded whitespace."""
+    with pytest.raises(ValidationError) as exc_info:
+        ToolCreate(
+            name="my_tool",
+            url="https://api.example.com/endpoint",
+            request_type="POST",
+            auth_type="authheaders",
+            auth_headers=[{"key": "X Api Key", "value": "secret"}],
+        )
+    assert "Invalid header key format" in str(exc_info.value)
+
+
+def test_gateway_create_embedded_whitespace_key_rejected():
+    """GatewayCreate rejects a header key with embedded whitespace (shared helper parity)."""
+    with pytest.raises(ValidationError) as exc_info:
+        GatewayCreate(
+            name="gw",
+            url="https://example.com",
+            auth_type="authheaders",
+            auth_headers=[{"key": "X Api Key", "value": "secret"}],
+        )
+    assert "Invalid header key format" in str(exc_info.value)

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -647,6 +647,19 @@ def test_tool_create_authheaders_array_takes_precedence_over_legacy():
     assert "X-Old-Key" not in decoded
 
 
+def test_tool_update_authheaders_array_takes_precedence_over_legacy():
+    """ToolUpdate: auth_headers array takes precedence over legacy auth_header_key/value when both supplied."""
+    update = ToolUpdate(
+        auth_type="authheaders",
+        auth_headers=[{"key": "X-New-Key", "value": "new-value"}],
+        auth_header_key="X-Old-Key",
+        auth_header_value="old-value",
+    )
+    decoded = decode_auth(update.auth.auth_value)
+    assert "X-New-Key" in decoded
+    assert "X-Old-Key" not in decoded
+
+
 def test_tool_update_authheaders_array_multi():
     """ToolUpdate encodes all entries from auth_headers list."""
     update = ToolUpdate(
@@ -675,27 +688,27 @@ def test_tool_update_authheaders_legacy_fallback():
     assert decoded["X-API-Key"] == "legacy-secret"
 
 
-def test_tool_create_authheaders_array_all_empty_keys_gives_null_value():
-    """ToolCreate with a non-empty auth_headers list where every entry has an empty/missing key gives auth_value=None."""
-    tool = ToolCreate(
-        name="my_tool",
-        url="https://api.example.com/endpoint",
-        request_type="POST",
-        auth_type="authheaders",
-        auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
-    )
-    assert tool.auth is not None
-    assert tool.auth.auth_value is None
+def test_tool_create_authheaders_array_all_empty_keys_raises():
+    """ToolCreate with a non-empty auth_headers list where every entry has an empty/missing key is rejected (gateway parity)."""
+    with pytest.raises(ValidationError) as exc_info:
+        ToolCreate(
+            name="my_tool",
+            url="https://api.example.com/endpoint",
+            request_type="POST",
+            auth_type="authheaders",
+            auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
+        )
+    assert "at least one valid header with a key must be provided" in str(exc_info.value)
 
 
-def test_tool_update_authheaders_array_all_empty_keys_gives_null_value():
-    """ToolUpdate with a non-empty auth_headers list where every entry has an empty/missing key gives auth_value=None."""
-    update = ToolUpdate(
-        auth_type="authheaders",
-        auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
-    )
-    assert update.auth is not None
-    assert update.auth.auth_value is None
+def test_tool_update_authheaders_array_all_empty_keys_raises():
+    """ToolUpdate with a non-empty auth_headers list where every entry has an empty/missing key is rejected (gateway parity)."""
+    with pytest.raises(ValidationError) as exc_info:
+        ToolUpdate(
+            auth_type="authheaders",
+            auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
+        )
+    assert "at least one valid header with a key must be provided" in str(exc_info.value)
 
 
 def test_tool_update_authheaders_empty_array_gives_null_value():
@@ -714,8 +727,22 @@ def test_encode_auth_headers_list_skips_non_dict_and_keyless_entries():
     encoded = _encode_auth_headers_list(["not-a-dict", {"value": "no-key"}, {"key": "X-API-Key", "value": "secret"}])
     assert decode_auth(encoded) == {"X-API-Key": "secret"}
 
-    # An all-invalid list yields None rather than encoding an empty header set.
-    assert _encode_auth_headers_list(["not-a-dict", {"value": "no-key"}, {"key": ""}]) is None
+    # An all-invalid list raises rather than silently encoding an empty header set (gateway parity).
+    with pytest.raises(ValueError, match="at least one valid header with a key must be provided"):
+        _encode_auth_headers_list(["not-a-dict", {"value": "no-key"}, {"key": ""}])
+
+
+def test_encode_auth_headers_list_invalid_key_format_raises():
+    """The shared helper rejects header keys with an invalid format."""
+    with pytest.raises(ValueError, match="Invalid header key format"):
+        _encode_auth_headers_list([{"key": "Bad@Key!", "value": "x"}])
+
+
+def test_encode_auth_headers_list_too_many_headers_raises():
+    """The shared helper rejects more than 100 headers."""
+    headers = [{"key": f"Header-{i}", "value": f"value-{i}"} for i in range(101)]
+    with pytest.raises(ValueError, match="Maximum of 100 headers allowed"):
+        _encode_auth_headers_list(headers)
 
 
 def test_tool_create_authheaders_non_dict_entry_rejected_cleanly():

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -673,3 +673,26 @@ def test_tool_update_authheaders_legacy_fallback():
     assert update.auth is not None
     decoded = decode_auth(update.auth.auth_value)
     assert decoded["X-API-Key"] == "legacy-secret"
+
+
+def test_tool_create_authheaders_array_all_empty_keys_gives_null_value():
+    """ToolCreate with a non-empty auth_headers list where every entry has an empty/missing key gives auth_value=None."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
+    )
+    assert tool.auth is not None
+    assert tool.auth.auth_value is None
+
+
+def test_tool_update_authheaders_array_all_empty_keys_gives_null_value():
+    """ToolUpdate with a non-empty auth_headers list where every entry has an empty/missing key gives auth_value=None."""
+    update = ToolUpdate(
+        auth_type="authheaders",
+        auth_headers=[{"key": "", "value": "something"}, {"value": "no-key-field"}],
+    )
+    assert update.auth is not None
+    assert update.auth.auth_value is None

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -16,7 +16,7 @@ import pytest
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.schemas import A2AAgentCreate, A2AAgentUpdate, AdminCreateUserRequest, EmailRegistrationRequest, GatewayCreate, GatewayUpdate, PublicRegistrationRequest, ToolCreate, ToolUpdate
+from mcpgateway.schemas import _encode_auth_headers_list, A2AAgentCreate, A2AAgentUpdate, AdminCreateUserRequest, EmailRegistrationRequest, GatewayCreate, GatewayUpdate, PublicRegistrationRequest, ToolCreate, ToolUpdate
 from mcpgateway.utils.services_auth import decode_auth
 
 
@@ -696,3 +696,44 @@ def test_tool_update_authheaders_array_all_empty_keys_gives_null_value():
     )
     assert update.auth is not None
     assert update.auth.auth_value is None
+
+
+def test_tool_update_authheaders_empty_array_gives_null_value():
+    """ToolUpdate with an empty auth_headers list produces auth_value=None (symmetry with ToolCreate)."""
+    update = ToolUpdate(
+        auth_type="authheaders",
+        auth_headers=[],
+    )
+    assert update.auth is not None
+    assert update.auth.auth_value is None
+
+
+def test_encode_auth_headers_list_skips_non_dict_and_keyless_entries():
+    """The shared helper skips non-dict and keyless entries instead of raising AttributeError."""
+    # Non-dict entries and entries without a key are ignored (no AttributeError).
+    encoded = _encode_auth_headers_list(["not-a-dict", {"value": "no-key"}, {"key": "X-API-Key", "value": "secret"}])
+    assert decode_auth(encoded) == {"X-API-Key": "secret"}
+
+    # An all-invalid list yields None rather than encoding an empty header set.
+    assert _encode_auth_headers_list(["not-a-dict", {"value": "no-key"}, {"key": ""}]) is None
+
+
+def test_tool_create_authheaders_non_dict_entry_rejected_cleanly():
+    """A non-dict auth_headers entry produces a clean ValidationError, not a 500 AttributeError."""
+    with pytest.raises(ValidationError):
+        ToolCreate(
+            name="my_tool",
+            url="https://api.example.com/endpoint",
+            request_type="POST",
+            auth_type="authheaders",
+            auth_headers=["not-a-dict"],
+        )
+
+
+def test_tool_update_authheaders_non_dict_entry_rejected_cleanly():
+    """A non-dict auth_headers entry produces a clean ValidationError, not a 500 AttributeError (ToolUpdate)."""
+    with pytest.raises(ValidationError):
+        ToolUpdate(
+            auth_type="authheaders",
+            auth_headers=["not-a-dict"],
+        )

--- a/tests/unit/mcpgateway/test_schemas_auth_validation.py
+++ b/tests/unit/mcpgateway/test_schemas_auth_validation.py
@@ -16,7 +16,7 @@ import pytest
 
 # First-Party
 from mcpgateway.config import settings
-from mcpgateway.schemas import A2AAgentCreate, A2AAgentUpdate, AdminCreateUserRequest, EmailRegistrationRequest, GatewayCreate, GatewayUpdate, PublicRegistrationRequest
+from mcpgateway.schemas import A2AAgentCreate, A2AAgentUpdate, AdminCreateUserRequest, EmailRegistrationRequest, GatewayCreate, GatewayUpdate, PublicRegistrationRequest, ToolCreate, ToolUpdate
 from mcpgateway.utils.services_auth import decode_auth
 
 
@@ -559,3 +559,117 @@ def test_a2a_agent_update_invalid_passthrough_header_with_colon():
         )
     error_str = str(exc_info.value)
     assert "Invalid header names" in error_str or "RFC 7230" in error_str
+
+
+# =========================================================================
+# ToolCreate / ToolUpdate: auth_headers array support (issue #5201)
+# Verify that POST /tools and PUT /tools/{id} correctly persist all entries
+# in the auth_headers array instead of silently dropping them.
+# =========================================================================
+
+
+def test_tool_create_authheaders_array_multi():
+    """ToolCreate encodes all entries from auth_headers list."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_headers=[
+            {"key": "X-API-Key", "value": "secret"},
+            {"key": "X-Tenant", "value": "acme"},
+        ],
+    )
+    assert tool.auth is not None
+    assert tool.auth.auth_type == "authheaders"
+    assert tool.auth.auth_value is not None
+    decoded = decode_auth(tool.auth.auth_value)
+    assert decoded["X-API-Key"] == "secret"
+    assert decoded["X-Tenant"] == "acme"
+
+
+def test_tool_create_authheaders_array_single():
+    """ToolCreate handles a single-entry auth_headers array correctly."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_headers=[{"key": "Authorization", "value": "Bearer tok"}],
+    )
+    assert tool.auth is not None
+    decoded = decode_auth(tool.auth.auth_value)
+    assert decoded["Authorization"] == "Bearer tok"
+
+
+def test_tool_create_authheaders_legacy_fallback():
+    """ToolCreate falls back to auth_header_key/auth_header_value when no array is provided."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_header_key="X-API-Key",
+        auth_header_value="legacy-secret",
+    )
+    assert tool.auth is not None
+    assert tool.auth.auth_type == "authheaders"
+    decoded = decode_auth(tool.auth.auth_value)
+    assert decoded["X-API-Key"] == "legacy-secret"
+
+
+def test_tool_create_authheaders_empty_array_gives_null_value():
+    """ToolCreate with an empty auth_headers list produces auth_value=None."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_headers=[],
+    )
+    assert tool.auth is not None
+    assert tool.auth.auth_value is None
+
+
+def test_tool_create_authheaders_array_takes_precedence_over_legacy():
+    """auth_headers array takes precedence over legacy auth_header_key/value when both supplied."""
+    tool = ToolCreate(
+        name="my_tool",
+        url="https://api.example.com/endpoint",
+        request_type="POST",
+        auth_type="authheaders",
+        auth_headers=[{"key": "X-New-Key", "value": "new-value"}],
+        auth_header_key="X-Old-Key",
+        auth_header_value="old-value",
+    )
+    decoded = decode_auth(tool.auth.auth_value)
+    assert "X-New-Key" in decoded
+    assert "X-Old-Key" not in decoded
+
+
+def test_tool_update_authheaders_array_multi():
+    """ToolUpdate encodes all entries from auth_headers list."""
+    update = ToolUpdate(
+        auth_type="authheaders",
+        auth_headers=[
+            {"key": "X-API-Key", "value": "newsecret"},
+            {"key": "X-Tenant", "value": "newacme"},
+        ],
+    )
+    assert update.auth is not None
+    assert update.auth.auth_type == "authheaders"
+    decoded = decode_auth(update.auth.auth_value)
+    assert decoded["X-API-Key"] == "newsecret"
+    assert decoded["X-Tenant"] == "newacme"
+
+
+def test_tool_update_authheaders_legacy_fallback():
+    """ToolUpdate falls back to auth_header_key/auth_header_value when no array is provided."""
+    update = ToolUpdate(
+        auth_type="authheaders",
+        auth_header_key="X-API-Key",
+        auth_header_value="legacy-secret",
+    )
+    assert update.auth is not None
+    decoded = decode_auth(update.auth.auth_value)
+    assert decoded["X-API-Key"] == "legacy-secret"


### PR DESCRIPTION
## :red_circle: Summary

`POST /tools` and `PUT /tools/{tool_id}` silently dropped custom auth headers when
the client sent `auth_type: "authheaders"` with an `auth_headers` array. The stored
tool always had `auth_value: null`, making authenticated tool calls fail at runtime.

## :link: Related Issue

Closes: #5201

## :repeat: Reproduction Steps

1. `POST /tools` with body:
   ```json
   {
     "name": "my-tool",
     "url": "https://api.example.com/endpoint",
     "request_type": "POST",
     "auth_type": "authheaders",
     "auth_headers": [
       {"key": "X-API-Key", "value": "secret"},
       {"key": "X-Tenant", "value": "acme"}
     ]
   }
   ```
2. Inspect the created tool — `auth_value` is `null` and no headers are stored.

## :bug: Root Cause

`ToolCreate.assemble_auth()` and `ToolUpdate.assemble_auth()` in `mcpgateway/schemas.py`
only read the legacy `auth_header_key` / `auth_header_value` single-header pair when
`auth_type` is `"authheaders"`. The `auth_headers` array sent by the React admin UI was
present in the raw model-validator dict but never read, so it was silently discarded and
`auth_value` was stored as `null`.

The same multi-header path was already fixed for the legacy HTML admin UI routes
(`POST /admin/tools/`, `POST /admin/tools/{id}/edit`) via `_build_auth_obj_from_form()`
in `mcpgateway/admin.py` (commit e27bdf180, #3490), but that fix was never ported to
the JSON API schemas.

## :bulb: Fix Description

Extended both `ToolCreate.assemble_auth()` and `ToolUpdate.assemble_auth()` to mirror
the logic already in `_build_auth_obj_from_form()`:

1. **Check `auth_headers` list first** — build a `{key: value}` dict from the array
   and encode it via `encode_auth()`.
2. **Fall back to legacy** `auth_header_key` / `auth_header_value` when no array is
   present — preserving full backward compatibility with existing integrations.

Updated the docstring for `ToolCreate.assemble_auth()` to document both input paths and
corrected the stale log message in `ToolUpdate.assemble_auth()`.

## :test_tube: Verification

| Check                             | Command                | Status |
|-----------------------------------|------------------------|--------|
| Lint suite                        | `make lint`            | Passed |
| Unit tests                        | `make test`            | Passed |
| Coverage ≥ 90 %                   | `make coverage`        | Passed |
| Manual regression no longer fails | steps above            | Passed |

## :triangular_ruler: MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## :white_check_mark: Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed