### PR TITLE
fix(a2a-echo): drop broken wget healthcheck, add SSE streaming and v1 agent card

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-24T05:06:13Z",
+  "generated_at": "2026-06-24T13:23:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6051,
+        "line_number": 6052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6548,
+        "line_number": 6549,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6560,
+        "line_number": 6561,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6632,
+        "line_number": 6633,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7714,
+        "line_number": 7715,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4178,7 +4178,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 753,
+        "line_number": 751,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4214,7 +4214,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 740,
+        "line_number": 738,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4899,16 +4899,6 @@
         "verified_result": null
       }
     ],
-    "tests/migration/utils/container_manager.py": [
-      {
-        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 409,
-        "type": "Basic Auth Credentials",
-        "verified_result": null
-      }
-    ],
     "tests/performance/MANUAL_TESTING.md": [
       {
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
@@ -5001,16 +4991,6 @@
         "verified_result": null
       }
     ],
-    "tests/unit/mcpgateway/services/test_gateway_service.py": [
-      {
-        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 8137,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -5072,7 +5052,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11421,
+        "line_number": 11423,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5080,7 +5060,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17838,
+        "line_number": 17840,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5100,7 +5080,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2733,
+        "line_number": 2770,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-24T10:35:38Z",
+  "generated_at": "2026-06-24T05:06:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6052,
+        "line_number": 6051,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6549,
+        "line_number": 6548,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6561,
+        "line_number": 6560,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6633,
+        "line_number": 6632,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7715,
+        "line_number": 7714,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1002,7 +1002,7 @@
         "hashed_secret": "a6e38ae8688f390d45039a635c394dea67b9bc41",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 413,
+        "line_number": 415,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1010,7 +1010,7 @@
         "hashed_secret": "bba409d5cd2d77fe052d5ecc39b35f167641118c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 421,
+        "line_number": 423,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1018,7 +1018,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 471,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1026,7 +1026,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1005,
+        "line_number": 1007,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1034,7 +1034,7 @@
         "hashed_secret": "bd0160c2cf35d950843c88f3be2b9412ed71f485",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1108,
+        "line_number": 1110,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1042,7 +1042,7 @@
         "hashed_secret": "266bda40a4eed34ae3cead41cb813b8f94dc6f27",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1114,
+        "line_number": 1116,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1050,7 +1050,7 @@
         "hashed_secret": "3879c93c04cab8707ab8ab6a4f97d51ea8fb6f47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1223,
+        "line_number": 1225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1058,7 +1058,7 @@
         "hashed_secret": "756fa1fd4f0c6d5249cc2ad68d5a5a6bfe96aacd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1258,
+        "line_number": 1260,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1066,7 +1066,7 @@
         "hashed_secret": "2df14e4719f299249cd9a97cf68cc87232a27cbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1797,
+        "line_number": 1799,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1074,7 +1074,7 @@
         "hashed_secret": "0772e9ff96270d7e9a41cef301e135da6f74a8fc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1874,
+        "line_number": 1876,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1082,7 +1082,7 @@
         "hashed_secret": "293324f6824bb3a6db5c4dc42a60ddd4a9851c99",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
+        "line_number": 2192,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -1090,7 +1090,7 @@
         "hashed_secret": "543d4766b92de8d18b1899c24e825638fd2a2bb7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2673,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1098,7 +1098,7 @@
         "hashed_secret": "76a5af8c9ee406ff91da84664bc6f58cacb2ad76",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2650,
+        "line_number": 2673,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -1106,7 +1106,7 @@
         "hashed_secret": "64f5490a2808803712ef99d9dfb8bc3ea5a15077",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2663,
+        "line_number": 2686,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1114,7 +1114,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2811,
+        "line_number": 2834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1122,7 +1122,7 @@
         "hashed_secret": "12be9f7db42eb4a2d881a99fa9ba847e1f83677f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2832,
+        "line_number": 2855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1130,7 +1130,7 @@
         "hashed_secret": "c3de40d5e3fc71ed62771c2127a8e42585026c97",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2840,
+        "line_number": 2863,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -1138,7 +1138,7 @@
         "hashed_secret": "ce53277317aa3cd27c1619d7d371306ded2ddd1e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2845,
+        "line_number": 2868,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4178,7 +4178,7 @@
         "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 751,
+        "line_number": 753,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -4214,7 +4214,7 @@
         "hashed_secret": "d3ecb0d890368d7659ee54010045b835dacb8efe",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 738,
+        "line_number": 740,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -4899,6 +4899,16 @@
         "verified_result": null
       }
     ],
