### PR TITLE
fix(admin-ui): improve modal and validation accessibility

### DIFF
--- a/mcpgateway/admin_ui/formValidation.js
+++ b/mcpgateway/admin_ui/formValidation.js
@@ -4,6 +4,72 @@
 
 import { validateInputName, validateUrl } from "./security.js";
 
+const errorClasses = [
+  "border-red-500",
+  "focus:ring-red-500",
+  "dark:border-red-500",
+  "dark:ring-red-500",
+];
+
+function ensureErrorId(field, errorMessageElement) {
+  if (!errorMessageElement) return null;
+  if (!errorMessageElement.id) {
+    const baseId = field.id || field.name || "field";
+    errorMessageElement.id = `${baseId}-error`;
+  }
+  return errorMessageElement.id;
+}
+
+function addDescribedBy(field, id) {
+  if (!id) return;
+  const currentIds = (field.getAttribute("aria-describedby") || "")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (!currentIds.includes(id)) {
+    currentIds.push(id);
+  }
+  field.setAttribute("aria-describedby", currentIds.join(" "));
+}
+
+function removeDescribedBy(field, id) {
+  if (!id) return;
+  const remainingIds = (field.getAttribute("aria-describedby") || "")
+    .split(/\s+/)
+    .filter((currentId) => currentId && currentId !== id);
+  if (remainingIds.length > 0) {
+    field.setAttribute("aria-describedby", remainingIds.join(" "));
+  } else {
+    field.removeAttribute("aria-describedby");
+  }
+}
+
+function showFieldError(field, errorMessageElement, message) {
+  field.setCustomValidity(message);
+  field.setAttribute("aria-invalid", "true");
+  field.classList.add(...errorClasses);
+
+  if (errorMessageElement) {
+    const errorId = ensureErrorId(field, errorMessageElement);
+    errorMessageElement.innerText = message;
+    errorMessageElement.setAttribute("role", "status");
+    errorMessageElement.setAttribute("aria-live", "polite");
+    errorMessageElement.classList.remove("invisible");
+    addDescribedBy(field, errorId);
+  }
+}
+
+function clearFieldError(field, errorMessageElement) {
+  field.setCustomValidity("");
+  field.setAttribute("aria-invalid", "false");
+  field.classList.remove(...errorClasses);
+
+  if (errorMessageElement) {
+    const errorId = ensureErrorId(field, errorMessageElement);
+    errorMessageElement.classList.add("invisible");
+    removeDescribedBy(field, errorId);
+  }
+}
+
 export const setupFormValidation = function () {
   // Add validation to all forms on the page
   const forms = document.querySelectorAll("form");
@@ -38,29 +104,10 @@ export const setupFormValidation = function () {
           inputLabel?.innerText,
         );
         if (!validation.valid) {
-          this.setCustomValidity(validation.error);
-          this.classList.add(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
-          if (errorMessageElement) {
-            errorMessageElement.innerText = validation.error;
-            errorMessageElement.classList.remove("invisible");
-          }
+          showFieldError(this, errorMessageElement, validation.error);
         } else {
-          this.setCustomValidity("");
+          clearFieldError(this, errorMessageElement);
           this.value = validation.value;
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
-          if (errorMessageElement) {
-            errorMessageElement.classList.add("invisible");
-          }
         }
       });
     });
