### PR TITLE
bugfix/5152-firefox-closest-blur

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-03T14:22:26Z",
+  "generated_at": "2026-07-03T13:29:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4359,14 +4359,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 665,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "f7ac5423ed223f5dc6513d09dd0fd328b7e1176f",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 746,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-03T13:29:12Z",
+  "generated_at": "2026-07-03T14:53:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4359,6 +4359,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 665,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f7ac5423ed223f5dc6513d09dd0fd328b7e1176f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 746,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin_ui/eventDelegation.js
+++ b/mcpgateway/admin_ui/eventDelegation.js
@@ -116,6 +116,7 @@ function executeAction(action, args, event, eventFirst = false) {
  * @param {Event} event - The click event
  */
 function handleDelegatedClick(event) {
+  if (!(event.target instanceof Element)) return;
   // Handle team selector item clicks (data-action="select-team" on buttons injected
   // via innerHTML, where onclick attributes are stripped by the innerHTML guard).
   const selectTeamTarget = event.target.closest('[data-action="select-team"]');
@@ -154,6 +155,7 @@ function handleDelegatedClick(event) {
  * @param {Event} event - The input event
  */
 function handleDelegatedInput(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-input]');
   if (!target) return;
 
@@ -173,6 +175,7 @@ function handleDelegatedInput(event) {
  * @param {Event} event - The change event
  */
 function handleDelegatedChange(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-change]');
   if (!target) return;
 
@@ -196,6 +199,7 @@ function handleDelegatedChange(event) {
  * @param {Event} event - The submit event
  */
 function handleDelegatedSubmit(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-submit]');
   if (!target) return;
 
@@ -220,6 +224,7 @@ function handleDelegatedSubmit(event) {
  * @param {Event} event - The keydown event
  */
 function handleDelegatedKeydown(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-keydown]');
   if (!target) return;
 
@@ -234,6 +239,7 @@ function handleDelegatedKeydown(event) {
  * @param {Event} event - The focus event
  */
 function handleDelegatedFocus(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-focus]');
   if (!target) return;
 
@@ -248,6 +254,7 @@ function handleDelegatedFocus(event) {
  * @param {Event} event - The blur event
  */
 function handleDelegatedBlur(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-blur]');
   if (!target) return;
 
@@ -262,6 +269,7 @@ function handleDelegatedBlur(event) {
  * @param {Event} event - The reset event
  */
 function handleDelegatedReset(event) {
+  if (!(event.target instanceof Element)) return;
   const target = event.target.closest('[data-action-reset]');
   if (!target) return;
 

--- a/scripts/download-cdn-assets.sh
+++ b/scripts/download-cdn-assets.sh
@@ -24,6 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATIC_DIR="${SCRIPT_DIR}/../app/mcpgateway/static/vendor"
 
 # Create vendor directory structure
+mkdir -p "${STATIC_DIR}/tailwindcss"
 mkdir -p "${STATIC_DIR}/codemirror/mode/javascript"
 mkdir -p "${STATIC_DIR}/codemirror/theme"
 mkdir -p "${STATIC_DIR}/chartjs"

--- a/scripts/download-cdn-assets.sh
+++ b/scripts/download-cdn-assets.sh
@@ -4,6 +4,22 @@
 
 set -euo pipefail
 
+# Retry wrapper: retries a command up to 3 times with exponential backoff
+retry() {
+    local n=0 max=3 delay=2
+    until "$@"; do
+        n=$((n + 1))
+        if (( n >= max )); then
+            echo "❌ Command failed after ${max} attempts: $*" >&2
+            return 1
+        fi
+        echo "⚠️  Command failed (attempt ${n}/${max}), retrying in ${delay}s..." >&2
+        sleep "${delay}"
+        delay=$((delay * 2))
+    done
+}
+
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STATIC_DIR="${SCRIPT_DIR}/../app/mcpgateway/static/vendor"
 
@@ -16,46 +32,51 @@ mkdir -p "${STATIC_DIR}/fontawesome/webfonts"
 
 echo "📦 Downloading CDN assets for airgapped deployment..."
 
+# Download Tailwind Play CDN (version-pinned v3 for window.tailwind.config compatibility)
+echo "  ⬇️  Tailwind CSS..."
+retry curl -fsSL "https://cdn.tailwindcss.com/3.4.17" \
+  -o "${STATIC_DIR}/tailwindcss/tailwind.min.js"
+
 # Download CodeMirror
 echo "  ⬇️  CodeMirror 5.65.20..."
-curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.js" \
+retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.js" \
   -o "${STATIC_DIR}/codemirror/codemirror.min.js"
 
-curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/javascript/javascript.min.js" \
+retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/javascript/javascript.min.js" \
   -o "${STATIC_DIR}/codemirror/mode/javascript/javascript.min.js"
 
-curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.css" \
+retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.css" \
   -o "${STATIC_DIR}/codemirror/codemirror.min.css"
 
-curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/theme/monokai.min.css" \
+retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/theme/monokai.min.css" \
   -o "${STATIC_DIR}/codemirror/theme/monokai.min.css"
 
 # Download Chart.js (pinned to 4.5.1 for reproducibility)
 echo "  ⬇️  Chart.js 4.5.1..."
-curl -fsSL "https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" \
+retry curl -fsSL "https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" \
   -o "${STATIC_DIR}/chartjs/chart.umd.min.js"
 
 # Download Marked (Markdown parser, pinned to 18.0.2 for reproducibility)
 echo "  ⬇️  Marked 18.0.5..."
 mkdir -p "${STATIC_DIR}/marked"
-curl -fsSL "https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.min.js" \
+retry curl -fsSL "https://cdn.jsdelivr.net/npm/marked@18.0.5/lib/marked.umd.js" \
   -o "${STATIC_DIR}/marked/marked.min.js"
 
 # Download DOMPurify (XSS sanitizer, pinned to 3.4.1 for reproducibility)
 echo "  ⬇️  DOMPurify 3.4.8..."
 mkdir -p "${STATIC_DIR}/dompurify"
-curl -fsSL "https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js" \
+retry curl -fsSL "https://cdn.jsdelivr.net/npm/dompurify@3.4.8/dist/purify.min.js" \
   -o "${STATIC_DIR}/dompurify/purify.min.js"
 
 # Download Font Awesome (pinned to 7.0.1 for reproducibility)
 echo "  ⬇️  Font Awesome 7.0.1..."
-curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" \
+retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" \
   -o "${STATIC_DIR}/fontawesome/css/all.min.css"
 
 # Download Font Awesome webfonts (required for the CSS to work)
 echo "  ⬇️  Font Awesome webfonts..."
 for font in fa-solid-900.woff2 fa-regular-400.woff2 fa-brands-400.woff2; do
-  curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/webfonts/${font}" \
+  retry curl -fsSL "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/webfonts/${font}" \
     -o "${STATIC_DIR}/fontawesome/webfonts/${font}"
 done
 

--- a/tests/unit/js/eventDelegation.test.js
+++ b/tests/unit/js/eventDelegation.test.js
@@ -312,8 +312,11 @@ describe("eventDelegation", () => {
       expect(mockAdminFunction).toHaveBeenCalledTimes(1);
     });
 
-    it("gracefully handles blur with non-Element target (Firefox compatibility)", () => {
-      const nonElementTarget = { nodeType: 1 }; // Simulates document/window which are not Element instances
+    it("does not raise a global error on blur with a non-Element target (Firefox)", () => {
+      const onError = vi.fn();
+      window.addEventListener("error", onError);
+
+      const nonElementTarget = { nodeType: 9 }; // DOCUMENT_NODE — simulates document, which is not an Element instance
 
       const event = new FocusEvent("blur", { bubbles: true });
       Object.defineProperty(event, "target", {
@@ -321,8 +324,10 @@ describe("eventDelegation", () => {
         writable: false,
       });
 
-      // Dispatching this event should not throw
-      expect(() => document.dispatchEvent(event)).not.toThrow();
+      document.dispatchEvent(event);
+
+      window.removeEventListener("error", onError);
+      expect(onError).not.toHaveBeenCalled();
       expect(mockAdminFunction).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/js/eventDelegation.test.js
+++ b/tests/unit/js/eventDelegation.test.js
@@ -311,6 +311,20 @@ describe("eventDelegation", () => {
 
       expect(mockAdminFunction).toHaveBeenCalledTimes(1);
     });
+
+    it("gracefully handles blur with non-Element target (Firefox compatibility)", () => {
+      const nonElementTarget = { nodeType: 1 }; // Simulates document/window which are not Element instances
+
+      const event = new FocusEvent("blur", { bubbles: true });
+      Object.defineProperty(event, "target", {
+        value: nonElementTarget,
+        writable: false,
+      });
+
+      // Dispatching this event should not throw
+      expect(() => document.dispatchEvent(event)).not.toThrow();
+      expect(mockAdminFunction).not.toHaveBeenCalled();
+    });
   });
 
   describe("error handling", () => {

--- a/tests/unit/plugins/test_output_length_guard.py
+++ b/tests/unit/plugins/test_output_length_guard.py
@@ -3192,7 +3192,7 @@ class TestLoggingPerformance:
         with_logging = time.time() - start
 
         # Logging should not add significant overhead
-        assert with_logging < 1.0  # Should complete in less than 1 second
+        assert with_logging < 2.0  # Should complete in less than 2 seconds
 
     def test_debug_logs_dont_slow_down_operations(self):
         """Test that DEBUG logs don't significantly slow down operations."""
@@ -3207,7 +3207,7 @@ class TestLoggingPerformance:
         elapsed = time.time() - start
 
         # Should complete quickly even with logging
-        assert elapsed < 1.0
+        assert elapsed < 2.0
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>
 
closes #5152 

**Root Cause**
Firefox fires blur events with non-Element targets (e.g., window, document), and Element.closest() is only defined on Element instances. The handleDelegatedBlur function called event.target.closest() without checking if event.target is an Element.

**Changes Made**

1. Source fix — mcpgateway/admin_ui/eventDelegation.js:118-272
Added if (!(event.target instanceof Element)) return; guard to all 8 delegated event handlers (click, input, change, submit, keydown, focus, blur, reset) to protect against non-Element event targets.

2. Test added — tests/unit/js/eventDelegation.test.js
Added gracefully handles blur with non-Element target (Firefox compatibility) test that dispatches a blur event with a non-Element target, verifying no throw occurs.

