### PR TITLE
chore: document EXPOSE_ERROR_DETAILS in docs and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3344,6 +3344,14 @@ PLUGINS_CLI_MARKUP_MODE=rich
 # WARNING: May expose sensitive information!
 # DEBUG=false
 
+# Expose verbose error details (exception type and message) in HTTP error responses
+# Options: true, false (default)
+# When false, clients receive generic, sanitized error messages. Verbose detail is
+# exposed only when EXPOSE_ERROR_DETAILS=true OR (DEBUG=true AND DEV_MODE=true).
+# Note: bare DEBUG=true does NOT unlock verbose responses on its own.
+# WARNING: Only enable in development; verbose errors can leak sensitive information.
+# EXPOSE_ERROR_DETAILS=false
+
 # Header Passthrough (WARNING: Security implications)
 # ENABLE_HEADER_PASSTHROUGH=false
 # ENABLE_OVERWRITE_BASE_HEADERS=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-23T17:15:25Z",
+  "generated_at": "2026-06-24T05:46:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -2300,7 +2300,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1291,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2308,7 +2308,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1295,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -1073,11 +1073,22 @@ maxclients >= (num_gateway_instances × (REDIS_MAX_CONNECTIONS + RATELIMITER_RED
 
 ### Development
 
-| Setting    | Description            | Default | Options |
-| ---------- | ---------------------- | ------- | ------- |
-| `DEV_MODE` | Enable dev mode        | `false` | bool    |
-| `RELOAD`   | Auto-reload on changes | `false` | bool    |
-| `DEBUG`    | Debug logging          | `false` | bool    |
+| Setting                 | Description                            | Default | Options |
+| ----------------------- | -------------------------------------- | ------- | ------- |
+| `DEV_MODE`              | Enable dev mode                        | `false` | bool    |
+| `RELOAD`                | Auto-reload on changes                 | `false` | bool    |
+| `DEBUG`                 | Debug logging                          | `false` | bool    |
+| `EXPOSE_ERROR_DETAILS`  | Expose verbose error details to clients | `false` | bool    |
+
+!!! warning "EXPOSE_ERROR_DETAILS exposes internal error information"
+    When `false` (the default), HTTP error responses return generic, sanitized
+    messages. When verbose detail is enabled, the response includes the underlying
+    exception type and message, which can leak sensitive information (file paths,
+    SQL fragments, internal identifiers). Only enable this in development.
+
+    Verbose detail is exposed when **`EXPOSE_ERROR_DETAILS=true`** OR when
+    **`DEBUG=true` AND `DEV_MODE=true`**. Setting `DEBUG=true` on its own does
+    **not** unlock verbose responses.
 
 ### Well-Known URI Configuration
 


### PR DESCRIPTION
## 🔧 Chore Summary

`EXPOSE_ERROR_DETAILS` was added to the codebase in the follow-up work for #5087 
(`mcpgateway/config.py`, default `False`) and gates verbose error-detail exposure in
`mcpgateway/utils/error_formatter.py`. However, it was never documented and was missing from
`.env.example`. This PR closes that gap so operators can discover the flag and understand its
security implications.

Closes: #5324
Follow-up of: #5087 

## ⚙️ Why This Is Needed

- **Discoverability**: The flag was only findable by reading the source code.
- **Security**: Enabling it exposes verbose error details (exception type/message) to
  non-admin clients, which can leak sensitive information — operators need a clear warning.
- **Consistency**: Every environment variable should be documented and have an example value.

## 🛠️ Changes

- **`.env.example`**: Added a commented `EXPOSE_ERROR_DETAILS=false` entry (consistent with
  neighbouring optional vars like `DEBUG`) with an inline comment and security warning.
- **`docs/docs/manage/configuration.md`**: Added the setting to the *Development* settings
  table plus a `!!! warning` admonition. The docs mirror the code exactly — verbose detail is
  exposed when `EXPOSE_ERROR_DETAILS=true` **OR** (`DEBUG=true` **AND** `DEV_MODE=true`); bare
  `DEBUG=true` does **not** unlock it.
- **`AGENTS.md`**: No change required — the flag does not affect AI-assistant behaviour.

## ✅ Verification

- [x] `make check-env` passes
- [x] `make docs` / `make spellcheck`