### PR TITLE
fix(sso): merge Keycloak realm/client roles from access_token, not just userinfo/id_token

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-18T13:53:55Z",
+  "generated_at": "2026-06-20T09:17:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1378,7 +1378,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 104,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 106,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 114,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 142,
+        "line_number": 143,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 395,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 398,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 415,
+        "line_number": 416,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 514,
+        "line_number": 515,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 571,
+        "line_number": 572,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 580,
+        "line_number": 581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 585,
+        "line_number": 586,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 597,
+        "line_number": 598,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 618,
+        "line_number": 619,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 620,
+        "line_number": 621,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 623,
+        "line_number": 624,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 630,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 669,
+        "line_number": 670,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 680,
+        "line_number": 681,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 682,
+        "line_number": 683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 714,
+        "line_number": 715,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 717,
+        "line_number": 718,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4244,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15016,
+        "line_number": 15017,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4278,7 +4278,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-20T09:28:28Z",
+  "generated_at": "2026-06-20T09:30:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -2896,7 +2896,7 @@
         "hashed_secret": "c58994eefb19ae2d0bfc26a106de438359e53fb6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 314,
+        "line_number": 325,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2904,7 +2904,7 @@
         "hashed_secret": "8c9fdbd88e905d33102d0be537adeab8595fe0da",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 344,
+        "line_number": 355,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2912,7 +2912,7 @@
         "hashed_secret": "6ea1c94703f93074853165df24e0ded6917472af",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 370,
+        "line_number": 381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -2920,7 +2920,7 @@
         "hashed_secret": "b05b46675e3b6cecdb5ed7d0c24a8a183abd4de8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 751,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-20T09:30:14Z",
+  "generated_at": "2026-06-20T09:31:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3896,7 +3896,7 @@
         "hashed_secret": "1e5c2f367f02e47a8c160cda1cd9d91decbac441",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 200,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-20T09:27:38Z",
+  "generated_at": "2026-06-20T09:28:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1378,7 +1378,7 @@
         "hashed_secret": "ff2ccd73154c1c71ef9a2982fe16e3c529e7a1ae",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 105,
+        "line_number": 104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1386,7 +1386,7 @@
         "hashed_secret": "74f82b992f8a92b849c2be77447f98a510338333",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 106,
+        "line_number": 105,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1394,7 +1394,7 @@
         "hashed_secret": "64814a3b7fd8444a56ad3641fd3451c6deaf0757",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 113,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1402,7 +1402,7 @@
         "hashed_secret": "af84d91fde168566c7dc18f3121ea2fbe651af1f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 142,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1410,7 +1410,7 @@
         "hashed_secret": "d1081e351fbebe0deb0c2867d5f731c8f9cc3fd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 396,
+        "line_number": 395,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1418,7 +1418,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 397,
+        "line_number": 396,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1426,7 +1426,7 @@
         "hashed_secret": "6d244f58364223afcc2322f696137b01ece78d9d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 398,
+        "line_number": 397,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1434,7 +1434,7 @@
         "hashed_secret": "8bf177a72c93155020ebca9ee7f3c6e0fbdee946",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1442,7 +1442,7 @@
         "hashed_secret": "c41e6cd4245e404f07635fdbac351aad4d54a213",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 515,
+        "line_number": 514,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1450,7 +1450,7 @@
         "hashed_secret": "6568a9761e26d16a111247f279b6fcabff1c8c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1458,7 +1458,7 @@
         "hashed_secret": "314fc7fd580f8c510be196143946bbe5ea753443",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1466,7 +1466,7 @@
         "hashed_secret": "afb9d1dcf212fa33d079a070ab90f0bef03c324b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 565,
+        "line_number": 564,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1474,7 +1474,7 @@
         "hashed_secret": "2736fab291f04e69b62d490c3c09361f5b82461a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 572,
+        "line_number": 571,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1482,7 +1482,7 @@
         "hashed_secret": "7542c8f677ffbbe75a5301a5c76f88401dc42897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 581,
+        "line_number": 580,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1490,7 +1490,7 @@
         "hashed_secret": "ca20728d35f00c3a4c21b1fc8b0086b59f89df2d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 586,
+        "line_number": 585,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1498,7 +1498,7 @@
         "hashed_secret": "5b7dcd14a4faa2cdd54cf6eb8d4bc35da31914a1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 598,
