### PR TITLE
fix(security): reject weak secrets on exposed gateway binds

### DIFF
--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1478,6 +1478,10 @@ class Settings(BaseSettings):
         # client_mode is intentionally NOT exempted — secret-strength enforcement is always active.
         weak_secrets = {v.lower() for v in self.WEAK_VALUES}
         env = str(self.environment).lower()
+        bind_host = str(self.host).strip().lower()
+        local_only_hosts = {"127.0.0.1", "localhost", "::1"}
+        externally_reachable = bind_host not in local_only_hosts
+        strict_secret_context = env != "development" or externally_reachable
         for field_name, secret_field in (("jwt_secret_key", self.jwt_secret_key), ("auth_encryption_secret", self.auth_encryption_secret)):
             val = secret_field.get_secret_value()
             if val.lower().startswith("__replace_me__"):
@@ -1485,15 +1489,26 @@ class Settings(BaseSettings):
                     raise SecurityConfigurationError(f"{field_name}: Value is an unset placeholder (__REPLACE_ME__). " "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values.")
                 logger.warning(f"🔓 SECURITY WARNING - {field_name}: Value is an unset placeholder (__REPLACE_ME__). Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values.")
             if val.lower() in weak_secrets:
-                if env != "development":
+                if strict_secret_context:
+                    context_hint = f"host={self.host}" if externally_reachable else f"environment={env}"
                     raise SecurityConfigurationError(
-                        f"{field_name}: Weak/default secret rejected in '{env}' environment. " "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values."
+                        f"{field_name}: Weak/default secret rejected when the gateway is externally reachable ({context_hint}). "
+                        "Run 'python -m mcpgateway.scripts.init_secrets' to generate strong values or bind to localhost for local-only development."
                     )
         # In non-production environments, unset placeholder secrets emit SECURITY WARNINGs but
         # do not block startup. Production always rejects them. Weak secrets are rejected in
-        # staging and production; development allows them with warnings from the field validator.
+        # staging and production, and also in development when the gateway is bound to a
+        # non-local interface so exposed dev deployments cannot start with known secrets.
 
         if not self.client_mode:
+            platform_admin_pw = self.platform_admin_password.get_secret_value()
+            if self.email_auth_enabled and strict_secret_context and platform_admin_pw.lower() in weak_secrets:
+                context_hint = f"host={self.host}" if externally_reachable else f"environment={env}"
+                raise SecurityConfigurationError(
+                    "platform_admin_password: Weak/default bootstrap admin password rejected when the gateway is externally reachable "
+                    f"({context_hint}). Set PLATFORM_ADMIN_PASSWORD to a strong value before startup."
+                )
+
             # Check for dangerous combinations - only log warnings, don't raise errors
             if not self.auth_required and self.mcpgateway_ui_enabled:
                 logger.warning("🔓 SECURITY WARNING: Admin UI is enabled without authentication. Consider setting AUTH_REQUIRED=true for production.")


### PR DESCRIPTION
## Problem

ContextForge currently permits weak/default secrets in development mode even when the gateway is bound to a non-local interface such as `0.0.0.0`. The affected defaults include `JWT_SECRET_KEY`, `AUTH_ENCRYPTION_SECRET`, and `PLATFORM_ADMIN_PASSWORD`.

That matters because the auth path includes a platform-admin bootstrap flow when `REQUIRE_USER_IN_DB=false`: a valid JWT for `platform_admin_email` can be promoted into an admin context even if no database-backed user exists yet. In practice, an operator can expose the service on a public or LAN interface while it still accepts the documented default signing secret.

A network attacker who knows the default JWT secret can forge a token for `admin@example.com` and reach authenticated platform-admin behavior on exposed dev-style deployments.

## Fix

Fail closed whenever the gateway is externally reachable (non-local bind host) or running outside `development` and any of these remain weak/default:

- `JWT_SECRET_KEY`
- `AUTH_ENCRYPTION_SECRET`
- `PLATFORM_ADMIN_PASSWORD`

The patch adds a `strict_secret_context` check inside `Settings.validate_security_combinations()` and raises `SecurityConfigurationError` before startup when weak secrets are used on non-local binds. Localhost-only development remains unchanged.

## Why this approach

There is already an open upstream PR that replaces hardcoded defaults with `__REPLACE_ME__` placeholders globally. This branch takes a narrower compatibility-preserving route:

- **localhost-only dev still works** with existing test/dev workflows
- **externally reachable deployments fail safe** instead of merely logging warnings
- **bootstrap admin password is also covered** when the instance is reachable beyond localhost

## Test Plan

- [ ] `HOST=127.0.0.1` with weak secrets in `development` still starts for localhost-only development
- [ ] `HOST=0.0.0.0` with `JWT_SECRET_KEY=changeme` now raises `SecurityConfigurationError`
- [ ] non-development environments with weak secrets still fail startup
- [ ] `python3 -m py_compile mcpgateway/config.py` passes

## Security Note

Severity: **High**. This blocks a reachable configuration that otherwise accepts known auth secrets and a bootstrap-admin path.

## Dedup / context

Potential overlap: upstream PR #5001 (`fix(security): replace hardcoded default secrets with __REPLACE_ME__ placeholders`). This branch is an alternative fail-closed fix focused on exposed bind hosts rather than a blanket placeholder migration.

