### PR TITLE
Fix/wheels amd64 arm64 pypi only

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -102,6 +102,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          version: latest
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -215,6 +217,8 @@ jobs:
       - name: Set up Docker Buildx
         if: github.event_name != 'pull_request' || matrix.build_on_pr
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          version: latest
 
       # Login is needed both for pushing the final image (push/workflow_dispatch)
       # and for probing the wheel-image registry below.
@@ -329,6 +333,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          version: latest
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3

--- a/Containerfile.lite
+++ b/Containerfile.lite
@@ -47,9 +47,9 @@ ARG ENABLE_PROFILING=false
 #     --build-arg NODEJS_IMAGE=<internal-registry>/ubi9/nodejs-20:latest \
 #     --build-arg UBI_MINIMAL=<internal-registry>/ubi9/ubi-minimal:latest \
 #     .
-ARG UBI_BASE=registry.access.redhat.com/ubi10:1780550950
-ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:1780432202
-ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:1780550884
+ARG UBI_BASE=registry.access.redhat.com/ubi10:1781510254
+ARG NODEJS_IMAGE=registry.access.redhat.com/ubi10/nodejs-24:1781700998
+ARG UBI_MINIMAL=registry.access.redhat.com/ubi10/ubi-minimal:1781509581
 # Wheel closure stage — used only for s390x and ppc64le where PyPI manylinux
 # binary wheels are unavailable (tiktoken/psycopg/cryptography require native
 # compilation, and psycopg-binary has no s390x wheel at all).


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

---

## 📝 Summary

Two maintenance changes to `docker-multiplatform.yml` and `Containerfile.lite`:

**1. Pin `docker/setup-buildx-action` to `version: latest`**

All three `setup-buildx-action` steps (in the `wheels`, `build`, and `manifest` jobs) previously ran without a pinned buildx version. The action then pulls `moby/buildkit:buildx-stable-1` from Docker Hub at runtime, which is subject to anonymous pull rate limits. Pinning `version: latest` makes the action download the buildx binary from GitHub Releases instead, bypassing Docker Hub entirely.

**2. Bump UBI base image digests**

| Image | Old digest | New digest |
|---|---|---|
| `ubi10` | `1780550950` | `1781510254` |
| `ubi10/nodejs-24` | `1780432202` | `1781700998` |
| `ubi10/ubi-minimal` | `1780550884` | `1781509581` |

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)