### PR TITLE
fix(sso): emit Keycloak realm roles so admin mapping works

### DIFF
--- a/docs/docs/manage/sso-keycloak-tutorial.md
+++ b/docs/docs/manage/sso-keycloak-tutorial.md
@@ -241,6 +241,9 @@ To include roles in JWT tokens:
 
 - Maps realm roles to `realm_access.roles` claim
 - Should be enabled by default
+- Open the mapper and ensure **Add to ID token** and **Add to userinfo** are both ON. The
+  gateway reads roles from the id_token and userinfo, not the access token, so a realm-role
+  to admin mapping (Step 6.7) silently fails if these are off.
 
 **client roles**:
 
@@ -415,6 +418,37 @@ SSO_KEYCLOAK_CLIENT_ID=mcp-gateway-prod
 | `SSO_KEYCLOAK_ROLE_MAPPINGS` | No | `{}` | JSON map of Keycloak roles/groups to Gateway RBAC roles |
 | `SSO_KEYCLOAK_DEFAULT_ROLE` | No | _unset_ | Fallback role when no mapping matches |
 | `SSO_KEYCLOAK_RESOLVE_TEAM_SCOPE_TO_PERSONAL_TEAM` | No | `false` | Resolve team-scoped mapped roles to the user's personal team |
+
+### 6.7 Grant Admin and RBAC Roles via Role Mappings
+
+`SSO_KEYCLOAK_MAP_REALM_ROLES=true` only **includes** Keycloak roles/groups in the user
+profile. It does not, by itself, make anyone an admin. The actual grant is driven by
+`SSO_KEYCLOAK_ROLE_MAPPINGS`, a JSON map from a Keycloak role/group name to a Gateway RBAC
+role. With no mapping (the `{}` default), every SSO user lands on the default role
+(typically viewer) regardless of their Keycloak roles.
+
+To map the `gateway-admin` realm role to the platform admin role:
+
+```bash
+SSO_KEYCLOAK_MAP_REALM_ROLES=true
+SSO_KEYCLOAK_ROLE_MAPPINGS={"gateway-admin":"platform_admin","gateway-developer":"developer","gateway-viewer":"viewer"}
+```
+
+!!! warning "The mapped name must actually reach the gateway"
+    The gateway derives roles from the **id_token** and the **userinfo** endpoint. It does
+    **not** read the access token. Keycloak puts realm roles in the access token by default,
+    so a realm-role mapping silently fails unless the `realm roles` mapper at
+    **Client scopes → roles → Mappers** has both **Add to ID token** and
+    **Add to userinfo** enabled (see Step 4.4). After enabling, confirm with the userinfo
+    check in Step 7.2: the response must contain `realm_access.roles`.
+
+    Group names are simpler: the **Group Membership** mapper (Step 3.2 / 5.3) already emits
+    the `groups` claim to the id_token and userinfo, so mapping a group works without any
+    extra token config:
+
+    ```bash
+    SSO_KEYCLOAK_ROLE_MAPPINGS={"Administrators":"platform_admin","Developers":"developer","Viewers":"viewer"}
+    ```
 
 ## Step 7: Restart and Verify Gateway
 

--- a/infra/keycloak/realm-export.json
+++ b/infra/keycloak/realm-export.json
@@ -94,6 +94,20 @@
             "userinfo.token.claim": "true",
             "claim.name": "groups"
           }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

When using Keycloak SSO, a user mapped to an admin role via `SSO_KEYCLOAK_ROLE_MAPPINGS` (for example `gateway-admin` to `platform_admin`) was provisioned as a viewer instead of an admin.

Root cause is a claim-delivery gap, not gateway logic. The bundled `mcp-gateway` realm export only emitted the `groups` claim to the id_token and userinfo. Keycloak places realm roles such as `gateway-admin` in the access token by default, and the gateway reads roles from the id_token and userinfo, never the access token. So the mapped role never reached the gateway and the mapping silently fell through to the default role.

## Changes

- **`infra/keycloak/realm-export.json`**: add a `realm roles` protocol mapper to the `mcp-gateway` client so `realm_access.roles` is emitted to both the id_token and userinfo. The existing `groups` mapper is unchanged.
- **`docs/docs/manage/sso-keycloak-tutorial.md`**: document `SSO_KEYCLOAK_ROLE_MAPPINGS` (previously only listed in the reference table, never shown in an example) and explain the token-claim requirement. Adds a new "Grant Admin and RBAC Roles via Role Mappings" section and a note on the realm-roles mapper step, including the simpler group-name mapping path that needs no extra token config.

No gateway code change. The fix is configuration only.

## Verification

Tested on a freshly rebuilt gateway image (no code patch) with the realm re-imported from the updated export. Two fresh Keycloak users were created and logged in through the gateway via the OIDC authorization-code flow:

| User | Keycloak group / realm role | `is_admin` | Global RBAC role | Expected |
|------|-----------------------------|------------|------------------|----------|
| `ssotest-admin@example.com` | Administrators / `gateway-admin` | `t` | `platform_admin` | admin |
| `ssotest-dev@example.com` | Developers / `gateway-developer` | `f` | `developer` | not admin |

The developer case is the negative control: the mapper does not blanket-grant admin, it maps each role to its configured gateway role.

## Notes

- Existing deployments that prefer not to touch the realm export can instead map the group name, which is already delivered by the `groups` claim: `SSO_KEYCLOAK_ROLE_MAPPINGS={"Administrators":"platform_admin"}`.


## Manual verification (Keycloak console, end-user flow)

Reproduced the original report by hand, end to end in the browser, using the bundled SSO stack (`docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso up -d`):

1. Keycloak admin console (`http://localhost:8180`, realm `mcp-gateway`) → **Users** → **Add user**.
   - Username and Email: `joe-test@example.com`
   - Email verified: **On**
   - First / Last name set (so the profile is complete)
   - Join group **Administrators** (which carries the `gateway-admin` realm role)
2. **Credentials** tab → set a non-temporary password.
3. Incognito browser → `http://localhost:8080/admin/login` → **Continue with Keycloak** → sign in as the new user.
4. Result: the user lands on the **full admin dashboard** (Teams, Plugins, A2A Plugin Bindings, MCP Registry visible). A viewer would not see these.

Backend confirmation:

```
        email         | is_admin | auth_provider |  global_role
----------------------+----------+---------------+----------------
 joe-test@example.com | t        | keycloak      | platform_admin
```

### Note for testers

The user must have a populated **and verified** email in Keycloak. If you create the user with a blank email, Keycloak triggers a VERIFY_PROFILE step at first login; self-entering the email there sets `email_verified=false`, and the gateway correctly refuses to provision an unverified-email SSO user (returns `user_creation_failed`). This is unrelated to the role mapping. Set the email on the user and toggle **Email verified: On** before logging in.

