### PR TITLE
 bugfix/5325-render-prompt-csrf-token-invalid

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-18T13:53:55Z",
+  "generated_at": "2026-06-30T16:06:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5072,7 +5072,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11421,
+        "line_number": 11569,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5080,7 +5080,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17838,
+        "line_number": 17986,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-30T16:06:55Z",
+  "generated_at": "2026-06-30T16:11:27Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -153,6 +153,7 @@ from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.catalog_service import catalog_service
 from mcpgateway.services.content_security import ContentSizeError, ContentTypeError, TemplateValidationError
+from mcpgateway.services.csrf_service import clear_csrf_cookie, get_csrf_service
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.services.export_service import ExportError, ExportService
@@ -1671,9 +1672,7 @@ def _set_admin_csrf_cookie(request: Request, response: Response, user_id: str | 
     Returns:
         CSRF token value stored in the response cookie.
     """
-    if user_id and session_id:
-        from mcpgateway.services.csrf_service import get_csrf_service
-
+    if user_id is not None and session_id is not None:
         csrf_token = get_csrf_service().generate_csrf_token(user_id=user_id, session_id=session_id)
     else:
         existing_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
@@ -4155,7 +4154,7 @@ async def admin_ui(
     try:
         # Determine the admin user email
         admin_email = get_user_email(user)
-        is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else True)
+        is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else getattr(user, "is_admin", False))
         full_name = getattr(settings, "platform_admin_full_name", "Platform User")
         if isinstance(user, dict):
             full_name = user.get("full_name") or full_name
@@ -4193,8 +4192,11 @@ async def admin_ui(
                         auth_provider = "keycloak"
 
         # Generate a lightweight session JWT token
-        email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
-        sub_claim = str(email_user.id) if email_user else admin_email
+        if settings.email_auth_enabled:
+            email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
+            sub_claim = str(email_user.id) if email_user else admin_email
+        else:
+            sub_claim = admin_email
         jwt_jti = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
         payload = {
@@ -4214,13 +4216,13 @@ async def admin_ui(
 
         # Set HTTP-only cookie using centralized security cookie utility
         set_auth_cookie(response, token, remember_me=False)
-        LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
+        LOGGER.debug("Set session JWT token cookie for user: %s", admin_email)
 
         # Capture user/session identifiers for HMAC-bound CSRF cookie
         csrf_user_id = sub_claim
         csrf_session_id = jwt_jti
     except Exception as e:
-        LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
+        LOGGER.error("Failed to set JWT token cookie for user %s: %s — CSRF protection degraded (falling back to random token)", get_user_email(user), e)
 
     cookie_action = ui_visibility_config.get("cookie_action")
     if cookie_action:
@@ -4915,9 +4917,6 @@ async def _admin_logout(request: Request) -> Response:
     clear_auth_cookie(response)
 
     # Clear CSRF token cookie
-    # First-Party
-    from mcpgateway.services.csrf_service import clear_csrf_cookie
-
     clear_csrf_cookie(response, settings)
 
     use_secure = (settings.environment == "production") or settings.secure_cookies

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -1655,18 +1655,29 @@ def _request_origin_matches(request: Request) -> bool:
     return False
 
 
-def _set_admin_csrf_cookie(request: Request, response: Response) -> str:
+def _set_admin_csrf_cookie(request: Request, response: Response, user_id: str | None = None, session_id: str | None = None) -> str:
     """Set or refresh admin CSRF cookie and return token value.
+
+    When user_id and session_id are both provided, generates an HMAC-bound
+    CSRF token that the global CSRFMiddleware can validate. Otherwise falls
+    back to a random token (suitable for anonymous/unauthenticated pages).
 
     Args:
         request: Incoming request used for existing token and path scoping.
         response: Outgoing response where the cookie will be written.
+        user_id: User identifier for HMAC-bound token generation.
+        session_id: Session identifier for HMAC-bound token generation.
 
     Returns:
         CSRF token value stored in the response cookie.
     """
-    existing_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
-    csrf_token = existing_token if isinstance(existing_token, str) and len(existing_token) >= 32 else secrets.token_urlsafe(32)
+    if user_id and session_id:
+        from mcpgateway.services.csrf_service import get_csrf_service
+
+        csrf_token = get_csrf_service().generate_csrf_token(user_id=user_id, session_id=session_id)
+    else:
+        existing_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
+        csrf_token = existing_token if isinstance(existing_token, str) and len(existing_token) >= 32 else secrets.token_urlsafe(32)
 
     use_secure = (settings.environment == "production") or settings.secure_cookies
     max_age = max(300, int(getattr(settings, "token_expiry", 60)) * 60)
@@ -4137,74 +4148,79 @@ async def admin_ui(
         },
     )
 
-    # Set JWT token cookie for HTMX requests if email auth is enabled
-    if getattr(settings, "email_auth_enabled", False):
-        try:
-            # JWT library is imported at top level as jwt
+    # Set JWT token cookie for HTMX requests so the CSRF middleware can
+    # derive user_id/session_id from the JWT for subsequent non-GET requests.
+    csrf_user_id = None
+    csrf_session_id = None
+    try:
+        # Determine the admin user email
+        admin_email = get_user_email(user)
+        is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else True)
+        full_name = getattr(settings, "platform_admin_full_name", "Platform User")
+        if isinstance(user, dict):
+            full_name = user.get("full_name") or full_name
+        else:
+            full_name = getattr(user, "full_name", full_name) or full_name
 
-            # Determine the admin user email
-            admin_email = get_user_email(user)
-            is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else True)
-            full_name = getattr(settings, "platform_admin_full_name", "Platform User")
-            if isinstance(user, dict):
-                full_name = user.get("full_name") or full_name
-            else:
-                full_name = getattr(user, "full_name", full_name) or full_name
+        # Preserve auth provider across admin UI token refreshes so logout behavior
+        # can reliably detect SSO sessions (e.g., Keycloak) later.
+        auth_provider = "local"
+        if isinstance(user, dict):
+            provider_from_user = user.get("auth_provider")
+            if isinstance(provider_from_user, str) and provider_from_user.strip():
+                auth_provider = provider_from_user.strip()
+        else:
+            provider_from_user = getattr(user, "auth_provider", None)
+            if isinstance(provider_from_user, str) and provider_from_user.strip():
+                auth_provider = provider_from_user.strip()
 
-            # Preserve auth provider across admin UI token refreshes so logout behavior
-            # can reliably detect SSO sessions (e.g., Keycloak) later.
-            auth_provider = "local"
-            if isinstance(user, dict):
-                provider_from_user = user.get("auth_provider")
-                if isinstance(provider_from_user, str) and provider_from_user.strip():
-                    auth_provider = provider_from_user.strip()
-            else:
-                provider_from_user = getattr(user, "auth_provider", None)
-                if isinstance(provider_from_user, str) and provider_from_user.strip():
-                    auth_provider = provider_from_user.strip()
+        # get_current_user_with_permissions may not include auth_provider in its dict.
+        # Fall back to the current jwt_token cookie payload before refreshing it.
+        if auth_provider == "local":
+            jwt_cookie = request.cookies.get("jwt_token")
+            if isinstance(jwt_cookie, str) and jwt_cookie:
+                try:
+                    existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
+                    existing_user = existing_payload.get("user")
+                    provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
+                    if not provider_from_token:
+                        provider_from_token = existing_payload.get("auth_provider")
+                    if isinstance(provider_from_token, str) and provider_from_token.strip():
+                        auth_provider = provider_from_token.strip()
+                except Exception as provider_error:  # nosec B110 - best-effort provider preservation
+                    LOGGER.warning("Could not resolve auth_provider from existing JWT cookie; SSO logout may not function correctly: %s", provider_error)
+                    if settings.sso_keycloak_enabled:
+                        auth_provider = "keycloak"
 
-            # get_current_user_with_permissions may not include auth_provider in its dict.
-            # Fall back to the current jwt_token cookie payload before refreshing it.
-            if auth_provider == "local":
-                jwt_cookie = request.cookies.get("jwt_token")
-                if isinstance(jwt_cookie, str) and jwt_cookie:
-                    try:
-                        existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
-                        existing_user = existing_payload.get("user")
-                        provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
-                        if not provider_from_token:
-                            provider_from_token = existing_payload.get("auth_provider")
-                        if isinstance(provider_from_token, str) and provider_from_token.strip():
-                            auth_provider = provider_from_token.strip()
-                    except Exception as provider_error:  # nosec B110 - best-effort provider preservation
-                        LOGGER.warning("Could not resolve auth_provider from existing JWT cookie; SSO logout may not function correctly: %s", provider_error)
-                        if settings.sso_keycloak_enabled:
-                            auth_provider = "keycloak"
+        # Generate a lightweight session JWT token
+        email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
+        sub_claim = str(email_user.id) if email_user else admin_email
+        jwt_jti = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        payload = {
+            "sub": sub_claim,
+            "iss": settings.jwt_issuer,
+            "aud": settings.jwt_audience,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=settings.token_expiry)).timestamp()),
+            "jti": jwt_jti,
+            "auth_provider": auth_provider,
+            "token_use": "session",  # nosec B105 - token type marker, not a password
+            "scopes": {"server_id": None, "permissions": ["*"] if is_admin_flag else [], "ip_restrictions": [], "time_restrictions": {}},
+        }
 
-            # Generate a lightweight session JWT token
-            email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
-            sub_claim = str(email_user.id) if email_user else admin_email
-            now = datetime.now(timezone.utc)
-            payload = {
-                "sub": sub_claim,
-                "iss": settings.jwt_issuer,
-                "aud": settings.jwt_audience,
-                "iat": int(now.timestamp()),
-                "exp": int((now + timedelta(minutes=settings.token_expiry)).timestamp()),
-                "jti": str(uuid.uuid4()),
-                "auth_provider": auth_provider,
-                "token_use": "session",  # nosec B105 - token type marker, not a password
-                "scopes": {"server_id": None, "permissions": ["*"] if is_admin_flag else [], "ip_restrictions": [], "time_restrictions": {}},
-            }
+        # Generate token using centralized token creation
+        token = await create_jwt_token(payload)
 
-            # Generate token using centralized token creation
-            token = await create_jwt_token(payload)
+        # Set HTTP-only cookie using centralized security cookie utility
+        set_auth_cookie(response, token, remember_me=False)
+        LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
 
-            # Set HTTP-only cookie using centralized security cookie utility
-            set_auth_cookie(response, token, remember_me=False)
-            LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
-        except Exception as e:
-            LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
+        # Capture user/session identifiers for HMAC-bound CSRF cookie
+        csrf_user_id = sub_claim
+        csrf_session_id = jwt_jti
+    except Exception as e:
+        LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
 
     cookie_action = ui_visibility_config.get("cookie_action")
     if cookie_action:
@@ -4231,7 +4247,7 @@ async def admin_ui(
                 samesite=samesite,
             )
 
-    _set_admin_csrf_cookie(request, response)
+    _set_admin_csrf_cookie(request, response, user_id=csrf_user_id, session_id=csrf_session_id)
     return response
 
 

--- a/mcpgateway/middleware/auth_middleware.py
+++ b/mcpgateway/middleware/auth_middleware.py
@@ -288,7 +288,7 @@ class AuthContextMiddleware(BaseHTTPMiddleware):
                         # Match if referer host matches request host and path contains /admin or /oauth/callback
                         if referer_parsed.netloc == request_host and ("/admin" in referer_parsed.path or "/oauth/callback" in referer_parsed.path):
                             is_same_origin_referer = True
-                    except Exception: # noqa: BLE001  # nosec B110
+                    except Exception:  # noqa: BLE001  # nosec B110
                         pass  # Invalid referer URL, treat as not same-origin
 
                 is_browser = "text/html" in accept_header or is_htmx or is_same_origin_referer

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -3749,14 +3749,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             claim_filter = or_(DbGateway.lifecycle_claim_expires_at.is_(None), DbGateway.lifecycle_claim_expires_at <= now)
             deleting_ids = db.execute(select(DbGateway.id).where(DbGateway.status == "deleting").where(claim_filter)).scalars().all()
             pending_ids = (
-                db.execute(
-                    select(DbGateway.id)
-                    .where(DbGateway.status == "pending")
-                    .where(or_(DbGateway.next_retry_at.is_(None), DbGateway.next_retry_at <= now))
-                    .where(claim_filter)
-                )
-                .scalars()
-                .all()
+                db.execute(select(DbGateway.id).where(DbGateway.status == "pending").where(or_(DbGateway.next_retry_at.is_(None), DbGateway.next_retry_at <= now)).where(claim_filter)).scalars().all()
             )
         return [*deleting_ids, *(f"pending:{gateway_id}" for gateway_id in pending_ids)]
 
@@ -4933,6 +4926,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         while True:
             try:
                 if self._redis_client and settings.cache_type == "redis":
+
                     async def require_redis_leader() -> bool:
                         """Check for redis leader"""
                         current_leader = await self._redis_client.get(self._leader_key)
@@ -5572,9 +5566,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         stale_resource_ids = []
         if not skip_stale_cleanup and catalog_sync.new_resource_uris is not None:
-            stale_resource_ids = [
-                resource.id for resource in gateway.resources if resource.uri not in catalog_sync.new_resource_uris and _created_via_allowed(getattr(resource, "created_via", None))
-            ]
+            stale_resource_ids = [resource.id for resource in gateway.resources if resource.uri not in catalog_sync.new_resource_uris and _created_via_allowed(getattr(resource, "created_via", None))]
             if stale_resource_ids:
                 for i in range(0, len(stale_resource_ids), 500):
                     chunk = stale_resource_ids[i : i + 500]
@@ -5585,9 +5577,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
 
         stale_prompt_ids = []
         if not skip_stale_cleanup and catalog_sync.new_prompt_names is not None:
-            stale_prompt_ids = [
-                prompt.id for prompt in gateway.prompts if prompt.original_name not in catalog_sync.new_prompt_names and _created_via_allowed(getattr(prompt, "created_via", None))
-            ]
+            stale_prompt_ids = [prompt.id for prompt in gateway.prompts if prompt.original_name not in catalog_sync.new_prompt_names and _created_via_allowed(getattr(prompt, "created_via", None))]
             if stale_prompt_ids:
                 for i in range(0, len(stale_prompt_ids), 500):
                     chunk = stale_prompt_ids[i : i + 500]
@@ -5601,13 +5591,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         if not skip_stale_cleanup:
             gateway.tools = [tool for tool in gateway.tools if tool.original_name in catalog_sync.new_tool_names or not _created_via_allowed(getattr(tool, "created_via", None))]
             if catalog_sync.new_resource_uris is not None:
-                gateway.resources = [
-                    resource for resource in gateway.resources if resource.uri in catalog_sync.new_resource_uris or not _created_via_allowed(getattr(resource, "created_via", None))
-                ]
+                gateway.resources = [resource for resource in gateway.resources if resource.uri in catalog_sync.new_resource_uris or not _created_via_allowed(getattr(resource, "created_via", None))]
             if catalog_sync.new_prompt_names is not None:
-                gateway.prompts = [
-                    prompt for prompt in gateway.prompts if prompt.original_name in catalog_sync.new_prompt_names or not _created_via_allowed(getattr(prompt, "created_via", None))
-                ]
+                gateway.prompts = [prompt for prompt in gateway.prompts if prompt.original_name in catalog_sync.new_prompt_names or not _created_via_allowed(getattr(prompt, "created_via", None))]
 
         tools_removed = len(stale_tool_ids)
         resources_removed = len(stale_resource_ids)

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -260,7 +260,7 @@ def _get_gateway_lifecycle_pending_registration_attempts_gauge():
 def _collect_gateway_lifecycle_metrics() -> tuple[dict[str, int], int, int]:
     """Collect aggregate lifecycle metrics from gateway rows."""
     # First-Party
-    from mcpgateway.db import Gateway, fresh_db_session  # pylint: disable=import-outside-toplevel
+    from mcpgateway.db import fresh_db_session, Gateway  # pylint: disable=import-outside-toplevel
 
     lifecycle_counts = {"pending": 0, "active": 0, "deleting": 0}
     pending_due_count = 0

--- a/mcpgateway/tools/builder/build_hooks.py
+++ b/mcpgateway/tools/builder/build_hooks.py
@@ -9,11 +9,13 @@ This hook runs during `python -m build` to ensure bundle-*.js and tailwind.min.c
 are generated and included in the wheel/sdist, without requiring them to be committed to git.
 """
 
+# Standard
 import logging
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
+# Third-Party
 from setuptools.command.build_py import build_py
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,7 @@ class BuildPyWithUI(build_py):
 
     def run(self):
         """Run UI build before standard build_py."""
+        # Standard
         import os
 
         # Only run npm build when explicitly requested via BUILD_UI_ASSETS=true.

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -58,6 +58,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     _parse_tag_filter_groups,
     _read_request_json,
     _render_user_card_html,
+    _set_admin_csrf_cookie,
     _validated_team_id_param,
     admin_a2a_partial_html,
     admin_activate_user,
@@ -5421,6 +5422,153 @@ class TestAdminUIRoute:
         assert isinstance(response, HTMLResponse)
         context = mock_request.app.state.templates.TemplateResponse.call_args[0][2]
         assert any(t.get("team_id") == "team-1" for t in context["tools"])
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_csrf_with_email_auth_disabled(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """HMAC-bound CSRF token should be issued when email_auth_enabled=False (the original #5325 bug)."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+
+        monkeypatch.setattr(settings, "email_auth_enabled", False, raising=False)
+
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "a" * 64
+
+        with patch("mcpgateway.admin.get_csrf_service", return_value=mock_csrf_service):
+            response = await admin_ui(
+                request=mock_request,
+                team_id=None,
+                include_inactive=False,
+                db=mock_db,
+                user={"email": "admin@example.com", "is_admin": True, "db": mock_db},
+            )
+
+        assert isinstance(response, HTMLResponse)
+        assert response.status_code == 200
+        mock_csrf_service.generate_csrf_token.assert_called_once()
+        call_kwargs = mock_csrf_service.generate_csrf_token.call_args[1]
+        assert "user_id" in call_kwargs and call_kwargs["user_id"] is not None
+        assert "session_id" in call_kwargs and call_kwargs["session_id"] is not None
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_csrf_degraded_on_jwt_failure(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """When create_jwt_token fails, admin_ui should still return 200 with degraded CSRF fallback."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+
+        mock_csrf_service = MagicMock()
+
+        with (
+            patch("mcpgateway.admin.create_jwt_token", new_callable=AsyncMock) as mock_create_jwt,
+            patch("mcpgateway.admin.LOGGER") as mock_logger,
+            patch("mcpgateway.admin.get_csrf_service", return_value=mock_csrf_service),
+        ):
+            mock_create_jwt.side_effect = RuntimeError("JWT signing failed")
+
+            response = await admin_ui(
+                request=mock_request,
+                team_id=None,
+                include_inactive=False,
+                db=mock_db,
+                user={"email": "admin@example.com", "is_admin": True, "db": mock_db},
+            )
+
+        assert isinstance(response, HTMLResponse)
+        assert response.status_code == 200
+        mock_logger.error.assert_called_once()
+        assert "CSRF protection degraded" in str(mock_logger.error.call_args[0])
+        mock_csrf_service.generate_csrf_token.assert_not_called()
+
+
+class TestAdminCsrfCookie:
+    """Direct unit tests for _set_admin_csrf_cookie HMAC vs random-token branching."""
+
+    @staticmethod
+    def _make_request():
+        request = MagicMock(spec=Request)
+        request.scope = {"root_path": ""}
+        request.cookies = {}
+        return request
+
+    def test_set_admin_csrf_cookie_hmac_path(self):
+        """When user_id and session_id are provided, generate_csrf_token should be called."""
+        request = self._make_request()
+        response = MagicMock(spec=Response)
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "a" * 64
+
+        with patch("mcpgateway.admin.get_csrf_service", return_value=mock_csrf_service):
+            token = _set_admin_csrf_cookie(request, response, user_id="u1", session_id="s1")
+
+        mock_csrf_service.generate_csrf_token.assert_called_once_with(user_id="u1", session_id="s1")
+        assert token == "a" * 64
+        response.set_cookie.assert_called_once()
+        assert response.set_cookie.call_args[1]["key"] == "mcpgateway_csrf_token"
+
+    def test_set_admin_csrf_cookie_empty_string_takes_hmac_path(self):
+        """Empty-string user_id should NOT silently bypass HMAC (previous bug)."""
+        request = self._make_request()
+        response = MagicMock(spec=Response)
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "a" * 64
+
+        with patch("mcpgateway.admin.get_csrf_service", return_value=mock_csrf_service):
+            token = _set_admin_csrf_cookie(request, response, user_id="", session_id="s1")
+
+        mock_csrf_service.generate_csrf_token.assert_called_once_with(user_id="", session_id="s1")
+        assert token == "a" * 64
+
+    def test_set_admin_csrf_cookie_none_fallback(self):
+        """None user_id/session_id should fall back to random token."""
+        request = self._make_request()
+        response = MagicMock(spec=Response)
+        mock_csrf_service = MagicMock()
+
+        with patch("mcpgateway.admin.get_csrf_service", return_value=mock_csrf_service):
+            token = _set_admin_csrf_cookie(request, response, user_id=None, session_id=None)
+
+        mock_csrf_service.generate_csrf_token.assert_not_called()
+        assert isinstance(token, str) and len(token) >= 32
 
 
 class TestRateLimiting:

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -5515,8 +5515,8 @@ class TestAdminUIRoute:
 
         assert isinstance(response, HTMLResponse)
         assert response.status_code == 200
-        mock_logger.error.assert_called_once()
-        assert "CSRF protection degraded" in str(mock_logger.error.call_args[0])
+        degradation_calls = [c for c in mock_logger.error.call_args_list if "CSRF protection degraded" in str(c[0])]
+        assert len(degradation_calls) == 1, f"Expected 1 CSRF degradation call, got {len(degradation_calls)}"
         mock_csrf_service.generate_csrf_token.assert_not_called()
 
 

--- a/tests/unit/mcpgateway/test_admin_module.py
+++ b/tests/unit/mcpgateway/test_admin_module.py
@@ -15,6 +15,7 @@ import json
 import os
 import time
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 
@@ -22,7 +23,6 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 # First-Party
 from mcpgateway import admin
@@ -157,7 +157,11 @@ async def test_admin_add_gateway_includes_gateway_payload(monkeypatch):
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "_parse_gateway_data_from_request", AsyncMock(return_value={"name": "gw", "url": "http://example.com", "transport": "SSE"}))
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_creation_metadata", MagicMock(return_value={"created_by": "admin@example.com", "created_from_ip": "127.0.0.1", "created_via": "test", "created_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_creation_metadata",
+        MagicMock(return_value={"created_by": "admin@example.com", "created_from_ip": "127.0.0.1", "created_via": "test", "created_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "register_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_add_gateway)(request, db, user)
@@ -176,7 +180,11 @@ async def test_admin_update_gateway_rest_includes_gateway_payload(monkeypatch):
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "_parse_gateway_data_from_request", AsyncMock(return_value={"name": "gw", "url": "http://example.com", "transport": "SSE"}))
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_modification_metadata", MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_modification_metadata",
+        MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "update_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_update_gateway_rest)("gw-1", request, db, user)
@@ -195,7 +203,11 @@ async def test_admin_edit_gateway_includes_gateway_payload(monkeypatch):
     user = {"email": "admin@example.com"}
     result = {"id": "gw-1", "status": "pending", "name": "gw"}
     monkeypatch.setattr(admin, "TeamManagementService", _GatewayPayloadTeamService)
-    monkeypatch.setattr(admin.MetadataCapture, "extract_modification_metadata", MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}))
+    monkeypatch.setattr(
+        admin.MetadataCapture,
+        "extract_modification_metadata",
+        MagicMock(return_value={"modified_by": "admin@example.com", "modified_from_ip": "127.0.0.1", "modified_via": "test", "modified_user_agent": "pytest"}),
+    )
     monkeypatch.setattr(admin.gateway_service, "update_gateway", AsyncMock(return_value=result))
 
     response = await _unwrap(admin.admin_edit_gateway)("gw-1", request, db, user)
