### PR TITLE
fix(deps): remove duplicate python-multipart entry in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -5191,12 +5191,9 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.32"
-version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 


### PR DESCRIPTION
The `python-multipart` block in `uv.lock` has its `version`, `sdist`, and wheel `url` lines duplicated (introduced in the dependabot merge on `Release/v1.0.4`). Two of the same key inside one `[[package]]` table is invalid TOML, so `uv` cannot parse the lockfile at all:

```
❯ uv sync
error: Failed to parse `uv.lock`
  Caused by: TOML parse error at line 5194, column 1
     |
5194 | version = "0.0.32"
     | ^^^^^^^
duplicate key
 ~/De/w/c/mcp-context-forge  Release/v1.0.4 ?2    
```

Because the parse fails up front, this affects any `uv` operation against the branch (`uv sync`, `uv run`, `uv lock`, installs, etc.) for anyone working from `Release/v1.0.4`.

This PR removes the three duplicate lines so the `python-multipart` block is well-formed again. Only `python-multipart` was affected; no other package changed.