### PR TITLE
fix: standardize root path redirects

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1040,7 +1040,7 @@ def _build_admin_redirect(
         except ValueError:
             pass
     query = urllib.parse.urlencode(params, quote_via=urllib.parse.quote) if params else ""
-    sep = "/?" if query else ""
+    sep = "/?" if query else "/"
     return f"{root_path}/admin{sep}{query}#{fragment}"
 
 
@@ -4273,9 +4273,9 @@ async def admin_login_page(request: Request) -> Response:
     # Check if email auth is enabled
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
-    root_path = settings.app_root_path
+    root_path = _resolve_root_path(request)
 
     # Check if user is already authenticated via JWT cookie
     # Skip redirect when an error param is present — the user was sent here
@@ -4295,7 +4295,7 @@ async def admin_login_page(request: Request) -> Response:
                 if token_teams is not None and len(token_teams) == 0:
                     pass  # Render login page; do not redirect to /admin
                 elif auth_user.is_admin:
-                    return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                    return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
                 else:
                     # Non-admin with valid token: check RBAC admin permission
                     with SessionLocal() as db:
@@ -4306,7 +4306,7 @@ async def admin_login_page(request: Request) -> Response:
                             token_teams=token_teams,
                         )
                         if has_admin_access:
-                            return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                            return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
                         # else: render login page; token is valid but lacks admin access
             except Exception:
                 clear_invalid_cookies = True
@@ -4388,7 +4388,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
     root_path = _resolve_root_path(request)
 
     if not getattr(settings, "email_auth_enabled", False):
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -4482,7 +4482,7 @@ async def admin_login_handler(request: Request, db: Session = Depends(get_db)) -
             token, _ = await create_access_token(user)  # expires_seconds not needed here
 
             # Create redirect response
-            response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+            response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
             # Set JWT token as secure cookie
             try:
@@ -4978,7 +4978,7 @@ async def change_password_required_page(request: Request) -> HTMLResponse:
     """
     if not getattr(settings, "email_auth_enabled", False):
         root_path = _resolve_root_path(request)
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     # Get root path for template
     root_path = _resolve_root_path(request)
@@ -5059,7 +5059,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
     root_path = _resolve_root_path(request)
 
     if not getattr(settings, "email_auth_enabled", False):
-        return RedirectResponse(url=f"{root_path}/admin", status_code=303)
+        return RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
     try:
         form = await request.form()
@@ -5125,7 +5125,7 @@ async def change_password_required_handler(request: Request, db: Session = Depen
                 token, _ = await create_access_token(current_user)
 
                 # Create redirect response to admin panel
-                response = RedirectResponse(url=f"{root_path}/admin", status_code=303)
+                response = RedirectResponse(url=f"{root_path}/admin/", status_code=303)
 
                 # Update JWT token cookie
                 try:
@@ -16479,7 +16479,7 @@ async def admin_set_a2a_agent_state(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     user_email = get_user_email(user)
     error_message = None
@@ -16533,7 +16533,7 @@ async def admin_delete_a2a_agent(
     """
     if not a2a_service or not settings.mcpgateway_a2a_enabled:
         root_path = _resolve_root_path(request)
-        return RedirectResponse(f"{root_path}/admin#a2a-agents", status_code=303)
+        return RedirectResponse(f"{root_path}/admin/#a2a-agents", status_code=303)
 
     error_message = None
     is_inactive_checked = "false"

--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -383,7 +383,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # Determine the route-only path (strip root_path for path matching)
         path = request.url.path
-        root_path = resolve_root_path(request, fallback=settings.app_root_path)
+        settings_root_path = getattr(settings, "app_root_path", None)
+        root_path = resolve_root_path(request, fallback=settings_root_path if isinstance(settings_root_path, str) else None)
         if root_path and path.startswith(root_path):
             path = path[len(root_path) :]
 