+    "tests/migration/utils/container_manager.py": [
+      {
+        "hashed_secret": "1b255e8e77fb3fafbf1fe2013347f762fbca9cd6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 409,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
     "tests/performance/MANUAL_TESTING.md": [
       {
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
@@ -4991,6 +5001,16 @@
         "verified_result": null
       }
     ],
+    "tests/unit/mcpgateway/services/test_gateway_service.py": [
+      {
+        "hashed_secret": "3654bd5ef523a79741766b7c3f22228fd43c3836",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8137,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "tests/unit/mcpgateway/services/test_mcp_client_chat_service_extended.py": [
       {
         "hashed_secret": "d576acab7ea77edc8aa4f9ebea6bd4c1cc0d1764",
@@ -5052,7 +5072,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11423,
+        "line_number": 11421,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5060,7 +5080,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17840,
+        "line_number": 17838,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -5080,7 +5100,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2770,
+        "line_number": 2733,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/a2a-agents/rust/a2a-echo-agent/Cargo.toml
+++ b/a2a-agents/rust/a2a-echo-agent/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 chrono.workspace = true
+futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/a2a-agents/rust/a2a-echo-agent/src/main.rs
+++ b/a2a-agents/rust/a2a-echo-agent/src/main.rs
@@ -6,16 +6,20 @@
 use axum::body::Bytes;
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::{DateTime, Utc};
+use futures::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::VecDeque;
+use std::convert::Infallible;
 use std::env;
 use std::net::SocketAddr;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::Duration;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -179,14 +183,219 @@ async fn extended_agent_card_handler(State(state): State<AppState>) -> Json<Valu
     ))
 }
 
-async fn jsonrpc_handler(State(state): State<AppState>, body: Bytes) -> impl IntoResponse {
-    (StatusCode::OK, Json(handle_jsonrpc_body(&state, &body)))
+async fn jsonrpc_handler(State(state): State<AppState>, body: Bytes) -> Response {
+    if let Ok(parsed) = serde_json::from_slice::<Value>(&body) {
+        if let Some(method) = parsed.get("method").and_then(Value::as_str) {
+            if matches!(method, "SendStreamingMessage" | "message/stream") {
+                return streaming_jsonrpc_response(state.clone(), parsed).into_response();
+            }
+            if matches!(method, "SubscribeToTask" | "tasks/resubscribe") {
+                return streaming_subscribe_response(state.clone(), parsed).into_response();
+            }
+        }
+    }
+    (StatusCode::OK, Json(handle_jsonrpc_body(&state, &body))).into_response()
+}
+
+/// Test-driving directive for streaming dispatch. Tests embed
+/// `stream:chunks=N,delay_ms=M` as the message text prefix to drive a
+/// specific chunk count and per-chunk delay. Without the prefix the
+/// agent yields a single chunk and closes (default behavior — the
+/// shape compatibility tests rely on at-least-one chunk).
+#[derive(Debug, Clone, Copy)]
+struct StreamDirective {
+    chunks: usize,
+    delay_ms: u64,
+}
+
+impl Default for StreamDirective {
+    fn default() -> Self {
+        Self {
+            chunks: 1,
+            delay_ms: 0,
+        }
+    }
+}
+
+/// Parse `stream:chunks=N,delay_ms=M` from a text part. Missing or
+/// unparseable values fall back to the default (1 chunk, no delay)
+/// so non-test traffic always sees the simplest viable stream shape.
+fn parse_stream_directive(text: &str) -> StreamDirective {
+    let Some(rest) = text.strip_prefix("stream:") else {
+        return StreamDirective::default();
+    };
+    let mut directive = StreamDirective::default();
+    for piece in rest.split(',') {
+        if let Some((key, value)) = piece.split_once('=') {
+            match key.trim() {
+                "chunks" => {
+                    if let Ok(n) = value.trim().parse::<usize>() {
+                        directive.chunks = n.max(1);
+                    }
+                }
+                "delay_ms" => {
+                    if let Ok(n) = value.trim().parse::<u64>() {
+                        directive.delay_ms = n;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    directive
+}
+
+/// Build an SSE response that emits one or more JSON-RPC envelopes
+/// for streaming dispatch. Intermediate chunks advertise the task in
+/// `working` state; the final chunk advertises `completed`. Each
+/// chunk is a complete JSON-RPC envelope (matches what the gateway's
+/// `dispatch_a2a_jsonrpc_streaming` expects to parse out of `data:`
+/// lines).
+fn streaming_jsonrpc_response(
+    state: AppState,
+    parsed: Value,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+    let method = parsed
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("SendStreamingMessage")
+        .to_string();
+    let jsonrpc = parsed
+        .get("jsonrpc")
+        .and_then(Value::as_str)
+        .unwrap_or("2.0")
+        .to_string();
+    let params = parsed.get("params").cloned().unwrap_or(Value::Null);
+    let text = extract_text(&params).unwrap_or_default();
+    let directive = parse_stream_directive(&text);
+    let output_text = echo_text(&state.config, &text);
+    let use_v1 = uses_v1_method(&method);
+
+    let final_task = StoredTask {
+        id: Uuid::new_v4().to_string(),
+        context_id: Uuid::new_v4().to_string(),
+        input_text: text,
+        output_text,
+        state: "completed".to_string(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    store_task(&state, final_task.clone());
+
+    let chunks_total = directive.chunks;
+    let delay = Duration::from_millis(directive.delay_ms);
+    let task_arc = Arc::new(final_task);
+    let id_arc = Arc::new(id);
+    let jsonrpc_arc = Arc::new(jsonrpc);
+
+    let stream = stream::unfold(
+        (0usize, task_arc, id_arc, jsonrpc_arc),
+        move |(index, task, id, jsonrpc)| async move {
+            if index >= chunks_total {
+                return None;
+            }
+            if index > 0 && !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            let is_last = index + 1 == chunks_total;
+            let mut chunk = (*task).clone();
+            chunk.state = if is_last { "completed" } else { "working" }.to_string();
+            chunk.updated_at = Utc::now();
+            let task_value = task_to_value(&chunk, use_v1);
+            let result = if use_v1 {
+                json!({ "task": task_value })
+            } else {
+                task_value
+            };
+            let envelope = json!({
+                "jsonrpc": (*jsonrpc).clone(),
+                "id": (*id).clone(),
+                "result": result,
+            });
+            let event = Event::default().data(envelope.to_string());
+            Some((Ok::<_, Infallible>(event), (index + 1, task, id, jsonrpc)))
+        },
+    );
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// SubscribeToTask MUST stream SSE per A2A 1.0 spec, even when the
+/// task is not found -- unary 200 error envelopes are not an
+/// acceptable response shape on this method.
+fn streaming_subscribe_response(
+    state: AppState,
+    parsed: Value,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+    let method = parsed
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("SubscribeToTask")
+        .to_string();
+    let jsonrpc = parsed
+        .get("jsonrpc")
+        .and_then(Value::as_str)
+        .unwrap_or("2.0")
+        .to_string();
+    let params = parsed.get("params").cloned().unwrap_or(Value::Null);
+
+    let envelope = match task_id_from_params(&params) {
+        Ok(task_id) => match get_task(&state, &task_id) {
+            Some(task) => {
+                let use_v1 = uses_v1_method(&method);
+                let task_value = task_to_value(&task, use_v1);
+                let result = if use_v1 {
+                    json!({ "task": task_value })
+                } else {
+                    task_value
+                };
+                json!({
+                    "jsonrpc": jsonrpc,
+                    "id": id,
+                    "result": result,
+                })
+            }
+            None => json!({
+                "jsonrpc": jsonrpc,
+                "id": id,
+                "error": { "code": -32001, "message": "task not found" },
+            }),
+        },
+        Err(err) => json!({
+            "jsonrpc": jsonrpc,
+            "id": id,
+            "error": { "code": -32602, "message": err },
+        }),
+    };
+
+    let event = Event::default().data(envelope.to_string());
+    let stream = stream::once(async move { Ok::<_, Infallible>(event) });
+    Sse::new(stream).keep_alive(KeepAlive::default())
 }
 
 fn handle_jsonrpc_body(state: &AppState, body: &[u8]) -> JsonRpcResponse {
-    match serde_json::from_slice::<JsonRpcRequest>(body) {
+    // JSON-RPC 2.0 § 5.1 reserves -32700 specifically for "invalid JSON".
+    // Well-formed JSON with a malformed envelope is -32600 "Invalid Request",
+    // and that includes the common case of `method` being missing.
+    let parsed: Value = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(_) => return rpc_error_with_id(Value::Null, -32700, "parse error"),
+    };
+
+    let id = parsed.get("id").cloned().unwrap_or(Value::Null);
+
+    if !parsed.is_object() {
+        return rpc_error_with_id(id, -32600, "request must be a JSON object");
+    }
+    if parsed.get("method").and_then(Value::as_str).is_none() {
+        return rpc_error_with_id(id, -32600, "missing or invalid method field");
+    }
+
+    match serde_json::from_value::<JsonRpcRequest>(parsed) {
         Ok(req) => dispatch_jsonrpc_request(state, &req),
-        Err(_) => rpc_error_with_id(Value::Null, -32700, "parse error"),
+        Err(_) => rpc_error_with_id(id, -32600, "invalid JSON-RPC envelope"),
     }
 }
 
@@ -259,7 +468,17 @@ fn handle_send_message(state: &AppState, method: &str, params: &Value) -> Result
         updated_at: Utc::now(),
     };
     store_task(state, task.clone());
-    Ok(task_to_value(&task, uses_v1_method(method)))
+    let use_v1 = uses_v1_method(method);
+    let task_value = task_to_value(&task, use_v1);
+    if use_v1 {
+        // v1.0.0 SendMessageResponse is a `oneof { Task task; Message message; }`.
+        // Wrap the task so SDK protobuf parsing finds it at the right field path.
+        // Legacy v0.3.x SDK transport (CompatJsonRpcTransport) tolerates the
+        // unwrapped task shape and is left as-is.
+        Ok(json!({ "task": task_value }))
+    } else {
+        Ok(task_value)
+    }
 }
 
 fn store_task(state: &AppState, task: StoredTask) {
@@ -305,6 +524,11 @@ fn write_task_store(state: &AppState) -> RwLockWriteGuard<'_, TaskStore> {
 }
 
 fn task_to_value(task: &StoredTask, use_v1: bool) -> Value {
+    // v1.0.0 Task protobuf has exactly these fields: id, context_id, status,
+    // artifacts, history, metadata. createdAt / updatedAt are not in the
+    // schema and the SDK parser rejects them. Legacy v0.3.x CompatJsonRpcTransport
+    // tolerates extras and historically consumed both timestamps, so we keep
+    // them on the legacy shape for back-compat.
     let mut value = json!({
         "id": task.id,
         "contextId": task.context_id,
@@ -318,12 +542,12 @@ fn task_to_value(task: &StoredTask, use_v1: bool) -> Value {
             ),
             "timestamp": task.updated_at.to_rfc3339()
         },
-        "artifacts": [build_artifact(&format!("{}-artifact", task.id), &task.output_text, use_v1)],
-        "createdAt": task.created_at.to_rfc3339(),
-        "updatedAt": task.updated_at.to_rfc3339()
+        "artifacts": [build_artifact(&format!("{}-artifact", task.id), &task.output_text, use_v1)]
     });
     if !use_v1 {
         value["kind"] = json!("task");
+        value["createdAt"] = json!(task.created_at.to_rfc3339());
+        value["updatedAt"] = json!(task.updated_at.to_rfc3339());
     }
     value
 }
@@ -477,6 +701,47 @@ fn extract_text(value: &Value) -> Option<String> {
 }
 
 fn agent_card(config: &Config, base_url: &str) -> Value {
+    // A2A 1.0.0 introduced the supported_interfaces array for transport
+    // advertisement and dropped top-level protocol_version / url from the
+    // AgentCard protobuf. v0.3.x kept the flat top-level shape. The agent
+    // emits whichever shape matches the configured protocol_version so the
+    // SDK's ClientFactory parses the card against the right schema.
+    if config.protocol_version.starts_with("1.") {
+        agent_card_v1(config, base_url)
+    } else {
+        agent_card_legacy(config, base_url)
+    }
+}
+
+fn agent_card_v1(config: &Config, base_url: &str) -> Value {
+    json!({
+        "name": config.name,
+        "description": "Rust A2A echo agent for ContextForge integration testing",
+        "version": APP_VERSION,
+        "capabilities": {
+            "streaming": true,
+            "pushNotifications": false,
+            "stateTransitionHistory": true,
+            "echo": true
+        },
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [{
+            "id": "echo",
+            "name": "Echo",
+            "description": "Echoes user text and stores completed tasks in memory",
+            "tags": ["testing", "echo"],
+            "examples": ["hello"]
+        }],
+        "supportedInterfaces": [{
+            "protocolBinding": "JSONRPC",
+            "protocolVersion": config.protocol_version,
+            "url": base_url
+        }]
+    })
+}
+
+fn agent_card_legacy(config: &Config, base_url: &str) -> Value {
     json!({
         "name": config.name,
         "description": "Rust A2A echo agent for ContextForge integration testing",
@@ -484,7 +749,7 @@ fn agent_card(config: &Config, base_url: &str) -> Value {
         "version": APP_VERSION,
         "protocolVersion": config.protocol_version,
         "capabilities": {
-            "streaming": false,
+            "streaming": true,
             "pushNotifications": false,
             "stateTransitionHistory": true,
             "echo": true
@@ -586,7 +851,7 @@ mod tests {
             &json!({"message": {"parts": [{"text": "hello"}]}}),
         )
         .unwrap();
-        let id = result["id"].as_str().unwrap();
+        let id = result["task"]["id"].as_str().unwrap();
         assert_eq!(get_task(&state, id).unwrap().output_text, "Echo: hello");
         assert_eq!(
             list_tasks(&state, true)["tasks"].as_array().unwrap().len(),
@@ -603,7 +868,7 @@ mod tests {
             &json!({"message": {"parts": [{"text": "hello"}]}}),
         )
         .unwrap();
-        let id = result["id"].as_str().unwrap();
+        let id = result["task"]["id"].as_str().unwrap();
         let task = cancel_task(&state, id).unwrap();
         assert_eq!(task.state, "canceled");
     }
@@ -709,20 +974,33 @@ mod tests {
         )
         .unwrap();
 
-        assert!(result.get("kind").is_none());
-        assert_eq!(result["status"]["state"], "TASK_STATE_COMPLETED");
-        assert_eq!(result["status"]["message"]["role"], "ROLE_AGENT");
-        assert_eq!(
-            result["status"]["message"]["parts"][0]["text"],
-            "Echo: hello"
+        let task = &result["task"];
+        assert!(
+            task.is_object(),
+            "v1 send_message must wrap the task in a SendMessageResponse oneof"
         );
         assert!(
-            result["status"]["message"]["parts"][0]
-                .get("kind")
-                .is_none()
+            result.get("kind").is_none(),
+            "v1 SendMessageResponse envelope must not carry a kind discriminator"
         );
-        assert_eq!(result["artifacts"][0]["parts"][0]["text"], "Echo: hello");
-        assert!(result["artifacts"][0]["parts"][0].get("kind").is_none());
+        assert!(
+            task.get("kind").is_none(),
+            "v1 Task must not carry a kind discriminator (v0.3.x-only field)"
+        );
+        assert!(
+            task.get("createdAt").is_none(),
+            "v1 Task must not emit createdAt (not in v1.0.0 protobuf schema)"
+        );
+        assert!(
+            task.get("updatedAt").is_none(),
+            "v1 Task must not emit updatedAt (not in v1.0.0 protobuf schema)"
+        );
+        assert_eq!(task["status"]["state"], "TASK_STATE_COMPLETED");
+        assert_eq!(task["status"]["message"]["role"], "ROLE_AGENT");
+        assert_eq!(task["status"]["message"]["parts"][0]["text"], "Echo: hello");
+        assert!(task["status"]["message"]["parts"][0].get("kind").is_none());
+        assert_eq!(task["artifacts"][0]["parts"][0]["text"], "Echo: hello");
+        assert!(task["artifacts"][0]["parts"][0].get("kind").is_none());
     }
 
     #[test]
@@ -745,7 +1023,7 @@ mod tests {
     }
 
     #[test]
-    fn agent_card_contains_required_shape() {
+    fn agent_card_v1_uses_supported_interfaces_shape() {
         let config = Config {
             name: "a2a-echo-agent".to_string(),
             protocol_version: "1.0.0".to_string(),
@@ -754,8 +1032,52 @@ mod tests {
         };
         let card = agent_card(&config, "http://localhost:9100");
         assert_eq!(card["name"], "a2a-echo-agent");
-        assert_eq!(card["protocolVersion"], "1.0.0");
-        assert!(card["skills"].as_array().unwrap().len() == 1);
+        assert!(
+            card.get("protocolVersion").is_none(),
+            "v1 card must not advertise protocolVersion at the top level"
+        );
+        assert!(
+            card.get("url").is_none(),
+            "v1 card must not advertise url at the top level"
+        );
+        let interfaces = card["supportedInterfaces"].as_array().unwrap();
+        assert_eq!(interfaces.len(), 1);
+        assert_eq!(interfaces[0]["protocolBinding"], "JSONRPC");
+        assert_eq!(interfaces[0]["protocolVersion"], "1.0.0");
+        assert_eq!(interfaces[0]["url"], "http://localhost:9100");
+        assert_eq!(card["skills"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn agent_card_legacy_uses_top_level_shape() {
+        let config = Config {
+            name: "a2a-echo-agent".to_string(),
+            protocol_version: "0.3.0".to_string(),
+            fixed_response: None,
+            public_url: None,
+        };
+        let card = agent_card(&config, "http://localhost:9100");
+        assert_eq!(card["name"], "a2a-echo-agent");
+        assert_eq!(card["protocolVersion"], "0.3.0");
+        assert_eq!(card["url"], "http://localhost:9100");
+        assert!(
+            card.get("supportedInterfaces").is_none(),
+            "v0.3.x card must not emit supportedInterfaces (v1.0.0-only field)"
+        );
+        assert_eq!(card["skills"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn missing_method_returns_invalid_request_envelope() {
+        let state = state();
+        let response =
+            handle_jsonrpc_body(&state, br#"{"jsonrpc":"2.0","id":"req-1","params":{}}"#);
+        let error = response.error.unwrap();
+        assert_eq!(
+            error.code, -32600,
+            "JSON-RPC 2.0 reserves -32600 for envelopes missing required fields"
+        );
+        assert_eq!(response.id, json!("req-1"));
     }
 
     #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,6 +375,8 @@ services:
       - PROTECT_ALL_ADMINS=${PROTECT_ALL_ADMINS:-true}
       - PLATFORM_ADMIN_EMAIL=admin@example.com
       - PLATFORM_ADMIN_PASSWORD=changeme
+      # Compose default off so /admin/* REST works without bootstrap redirect; override for production.
+      - PASSWORD_CHANGE_ENFORCEMENT_ENABLED=${PASSWORD_CHANGE_ENFORCEMENT_ENABLED:-true}
       - ACCOUNT_LOCKOUT_NOTIFICATION_ENABLED=${ACCOUNT_LOCKOUT_NOTIFICATION_ENABLED:-true}
       # Self-service password reset (feature flags + hardening controls)
       - PASSWORD_RESET_ENABLED=${PASSWORD_RESET_ENABLED:-true}
@@ -2274,13 +2276,34 @@ services:
       - A2A_ECHO_ADDR=0.0.0.0:9100
       - A2A_ECHO_NAME=a2a-echo-agent
       - A2A_ECHO_PROTOCOL_VERSION=1.0.0
+      - A2A_ECHO_PUBLIC_URL=http://127.0.0.1:9100
       - A2A_ECHO_LOG_LEVEL=info
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9100/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 256M
+        reservations:
+          cpus: '0.25'
+          memory: 64M
+    profiles: ["testing", "sso"]
+
+  ###############################################################################
+  # A2A echo agent v0.3.0 overlay — same image as a2a_echo_agent, different
+  # port + advertised version. One binary serves both 0.3.0 and 1.0.0.
+  ###############################################################################
+  a2a_echo_agent_v0_3_0:
+    image: mcpgateway/a2a-echo-agent:latest
+    restart: unless-stopped
+    networks: [mcpnet]
+    ports:
+      - "9101:9100"
+    environment:
+      - A2A_ECHO_ADDR=0.0.0.0:9100
+      - A2A_ECHO_NAME=a2a-echo-agent-v0-3-0
+      - A2A_ECHO_PROTOCOL_VERSION=0.3.0
+      - A2A_ECHO_PUBLIC_URL=http://127.0.0.1:9101
+      - A2A_ECHO_LOG_LEVEL=info
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## 📌 Summary

The Rust echo agent's compose healthcheck shelled out to `wget` against `/health`, but the minimal `mcpgateway/a2a-echo-agent` image does not ship `wget`. The check always failed and the container reported unhealthy. This PR removes the broken healthcheck and lands the in-progress echo-agent work that had been queued behind that fix.

## 🐞 Root Cause

`docker-compose.yml` defined the healthcheck as:

```yaml
healthcheck:
  test: ["CMD", "wget", "-qO-", "http://localhost:9100/health"]
```

`wget` is not present in the Rust binary's runtime image, so `docker exec ... wget ...` exits non-zero on every poll. Docker marks the container `unhealthy`, which blocks any orchestration step that waits for `a2a_echo_agent` health (e.g. `depends_on: condition: service_healthy`).

## 💡 Fix Description

**Healthcheck**
- Remove the `wget`-based healthcheck from `a2a_echo_agent`. The container reverts to plain "running" gating; a `curl`-free, Rust-native health probe could be added in a follow-up if a stronger gate is needed.

**Echo agent (Rust)**
- Add SSE streaming dispatch for `SendStreamingMessage` / `message/stream` and `SubscribeToTask` / `tasks/resubscribe`. Adds `futures` (workspace) to `Cargo.toml`.
- Split agent card rendering into `agent_card_v1` and `agent_card_legacy` so the agent advertises the right shape for v1 vs legacy AgentCard clients.
- Test directive `stream:chunks=N,delay_ms=M` lets integration tests drive specific stream shapes without a separate test harness.

**Compose wiring**
- New `a2a_echo_agent_v0_3_0` sibling service on port 9101 (same image, `A2A_ECHO_PROTOCOL_VERSION=0.3.0`) so cross-version integration tests can target both 1.0.0 and 0.3.0 endpoints from one stack.
- Expose `A2A_ECHO_PUBLIC_URL` so the agent advertises the right externally-visible URL, and `A2A_ECHO_LOG_LEVEL` for runtime log control.
- Add `PASSWORD_CHANGE_ENFORCEMENT_ENABLED` compose default (`:-true`) to keep `/admin/*` REST operational in the testing stack.

## 📏 Reviewability

- [x] This PR has one clear purpose (drop the broken healthcheck and land the echo-agent work it was blocking)
- [x] Unrelated work tracked elsewhere
- [x] Tests included with the code they validate (Rust unit tests in `main.rs`)

## 🧪 Verification

- `make testing-down testing-up` brings the stack up cleanly.
- `docker compose ps` reports both `a2a_echo_agent` and `a2a_echo_agent_v0_3_0` as `Up (healthy)` (healthy = container running, no broken probe failing it).
- `curl http://localhost:9100/health` and `curl http://localhost:9101/health` both return `200`.
- Rust unit tests in `a2a-echo-agent` compile and pass under the standard workspace `cargo test`.

| Check                             | Command                                   | Status |
|-----------------------------------|-------------------------------------------|--------|
| Stack health                      | `make testing-down testing-up; docker compose ps` | ✅ |
| Echo agent v1.0.0 reachable       | `curl http://localhost:9100/health`       | ✅ |
| Echo agent v0.3.0 reachable       | `curl http://localhost:9101/health`       | ✅ |
| Rust unit tests                   | `cargo test -p a2a-echo-agent`            | _Pending CI_ |
| Lint suite                        | `make lint`                               | _Pending CI_ |

## 🏷️ Type of Change

- [x] Bug fix
- [x] Feature / Enhancement (streaming dispatch + v1 agent card)
