### PR TITLE
fix(oauth): raise gateway OAuth callback code max_length for Microsoft Entra work-account codes

### DIFF
--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -522,7 +522,7 @@ async def oauth_callback(
     #   validation.
     # - `error` is a small, well-defined RFC 6749 Section 4.1.2.1 enum-like value.
     # - `error_description` is human-readable free text per RFC 6749 Section 5.2.
-    code: Annotated[str | None, Query(max_length=2048, description="Authorization code from OAuth provider")] = None,
+    code: Annotated[str | None, Query(max_length=16384, description="Authorization code from OAuth provider (Microsoft Entra work-account codes exceed 2 KB)")] = None,
     state: Annotated[str | None, Query(max_length=2048, description="State parameter for CSRF protection")] = None,
     error: QueryErrorCode = None,
     error_description: Annotated[str | None, Query(max_length=500, description="OAuth provider error description")] = None,


### PR DESCRIPTION
## 🔗 Related Issue

No existing issue tracks the **gateway federation** callback specifically. This is the sibling of #4490, which fixed the same Microsoft Entra ">2 KB authorization code" problem for the **SSO login** callback; the gateway OAuth callback is still capped at 2048 on `main`. Glad to file a tracking issue if you'd prefer one.

---

## 📝 Summary

The gateway OAuth callback (`mcpgateway/routers/oauth_router.py::oauth_callback`) caps the `code` query parameter at `max_length=2048`. Microsoft Entra **work / organization** account authorization codes routinely exceed 2 KB, so the callback rejects them with HTTP 422 (`string_too_long`) **before** the token exchange — gateway authorization never completes. Consumer (personal) Microsoft account codes are shorter, which masks the issue in most testing.

Raise the `code` cap from 2048 → 16384 (the `state` / `error` params are unchanged):

```diff
-    code: Annotated[str | None, Query(max_length=2048, description="Authorization code from OAuth provider")] = None,
+    code: Annotated[str | None, Query(max_length=16384, description="Authorization code from OAuth provider (Microsoft Entra work-account codes exceed 2 KB)")] = None,
```

16384 comfortably covers observed Entra work-account codes while still bounding the input. Happy to align the exact value with whatever the SSO callback landed on (#4490) for consistency.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate — not included; glad to add a boundary test for the new limit if desired

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

Reproduced against a real Microsoft Entra (work-tenant) `authorization_code` gateway:

- **Before:** a >2 KB authorization `code` returns HTTP 422 (`string_too_long`) at the callback, before token exchange.
- **After:** the callback accepts the code and the token exchange proceeds; the gateway authorizes successfully.

`make lint` / `make test` not run in this environment.

---

## ✅ Checklist

- [x] Code formatted (matches surrounding style; single-line change)
- [ ] Tests added/updated — see note above
- [ ] Documentation updated (n/a — internal request-validation limit)
- [x] No secrets or credentials committed

---

## 📓 Notes

One-line change; `state` and `error` query params intentionally left at their existing limits.
