### PR TITLE
fix: propagate tool validation errors in gateway refresh response (#5290)

### DIFF
--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -5796,7 +5796,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     _refresh_key = _enc.decrypt_secret_or_plaintext(_refresh_key)
                 except Exception:
                     logger.debug("client_key decryption skipped during gateway refresh")
-            _capabilities, tools, resources, prompts, _ = await self._initialize_gateway(
+            _capabilities, tools, resources, prompts, validation_errors = await self._initialize_gateway(
                 url=gateway_url,
                 authentication=gateway_auth_value,
                 transport=gateway_transport,
@@ -5815,6 +5815,8 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             result["success"] = False
             result["error"] = str(e)
             return result
+
+        result["validation_errors"] = validation_errors
 
         # For authorization_code OAuth gateways, empty responses may indicate incomplete auth flow
         # Skip only if it's an auth_code gateway with no data (user may not have completed authorization)

--- a/tests/unit/mcpgateway/services/test_gateway_auto_refresh.py
+++ b/tests/unit/mcpgateway/services/test_gateway_auto_refresh.py
@@ -213,6 +213,29 @@ class TestAutoRefreshGatewayToolsResourcesPrompts:
         assert result["tools_removed"] == 0
 
     @pytest.mark.asyncio
+    async def test_refresh_propagates_validation_errors(self, gateway_service):
+        """Validation errors from _initialize_gateway should propagate through auto-refresh."""
+        mock_gateway = _make_mock_gateway()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.scalar_one_or_none.return_value = mock_gateway
+
+        validation_errors = [
+            "bad_tool: Tool name exceeds MCP spec limit of 128 characters (got 129)",
+        ]
+
+        with (
+            patch("mcpgateway.services.gateway_service.fresh_db_session") as mock_fresh,
+            patch.object(gateway_service, "_initialize_gateway", new_callable=AsyncMock) as mock_init,
+        ):
+            mock_fresh.return_value.__enter__.return_value = mock_session
+            mock_init.return_value = ({}, [], [], [], validation_errors)
+
+            result = await gateway_service._refresh_gateway_tools_resources_prompts("gw-123")
+
+        assert result["validation_errors"] == validation_errors
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
     async def test_refresh_processes_empty_non_auth_code_gateway(self, gateway_service):
         """Test that refresh processes empty responses from non-auth_code gateways."""
         # Gateway with client_credentials OAuth - empty response should trigger cleanup

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -6472,6 +6472,29 @@ class TestRefreshGatewayToolsResourcesPrompts:
         assert "connection refused" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_validation_errors_propagated(self, gateway_service):
+        """Validation errors from _initialize_gateway populate result['validation_errors'] before early return."""
+        gw = SimpleNamespace(
+            enabled=True,
+            reachable=True,
+            name="val-gw",
+            url="http://example.com",
+            transport="sse",
+            auth_type="oauth",
+            auth_value=None,
+            oauth_config={"grant_type": "authorization_code"},
+            ca_certificate=None,
+            auth_query_params=None,
+        )
+        validation_errors = [
+            "bad_tool: Tool name exceeds MCP spec limit of 128 characters (got 129)",
+        ]
+        gateway_service._initialize_gateway = AsyncMock(return_value=({}, [], [], [], validation_errors))
+        result = await gateway_service._refresh_gateway_tools_resources_prompts("gw-1", gateway=gw)
+        assert result["validation_errors"] == validation_errors
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
     async def test_auth_code_empty_response_returns_early(self, gateway_service):
         gw = SimpleNamespace(
             enabled=True,

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -4941,6 +4941,7 @@ class TestGatewayEndpointsCoverage:
             "duration_ms": 1.0,
             "refreshed_at": datetime.now(timezone.utc),
             "tools_added": 1,
+            "validation_errors": [],
         }
         monkeypatch.setattr(main_mod.gateway_service, "get_gateway", AsyncMock(return_value=SimpleNamespace(id="gw-1")))
         monkeypatch.setattr(main_mod, "_enforce_scoped_resource_access", lambda *_args, **_kwargs: None)
@@ -4955,6 +4956,25 @@ class TestGatewayEndpointsCoverage:
         )
         assert response.gateway_id == "gw-1"
         assert response.tools_added == 1
+        assert response.validation_errors == []
+
+        # Test with non-empty validation errors
+        result_payload_with_errors = {
+            "duration_ms": 1.0,
+            "refreshed_at": datetime.now(timezone.utc),
+            "tools_added": 0,
+            "validation_errors": ["bad_tool: Tool name exceeds MCP spec limit of 128 characters (got 129)"],
+        }
+        monkeypatch.setattr(main_mod.gateway_service, "refresh_gateway_manually", AsyncMock(return_value=result_payload_with_errors))
+        response_with_errors = await main_mod.refresh_gateway_tools(
+            "gw-1",
+            request,
+            include_resources=True,
+            include_prompts=False,
+            db=db,
+            user={"email": "user@example.com"},
+        )
+        assert response_with_errors.validation_errors == result_payload_with_errors["validation_errors"]
 
         monkeypatch.setattr(main_mod.gateway_service, "refresh_gateway_manually", AsyncMock(side_effect=GatewayNotFoundError("missing")))
         with pytest.raises(HTTPException) as excinfo:


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Tool validation errors collected during gateway refresh were silently discarded — the `GatewayRefreshResponse.validation_errors` field always returned an empty list, even when tools failed validation (e.g., name too long, schema too deeply nested).

## 🔁 Reproduction Steps

Fixes #5290

1. Register a gateway with a mix of valid and invalid tools
2. Call `POST /gateways/{id}/tools/refresh`
3. Observe `response.validation_errors` is always `[]` even when tools were skipped

## 🐞 Root Cause

In `_refresh_gateway_tools_resources_prompts()` at `mcpgateway/services/gateway_service.py:5822`, the 5th return value (`validation_errors`) from `_initialize_gateway()` was discarded with `_`:

```python
_capabilities, tools, resources, prompts, _ = await self._initialize_gateway(...)
```

The `result` dict was initialized with `"validation_errors": []` at line 5740, but was **never populated** with the actual errors from `_validate_tools()`.

## 💡 Fix Description

**Production fix** (2 lines):
1. **Line 5822**: Changed `_` → `validation_errors` to capture the return value
2. **Line 5842**: Added `result["validation_errors"] = validation_errors` after the `except` block to populate the result on the success path

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Ruff linter                           | `make ruff`          | ✅ Pass |
| Black formatter                       | `make black`         | ✅ Pass |
| Isort                                 | `make isort`         | ✅ Pass |
| Pre-commit (secrets, formatting, etc) | `make pre-commit`    | ✅ Pass |
| Unit tests (TestRefreshGatewayToolsResourcesPrompts) | `pytest tests/unit/mcpgateway/services/test_gateway_service.py -k TestRefreshGatewayToolsResourcesPrompts -x` | ✅ 9/9 |
| Unit tests (TestAutoRefreshGatewayToolsResourcesPrompts) | `pytest tests/unit/mcpgateway/services/test_gateway_auto_refresh.py -k TestAutoRefreshGatewayToolsResourcesPrompts -x` | ✅ 9/9 |
| Route handler tests (test_refresh_gateway_tools) | `pytest tests/unit/mcpgateway/test_main_extended.py -k test_refresh_gateway_tools -x` | ✅ 2/2 |

### Test Coverage

Three new tests validate the fix:

1. **`test_gateway_service.py::test_validation_errors_propagated`** — Mocks `_initialize_gateway` to return non-empty validation errors and asserts `result["validation_errors"]` contains them
2. **`test_gateway_auto_refresh.py::test_refresh_propagates_validation_errors`** — Same pattern via `patch.object` for the auto-refresh path
3. **`test_main_extended.py::test_refresh_gateway_tools_success_and_errors`** — Extended to assert both empty and non-empty `validation_errors` in the API response

## 📐 MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
