### PR TITLE
chore: speed up merge queue Docker validation

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -24,6 +24,7 @@ on:
     branches: ["main"]
     tags: ["v*"]
     paths:
+      - '.dockerignore'
       - 'Containerfile.lite'
       - 'mcpgateway/**'
       - 'plugins/**'
@@ -35,6 +36,7 @@ on:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
     paths:
+      - '.dockerignore'
       - 'Containerfile.lite'
       - 'mcpgateway/**'
       - 'plugins/**'
@@ -58,6 +60,69 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  docker-inputs:
+    name: Detect Docker Build Inputs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      changed: ${{ steps.changed.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check changed Docker build inputs
+        id: changed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" != "merge_group" ]]; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+            echo "Non-merge-group event; using workflow path filters."
+            exit 0
+          fi
+
+          git fetch --no-tags --prune --depth=1 origin "${{ github.event.repository.default_branch }}"
+          base="$(git merge-base HEAD "origin/${{ github.event.repository.default_branch }}")"
+          changed_paths="$(git diff --name-only "${base}" HEAD)"
+
+          is_docker_build_input() {
+            local path="$1"
+
+            case "${path}" in
+              .dockerignore|Containerfile.lite|pyproject.toml|uv.lock|.github/workflows/docker-multiplatform.yml)
+                return 0
+                ;;
+              infra/wheels/*|mcpgateway/*|plugins/*)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          docker_input_changes=()
+
+          while IFS= read -r path; do
+            [[ -z "${path}" ]] && continue
+            if is_docker_build_input "${path}"; then
+              docker_input_changes+=("${path}")
+            fi
+          done <<< "${changed_paths}"
+
+          if ((${#docker_input_changes[@]} == 0)); then
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+            echo "No Docker build inputs changed in this merge group."
+            exit 0
+          fi
+
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+          printf 'Docker build input changed: %s\n' "${docker_input_changes[@]}"
+
   # ---------------------------------------------------------------
   # Build the full dependency-closure wheel image for s390x and ppc64le only.
   # amd64/arm64 have full PyPI manylinux coverage and do not need a wheel
@@ -68,7 +133,10 @@ jobs:
   # (push/merge_group/workflow_dispatch).
   # ---------------------------------------------------------------
   wheels:
-    if: github.event_name != 'pull_request'
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.docker-inputs.outputs.changed == 'true'
+    needs: docker-inputs
     name: Build wheels (${{ matrix.suffix }})
     strategy:
       fail-fast: false
@@ -150,9 +218,13 @@ jobs:
     # inspect` when the lock hash is unchanged, so the wait is ~2-3 min in steady
     # state; only a real dependency change pays the full build time. `always() &&
     # needs.wheels.result != 'failure'` tolerates `wheels` being skipped entirely
-    # on PR events.
-    if: always() && needs.wheels.result != 'failure' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
-    needs: wheels
+    # on PR events and merge groups with no Docker build input changes.
+    if: >-
+      always() &&
+      needs.docker-inputs.outputs.changed == 'true' &&
+      needs.wheels.result != 'failure' &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft)
+    needs: [docker-inputs, wheels]
     name: Build ${{ matrix.suffix }}
     strategy:
       fail-fast: false
@@ -189,8 +261,8 @@ jobs:
       contents: read
       packages: write
 
-    # amd64: builds (no push) on PR and merge queue; full build+push on push
-    # arm64/s390x/ppc64le: builds (no push) on merge queue; full build+push on push
+    # amd64: cache-only validation on PR and merge queue; full build+push on push
+    # arm64/s390x/ppc64le: cache-only validation on merge queue; full build+push on push
     # Condition for build steps: always except PRs skip non-amd64 (build_on_pr)
     # Condition for push-only steps (login, digest): push/workflow_dispatch only
     steps:
@@ -287,7 +359,7 @@ jobs:
             ${{ env.WHEELS_REF && format('WHEELS_REF={0}', env.WHEELS_REF) || '' }}
 
           push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-          load: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+          outputs: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'type=cacheonly' || '' }}
 
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -457,12 +529,30 @@ jobs:
   # ---------------------------------------------------------------
   build-complete:
     name: Docker Build Complete
-    needs: build
+    needs: [docker-inputs, wheels, build]
     runs-on: ubuntu-24.04
     if: always()
     steps:
       - name: Check all platform builds passed
         run: |
+          changes_result="${{ needs.docker-inputs.result }}"
+          if [[ "$changes_result" != "success" ]]; then
+            echo "Docker build input detection failed (result: $changes_result)"
+            exit 1
+          fi
+
+          changed="${{ needs.docker-inputs.outputs.changed }}"
+          if [[ "$changed" != "true" ]]; then
+            echo "Docker build skipped — no relevant files changed in this merge group"
+            exit 0
+          fi
+
+          wheels_result="${{ needs.wheels.result }}"
+          if [[ "$wheels_result" == "failure" || "$wheels_result" == "cancelled" ]]; then
+            echo "Docker wheel builds failed (result: $wheels_result)"
+            exit 1
+          fi
+
           result="${{ needs.build.result }}"
           if [[ "$result" == "success" || "$result" == "skipped" ]]; then
             echo "Docker builds passed (result: $result)"

--- a/.github/workflows/docker-required.yml
+++ b/.github/workflows/docker-required.yml
@@ -21,6 +21,7 @@ on:
     types: [opened, synchronize, ready_for_review]
     branches: ["main"]
     paths-ignore:
+      - '.dockerignore'
       - 'Containerfile.lite'
       - 'mcpgateway/**'
       - 'plugins/**'


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5365

---

## 📝 Summary

Speeds up merge-queue Docker validation by adding a lightweight Docker-input change gate before native architecture jobs are scheduled.

Also switches PR and merge-queue validation builds to BuildKit cache-only output and treats `.dockerignore` as a Docker build input in path filters.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Workflow syntax | `actionlint .github/workflows/docker-multiplatform.yml .github/workflows/docker-required.yml` | Pass |
| YAML lint | `make yamllint` | Pass |
| Workflow graph parse | `act -l -W .github/workflows/docker-multiplatform.yml` | Pass |
| Merge-group dry run | `act merge_group -n -W .github/workflows/docker-multiplatform.yml` | Pass; native runner labels are not executable locally |
| Merge-queue diff gate | git worktree simulation for docs-only and `.dockerignore` changes | Pass |

### Performance Evidence

I replayed the new Docker-input gate against the last 15 successful `Multiplatform Docker Build` merge-queue runs from GitHub Actions, using each run's PR file list and the actual job durations from `gh run view`.

Result: 3 of 15 successful merge-queue runs had no Docker build inputs and would have skipped the `wheels` job plus the four-platform Docker build matrix.

| Run | PR | Docker inputs changed? | Actual elapsed | Longest skipped job | Skipped Docker runner-minutes |
|-----|----|------------------------|----------------|---------------------|-------------------------------|
| [28102274888](https://github.com/IBM/mcp-context-forge/actions/runs/28102274888) | #5360 | No | 12.0 min | `Build ppc64le` 10.1 min | 24.9 min |
| [28041309527](https://github.com/IBM/mcp-context-forge/actions/runs/28041309527) | #5277 | No | 22.5 min | `Build s390x` 7.5 min | 26.3 min |
| [28037561713](https://github.com/IBM/mcp-context-forge/actions/runs/28037561713) | #5310 | No | 11.6 min | `Build ppc64le` 9.8 min | 13.7 min |

Total observed avoidable Docker build work across those 3 runs: 64.9 runner-minutes. The required `Docker Build Complete` check for those runs spent 46.1 minutes elapsed waiting on work this gate would skip. After this change, those cases only run the small `docker-inputs` detector and the aggregate `build-complete` job; exact hosted runner overhead will be visible after this lands, but the native Docker build matrix is removed from the critical path when no Docker build inputs changed.

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

`act` can parse and dry-run the workflow, but it cannot fully execute this matrix locally because the real workflow depends on GitHub-hosted native `arm64`, `s390x`, and `ppc64le` runners plus GHCR behavior.