@@ -371,6 +383,7 @@ def test_validate_password_strength_requirement_failures(monkeypatch, password, 
 
 
 def test_admin_module_grpc_import_error_fallback(monkeypatch):
+    # Standard
     import builtins
     import importlib.util
     from pathlib import Path
@@ -434,6 +447,7 @@ async def test_update_global_passthrough_headers_errors(monkeypatch):
     config_update = admin.GlobalConfigUpdate(passthrough_headers=["X-New"])
     update_func = _unwrap(admin.update_global_passthrough_headers)
 
+    # Third-Party
     from sqlalchemy.exc import IntegrityError
 
     db.commit.side_effect = IntegrityError("stmt", {}, None)
@@ -443,6 +457,7 @@ async def test_update_global_passthrough_headers_errors(monkeypatch):
     db.rollback.assert_called()
 
     # Pydantic ValidationError is a subclass of ValueError; ensure it's handled distinctly (422).
+    # Third-Party
     from pydantic import ValidationError
     from pydantic_core import InitErrorDetails
 
@@ -1865,3 +1880,289 @@ def test_get_bundle_js_filename_no_bundles_returns_empty_string(monkeypatch, tmp
     monkeypatch.setattr(admin, "_bundle_js_cache", {"filename": None})
 
     assert admin.get_bundle_js_filename() == ""
+
+
+# ---------------------------------------------------------------------------
+# _set_admin_csrf_cookie tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetAdminCsrfCookie:
+    """Tests for _set_admin_csrf_cookie()."""
+
+    def test_generates_hmac_token_when_user_and_session_provided(self):
+        """When both user_id and session_id are provided, should generate an
+        HMAC-bound CSRF token via the CSRF service."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, user_id="user-1", session_id="sess-1")
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["key"] == admin.ADMIN_CSRF_COOKIE_NAME
+        assert call_kwargs["value"] == result
+
+    def test_generates_hmac_token_is_64_char_hex(self):
+        """HMAC-bound token should be 64-char hex (HMAC-SHA256 output)."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, user_id="user-1", session_id="sess-1")
+
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_different_user_ids_produce_different_tokens(self):
+        """Different user_id values should produce different CSRF tokens."""
+        request = _make_request(root_path="/admin")
+        response1 = MagicMock()
+        response2 = MagicMock()
+
+        token1 = admin._set_admin_csrf_cookie(request, response1, user_id="alice", session_id="sess-1")
+        token2 = admin._set_admin_csrf_cookie(request, response2, user_id="bob", session_id="sess-1")
+
+        assert token1 != token2
+
+    def test_different_session_ids_produce_different_tokens(self):
+        """Different session_id values should produce different CSRF tokens."""
+        request = _make_request(root_path="/admin")
+        response1 = MagicMock()
+        response2 = MagicMock()
+
+        token1 = admin._set_admin_csrf_cookie(request, response1, user_id="user-1", session_id="sess-a")
+        token2 = admin._set_admin_csrf_cookie(request, response2, user_id="user-1", session_id="sess-b")
+
+        assert token1 != token2
+
+    def test_falls_back_to_random_token_when_no_ids(self):
+        """When neither user_id nor session_id provided, should use random token."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response)
+
+        assert isinstance(result, str)
+        assert len(result) >= 32
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["key"] == admin.ADMIN_CSRF_COOKIE_NAME
+        assert call_kwargs["value"] == result
+
+    def test_falls_back_to_random_token_when_only_user_id(self):
+        """When only user_id provided without session_id, should fall back to random token."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, user_id="user-1")
+
+        assert isinstance(result, str)
+        assert len(result) >= 32
+
+    def test_falls_back_to_random_token_when_only_session_id(self):
+        """When only session_id provided without user_id, should fall back to random token."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, session_id="sess-1")
+
+        assert isinstance(result, str)
+        assert len(result) >= 32
+
+    def test_preserves_existing_valid_token_when_no_ids(self):
+        """When valid token already exists in cookie and no user/session ids, preserve it."""
+        existing_token = "a" * 32
+        request = _make_request(root_path="/admin")
+        request.cookies = {admin.ADMIN_CSRF_COOKIE_NAME: existing_token}
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response)
+
+        assert result == existing_token
+
+    def test_replaces_short_existing_token_when_no_ids(self):
+        """When existing token is too short (<32 chars), generate a new one."""
+        request = _make_request(root_path="/admin")
+        request.cookies = {admin.ADMIN_CSRF_COOKIE_NAME: "short"}
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response)
+
+        assert len(result) >= 32
+        assert result != "short"
+
+    def test_replaces_non_string_existing_token_when_no_ids(self):
+        """When existing cookie value is not a string, generate a new token."""
+        request = _make_request(root_path="/admin")
+        request.cookies = {admin.ADMIN_CSRF_COOKIE_NAME: 12345}
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response)
+
+        assert len(result) >= 32
+
+    def test_sets_cookie_with_correct_security_params(self, monkeypatch):
+        """Cookie should have correct security settings."""
+        monkeypatch.setattr(admin.settings, "environment", "production")
+        monkeypatch.setattr(admin.settings, "secure_cookies", True)
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        admin._set_admin_csrf_cookie(request, response)
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["key"] == admin.ADMIN_CSRF_COOKIE_NAME
+        assert call_kwargs["httponly"] is False
+        assert call_kwargs["samesite"] == "strict"
+        assert call_kwargs["secure"] is True
+        assert call_kwargs["max_age"] >= 300
+        assert call_kwargs["path"] == "/admin"
+
+    def test_return_value_matches_cookie_value(self):
+        """Return value should match what was set in the cookie."""
+        request = _make_request(root_path="/admin")
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, user_id="user-1", session_id="sess-1")
+
+        call_kwargs = response.set_cookie.call_args[1]
+        assert call_kwargs["value"] == result
+
+    def test_does_not_preserve_existing_token_when_user_and_session_provided(self):
+        """When user_id/session_id are provided, existing cookie token is ignored
+        and replaced with a fresh HMAC-bound token."""
+        existing_token = "a" * 32
+        request = _make_request(root_path="/admin")
+        request.cookies = {admin.ADMIN_CSRF_COOKIE_NAME: existing_token}
+        response = MagicMock()
+
+        result = admin._set_admin_csrf_cookie(request, response, user_id="user-1", session_id="sess-1")
+
+        assert result != existing_token
+        assert len(result) == 64  # HMAC-SHA256 hex
+
+
+# ---------------------------------------------------------------------------
+# admin_ui CSRF/JWT integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_ui_sets_jwt_and_csrf_cookies_when_email_auth_disabled(monkeypatch):
+    """admin_ui should set JWT and HMAC-bound CSRF cookies even when
+    email_auth_enabled is False (the key fix for #5325)."""
+    request = _make_request(root_path="/root")
+    request.cookies = {}
+    mock_db = MagicMock()
+    mock_db.commit = MagicMock()
+    user = {"email": "admin@example.com", "is_admin": True, "db": mock_db}
+
+    _configure_admin_ui_test_dependencies(monkeypatch)
+    # Explicitly disable email auth to test the fix
+    monkeypatch.setattr(admin.settings, "email_auth_enabled", False)
+    create_jwt = AsyncMock(return_value="test-jwt-token")
+    monkeypatch.setattr(admin, "create_jwt_token", create_jwt)
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = await admin.admin_ui(request, None, False, mock_db, user=user)
+
+    assert isinstance(response, HTMLResponse)
+    # JWT cookie should be set regardless of email_auth_enabled
+    set_cookie_headers = response.headers.getlist("set-cookie")
+    cookie_text = " ".join(set_cookie_headers)
+    assert "jwt_token=" in cookie_text
+    # CSRF cookie should also be set
+    assert admin.ADMIN_CSRF_COOKIE_NAME + "=" in cookie_text
+
+
+@pytest.mark.asyncio
+async def test_admin_ui_csrf_token_is_hmac_bound_when_jwt_set(monkeypatch):
+    """When admin_ui successfully sets a JWT, the CSRF cookie should contain
+    an HMAC-bound token (64-char hex) not a random one."""
+    request = _make_request(root_path="/root")
+    request.cookies = {}
+    mock_db = MagicMock()
+    mock_db.commit = MagicMock()
+    user = {"email": "admin@example.com", "is_admin": True, "db": mock_db}
+
+    _configure_admin_ui_test_dependencies(monkeypatch)
+    monkeypatch.setattr(admin.settings, "email_auth_enabled", False)
+    create_jwt = AsyncMock(return_value="test-jwt-token")
+    monkeypatch.setattr(admin, "create_jwt_token", create_jwt)
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = await admin.admin_ui(request, None, False, mock_db, user=user)
+
+    # The CSRF cookie should have an HMAC-bound value (64-char hex)
+    set_cookie_headers = response.headers.getlist("set-cookie")
+    csrf_cookie = [h for h in set_cookie_headers if admin.ADMIN_CSRF_COOKIE_NAME in h]
+    assert len(csrf_cookie) > 0
+    # Parse the cookie value
+    cookie_header = csrf_cookie[0]
+    prefix = admin.ADMIN_CSRF_COOKIE_NAME + "="
+    if prefix in cookie_header:
+        value_part = cookie_header.split(prefix)[1].split(";")[0].strip()
+        assert len(value_part) == 64
+        assert all(c in "0123456789abcdef" for c in value_part)
+
+
+@pytest.mark.asyncio
+async def test_admin_ui_jwt_failure_still_sets_random_csrf_token(monkeypatch):
+    """If JWT generation fails, admin_ui should still set a random CSRF token
+    (graceful degradation)."""
+    request = _make_request(root_path="/root")
+    request.cookies = {}
+    mock_db = MagicMock()
+    mock_db.commit = MagicMock()
+    user = {"email": "admin@example.com", "db": mock_db}
+
+    _configure_admin_ui_test_dependencies(monkeypatch)
+    monkeypatch.setattr(admin.settings, "email_auth_enabled", False)
+    monkeypatch.setattr(admin, "create_jwt_token", AsyncMock(side_effect=RuntimeError("JWT failure")))
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    response = await admin.admin_ui(request, None, False, mock_db, user=user)
+
+    assert isinstance(response, HTMLResponse)
+    # CSRF cookie should still be set (with random token)
+    set_cookie_headers = response.headers.getlist("set-cookie")
+    cookie_text = " ".join(set_cookie_headers)
+    assert admin.ADMIN_CSRF_COOKIE_NAME + "=" in cookie_text
+
+
+@pytest.mark.asyncio
+async def test_admin_ui_csrf_token_differs_across_requests(monkeypatch):
+    """Each admin_ui call generates a fresh jti, so CSRF tokens should differ."""
+    mock_db = MagicMock()
+    mock_db.commit = MagicMock()
+    user = {"email": "admin@example.com", "is_admin": True, "db": mock_db}
+
+    _configure_admin_ui_test_dependencies(monkeypatch)
+    monkeypatch.setattr(admin.settings, "email_auth_enabled", False)
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+
+    # Use separate requests so TemplateResponse returns distinct response objects
+    request1 = _make_request(root_path="/root")
+    request1.cookies = {}
+    request2 = _make_request(root_path="/root")
+    request2.cookies = {}
+
+    response1 = await admin.admin_ui(request1, None, False, mock_db, user=user)
+    response2 = await admin.admin_ui(request2, None, False, mock_db, user=user)
+
+    def _get_csrf_token(resp):
+        for h in resp.headers.getlist("set-cookie"):
+            if admin.ADMIN_CSRF_COOKIE_NAME in h:
+                prefix = admin.ADMIN_CSRF_COOKIE_NAME + "="
+                return h.split(prefix)[1].split(";")[0].strip()
+        return None
+
+    token1 = _get_csrf_token(response1)
+    token2 = _get_csrf_token(response2)
+
+    assert token1 is not None
+    assert token2 is not None
+    # Different jti values should produce different CSRF tokens
+    assert token1 != token2


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #5325 

Root Cause: The admin_ui route (GET /admin) was guarded by if getattr(settings, "email_auth_enabled", False), so the JWT session cookie (which provides sub/jti for CSRF HMAC binding) was only set for email-auth users. For platform admin (basic auth) sessions — the default — no JWT cookie was set, so _set_admin_csrf_cookie fell back to a plain random token that the global CSRFMiddleware couldn't HMAC-validate.
Changes (mcpgateway/admin.py):
1. _set_admin_csrf_cookie() (line 1658): Added optional user_id and session_id parameters. When both are provided, generates an HMAC-bound token via get_csrf_service().generate_csrf_token() — same algorithm the CSRF middleware uses for validation. Otherwise preserves the existing random-token fallback for anonymous pages.
2. admin_ui() (lines 4151-4223): Removed the if email_auth_enabled guard so the JWT session cookie is set for all authenticated admin users, regardless of auth provider. After generating the JWT, captures sub_claim and jti as csrf_user_id/csrf_session_id and passes them to _set_admin_csrf_cookie().