--- a/mcpgateway/middleware/security_headers.py
+++ b/mcpgateway/middleware/security_headers.py
@@ -22,6 +22,7 @@ from starlette.responses import Response
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.paths import resolve_root_path
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -382,7 +383,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # Determine the route-only path (strip root_path for path matching)
         path = request.url.path
-        root_path = request.scope.get("root_path", "")
+        root_path = resolve_root_path(request, fallback=settings.app_root_path)
         if root_path and path.startswith(root_path):
             path = path[len(root_path) :]
 
@@ -482,7 +483,6 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Hardened Cache Control for Protected Endpoints
         # Implements defense-in-depth caching policies
         path = request.url.path
-        root_path = request.scope.get("root_path", "")
         if root_path and path.startswith(root_path):
             path = path[len(root_path) :]
 

--- a/mcpgateway/routers/sso.py
+++ b/mcpgateway/routers/sso.py
@@ -413,7 +413,7 @@ async def handle_sso_callback(
         user_email = user_info.get("email")
 
     # Determine redirect URL
-    redirect_url = f"{root_path}/admin"
+    redirect_url = f"{root_path}/admin/"
 
     # For non-admin users, try to redirect to their first team's admin view
     if not is_admin and user_email:
@@ -425,7 +425,7 @@ async def handle_sso_callback(
                 # Redirect to first team's admin view
                 # Use first team in list (arbitrary selection - user can switch teams in UI)
                 first_team_id = user_teams[0].id
-                redirect_url = f"{root_path}/admin?team_id={first_team_id}"
+                redirect_url = f"{root_path}/admin/?team_id={first_team_id}"
                 logger.info(f"Redirecting non-admin SSO user {sanitize_for_log(user_email)} to team-scoped admin: {first_team_id}")
             else:
                 # User has no teams - redirect to admin gateways view
@@ -435,8 +435,8 @@ async def handle_sso_callback(
                 redirect_url = f"{root_path}/admin/#gateways"
                 logger.info(f"Redirecting non-admin SSO user {sanitize_for_log(user_email)} with no teams to admin gateways view")
         except Exception as e:
-            logger.warning(f"Failed to retrieve teams for SSO user {sanitize_for_log(user_email)}: {e}. Redirecting to /admin")
-            # Fall back to /admin - middleware will handle permission check
+            logger.warning(f"Failed to retrieve teams for SSO user {sanitize_for_log(user_email)}: {e}. Redirecting to /admin/")
+            # Fall back to /admin/ - middleware will handle permission check
 
     # Create redirect response
     redirect_response = RedirectResponse(url=redirect_url, status_code=302)

--- a/mcpgateway/utils/paths.py
+++ b/mcpgateway/utils/paths.py
@@ -63,7 +63,8 @@ def resolve_root_path(request: Request, *, fallback: str | None = None) -> str:
     Args:
         request: Incoming ASGI request whose scope is inspected. Should not be none.
         fallback: Optional explicit fallback string.  When *None* (default)
-            ``settings.app_root_path`` is used as the fallback.
+            ``settings.app_root_path`` is used as the fallback.  Non-string
+            fallback values are ignored.
 
     Returns:
         Normalised root path (leading ``/``, no trailing ``/``), or an empty
@@ -88,7 +89,14 @@ def resolve_root_path(request: Request, *, fallback: str | None = None) -> str:
         raw = ""
     root_path = (raw if isinstance(raw, str) else "").strip()
     if not root_path:
-        root_path = (fallback if fallback is not None else (settings.app_root_path or "")).strip()
+        fallback_value = fallback if fallback is not None else settings.app_root_path
+        if fallback_value is None:
+            root_path = ""
+        elif isinstance(fallback_value, str):
+            root_path = fallback_value.strip()
+        else:
+            logger.warning("Non-string root_path fallback (type=%s), ignoring", type(fallback_value).__name__)
+            root_path = ""
     if root_path:
         root_path = _validate_root_path(root_path)
     if root_path:

--- a/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
@@ -16,15 +16,17 @@ from starlette.responses import Response
 from mcpgateway.middleware.security_headers import SecurityHeadersMiddleware
 
 
-def _make_request(headers=None, scheme="https"):
+def _make_request(headers=None, scheme="https", path="/", root_path=None):
     """Create a test request."""
     scope = {
         "type": "http",
         "method": "GET",
-        "path": "/",
+        "path": path,
         "scheme": scheme,
         "headers": headers or [],
     }
+    if root_path is not None:
+        scope["root_path"] = root_path
     return Request(scope)
 
 
@@ -46,6 +48,7 @@ def _mock_settings():
     settings.remove_server_headers = False
     settings.environment = "production"
     settings.allowed_origins = []
+    settings.app_root_path = ""
     return mock, settings
 
 
@@ -220,11 +223,8 @@ async def test_hsts_enabled():
     try:
         middleware = SecurityHeadersMiddleware(app=None)
         request = _make_request(headers=[(b"x-forwarded-proto", b"https")])
-        response = await middleware.dispatch(request, _call_next)
-        hsts = response.headers.get("Strict-Transport-Security")
-        assert hsts is not None
-        assert "max-age=31536000" in hsts
-        assert "includeSubDomains" in hsts
+        hsts = (await middleware.dispatch(request, _call_next)).headers.get("Strict-Transport-Security")
+        assert hsts is not None and "max-age=31536000" in hsts and "includeSubDomains" in hsts
     finally:
         mock.stop()
 
@@ -315,19 +315,43 @@ async def test_root_path_is_stripped_from_path_for_csp_skip_check():
     mock, settings = _mock_settings()
     try:
         middleware = SecurityHeadersMiddleware(app=None)
-        request = Request(
-            {
-                "type": "http",
-                "method": "GET",
-                "path": "/app/docs",
-                "root_path": "/app",
-                "scheme": "https",
-                "headers": [],
-            }
-        )
+        request = _make_request(path="/app/docs", root_path="/app")
 
         response = await middleware.dispatch(request, _call_next)
 
         assert response.status_code == 200
+        assert "Content-Security-Policy" not in response.headers
+    finally:
+        mock.stop()
+
+
+@pytest.mark.asyncio
+async def test_settings_root_path_is_stripped_from_path_for_csp_skip_check():
+    mock, settings = _mock_settings()
+    settings.app_root_path = "/app"
+    try:
+        middleware = SecurityHeadersMiddleware(app=None)
+        request = _make_request(path="/app/docs", root_path="")
+
+        response = await middleware.dispatch(request, _call_next)
+
+        assert response.status_code == 200
+        assert "Content-Security-Policy" not in response.headers
+    finally:
+        mock.stop()
+
+
+@pytest.mark.asyncio
+async def test_settings_root_path_is_stripped_from_path_for_cache_exemption():
+    mock, settings = _mock_settings()
+    settings.app_root_path = "/app"
+    try:
+        middleware = SecurityHeadersMiddleware(app=None)
+        request = _make_request(path="/app/health", root_path="")
+
+        response = await middleware.dispatch(request, _call_next)
+
+        assert response.status_code == 200
+        assert all(header not in response.headers for header in ("Cache-Control", "Pragma", "Expires"))
     finally:
         mock.stop()

--- a/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_security_headers_middleware.py
@@ -342,6 +342,27 @@ async def test_settings_root_path_is_stripped_from_path_for_csp_skip_check():
 
 
 @pytest.mark.asyncio
+async def test_mocked_settings_without_app_root_path_does_not_crash():
+    with patch("mcpgateway.middleware.security_headers.settings") as settings:
+        settings.security_headers_enabled = True
+        settings.x_content_type_options_enabled = True
+        settings.x_frame_options = "DENY"
+        settings.x_xss_protection_enabled = True
+        settings.x_download_options_enabled = True
+        settings.hsts_enabled = False
+        settings.remove_server_headers = True
+        settings.environment = "production"
+        settings.allowed_origins = []
+        settings.cors_allow_credentials = True
+
+        middleware = SecurityHeadersMiddleware(app=None)
+        response = await middleware.dispatch(_make_request(path="/test", root_path=""), _call_next)
+
+        assert response.status_code == 200
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+@pytest.mark.asyncio
 async def test_settings_root_path_is_stripped_from_path_for_cache_exemption():
     mock, settings = _mock_settings()
     settings.app_root_path = "/app"

--- a/tests/unit/mcpgateway/routers/test_sso_router.py
+++ b/tests/unit/mcpgateway/routers/test_sso_router.py
@@ -290,11 +290,8 @@ async def test_handle_sso_callback_success_sets_cookie(monkeypatch: pytest.Monke
 
     # Create a valid JWT token with admin status
     import jwt
-    admin_token = jwt.encode(
-        {"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    admin_token = jwt.encode({"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -321,7 +318,7 @@ async def test_handle_sso_callback_success_sets_cookie(monkeypatch: pytest.Monke
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "") == "/admin/"
     assert set_cookie.called
 
 
@@ -336,11 +333,8 @@ async def test_handle_sso_callback_keycloak_sets_id_token_hint_cookie(monkeypatc
 
     # Create a valid JWT token with admin status
     import jwt
-    admin_token = jwt.encode(
-        {"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    admin_token = jwt.encode({"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -367,7 +361,7 @@ async def test_handle_sso_callback_keycloak_sets_id_token_hint_cookie(monkeypatc
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "") == "/admin/"
     assert "sso_id_token_hint=id-token-hint" in response.headers.get("set-cookie", "")
     assert set_cookie.called
 
@@ -383,11 +377,8 @@ async def test_handle_sso_callback_keycloak_oversized_id_token_skips_hint_cookie
 
     # Create a valid JWT token with admin status
     import jwt
-    admin_token = jwt.encode(
-        {"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    admin_token = jwt.encode({"user": {"email": "admin@example.com", "is_admin": True}, "email": "admin@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -415,10 +406,11 @@ async def test_handle_sso_callback_keycloak_oversized_id_token_skips_hint_cookie
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "").endswith("/admin")
+    assert response.headers.get("location", "") == "/admin/"
     assert "sso_id_token_hint=" not in response.headers.get("set-cookie", "")
     assert "id_token too large for cookie storage" in caplog.text
     assert set_cookie.called
+
 
 @pytest.mark.asyncio
 async def test_handle_sso_callback_non_admin_with_team_redirects_to_team(monkeypatch: pytest.MonkeyPatch):
@@ -427,11 +419,8 @@ async def test_handle_sso_callback_non_admin_with_team_redirects_to_team(monkeyp
 
     # Create a valid JWT token for non-admin user
     import jwt
-    non_admin_token = jwt.encode(
-        {"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    non_admin_token = jwt.encode({"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -471,7 +460,7 @@ async def test_handle_sso_callback_non_admin_with_team_redirects_to_team(monkeyp
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "") == "/admin?team_id=team-123"
+    assert response.headers.get("location", "") == "/admin/?team_id=team-123"
     assert set_cookie.called
 
 
@@ -486,11 +475,8 @@ async def test_handle_sso_callback_non_admin_no_teams_redirects_to_admin_gateway
 
     # Create a valid JWT token for non-admin user
     import jwt
-    non_admin_token = jwt.encode(
-        {"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    non_admin_token = jwt.encode({"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -533,16 +519,13 @@ async def test_handle_sso_callback_non_admin_no_teams_redirects_to_admin_gateway
 
 @pytest.mark.asyncio
 async def test_handle_sso_callback_team_service_error_falls_back_to_admin(monkeypatch: pytest.MonkeyPatch):
-    """Test that team service errors fall back to /admin redirect."""
+    """Test that team service errors fall back to /admin/ redirect."""
     monkeypatch.setattr(sso_router.settings, "sso_enabled", True)
 
     # Create a valid JWT token for non-admin user
     import jwt
-    non_admin_token = jwt.encode(
-        {"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"},
-        "secret",
-        algorithm="HS256"
-    )
+
+    non_admin_token = jwt.encode({"user": {"email": "user@example.com", "is_admin": False}, "email": "user@example.com"}, "secret", algorithm="HS256")
 
     class DummyService:
         def __init__(self, _db):
@@ -579,8 +562,9 @@ async def test_handle_sso_callback_team_service_error_falls_back_to_admin(monkey
 
     assert isinstance(response, RedirectResponse)
     assert response.status_code == 302
-    assert response.headers.get("location", "") == "/admin"
+    assert response.headers.get("location", "") == "/admin/"
     assert set_cookie.called
+
 
 @pytest.mark.asyncio
 async def test_handle_sso_callback_invalid_jwt_falls_back_to_user_info(monkeypatch: pytest.MonkeyPatch):
@@ -632,8 +616,6 @@ async def test_handle_sso_callback_invalid_jwt_falls_back_to_user_info(monkeypat
     # Should redirect to admin gateways view since user has no teams and is not admin
     assert response.headers.get("location", "") == "/admin/#gateways"
     assert set_cookie.called
-
-
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -1183,7 +1183,7 @@ class TestAdminServerRoutes:
         mock_set_state.assert_called_once_with(mock_db, "server-1", True, user_email="test-user")
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#catalog"
+        assert result.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "set_server_state")
     async def test_admin_set_server_state_deactivate(self, mock_set_state, mock_request, mock_db):
@@ -1197,7 +1197,7 @@ class TestAdminServerRoutes:
         mock_set_state.assert_called_once_with(mock_db, "server-1", False, user_email="test-user")
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#catalog"
+        assert result.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "set_server_state")
     async def test_admin_set_server_state_with_inactive_checked(self, mock_set_state, mock_request, mock_db):
@@ -1292,7 +1292,7 @@ class TestAdminServerRoutes:
         response = await admin_delete_server("server-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert response.status_code == 303
-        assert response.headers["location"] == "/admin#catalog"
+        assert response.headers["location"] == "/admin/#catalog"
         mock_delete_server.assert_called_once()
 
     @patch.object(ServerService, "delete_server")
@@ -1317,7 +1317,7 @@ class TestAdminServerRoutes:
         response = await admin_delete_server("server-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert "team_id" not in response.headers["location"]
-        assert response.headers["location"] == "/admin#catalog"
+        assert response.headers["location"] == "/admin/#catalog"
 
     @patch.object(ServerService, "delete_server")
     async def test_admin_delete_server_error_handlers(self, mock_delete_server, mock_request, mock_db):
@@ -3668,7 +3668,7 @@ class TestAdminRootRoutes:
         response = await admin_delete_root("/test/root", mock_request, user={"email": "test-user", "db": mock_db})
         assert isinstance(response, RedirectResponse)
         assert response.status_code == 303
-        assert response.headers["location"] == "/root/admin#roots"
+        assert response.headers["location"] == "/root/admin/#roots"
 
     @patch("mcpgateway.admin.root_service.remove_root", new_callable=AsyncMock)
     async def test_admin_delete_root_preserves_team_id(self, mock_remove_root, mock_request, mock_db):
@@ -5808,7 +5808,7 @@ class TestA2AAgentManagement:
         result = await admin_set_a2a_agent_state("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/root/admin#a2a-agents"
+        assert result.headers["location"] == "/root/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "delete_agent")
     async def test_admin_delete_a2a_agent_success(self, mock_delete_agent, mock_request, mock_db):
@@ -5884,7 +5884,7 @@ class TestA2AAgentManagement:
         result = await admin_delete_a2a_agent("agent-1", mock_request, mock_db, user={"email": "test-user", "db": mock_db})
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/admin#a2a-agents"
+        assert result.headers["location"] == "/admin/#a2a-agents"
 
     @patch.object(A2AAgentService, "get_agent")
     @patch.object(A2AAgentService, "invoke_agent")
@@ -15475,7 +15475,7 @@ async def test_change_password_required_handler_success(monkeypatch, mock_db):
 
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -15485,7 +15485,7 @@ async def test_change_password_required_handler_email_auth_disabled(monkeypatch,
     request.scope = {"root_path": "/root"}
     response = await change_password_required_handler(request, db=mock_db)
     assert isinstance(response, RedirectResponse)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -16509,7 +16509,7 @@ async def test_admin_delete_tool_success(mock_delete, mock_db):
 
     response = await admin_delete_tool("550e8400e29b41d4a7164466554400b1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#tools"
+    assert response.headers["location"] == "/root/admin/#tools"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400b1", user_email="user@example.com", purge_metrics=True)  # pragma: allowlist secret
 
 
@@ -16565,7 +16565,7 @@ async def test_admin_delete_gateway_success(mock_delete, mock_db):
 
     response = await admin_delete_gateway("gateway-1", request, mock_db, user={"email": "user@example.com"})
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#gateways"
+    assert response.headers["location"] == "/root/admin/#gateways"
     mock_delete.assert_called_once_with(mock_db, "gateway-1", user_email="user@example.com")
 
 
@@ -16665,7 +16665,7 @@ async def test_admin_delete_resource_success_inactive_unchecked_redirect(mock_de
 
     response = await admin_delete_resource("550e8400e29b41d4a7164466554400c1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#resources"
+    assert response.headers["location"] == "/root/admin/#resources"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400c1", user_email="user@example.com", purge_metrics=False)  # pragma: allowlist secret
 
 
@@ -16715,7 +16715,7 @@ async def test_admin_delete_prompt_success(mock_delete, mock_db):
 
     response = await admin_delete_prompt("550e8400e29b41d4a7164466554400d1", request, mock_db, user={"email": "user@example.com"})  # pragma: allowlist secret
     assert response.status_code == 303
-    assert response.headers["location"] == "/root/admin#prompts"
+    assert response.headers["location"] == "/root/admin/#prompts"
     mock_delete.assert_called_once_with(mock_db, "550e8400e29b41d4a7164466554400d1", user_email="user@example.com", purge_metrics=False)  # pragma: allowlist secret
 
 
@@ -18132,10 +18132,10 @@ class TestUtilityFunctions:
         assert exc_info.value.status_code == 400
 
     def test_build_admin_redirect_no_params(self):
-        assert _build_admin_redirect("", "catalog") == "/admin#catalog"
+        assert _build_admin_redirect("", "catalog") == "/admin/#catalog"
 
     def test_build_admin_redirect_with_root_path(self):
-        assert _build_admin_redirect("/root", "tools") == "/root/admin#tools"
+        assert _build_admin_redirect("/root", "tools") == "/root/admin/#tools"
 
     def test_build_admin_redirect_error_only(self):
         result = _build_admin_redirect("", "catalog", error="Error msg")
@@ -18183,11 +18183,11 @@ class TestUtilityFunctions:
 
     def test_build_admin_redirect_with_invalid_team_id(self):
         result = _build_admin_redirect("", "tools", team_id="invalid-uuid")
-        assert result == "/admin#tools"
+        assert result == "/admin/#tools"
 
     def test_build_admin_redirect_with_empty_team_id(self):
         result = _build_admin_redirect("", "tools", team_id="")
-        assert result == "/admin#tools"
+        assert result == "/admin/#tools"
 
     def test_build_admin_redirect_with_valid_team_id(self):
         uid = "12345678-1234-5678-1234-567812345678"
@@ -18393,7 +18393,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard, not show login page
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_shows_form_for_invalid_token(self, monkeypatch):
@@ -18500,7 +18500,7 @@ class TestAuthLogin:
         # Should redirect to admin dashboard
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_access_token_cookie_invalid_shows_form(self, monkeypatch):
@@ -18557,7 +18557,7 @@ class TestAuthLogin:
 
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"] == "/app/admin"
+        assert result.headers["location"] == "/app/admin/"
 
     @pytest.mark.asyncio
     async def test_admin_login_page_non_admin_without_rbac_admin_shows_form(self, monkeypatch):
@@ -18861,7 +18861,7 @@ class TestAuthLogin:
         result = await admin_login_handler(request, mock_db)
         assert isinstance(result, RedirectResponse)
         assert result.status_code == 303
-        assert result.headers["location"].endswith("/admin")
+        assert result.headers["location"].endswith("/admin/")
 
     @pytest.mark.asyncio
     async def test_admin_login_handler_auth_failure(self, monkeypatch, mock_db):

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -157,7 +157,11 @@ async def test_admin_add_gateway_includes_gateway_payload(monkeypatch):
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "_parse_gateway_data_from_request", AsyncMock(return_value={"name": "gw", "url": "http://example.com", "transport": "SSE"}))
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_creation_metadata", MagicMock(return_value={"created_by": "admin@example.com", "created_from_ip": "127.0.0.1", "created_via": "test", "created_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_creation_metadata",
+        MagicMock(return_value={"created_by": "admin@example.com", "created_from_ip": "127.0.0.1", "created_via": "test", "created_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "register_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_add_gateway)(request, db, user)
@@ -176,7 +180,11 @@ async def test_admin_update_gateway_rest_includes_gateway_payload(monkeypatch):
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "_parse_gateway_data_from_request", AsyncMock(return_value={"name": "gw", "url": "http://example.com", "transport": "SSE"}))
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_modification_metadata", MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_modification_metadata",
+        MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "update_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_update_gateway_rest)("gw-1", request, db, user)
@@ -195,7 +203,11 @@ async def test_admin_edit_gateway_includes_gateway_payload(monkeypatch):
     user = {"email": "admin@example.com"}
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_modification_metadata", MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_modification_metadata",
+        MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "update_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_edit_gateway)("gw-1", request, db, user)
@@ -504,7 +516,7 @@ async def test_admin_login_handler_paths(monkeypatch):
     user.password_change_required = False
     monkeypatch.setattr(admin.settings, "password_change_enforcement_enabled", False)
     response = await admin.admin_login_handler(request, mock_db)
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
 
 
 @pytest.mark.asyncio
@@ -1198,7 +1210,7 @@ async def test_change_password_required_handler(monkeypatch):
     with patch("sqlalchemy.inspect", return_value=SimpleNamespace(transient=False, detached=False)):
         response = await admin.change_password_required_handler(request, mock_db)
 
-    assert response.headers["location"].endswith("/root/admin")
+    assert response.headers["location"].endswith("/root/admin/")
     assert set_cookie.called
 
 

--- a/tests/unit/mcpgateway/utils/test_paths.py
+++ b/tests/unit/mcpgateway/utils/test_paths.py
@@ -15,6 +15,7 @@ that lacked the ``settings.app_root_path`` fallback.
 from __future__ import annotations
 
 # Standard
+from typing import cast
 from unittest.mock import MagicMock
 
 # Third-Party
@@ -107,6 +108,13 @@ def test_empty_scope_and_none_settings_returns_empty_string(monkeypatch: pytest.
     assert resolve_root_path(req) == ""
 
 
+def test_empty_scope_and_non_string_settings_returns_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When settings.app_root_path is not a string, an empty string is returned."""
+    monkeypatch.setattr("mcpgateway.utils.paths.settings", MagicMock(app_root_path=MagicMock()))
+    req = _make_request("")
+    assert resolve_root_path(req) == ""
+
+
 # ---------------------------------------------------------------------------
 # Explicit fallback parameter overrides settings
 # ---------------------------------------------------------------------------
@@ -122,6 +130,12 @@ def test_explicit_fallback_empty_string_returns_empty() -> None:
     """An explicit empty-string fallback returns empty string."""
     req = _make_request("")
     assert resolve_root_path(req, fallback="") == ""
+
+
+def test_non_string_explicit_fallback_returns_empty() -> None:
+    """A non-string explicit fallback is ignored."""
+    req = _make_request("")
+    assert resolve_root_path(req, fallback=cast(str, MagicMock())) == ""
 
 
 def test_explicit_fallback_not_used_when_scope_has_value() -> None:


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #1588

---

## 📝 Summary

This PR finishes the current-main root path cleanup for #1588:

- routes `SecurityHeadersMiddleware` through the canonical `resolve_root_path()` helper instead of reading `request.scope["root_path"]` directly
- guards root-path fallback values so patched or mocked settings without a string `app_root_path` do not crash request processing
- normalizes admin dashboard redirects to `/admin/` and `/admin/#fragment`, avoiding slash-normalization redirects for dashboard targets
- normalizes SSO dashboard redirects to `/admin/` and `/admin/?team_id=...`
- updates focused admin, SSO, path utility, and security-header tests that assert these URL and fallback shapes

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Focused affected tests | `uv run --extra plugins pytest tests/unit/mcpgateway/routers/test_sso_router.py tests/unit/mcpgateway/middleware/test_security_headers_middleware.py tests/unit/mcpgateway/utils/test_paths.py tests/unit/mcpgateway/test_admin.py tests/unit/mcpgateway/test_admin_module.py -q` | ✅ Passed |
| Security/fuzz compatibility | `uv run --extra plugins pytest tests/security/test_security_middleware_comprehensive.py tests/fuzz/test_security_performance_compatibility.py -q` | ✅ Passed |
| Root-path doctests | `uv run --extra plugins pytest --doctest-modules mcpgateway/utils/paths.py mcpgateway/middleware/security_headers.py -q` | ✅ Passed |
| Formatting | `uv run black --target-version py311 --check mcpgateway/utils/paths.py mcpgateway/middleware/security_headers.py tests/unit/mcpgateway/utils/test_paths.py tests/unit/mcpgateway/middleware/test_security_headers_middleware.py` | ✅ Passed |
| Touched-file Ruff | `uv run ruff check mcpgateway/utils/paths.py mcpgateway/middleware/security_headers.py tests/unit/mcpgateway/utils/test_paths.py tests/unit/mcpgateway/middleware/test_security_headers_middleware.py` | ✅ Passed |
| Whitespace | `git diff --check` | ✅ Passed |
| Root-path direct reads and bare dashboard redirects | `rg -n 'request\.scope\.get\(["'"']root_path["'"']|resolve_root_path\([^\n]*fallback=settings\.app_root_path|fallback=settings\.app_root_path|RedirectResponse\([^\n]*\{root_path\}/admin($|[^/])|redirect_url\s*=\s*f["'"']\{root_path\}/admin($|[^/])|headers=\{["'"']Location["'"']:\s*f["'"']\{root_path\}/admin($|[^/])' mcpgateway tests --glob '*.py'` | ✅ Only canonical helper/docs comments remain |
| Lint suite | `make lint` | Not run; see focused checks above |
| Full unit tests | `make test` | Not run; focused affected tests passed |
| Coverage ≥ 80% | `make coverage` | Not run |

Note: direct file-level `ruff check` on large unrelated legacy files still reports pre-existing violations, so this PR verifies Ruff on the touched files and uses focused tests for the affected behavior. A direct Ruff run over the untouched fuzz compatibility file also reports pre-existing `F811`/`PLW0717`; the full fuzz compatibility tests pass.

---

## ✅ Checklist

- [x] Code formatted (`black --check` on touched files)
- [x] Tests added/updated for changes
- [x] Documentation updated (not applicable)
- [x] No secrets or credentials committed

---
