### PR TITLE
feat(ui-rewrite): Add Test Connection dialog for MCP server

### DIFF
--- a/client/src/components/servers/TestConnectionDialog.test.tsx
+++ b/client/src/components/servers/TestConnectionDialog.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestConnectionDialog } from "./TestConnectionDialog";
+
+describe("TestConnectionDialog", () => {
+  const mockOnOpenChange = vi.fn();
+  const defaultProps = {
+    open: true,
+    onOpenChange: mockOnOpenChange,
+    serverName: "Test Server",
+    serverUrl: "https://example.com",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with initial state", () => {
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    expect(screen.getByRole("heading", { name: /test connection/i })).toBeInTheDocument();
+    expect(screen.getByDisplayValue("https://example.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^test connection$/i })).toBeInTheDocument();
+    expect(screen.getByText(/run a test to see the response/i)).toBeInTheDocument();
+  });
+
+  it("displays all form fields", () => {
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    expect(screen.getByLabelText(/^url/i)).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: /method/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/^path/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/content type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/headers/i)).toBeInTheDocument();
+  });
+
+  it("exposes HTTP methods as radio options", () => {
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    expect(screen.getByRole("radio", { name: "Get" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Post" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Patch" })).toBeInTheDocument();
+  });
+
+  it("hides the body field for GET and shows it for other methods", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    // GET is selected by default — no body field.
+    expect(screen.queryByLabelText(/body/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: "Post" }));
+
+    expect(screen.getByLabelText(/body/i)).toBeInTheDocument();
+  });
+
+  it("shows a pending message until the test endpoint is available", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/api endpoint is pending/i)).toBeInTheDocument();
+    });
+  });
+
+  it("validates JSON in headers field before running", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const headersField = screen.getByLabelText(/headers/i);
+    await user.clear(headersField);
+    await user.type(headersField, "invalid json");
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid headers json/i)).toBeInTheDocument();
+    });
+  });
+
+  it("validates JSON in body field before running", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    // Body is only available for non-GET methods.
+    await user.click(screen.getByRole("radio", { name: "Post" }));
+
+    const bodyField = screen.getByLabelText(/body/i);
+    await user.type(bodyField, "not json");
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid body json/i)).toBeInTheDocument();
+    });
+  });
+
+  it("does not auto-focus the pre-filled URL field on open", () => {
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    // Focus is moved into the dialog (onto the title), not onto the URL input.
+    expect(screen.getByLabelText(/^url/i)).not.toHaveFocus();
+  });
+
+  it("closes dialog when close is clicked", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    // Two "Close" buttons exist: the footer button and the dialog's built-in X.
+    // The footer button is rendered first in the DOM.
+    const [footerClose] = screen.getAllByRole("button", { name: /^close$/i });
+    await user.click(footerClose);
+
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/components/servers/TestConnectionDialog.test.tsx
+++ b/client/src/components/servers/TestConnectionDialog.test.tsx
@@ -66,6 +66,35 @@ describe("TestConnectionDialog", () => {
     });
   });
 