+        "line_number": 597,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1506,7 +1506,7 @@
         "hashed_secret": "245dbfa0498aaa6898fe57a191a5b3130466a943",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 619,
+        "line_number": 618,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1514,7 +1514,7 @@
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 621,
+        "line_number": 620,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1522,7 +1522,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 624,
+        "line_number": 623,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1530,7 +1530,7 @@
         "hashed_secret": "a603075604516de626cda903868e457fad826533",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 631,
+        "line_number": 630,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1538,7 +1538,7 @@
         "hashed_secret": "95ef18f58f32e3821ec7e627af6ee4757f68760e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 632,
+        "line_number": 631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1546,7 +1546,7 @@
         "hashed_secret": "b3aca92c793ee0e9b1a9b0a5f5fc044e05140df3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 670,
+        "line_number": 669,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1554,7 +1554,7 @@
         "hashed_secret": "ae21c64a87f6bb0b8e16e55c48be4cc638d7bd3f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 681,
+        "line_number": 680,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1562,7 +1562,7 @@
         "hashed_secret": "58d1bbce297de3c304a9fefc3b483181872a5c6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 683,
+        "line_number": 682,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1570,7 +1570,7 @@
         "hashed_secret": "de93ba2d15f3dbf65f76e6fd21e1e4b002459dd8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 715,
+        "line_number": 714,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1578,7 +1578,7 @@
         "hashed_secret": "533739bb9d1dad53e71d8c93200cc2510d442226",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 718,
+        "line_number": 717,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4278,7 +4278,7 @@
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 551,
+        "line_number": 550,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-20T09:17:14Z",
+  "generated_at": "2026-06-20T09:27:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4244,7 +4244,7 @@
         "hashed_secret": "3ee08a29a2ca26171fe152b8741d0c90b598263a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15017,
+        "line_number": 15016,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/sso-keycloak-tutorial.md
+++ b/docs/docs/manage/sso-keycloak-tutorial.md
@@ -240,14 +240,25 @@ To include roles in JWT tokens:
 **realm roles**:
 
 - Maps realm roles to `realm_access.roles` claim
-- Should be enabled by default
+- Exists by default
 
 **client roles**:
 
 - Maps client roles to `resource_access.{client_id}.roles` claim
-- Should be enabled by default
+- Exists by default
 
 If missing, create them manually using **Add mapper** → **By configuration** → **User Realm Role** or **User Client Role**.
+
+**Important — enable on ID token and userinfo, not just the access token:**
+
+Keycloak's built-in **realm roles** and **client roles** mappers ship with only **Add to access token** turned on. **Add to ID token** and **Add to userinfo** are off by default. ContextForge reads roles from the userinfo response (and falls back to the ID token in some configurations) — it does not parse the access token — so with the defaults left as-is, `realm_access`/`resource_access` never reach the gateway and `SSO_KEYCLOAK_ROLE_MAPPINGS`/`SSO_KEYCLOAK_MAP_REALM_ROLES` silently have nothing to map, even though the role is assigned correctly in Keycloak.
+
+For each of the **realm roles** and **client roles** mappers, open it and switch on:
+
+- **Add to ID token**
+- **Add to userinfo**
+
+(in addition to the default **Add to access token**). The local `infra/keycloak/realm-export.json` dev seed already configures these mappers correctly — this step is only needed when wiring up your own Keycloak realm by hand.
 
 ## Step 5: Configure User Attributes and Groups
 
@@ -839,10 +850,11 @@ SSO_KEYCLOAK_PUBLIC_BASE_URL=http://localhost:8180   # Browser-facing (auth URL,
 **Problem**: User roles not included in JWT token
 **Solution**: Configure role mappers and enable role mapping
 
-1. Verify role mappers exist:
+1. Verify role mappers exist and reach the ID token / userinfo:
 
    - Go to **Client scopes** → **roles** → **Mappers**
    - Ensure **realm roles** and **client roles** mappers exist