@@ -73,19 +120,10 @@ export const setupFormValidation = function () {
       field.addEventListener("blur", function () {
         // Skip validation for empty optional URL fields
         if (!this.value && !this.required) {
-          this.setCustomValidity("");
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
           const errorMessageElement = this.parentNode?.querySelector(
             'p[data-error-message-for="url"]',
           );
-          if (errorMessageElement) {
-            errorMessageElement.classList.add("invisible");
-          }
+          clearFieldError(this, errorMessageElement);
           return;
         }
         const parentNode = this.parentNode;
@@ -100,29 +138,10 @@ export const setupFormValidation = function () {
           inputLabel?.innerText,
         );
         if (!validation.valid) {
-          this.setCustomValidity(validation.error);
-          this.classList.add(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
-          if (errorMessageElement) {
-            errorMessageElement.innerText = validation.error;
-            errorMessageElement.classList.remove("invisible");
-          }
+          showFieldError(this, errorMessageElement, validation.error);
         } else {
-          this.setCustomValidity("");
+          clearFieldError(this, errorMessageElement);
           this.value = validation.value;
-          this.classList.remove(
-            "border-red-500",
-            "focus:ring-red-500",
-            "dark:border-red-500",
-            "dark:ring-red-500",
-          );
-          if (errorMessageElement) {
-            errorMessageElement.classList.add("invisible");
-          }
         }
       });
     });

--- a/mcpgateway/admin_ui/modals.js
+++ b/mcpgateway/admin_ui/modals.js
@@ -12,6 +12,58 @@ import { resetEditSelections } from "./servers.js";
 import { cleanupToolTestModal } from "./tools.js";
 import { getCookie, safeGetElement } from "./utils.js";
 