+  it("requires a URL before running", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const urlField = screen.getByLabelText(/^url/i);
+    await user.clear(urlField);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/url is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it("rejects an invalid URL before running", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const urlField = screen.getByLabelText(/^url/i);
+    await user.clear(urlField);
+    await user.type(urlField, "not-a-url");
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/url must start with http/i)).toBeInTheDocument();
+    });
+  });
+
   it("validates JSON in headers field before running", async () => {
     const user = userEvent.setup();
     render(<TestConnectionDialog {...defaultProps} />);

--- a/client/src/components/servers/TestConnectionDialog.tsx
+++ b/client/src/components/servers/TestConnectionDialog.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CircleCheck, CircleAlert, Copy, Info, Loader2, TestTubeDiagonal } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import { Textarea } from "../ui/textarea";
+import { JsonHighlighter } from "../ui/json-highlighter";
+import { copyToClipboard } from "@/components/gateways/utils";
+import { cn } from "@/lib/utils";
+
+interface TestConnectionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  serverName: string;
+  serverUrl: string;
+}
+
+type TestStatus = "idle" | "testing" | "success" | "error";
+
+interface TestResponse {
+  status_code: number;
+  latency_ms: number;
+  body?: string | Record<string, unknown>;
+}
+
+const HTTP_METHODS = ["Get", "Post", "Put", "Delete", "Patch"] as const;
+
+function FieldLabel({
+  htmlFor,
+  children,
+  required,
+  hint,
+}: {
+  htmlFor?: string;
+  children: React.ReactNode;
+  required?: boolean;
+  hint?: string;
+}) {
+  return (
+    <Label htmlFor={htmlFor} className="flex items-center gap-1 text-sm font-medium">
+      <span>
+        {children}
+        {required && <span className="ml-0.5 text-destructive">*</span>}
+      </span>
+      {hint && (
+        <Info className="size-3.5 text-muted-foreground">
+          <title>{hint}</title>
+        </Info>
+      )}
+    </Label>
+  );
+}
+
+export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConnectionDialogProps) {
+  const [status, setStatus] = useState<TestStatus>("idle");
+  const [method, setMethod] = useState<string>("Get");
+  const [url, setUrl] = useState<string>("");
+  const [path, setPath] = useState<string>("");
+  const [headers, setHeaders] = useState<string>("");
+  const [contentType, setContentType] = useState<string>("application/json");
+  const [body, setBody] = useState<string>("");
+  const [response, setResponse] = useState<TestResponse | null>(null);
+  const [error, setError] = useState<string>("");
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setStatus("idle");
+      setMethod("Get");
+      setUrl(serverUrl);
+      setPath("");
+      setHeaders("");
+      setContentType("application/json");
+      setBody("");
+      setResponse(null);
+      setError("");
+    }
+  }, [open, serverUrl]);
+
+  const handleTest = useCallback(() => {
+    setResponse(null);
+    setError("");
+
+    // Validate JSON fields before they would be sent.
+    if (headers.trim()) {
+      try {
+        const parsed = JSON.parse(headers);
+        if (typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("Headers must be a JSON object");
+        }
+      } catch (e) {
+        setStatus("error");
+        setError(`Invalid headers JSON: ${e instanceof Error ? e.message : "Parse error"}`);
+        return;
+      }
+    }
+
+    if (body.trim() && method !== "Get" && method !== "HEAD") {
+      try {
+        JSON.parse(body);
+      } catch (e) {
+        setStatus("error");
+        setError(`Invalid body JSON: ${e instanceof Error ? e.message : "Parse error"}`);
+        return;
+      }
+    }
+
+    // TODO(#5326): Send the request to `POST /v1/mcp-servers/test` once that
+    // endpoint exists. The React UI must not call the legacy `/admin/**` routes
+    // (reserved for the HTMX admin UI), so live connection testing is disabled
+    // until the v1 endpoint is implemented.
+    // https://github.com/IBM/mcp-context-forge/issues/5326
+    setStatus("error");
+    setError("Connection testing isn't available yet — the API endpoint is pending (#5326).");
+  }, [headers, body, method]);
+
+  const handleClose = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  const responseBodyText = useMemo(() => {
+    if (!response?.body) return "";
+    return typeof response.body === "string"
+      ? response.body
+      : JSON.stringify(response.body, null, 2);
+  }, [response]);
+
+  const headline = response
+    ? `Status: ${response.status_code} ${status === "success" ? "OK" : "error"}`
+    : error || "Connection failed";
+
+  const isTesting = status === "testing";
+  const hasResult = status === "success" || status === "error";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-h-[90vh] w-[95vw] max-w-[1000px] overflow-y-auto"
+        onOpenAutoFocus={(e) => {
+          // Move focus into the dialog (so it is announced and the focus trap
+          // is seeded) without landing on the pre-filled URL field.
+          e.preventDefault();
+          titleRef.current?.focus();
+        }}
+      >
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <div className="flex h-6 w-6 items-center justify-center rounded-sm bg-[#ffd200] text-neutral-950 shadow-sm">
+              <TestTubeDiagonal className="h-4 w-4" />
+            </div>
+            <DialogTitle ref={titleRef} tabIndex={-1} className="outline-none">
+              Test connection
+            </DialogTitle>
+          </div>
+          <DialogDescription className="sr-only">
+            Send a test request to the MCP server and inspect the response.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-6 py-2 md:grid-cols-2">
+          {/* Left column — request form */}
+          <div className="space-y-4">
+            {/* URL */}
+            <div className="space-y-2">
+              <FieldLabel htmlFor="url" required hint="The full URL of the MCP server to test.">
+                URL
+              </FieldLabel>
+              <Input
+                id="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://mcp.github.com/mcp"
+                disabled={isTesting}
+                className="bg-transparent dark:bg-transparent"
+              />
+            </div>
+
+            {/* Method */}
+            <div className="space-y-2">
+              <FieldLabel>Method</FieldLabel>
+              <div
+                role="radiogroup"
+                aria-label="Method"
+                className="flex w-full gap-1 rounded-md bg-muted p-1"
+              >
+                {HTTP_METHODS.map((m) => (
+                  <button
+                    key={m}
+                    type="button"
+                    role="radio"
+                    aria-checked={method === m}
+                    onClick={() => setMethod(m)}
+                    disabled={isTesting}
+                    className={cn(
+                      "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+                      method === m
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {m}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Path */}
+            <div className="space-y-2">
+              <FieldLabel htmlFor="path" hint="Optional path appended to the URL.">
+                Path
+              </FieldLabel>
+              <Input
+                id="path"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                placeholder="/health"
+                disabled={isTesting}
+                className="bg-transparent dark:bg-transparent"
+              />
+            </div>
+
+            {/* Content type */}
+            <div className="space-y-2">
+              <FieldLabel htmlFor="content-type">Content type</FieldLabel>
+              <Select value={contentType} onValueChange={setContentType} disabled={isTesting}>
+                <SelectTrigger
+                  id="content-type"
+                  className="w-full bg-transparent dark:bg-transparent dark:hover:bg-transparent"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="application/json">application/json</SelectItem>
+                  <SelectItem value="application/x-www-form-urlencoded">
+                    application/x-www-form-urlencoded
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Headers */}
+            <div className="space-y-2">
+              <FieldLabel htmlFor="headers" hint="Request headers as a JSON object.">
+                Headers
+              </FieldLabel>
+              <Textarea
+                id="headers"
+                value={headers}
+                onChange={(e) => setHeaders(e.target.value)}
+                placeholder="Add request headers as JSON..."
+                className="min-h-[96px] bg-transparent font-mono text-sm focus-visible:ring-1 focus-visible:ring-offset-0"
+                disabled={isTesting}
+              />
+            </div>
+
+            {/* Body — not applicable to GET requests */}
+            {method !== "Get" && (
+              <div className="space-y-2">
+                <FieldLabel htmlFor="body" hint="Request body sent with non-GET methods.">
+                  Body
+                </FieldLabel>
+                <Textarea
+                  id="body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder="Add request body as JSON..."
+                  className="min-h-[116px] bg-transparent font-mono text-sm focus-visible:ring-1 focus-visible:ring-offset-0"
+                  disabled={isTesting}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Right column — response panel */}
+          <div className="flex min-h-[300px] flex-col overflow-hidden rounded-md border border-input bg-transparent">
+            {status === "idle" && (
+              <div className="flex flex-1 items-center justify-center p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Run a test to see the response here.
+                </p>
+              </div>
+            )}
+
+            {isTesting && (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                <p className="text-sm text-muted-foreground">Running test…</p>
+              </div>
+            )}
+
+            {hasResult && (
+              <div
+                className="relative flex flex-1 flex-col gap-2 overflow-auto p-4"
+                role={status === "error" ? "alert" : "status"}
+                aria-live="polite"
+              >
+                {responseBodyText && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label="Copy response body"
+                    className="absolute right-2 top-2 size-6 bg-neutral-800/80 text-neutral-400 hover:bg-neutral-700 hover:text-neutral-100"
+                    onClick={() => copyToClipboard(responseBodyText)}
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                )}
+
+                <div className="flex items-start gap-2 pr-8">
+                  {status === "success" ? (
+                    <CircleCheck className="mt-0.5 size-4 shrink-0 text-green-500" />
+                  ) : (
+                    <CircleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+                  )}
+                  <span className="text-sm font-medium break-words text-foreground">
+                    {headline}
+                  </span>
+                </div>
+
+                {response && (
+                  <p className="pl-6 text-[13px] text-muted-foreground">
+                    Latency: {response.latency_ms} ms
+                  </p>
+                )}
+
+                {responseBodyText && (
+                  <div className="mt-2 space-y-1">
+                    <p className="text-[13px] text-muted-foreground">Response body:</p>
+                    <pre className="overflow-auto text-[13px] leading-relaxed break-words whitespace-pre-wrap text-foreground">
+                      <code className="break-words">
+                        <JsonHighlighter text={responseBodyText} />
+                      </code>
+                    </pre>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter className="flex-row items-center justify-between sm:justify-between sm:space-x-0">
+          <Button onClick={handleTest} disabled={isTesting}>
+            {isTesting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Running test…
+              </>
+            ) : (
+              "Test connection"
+            )}
+          </Button>
+
+          <Button variant="ghost" onClick={handleClose} disabled={isTesting}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/servers/TestConnectionDialog.tsx
+++ b/client/src/components/servers/TestConnectionDialog.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { z } from "zod";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import { CircleCheck, CircleAlert, Copy, Info, Loader2, TestTubeDiagonal } from "lucide-react";
 import {
   Dialog,
@@ -11,6 +13,7 @@ import {
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import { RadioGroup } from "../ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Textarea } from "../ui/textarea";
 import { JsonHighlighter } from "../ui/json-highlighter";
@@ -33,6 +36,24 @@ interface TestResponse {
 }
 
 const HTTP_METHODS = ["Get", "Post", "Put", "Delete", "Patch"] as const;
+
+// Matches the URL validation convention used in useMCPServerForm/useToolForm:
+// required, and constrained to http/https schemes.
+const testUrlSchema = z
+  .string()
+  .trim()
+  .min(1, "URL is required.")
+  .refine(
+    (value) => {
+      try {
+        const parsed = new URL(value);
+        return parsed.protocol === "http:" || parsed.protocol === "https:";
+      } catch {
+        return false;
+      }
+    },
+    { message: "URL must start with http:// or https://." },
+  );
 
 function FieldLabel({
   htmlFor,
@@ -91,6 +112,14 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
     setResponse(null);
     setError("");
 
+    // URL is required and must be an http/https URL before sending.
+    const urlResult = testUrlSchema.safeParse(url);
+    if (!urlResult.success) {
+      setStatus("error");
+      setError(urlResult.error.issues[0].message);
+      return;
+    }
+
     // Validate JSON fields before they would be sent.
     if (headers.trim()) {
       try {
@@ -122,7 +151,7 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
     // https://github.com/IBM/mcp-context-forge/issues/5326
     setStatus("error");
     setError("Connection testing isn't available yet — the API endpoint is pending (#5326).");
-  }, [headers, body, method]);
+  }, [url, headers, body, method]);
 
   const handleClose = useCallback(() => {
     onOpenChange(false);
@@ -188,30 +217,29 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
             {/* Method */}
             <div className="space-y-2">
               <FieldLabel>Method</FieldLabel>
-              <div
-                role="radiogroup"
+              <RadioGroup
+                value={method}
+                onValueChange={setMethod}
+                disabled={isTesting}
                 aria-label="Method"
                 className="flex w-full gap-1 rounded-md bg-muted p-1"
               >
                 {HTTP_METHODS.map((m) => (
-                  <button
+                  <RadioGroupPrimitive.Item
                     key={m}
-                    type="button"
-                    role="radio"
-                    aria-checked={method === m}
-                    onClick={() => setMethod(m)}
-                    disabled={isTesting}
+                    value={m}
                     className={cn(
-                      "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
-                      method === m
-                        ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                      "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
+                      "text-muted-foreground hover:text-foreground",
+                      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      "disabled:pointer-events-none disabled:opacity-50",
+                      "data-[state=checked]:bg-background data-[state=checked]:text-foreground data-[state=checked]:shadow-sm",
                     )}
                   >
                     {m}
-                  </button>
+                  </RadioGroupPrimitive.Item>
                 ))}
-              </div>
+              </RadioGroup>
             </div>
 
             {/* Path */}

--- a/client/src/pages/Servers.test.tsx
+++ b/client/src/pages/Servers.test.tsx
@@ -384,7 +384,7 @@ describe("Servers", () => {
     });
   });
 
-  it("shows inline error notification when testConnection fails", async () => {
+  it("opens the test connection dialog from the actions menu", async () => {
     const user = userEvent.setup();
 
     vi.mocked(api.get).mockResolvedValueOnce({
@@ -398,18 +398,14 @@ describe("Servers", () => {
       expect(screen.getByText("Test Server 0")).toBeInTheDocument();
     });
 
-    vi.mocked(api.post).mockRejectedValueOnce(new Error("500 Internal Server Error"));
-
     const actionsButtons = screen.getAllByRole("button", { name: /actions for/i });
     await user.click(actionsButtons[0]);
 
     const testItem = await screen.findByRole("menuitem", { name: /test connection/i });
     await user.click(testItem);
 
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-      expect(screen.getByText(/server error/i)).toBeInTheDocument();
-    });
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByRole("heading", { name: /test connection/i })).toBeInTheDocument();
   });
 
   it("optimistically removes server from list immediately on delete confirmation", async () => {

--- a/client/src/pages/Servers.tsx
+++ b/client/src/pages/Servers.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { MCPServerForm } from "@/components/mcp-servers/MCPServerForm";
 import { ServersTable } from "@/components/servers/ServersTable";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
+import { TestConnectionDialog } from "@/components/servers/TestConnectionDialog";
 import { MCPServerDetailsPanel } from "@/components/servers/MCPServerDetailsPanel";
 import { useQuery } from "@/hooks/useQuery";
 import { api } from "@/api/client";
@@ -28,9 +29,8 @@ export function Servers() {
   const [testDialogOpen, setTestDialogOpen] = useState(false);
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
   const [updateServerId, setUpdateServerId] = useState<string | null>(null);
-  const [testResult, setTestResult] = useState<string | null>(null);
+  const [testServerId, setTestServerId] = useState<string | null>(null);
   const [toggleError, setToggleError] = useState<string | null>(null);
-  const [testError, setTestError] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [selectedServerIdForDetails, setSelectedServerIdForDetails] = useState<string | null>(null);
   const [isDetailsDrawerOpen, setIsDetailsDrawerOpen] = useState(false);
@@ -151,17 +151,9 @@ export function Servers() {
     intl,
   ]);
 
-  const handleTest = async (id: string) => {
-    setTestError(null);
-    try {
-      const result = await serversApi.testConnection(id);
-      setTestResult(result.message);
-      setTestDialogOpen(true);
-    } catch (err) {
-      const errorMsg = sanitizeError(err);
-      setTestError(errorMsg);
-      console.error("Failed to test connection:", errorMsg);
-    }
+  const handleTest = (id: string) => {
+    setTestServerId(id);
+    setTestDialogOpen(true);
   };
 
   const handleToggleEnabled = useCallback(
@@ -272,16 +264,6 @@ export function Servers() {
             </div>
           )}
 
-          {testError && (
-            <div className="mb-6">
-              <InlineNotification
-                type="error"
-                message={testError}
-                onDismiss={() => setTestError(null)}
-              />
-            </div>
-          )}
-
           {servers.length > 0 ? (
             <>
               <div className="flex justify-between items-center mb-6">
@@ -385,14 +367,15 @@ export function Servers() {
         onConfirm={confirmDelete}
       />
 
-      <ConfirmDialog
+      <TestConnectionDialog
         open={testDialogOpen}
         onOpenChange={setTestDialogOpen}
-        title="Connection Test Result"
-        description={testResult || "Testing connection..."}
-        confirmLabel="OK"
-        cancelLabel=""
-        onConfirm={() => setTestDialogOpen(false)}
+        serverName={
+          testServerId
+            ? servers.find((s) => s.id === testServerId)?.name || "Unknown Server"
+            : "Unknown Server"
+        }
+        serverUrl={testServerId ? servers.find((s) => s.id === testServerId)?.url || "" : ""}
       />
 
       <MCPServerDetailsPanel


### PR DESCRIPTION
Relates #5040

## Summary

Replaces the placeholder "Connection Test Result" confirm dialog on the Servers page with a dedicated **Test Connection** dialog that lets users compose and send a test HTTP request to an MCP server and inspect the response. The layout follows the Figma design (two-column: request form on the left, response panel on the right).

<img width="1652" height="876" alt="Screenshot 2026-06-24 at 12 35 01" src="https://github.com/user-attachments/assets/a0ee55b7-7af9-4904-a902-5eb0f70909ee" />
<img width="1640" height="868" alt="Screenshot 2026-06-24 at 12 34 36" src="https://github.com/user-attachments/assets/ade0c705-b0a2-4f8d-9946-31ea84340fe6" />


## Changes

**New component — `client/src/components/servers/TestConnectionDialog.tsx`**
  - Two-column dialog: request form (left) + response panel (right, always visible).
  - Request form: URL (required), Method (Get/Post/Put/Delete/Patch as a segmented radio group), Path, Content type, Headers, and Body (shown only for non-GET methods).
  - Client-side JSON validation for the Headers and Body fields before sending (matching the existing `useToolForm` `JSON.parse` convention).
  - Response panel states: idle placeholder, running, success (`CircleCheck` + status/latency + syntax-highlighted body via `JsonHighlighter` with a copy button), and error.
  - Resizable Headers/Body textareas; field backgrounds are transparent so they inherit the dialog's `popover` background; focus ring matches the `MCPServerForm` textareas.
  - Accessibility: on open, focus moves to the dialog title (`tabIndex={-1}`) rather than auto-focusing the pre-filled URL field, keeping focus inside the dialog and announced by screen readers.

**`client/src/pages/Servers.tsx`**
  - Wires the actions-menu "Test connection" item to open `TestConnectionDialog` (passes `serverName`/`serverUrl`).
  - Removes the old `serversApi.testConnection` call, its page-level inline error/result state, and the repurposed `ConfirmDialog`.

**Tests**
  - `TestConnectionDialog.test.tsx` (new): initial render, all form fields, method radios, Body hidden-for-GET / shown-for-POST, Headers and Body JSON validation, focus-not-on-URL behavior, and close.
  - `Servers.test.tsx`: updated the obsolete "inline error on test failure" case to "opens the test connection dialog from the actions menu", reflecting the new dialog-based flow.

  ## Notes / follow-up

  - The dialog does **not** yet perform a live request. The React UI must not call the legacy `/admin/**` routes, and the v1 endpoint isn't available yet, so the action currently surfaces a "pending API endpoint" message. A
  `TODO(#5326)` marks where to wire in `POST /v1/mcp-servers/test`. Tracked by #5326.
  - Once that endpoint lands, the success/HTTP-response rendering and copy button become reachable, and the response-driven unit tests should be restored.