+   - Open each mapper and confirm **Add to ID token** and **Add to userinfo** are both ON — Keycloak ships these mappers with only **Add to access token** enabled by default, and ContextForge reads roles from userinfo/ID token, not the access token. This is the most common cause of "role assigned in Keycloak but gateway treats user as default role" — see [Step 4.4](#44-configure-role-mappers).
 
 2. Enable role mapping in gateway:
 ```bash

--- a/infra/keycloak/realm-export.json
+++ b/infra/keycloak/realm-export.json
@@ -94,6 +94,34 @@
             "userinfo.token.claim": "true",
             "claim.name": "groups"
           }
+        },
+        {
+          "name": "realm roles (id+userinfo)",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "client roles (id+userinfo)",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String"
+          }
         }
       ]
     }

--- a/mcpgateway/services/sso_service.py
+++ b/mcpgateway/services/sso_service.py
@@ -1450,10 +1450,23 @@ class SSOService:
             return
 
         # Keycloak: merge realm_access, resource_access, and groups from id_token
-        if provider.id == "keycloak" and verified_id_token_claims:
+        # and, failing that, the access_token. Keycloak's built-in "realm roles"
+        # and "client roles" client-scope mappers default access.token.claim=true
+        # but id.token.claim=userinfo.token.claim=false, so on a stock Keycloak
+        # setup these claims are normally present ONLY on the access_token —
+        # never on the userinfo response or id_token. The access_token was
+        # already received directly from the trusted token endpoint, so decoding
+        # it here (without re-verifying the signature) carries the same trust
+        # level as the verified_id_token_claims fallback above.
+        if provider.id == "keycloak":
+            access_token_claims = self._decode_jwt_claims(access_token) or {}
             for claim in ["realm_access", "resource_access", "groups"]:
-                if claim in verified_id_token_claims and claim not in user_data:
+                if claim in user_data:
+                    continue
+                if verified_id_token_claims and claim in verified_id_token_claims:
                     user_data[claim] = verified_id_token_claims[claim]
+                elif claim in access_token_claims:
+                    user_data[claim] = access_token_claims[claim]
             return
 
         # Generic OIDC (including Okta, IBM Verify, and any custom provider):
@@ -1577,7 +1590,15 @@ class SSOService:
                     public_base_url,
                     metadata.get("base_url"),
                 )
-                return self._normalize_user_info(provider, verified_id_token_claims)
+                fallback_claims = dict(verified_id_token_claims)
+                # id_token also lacks realm_access/resource_access/groups by default
+                # on a stock Keycloak setup (see _enrich_user_data_from_claims) -
+                # pull them from the access_token, which carries them by default.
+                access_token_claims = self._decode_jwt_claims(access_token) or {}
+                for claim in ["realm_access", "resource_access", "groups"]:
+                    if claim not in fallback_claims and claim in access_token_claims:
+                        fallback_claims[claim] = access_token_claims[claim]
+                return self._normalize_user_info(provider, fallback_claims)
 
         logger.error("User info request failed for %s: HTTP %s - %s", provider.name, response.status_code, response.text)
 
@@ -2283,6 +2304,12 @@ class SSOService:
             logger.debug("No role mappings configured for provider %s, skipping role sync", provider.id)
             return role_assignments
 
+        # Match role_mappings keys case-insensitively, consistent with _should_user_be_admin().
+        # Without this, an IdP group/role casing that differs from the configured mapping key
+        # (e.g. Keycloak role "gateway-admin" vs a mapping key "Gateway-Admin") would silently
+        # skip RBAC role assignment even though is_admin could already be granted.
+        lower_role_mappings = {str(k).lower(): v for k, v in role_mappings.items()}
+
         personal_team_id: Optional[str] = None
         personal_team_checked = False
 
@@ -2339,10 +2366,9 @@ class SSOService:
         # Batch role lookups: collect all role names that need to be looked up
         role_names_to_lookup = set()
         for group in user_groups:
-            if group in role_mappings:
-                role_name = role_mappings[group]
-                if role_name not in ["admin", settings.default_admin_role]:
-                    role_names_to_lookup.add(role_name)
+            role_name = lower_role_mappings.get(group.lower())
+            if role_name and role_name not in ["admin", settings.default_admin_role]:
+                role_names_to_lookup.add(role_name)
 
         # Add default role to lookup if needed
         if has_provider_default_role and provider_default_role:
@@ -2361,8 +2387,8 @@ class SSOService:
 
         # Process role mappings for ALL providers
         for group in user_groups:
-            if group in role_mappings:
-                role_name = role_mappings[group]
+            role_name = lower_role_mappings.get(group.lower())
+            if role_name:
                 # Special case for "admin" shorthand or configured admin role name
                 if role_name in ["admin", settings.default_admin_role]:
                     role_assignments.append({"role_name": settings.default_admin_role, "scope": "global", "scope_id": None})

--- a/tests/unit/mcpgateway/services/test_sso_service.py
+++ b/tests/unit/mcpgateway/services/test_sso_service.py
@@ -754,6 +754,7 @@ class TestTokenExchange:
         assert auth_header.startswith("Basic ")
         # Verify it's valid base64
         import base64
+
         payload = auth_header[len("Basic "):]
         decoded = base64.b64decode(payload).decode("utf-8")
         assert decoded.startswith("test-client-id:")
@@ -809,6 +810,7 @@ class TestTokenExchange:
         header = sso_service._build_basic_auth_header("client@id", "secret:+?")
         assert header.startswith("Basic ")
         import base64
+
         payload = base64.b64decode(header[len("Basic "):]).decode("utf-8")
         assert payload == "client%40id:secret%3A%2B%3F"
 
@@ -1286,6 +1288,94 @@ class TestGetUserInfo:
         assert result["email"] == "user@kc.com"
         assert "admin" in result["groups"]
         assert "/team" in result["groups"]
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_keycloak_merges_realm_access_from_access_token_when_userinfo_succeeds(self, sso_service):
+        """Keycloak's default mappers only put realm_access/resource_access on the access_token
+        (userinfo.token.claim and id.token.claim default to false). Even when userinfo returns
+        200 and there's no id_token claim to fall back to, the gateway should still extract
+        roles by decoding the access_token it already received from the token endpoint."""
+        # Standard
+        import base64
+
+        # Third-Party
+        import orjson
+
+        user_response = MagicMock()
+        user_response.status_code = 200
+        user_response.json.return_value = {"email": "user@kc.com", "name": "KC User", "preferred_username": "kcuser", "sub": "kc-123"}
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=user_response)
+
+        provider = _make_provider(
+            id="keycloak",
+            name="keycloak",
+            provider_type="oidc",
+            provider_metadata={"map_realm_roles": True, "map_client_roles": True},
+        )
+
+        access_token_payload = orjson.dumps({"realm_access": {"roles": ["gateway-admin"]}, "resource_access": {"app": {"roles": ["edit"]}}})
+        access_token_payload_b64 = base64.urlsafe_b64encode(access_token_payload).decode().rstrip("=")
+        fake_access_token = f"eyJhbGciOiJSUzI1NiJ9.{access_token_payload_b64}.sig"
+
+        # No id_token / verified id_token claims at all - the bug surfaces even without
+        # the split-host fallback machinery being involved.
+        token_data = {"access_token": fake_access_token}
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client, patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_get_client.return_value = mock_client
+            mock_settings.sso_github_admin_orgs = []
+            result = await sso_service._get_user_info(provider, fake_access_token, token_data)
+
+        assert result is not None
+        assert result["provider"] == "keycloak"
+        assert "gateway-admin" in result["groups"]
+        assert "app:edit" in result["groups"]
+
+    @pytest.mark.asyncio
+    async def test_get_user_info_keycloak_fallback_merges_realm_access_from_access_token_when_id_token_lacks_it(self, sso_service):
+        """On the 401 + split-host fallback path, the id_token may itself lack realm_access
+        (same default-mapper gap as userinfo). The access_token, already in hand from the
+        token endpoint, should be decoded to fill in the missing roles."""
+        # Standard
+        import base64
+
+        # Third-Party
+        import orjson
+
+        fail_response = MagicMock()
+        fail_response.status_code = 401
+        fail_response.text = ""
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=fail_response)
+
+        provider = _make_provider(
+            id="keycloak",
+            name="keycloak",
+            provider_type="oidc",
+            provider_metadata={"map_realm_roles": True, "map_client_roles": False, "base_url": "http://keycloak:8080", "public_base_url": "http://localhost:8180"},
+        )
+
+        # id_token claims have no realm_access (matches Keycloak's default mapper config).
+        id_token_claims = {"sub": "kc-123", "email": "user@kc.com", "name": "KC User", "preferred_username": "kcuser"}
+
+        access_token_payload = orjson.dumps({"realm_access": {"roles": ["gateway-admin"]}})
+        access_token_payload_b64 = base64.urlsafe_b64encode(access_token_payload).decode().rstrip("=")
+        fake_access_token = f"eyJhbGciOiJSUzI1NiJ9.{access_token_payload_b64}.sig"
+
+        token_data = {"access_token": fake_access_token, "_verified_id_token_claims": id_token_claims}
+
+        with patch("mcpgateway.services.http_client_service.get_http_client", new_callable=AsyncMock) as mock_get_client, patch("mcpgateway.services.sso_service.settings") as mock_settings:
+            mock_get_client.return_value = mock_client
+            mock_settings.sso_github_admin_orgs = []
+            result = await sso_service._get_user_info(provider, fake_access_token, token_data)
+
+        assert result is not None
+        assert result["provider"] == "keycloak"
+        assert result["email"] == "user@kc.com"
+        assert "gateway-admin" in result["groups"]
 
     @pytest.mark.asyncio
     async def test_get_user_info_generic_oidc_merges_groups_from_id_token(self, sso_service):
@@ -2958,6 +3048,43 @@ class TestMapGroupsToRoles:
 
         assert len(result) == 1
         assert result[0]["role_name"] == "developer"
+
+    @pytest.mark.asyncio
+    async def test_role_mapping_matches_case_insensitively(self, sso_service):
+        """A group/role name whose casing differs from the configured role_mappings key
+        must still resolve. _should_user_be_admin() already matches case-insensitively;
+        _map_groups_to_roles() must do the same so is_admin and the RBAC role assignment
+        stay consistent (otherwise a user can get is_admin=True with no platform_admin
+        role row, or vice versa)."""
+        mock_role = SimpleNamespace(name="developer", scope="team", id="r1")
+        provider = _make_provider(provider_metadata={"role_mappings": {"Dev-Group": "developer"}})
+
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.role_service.RoleService") as MockRoleService:
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_default_role = None
+            mock_settings.sso_entra_role_mappings = {}
+            role_svc_instance = AsyncMock()
+            role_svc_instance.get_role_by_name = AsyncMock(return_value=mock_role)
+            MockRoleService.return_value = role_svc_instance
+            # IdP returned "dev-group" (lowercase), mapping key is "Dev-Group".
+            result = await sso_service._map_groups_to_roles("user@test.com", ["dev-group"], provider)
+
+        assert len(result) == 1
+        assert result[0]["role_name"] == "developer"
+
+    @pytest.mark.asyncio
+    async def test_admin_shorthand_matches_case_insensitively(self, sso_service):
+        """Same case-insensitivity guarantee for the 'admin'/default_admin_role shorthand path."""
+        provider = _make_provider(provider_metadata={"role_mappings": {"Gateway-Admin": "admin"}})
+        with patch("mcpgateway.services.sso_service.settings") as mock_settings, patch("mcpgateway.services.role_service.RoleService"):
+            mock_settings.sso_entra_admin_groups = []
+            mock_settings.sso_entra_default_role = None
+            mock_settings.sso_entra_role_mappings = {}
+            mock_settings.default_admin_role = "platform_admin"
+            # IdP returned the role with Keycloak-typical lowercase-hyphen casing.
+            result = await sso_service._map_groups_to_roles("user@test.com", ["gateway-admin"], provider)
+
+        assert any(r["role_name"] == "platform_admin" for r in result)
 
     @pytest.mark.asyncio
     async def test_entra_default_role_fallback(self, sso_service):
@@ -4707,6 +4834,7 @@ class TestADFSProvider:
     @pytest.mark.asyncio
     async def test_get_user_info_adfs_missing_id_token(self, sso_service):
         """ADFS provider raises error when id_token is missing."""
+        # First-Party
         from mcpgateway.services.sso_service import SSOProviderConfigError
 
         provider = _make_provider(id="adfs", name="adfs", provider_type="oidc")


### PR DESCRIPTION
## Summary

- Keycloak's built-in **realm roles** / **client roles** client-scope mappers default `access.token.claim=true` but `id.token.claim=userinfo.token.claim=false`. Since the gateway reads SSO claims from the userinfo response (falling back to `id_token` only on the documented split-host 401 case), `realm_access`/`resource_access` were silently absent on any stock Keycloak setup — even with `SSO_KEYCLOAK_ROLE_MAPPINGS` configured correctly and the right role assigned. New admins (or any role-mapped user) fell through to the default role.
- `_get_user_info()` / `_enrich_user_data_from_claims()` (`mcpgateway/services/sso_service.py`) now also decode the already-in-hand `access_token` and merge `realm_access`/`resource_access`/`groups` when missing from userinfo and id_token — fixes both the normal 200-OK path and the existing 401 split-host fallback.
- Fixed a related inconsistency in `_map_groups_to_roles()`: `role_mappings` lookups were case-sensitive while `_should_user_be_admin()` already matched case-insensitively. This could grant `is_admin=True` with no matching RBAC role row when IdP role casing differed from the configured mapping key.
- Updated the local Keycloak dev seed (`infra/keycloak/realm-export.json`) to explicitly enable `id_token`/`userinfo` claim inclusion on the realm/client role mappers, and documented the default-mapper gotcha in `docs/docs/manage/sso-keycloak-tutorial.md` (Step 4.4 + troubleshooting section).

Closes #5327. Both findings posted on the issue (https://github.com/IBM/mcp-context-forge/issues/5327#issuecomment-4756781399) are addressed by this PR.

## Config used to reproduce/verify locally

Local Docker Compose SSO stack (`make compose-sso` equivalent: `docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso up -d`):

- Gateway: `http://localhost:8080`, 3 replicas behind nginx
- Keycloak: `http://localhost:8180` (admin console `admin` / `changeme`)
- Realm: `mcp-gateway`, client: `mcp-gateway`
- `SSO_KEYCLOAK_BASE_URL=http://keycloak:8080`, `SSO_KEYCLOAK_PUBLIC_BASE_URL=http://localhost:8180`
- `SSO_KEYCLOAK_ROLE_MAPPINGS={"gateway-admin":"platform_admin","gateway-developer":"developer","gateway-viewer":"viewer"}`
- `SSO_KEYCLOAK_MAP_REALM_ROLES=true`, `SSO_KEYCLOAK_DEFAULT_ROLE=viewer`

## Test plan

- [x] `pytest tests/unit/mcpgateway/services/test_sso_service.py tests/unit/mcpgateway/services/test_sso_entra_role_mapping.py tests/unit/mcpgateway/services/test_sso_generic_oidc_role_mapping.py tests/unit/mcpgateway/services/test_sso_user_normalization.py tests/unit/mcpgateway/services/test_sso_admin_assignment.py tests/unit/mcpgateway/utils/test_sso_bootstrap.py tests/unit/mcpgateway/routers/test_sso_router.py tests/integration/test_sso_adfs_integration.py` — all pass, including 4 new regression tests added in this PR.
- [x] Manual end-to-end verification against a rebuilt local stack (fresh Keycloak volume re-imported with the updated mapper config, gateway image rebuilt from this branch):
  1. `docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso build gateway`
  2. Recreate Keycloak with a fresh volume so the updated `realm-export.json` mappers actually get imported (Keycloak's `--import-realm` won't retrofit mapper config onto an existing client):
     ```
     docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso stop keycloak gateway
     docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso rm -f keycloak
     docker volume rm mcp-context-forge_keycloakdata
     docker compose -f docker-compose.yml -f docker-compose.sso.yml --profile sso up -d keycloak gateway
     ```
  3. Create a fresh Keycloak user via the Admin REST API, assign it the `gateway-admin` realm role.
  4. Drive the real browser-facing OAuth flow: `GET /auth/sso/login/keycloak` -> Keycloak login form -> `GET /auth/sso/callback/keycloak`.
  5. Decode the resulting `jwt_token` cookie and call `GET /admin/overview/partial` (RBAC-gated, `allow_admin_bypass=False`) and `GET /admin/` with `Accept: text/html`.

  Before the fix: `scopes.permissions: []`, `/admin/overview/partial` -> `403 Admin privileges required`.
  After the fix: `scopes.permissions: ["*"]`, `/admin/overview/partial` -> `200`, `/admin/` -> `200`.