+const modalOpeners = new Map();
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function ensureModalAccessibility(modal, modalId) {
+  if (!modal.hasAttribute("role")) {
+    modal.setAttribute("role", "dialog");
+  }
+  modal.setAttribute("aria-modal", "true");
+
+  if (!modal.hasAttribute("aria-labelledby") && !modal.hasAttribute("aria-label")) {
+    const heading = modal.querySelector("h1, h2, h3, h4, h5, h6");
+    if (heading) {
+      if (!heading.id) {
+        heading.id = `${modalId}-title`;
+      }
+      modal.setAttribute("aria-labelledby", heading.id);
+    } else {
+      modal.setAttribute("aria-label", modalId.replace(/-/g, " "));
+    }
+  }
+}
+
+function focusModal(modal) {
+  const focusTarget = modal.querySelector(focusableSelector) || modal;
+  if (focusTarget === modal && !modal.hasAttribute("tabindex")) {
+    modal.setAttribute("tabindex", "-1");
+  }
+  focusTarget.focus({ preventScroll: true });
+}
+
+function rememberModalOpener(modalId) {
+  const activeElement = document.activeElement;
+  if (activeElement && activeElement !== document.body) {
+    modalOpeners.set(modalId, activeElement);
+  }
+}
+
+function restoreModalOpener(modalId) {
+  const opener = modalOpeners.get(modalId);
+  modalOpeners.delete(modalId);
+  if (opener?.isConnected && typeof opener.focus === "function") {
+    opener.focus({ preventScroll: true });
+  }
+}
+
 export function openModal(modalId) {
   try {
     if (AppState.isModalActive(modalId)) {
@@ -31,8 +83,11 @@ export function openModal(modalId) {
       resetModalState(modalId);
     }
 
+    ensureModalAccessibility(modal, modalId);
+    rememberModalOpener(modalId);
     modal.classList.remove("hidden");
     AppState.setModalActive(modalId);
+    focusModal(modal);
 
     console.log(`✓ Opened modal: ${modalId}`);
   } catch (error) {
@@ -78,6 +133,7 @@ export function closeModal(modalId, clearId = null) {
     // Always executes — modal hides even if cleanup failed
     modal.classList.add("hidden");
     AppState.setModalInactive(modalId);
+    restoreModalOpener(modalId);
 
     console.log(`✓ Closed modal: ${modalId}`);
   } catch (error) {
@@ -182,12 +238,16 @@ export const showCopyableModal = function (title, message, type = "info") {
   overlay.onclick = (e) => {
     if (e.target === overlay) {
       overlay.remove();
+      restoreModalOpener("copyable-modal-overlay");
     }
   };
 
   // Create modal content
   const modal = document.createElement("div");
   modal.className = `${colorScheme.bg} border-l-4 ${colorScheme.border} rounded-lg shadow-xl max-w-lg w-full mx-4 overflow-hidden`;
+  modal.setAttribute("role", "dialog");
+  modal.setAttribute("aria-modal", "true");
+  modal.setAttribute("aria-labelledby", "copyable-modal-title");
 
   modal.innerHTML = `
     <div class="p-4">
@@ -196,7 +256,7 @@ export const showCopyableModal = function (title, message, type = "info") {
           ${colorScheme.icon}
         </div>
         <div class="ml-3 flex-1">
-          <h3 class="text-lg font-medium ${colorScheme.title}">${escapeHtml(title)}</h3>
+          <h3 id="copyable-modal-title" class="text-lg font-medium ${colorScheme.title}">${escapeHtml(title)}</h3>
           <div class="mt-2">
             <pre id="copyable-modal-content" class="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono bg-white dark:bg-gray-800 p-3 rounded border border-gray-200 dark:border-gray-600 max-h-64 overflow-auto select-all cursor-text">${escapeHtml(message)}</pre>
           </div>
@@ -217,10 +277,15 @@ export const showCopyableModal = function (title, message, type = "info") {
   `;
 
   overlay.appendChild(modal);
+  rememberModalOpener("copyable-modal-overlay");
   document.body.appendChild(overlay);
+  focusModal(modal);
 
   // Add event listeners
-  safeGetElement("copyable-modal-close").onclick = () => overlay.remove();
+  safeGetElement("copyable-modal-close").onclick = () => {
+    overlay.remove();
+    restoreModalOpener("copyable-modal-overlay");
+  };
 
   safeGetElement("copyable-modal-copy").onclick = async () => {
     const content = safeGetElement("copyable-modal-content");
@@ -249,6 +314,7 @@ export const showCopyableModal = function (title, message, type = "info") {
   const handleEscape = (e) => {
     if (e.key === "Escape") {
       overlay.remove();
+      restoreModalOpener("copyable-modal-overlay");
       document.removeEventListener("keydown", handleEscape);
     }
   };

--- a/tests/unit/js/formValidation.test.js
+++ b/tests/unit/js/formValidation.test.js
@@ -74,7 +74,12 @@ describe("setupFormValidation", () => {
     nameField.dispatchEvent(new Event("blur"));
 
     expect(nameField.classList.contains("border-red-500")).toBe(true);
+    expect(nameField.getAttribute("aria-invalid")).toBe("true");
     const errorMsg = document.querySelector('[data-error-message-for="name"]');
+    expect(errorMsg.id).toBe("test-name-error");
+    expect(errorMsg.getAttribute("role")).toBe("status");
+    expect(errorMsg.getAttribute("aria-live")).toBe("polite");
+    expect(nameField.getAttribute("aria-describedby")).toContain("test-name-error");
     expect(errorMsg.classList.contains("invisible")).toBe(false);
   });
 
@@ -83,8 +88,9 @@ describe("setupFormValidation", () => {
       <form>
         <div>
           <label for="test-name">Name</label>
-          <input id="test-name" name="name" value="" class="border-red-500" />
-          <p data-error-message-for="name">Old error</p>
+          <input id="test-name" name="name" value="" class="border-red-500" aria-invalid="true" aria-describedby="test-name-help test-name-error" />
+          <p id="test-name-help">Use a unique name.</p>
+          <p id="test-name-error" data-error-message-for="name">Old error</p>
         </div>
       </form>
     `;
@@ -96,6 +102,8 @@ describe("setupFormValidation", () => {
     nameField.dispatchEvent(new Event("blur"));
 
     expect(nameField.classList.contains("border-red-500")).toBe(false);
+    expect(nameField.getAttribute("aria-invalid")).toBe("false");
+    expect(nameField.getAttribute("aria-describedby")).toBe("test-name-help");
     const errorMsg = document.querySelector('[data-error-message-for="name"]');
     expect(errorMsg.classList.contains("invisible")).toBe(true);
   });
@@ -138,6 +146,10 @@ describe("setupFormValidation", () => {
     urlField.dispatchEvent(new Event("blur"));
 
     expect(urlField.classList.contains("border-red-500")).toBe(true);
+    expect(urlField.getAttribute("aria-invalid")).toBe("true");
+    const errorMsg = document.querySelector('[data-error-message-for="url"]');
+    expect(errorMsg.id).toBe("test-url-error");
+    expect(urlField.getAttribute("aria-describedby")).toContain("test-url-error");
   });
 
   test("skips empty optional URL fields", () => {

--- a/tests/unit/js/modals.test.js
+++ b/tests/unit/js/modals.test.js
@@ -74,6 +74,31 @@ describe("openModal", () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("not found"));
     errorSpy.mockRestore();
   });
+
+  test("adds dialog semantics and moves focus into the modal", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const opener = document.createElement("button");
+    opener.textContent = "Open";
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const modal = document.createElement("div");
+    modal.id = "test-modal";
+    modal.classList.add("hidden");
+    modal.innerHTML = `
+      <h2 id="test-modal-title">Edit gateway</h2>
+      <input id="modal-name" />
+    `;
+    document.body.appendChild(modal);
+
+    openModal("test-modal");
+
+    expect(modal.getAttribute("role")).toBe("dialog");
+    expect(modal.getAttribute("aria-modal")).toBe("true");
+    expect(modal.getAttribute("aria-labelledby")).toBe("test-modal-title");
+    expect(document.activeElement).toBe(document.getElementById("modal-name"));
+    consoleSpy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -114,6 +139,27 @@ describe("closeModal", () => {
     closeModal("nonexistent");
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("not found"));
     errorSpy.mockRestore();
+  });
+
+  test("restores focus to the opener when the modal closes", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const opener = document.createElement("button");
+    opener.textContent = "Open";
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const modal = document.createElement("div");
+    modal.id = "test-modal";
+    modal.classList.add("hidden");
+    modal.innerHTML = `<button id="close-button">Close</button>`;
+    document.body.appendChild(modal);
+
+    openModal("test-modal");
+    expect(document.activeElement).toBe(document.getElementById("close-button"));
+
+    closeModal("test-modal");
+    expect(document.activeElement).toBe(opener);
+    consoleSpy.mockRestore();
   });
 });
 
@@ -173,6 +219,16 @@ describe("showCopyableModal", () => {
     expect(overlay).not.toBeNull();
     expect(overlay.innerHTML).toContain("Test Title");
     expect(overlay.innerHTML).toContain("Test message content");
+  });
+
+  test("creates an accessible dialog and focuses its first control", () => {
+    showCopyableModal("Test Title", "Test message content", "info");
+    const dialog = document.querySelector("#copyable-modal-overlay [role='dialog']");
+
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("copyable-modal-title");
+    expect(document.activeElement).toBe(document.getElementById("copyable-modal-copy"));
   });
 
   test("removes existing modal before creating new one", () => {


### PR DESCRIPTION
## Summary

This is a scoped follow-up for #2274 focused on shared Admin UI accessibility helpers rather than the full WCAG epic.

It improves two repeated patterns:

- modal helpers now add dialog semantics, label dialogs from their headings where possible, move focus into the modal, and restore focus to the opener on close
- shared form validation now exposes invalid state programmatically with `aria-invalid` and connects visible validation messages to fields via `aria-describedby`

The copyable-content modal generated in JavaScript also now renders as a labelled modal dialog and receives initial focus.

## Testing

- `npm test -- tests/unit/js/modals.test.js tests/unit/js/formValidation.test.js`
- `npm test -- tests/unit/js`
- `git diff --check`
- `make lint-web` *(completed with existing environment/audit warnings: `uvx` is not installed for nodejsscan, and npm audit reports existing dependency advisories for @babel/core, js-yaml, and undici)*

## Notes

This does not claim full WCAG 2.1 AA compliance for the Admin UI. Runtime screen-reader and keyboard walkthrough testing would still be needed for the broader epic.

Closes none; contributes to #2274.
