### PR TITLE
(feat)ui-rewrite: Adds prompts List page

### DIFF
--- a/client/src/i18n/locales/en-US/index.ts
+++ b/client/src/i18n/locales/en-US/index.ts
@@ -6,6 +6,7 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
+import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
 import prompts from "./prompts.json";
@@ -20,6 +21,7 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
+  ...teams,
   ...tools,
   ...resources,
   ...prompts,

--- a/client/src/i18n/locales/en-US/index.ts
+++ b/client/src/i18n/locales/en-US/index.ts
@@ -6,9 +6,9 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
-import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
+import prompts from "./prompts.json";
 import mcpServer from "./mcpServer.json";
 
 export default {
@@ -20,8 +20,8 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
-  ...teams,
   ...tools,
   ...resources,
+  ...prompts,
   ...mcpServer,
 };

--- a/client/src/i18n/locales/en-US/prompts.json
+++ b/client/src/i18n/locales/en-US/prompts.json
@@ -1,0 +1,9 @@
+{
+  "prompts.title": "Prompts",
+  "prompts.loading": "Loading prompts, please wait...",
+  "prompts.error.loading": "Error loading prompts",
+  "prompts.add.title": "Add prompts",
+  "prompts.add.description": "Connect a MCP server to load prompts automatically, or build a reusable template with named arguments.",
+  "prompts.card.moreOptionsFor": "More options for {name}",
+  "prompts.card.viewDetails": "View details"
+}

--- a/client/src/i18n/locales/es-ES/index.ts
+++ b/client/src/i18n/locales/es-ES/index.ts
@@ -6,9 +6,11 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
+import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
 import prompts from "./prompts.json";
+import mcpServer from "./mcpServer.json";
 
 export default {
   ...common,
@@ -19,7 +21,9 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
+  ...teams,
   ...tools,
   ...resources,
   ...prompts,
+  ...mcpServer,
 };

--- a/client/src/i18n/locales/es-ES/index.ts
+++ b/client/src/i18n/locales/es-ES/index.ts
@@ -6,10 +6,9 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
-import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
-import mcpServer from "./mcpServer.json";
+import prompts from "./prompts.json";
 
 export default {
   ...common,
@@ -20,8 +19,7 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
-  ...teams,
   ...tools,
   ...resources,
-  ...mcpServer,
+  ...prompts,
 };

--- a/client/src/i18n/locales/es-ES/prompts.json
+++ b/client/src/i18n/locales/es-ES/prompts.json
@@ -1,0 +1,9 @@
+{
+  "prompts.title": "Prompts",
+  "prompts.loading": "Cargando prompts, por favor espere...",
+  "prompts.error.loading": "Error al cargar los prompts",
+  "prompts.add.title": "Añadir prompts",
+  "prompts.add.description": "Conecte un servidor MCP para cargar prompts automáticamente, o cree una plantilla reutilizable con argumentos con nombre.",
+  "prompts.card.moreOptionsFor": "Más opciones para {name}",
+  "prompts.card.viewDetails": "Ver detalles"
+}

--- a/client/src/i18n/locales/pt-BR/index.ts
+++ b/client/src/i18n/locales/pt-BR/index.ts
@@ -6,9 +6,11 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
+import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
 import prompts from "./prompts.json";
+import mcpServer from "./mcpServer.json";
 
 export default {
   ...common,
@@ -19,7 +21,9 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
+  ...teams,
   ...tools,
   ...resources,
   ...prompts,
+  ...mcpServer,
 };

--- a/client/src/i18n/locales/pt-BR/index.ts
+++ b/client/src/i18n/locales/pt-BR/index.ts
@@ -6,10 +6,9 @@ import restApi from "./restApi.json";
 import grpc from "./grpc.json";
 import gateways from "./gateways.json";
 import users from "./users.json";
-import teams from "./teams.json";
 import tools from "./tools.json";
 import resources from "./resources.json";
-import mcpServer from "./mcpServer.json";
+import prompts from "./prompts.json";
 
 export default {
   ...common,
@@ -20,8 +19,7 @@ export default {
   ...grpc,
   ...gateways,
   ...users,
-  ...teams,
   ...tools,
   ...resources,
-  ...mcpServer,
+  ...prompts,
 };

--- a/client/src/i18n/locales/pt-BR/prompts.json
+++ b/client/src/i18n/locales/pt-BR/prompts.json
@@ -1,0 +1,9 @@
+{
+  "prompts.title": "Prompts",
+  "prompts.loading": "Carregando prompts, aguarde...",
+  "prompts.error.loading": "Erro ao carregar prompts",
+  "prompts.add.title": "Adicionar prompts",
+  "prompts.add.description": "Conecte um servidor MCP para carregar prompts automaticamente ou crie um modelo reutilizável com argumentos nomeados.",
+  "prompts.card.moreOptionsFor": "Mais opções para {name}",
+  "prompts.card.viewDetails": "Ver detalhes"
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -62,6 +62,7 @@
   --color-card: var(--card);
   /* Tool-specific semantic tokens */
   --color-tool-icon-bg: var(--tool-icon-bg);
+  --color-prompt-icon-bg: var(--prompt-icon-bg);
   --color-tool-status-active: var(--tool-status-active);
   --color-tool-status-inactive: var(--tool-status-inactive);
   --color-tool-badge-bg: var(--tool-badge-bg);
@@ -114,6 +115,7 @@
   --popover-foreground: oklch(0.145 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --tool-icon-bg: var(--color-fuchsia-400);
+  --prompt-icon-bg: #6fff9f;
   --tool-status-active: var(--color-emerald-500);
   --tool-status-inactive: var(--color-gray-500);
   --tool-badge-bg: var(--color-neutral-800);

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
+import { renderWithProviders } from "@/test/test-utils";
+import { Prompts } from "./Prompts";
+
+describe("Prompts", () => {
+  beforeEach(() => {
+    server.resetHandlers();
+  });
+
+  it("renders the add prompts card", async () => {
+    server.use(http.get("/prompts", () => HttpResponse.json([])));
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add prompts")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Connect a MCP server to load prompts automatically/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /More options for/i })).not.toBeInTheDocument();
+  });
+
+  it("renders loading state", () => {
+    server.use(
+      http.get("/prompts", async () => {
+        await new Promise(() => {});
+        return HttpResponse.json([]);
+      }),
+    );
+
+    renderWithProviders(<Prompts />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("Loading prompts, please wait...")).toBeInTheDocument();
+  });
+
+  it("renders error state when prompts fail to load", async () => {
+    server.use(http.get("/prompts", () => HttpResponse.json({ detail: "Nope" }, { status: 500 })));
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Error loading prompts")).toBeInTheDocument();
+    expect(screen.getByText("HTTP 500")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -1,9 +1,32 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
 import { renderWithProviders } from "@/test/test-utils";
 import { Prompts } from "./Prompts";
+import type { Prompt } from "@/types/prompts";
+
+function createMockPrompt(overrides: Partial<Prompt> = {}): Prompt {
+  return {
+    id: "prompt-1",
+    name: "summarize",
+    displayName: "Summarize document",
+    originalName: "summarize_document",
+    gatewayId: "gateway-1",
+    gatewaySlug: "gateway-1",
+    description: "Summarizes uploaded documents.",
+    tags: [{ id: "tag-summary", label: "summary" }],
+    arguments: [{ name: "topic", required: true }],
+    ...overrides,
+  };
+}
+
+function getPromptCard(label: string): HTMLElement {
+  const card = screen.getByText(label).closest('[data-slot="card"]');
+  expect(card).toBeInTheDocument();
+  return card as HTMLElement;
+}
 
 describe("Prompts", () => {
   beforeEach(() => {
@@ -37,6 +60,67 @@ describe("Prompts", () => {
 
     expect(screen.getByRole("status")).toBeInTheDocument();
     expect(screen.getByText("Loading prompts, please wait...")).toBeInTheDocument();
+  });
+
+  it("renders populated prompt cards with label fallbacks, tag and argument badges, filtered descriptions, and actions", async () => {
+    const user = userEvent.setup();
+    const prompts: Prompt[] = [
+      createMockPrompt({
+        id: "prompt-display-name",
+        name: "summarize",
+        displayName: "Summarize document",
+        originalName: "summarize_document",
+        description: "Summarizes uploaded documents.",
+        tags: [{ id: "tag-summary", label: "summary" }],
+        arguments: [
+          { name: "topic", required: true },
+          { name: "tone", required: false },
+        ],
+      }),
+      createMockPrompt({
+        id: "prompt-original-name",
+        name: "translate",
+        displayName: "",
+        originalName: "translate_text",
+        description: "None",
+        tags: [{ id: "tag-language", label: "language" }],
+        arguments: [{ name: "locale", required: true }],
+      }),
+      createMockPrompt({
+        id: "prompt-name",
+        name: "fallback_prompt",
+        displayName: undefined,
+        originalName: undefined,
+        description: "   ",
+        tags: [],
+        arguments: [],
+      }),
+    ];
+
+    server.use(http.get("/prompts", () => HttpResponse.json({ prompts })));
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Summarize document")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("translate_text")).toBeInTheDocument();
+    expect(screen.getByText("fallback_prompt")).toBeInTheDocument();
+    expect(screen.getByText("Summarizes uploaded documents.")).toBeInTheDocument();
+    expect(screen.queryByText("None")).not.toBeInTheDocument();
+
+    const summarizeCard = getPromptCard("Summarize document");
+    expect(within(summarizeCard).getByText("summary")).toBeInTheDocument();
+    expect(within(summarizeCard).getByText("topic")).toBeInTheDocument();
+    expect(within(summarizeCard).getByText("tone")).toBeInTheDocument();
+
+    const originalNameCard = getPromptCard("translate_text");
+    expect(within(originalNameCard).getByText("language")).toBeInTheDocument();
+    expect(within(originalNameCard).getByText("locale")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More options for Summarize document" }));
+    expect(await screen.findByRole("menuitem", { name: "View details" })).toBeInTheDocument();
   });
 
   it("renders error state when prompts fail to load", async () => {

--- a/client/src/pages/Prompts.tsx
+++ b/client/src/pages/Prompts.tsx
@@ -1,3 +1,167 @@
+import { MessageSquareCode, MoreHorizontal, Plus } from "lucide-react";
+import { useIntl } from "react-intl";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useQuery } from "@/hooks/useQuery";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Prompt, PromptsResponse } from "@/types/prompts";
+
 export function Prompts() {
-  return <h1 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">Prompts</h1>;
+  const intl = useIntl();
+  const {
+    data: promptsData,
+    error,
+    isLoading,
+  } = useQuery<PromptsResponse>("/prompts?limit=1000&include_inactive=true");
+
+  const getPromptItems = (data: PromptsResponse): Prompt[] => {
+    if (Array.isArray(data)) return data;
+    return data?.prompts ?? [];
+  };
+
+  const getPromptLabel = (prompt: Prompt): string =>
+    prompt.displayName || prompt.originalName || prompt.name;
+
+  const getPromptDescription = (prompt: Prompt): string | null => {
+    const description = prompt.description;
+    if (!description || description.trim() === "" || description.trim().toLowerCase() === "none") {
+      return null;
+    }
+    return description;
+  };
+
+  const promptItems = getPromptItems(promptsData ?? []);
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-6 text-base font-semibold text-neutral-900 dark:text-white">
+        {intl.formatMessage({ id: "prompts.title" })}
+      </h1>
+
+      {isLoading && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+          className="flex items-center justify-center p-12"
+        >
+          <span className="sr-only">{intl.formatMessage({ id: "prompts.loading" })}</span>
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-600 dark:border-gray-700 dark:border-t-blue-400" />
+        </div>
+      )}
+
+      {error && (
+        <div
+          className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-800 dark:bg-red-900/20"
+          role="alert"
+          aria-live="assertive"
+        >
+          <h3 className="mb-1 font-semibold">
+            {intl.formatMessage({ id: "prompts.error.loading" })}
+          </h3>
+          <p className="text-red-800 dark:text-red-200">{error.message}</p>
+        </div>
+      )}
+
+      {!isLoading && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 2xl:grid-cols-3">
+          <Card size="sm" className="cursor-pointer transition-opacity hover:opacity-90">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-tool-add-icon-bg shadow-sm">
+                  <Plus className="h-3.5 w-3.5 text-tool-add-icon-fg" />
+                </div>
+                <span className="text-sm font-semibold text-neutral-900 dark:text-white">
+                  {intl.formatMessage({ id: "prompts.add.title" })}
+                </span>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
+                {intl.formatMessage({ id: "prompts.add.description" })}
+              </p>
+            </CardContent>
+          </Card>
+
+          {promptItems.map((prompt) => {
+            const description = getPromptDescription(prompt);
+            const promptBadges = [
+              ...(prompt.tags ?? []).map((tag) => ({ id: `tag-${tag.id}`, label: tag.label })),
+              ...(prompt.arguments ?? []).map((argument) => ({
+                id: `argument-${argument.name}`,
+                label: argument.name,
+              })),
+            ];
+
+            return (
+              <Card key={prompt.id} size="sm">
+                <CardHeader>
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-prompt-icon-bg">
+                      <MessageSquareCode className="h-3.5 w-3.5 text-black" />
+                    </div>
+
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <span className="truncate text-sm font-semibold text-neutral-500 dark:text-neutral-400">
+                        {getPromptLabel(prompt)}
+                      </span>
+                    </div>
+
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          aria-label={intl.formatMessage(
+                            { id: "prompts.card.moreOptionsFor" },
+                            { name: getPromptLabel(prompt) },
+                          )}
+                          className="h-7 w-7 p-0"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem>
+                          {intl.formatMessage({ id: "prompts.card.viewDetails" })}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </CardHeader>
+
+                {(description || promptBadges.length > 0) && (
+                  <CardContent>
+                    {description && (
+                      <p className="mb-3 line-clamp-2 text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
+                        {description}
+                      </p>
+                    )}
+                    {promptBadges.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {promptBadges.map((badge) => (
+                          <span
+                            key={badge.id}
+                            className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
+                          >
+                            {badge.label}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </CardContent>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/client/src/types/prompts.ts
+++ b/client/src/types/prompts.ts
@@ -1,0 +1,19 @@
+export interface Prompt {
+  id: string;
+  name: string;
+  displayName?: string;
+  originalName?: string;
+  gatewayId?: string | null;
+  gatewaySlug?: string | null;
+  description?: string | null;
+  tags?: Array<{ id: string; label: string }>;
+  arguments?: PromptArgument[];
+}
+
+export interface PromptArgument {
+  name: string;
+  description?: string;
+  required?: boolean;
+}
+
+export type PromptsResponse = Prompt[] | { prompts?: Prompt[] };


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

---
https://github.com/IBM/mcp-context-forge/issues/5101

## 📝 Summary

_What does this PR do and why?_

---
This PR adds a list page for the existing Prompts stub.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
Updated screenshots:

Prompts cards, shows dropdown menu with 'View details' option
<img width="1544" height="626" alt="Screenshot 2026-07-02 at 12 03 14" src="https://github.com/user-attachments/assets/f298501d-f22e-44d1-8a94-1741e7155dbc" />

Light mode
<img width="1544" height="626" alt="Screenshot 2026-07-02 at 12 10 47" src="https://github.com/user-attachments/assets/e9b597fe-5047-44ed-835d-cc58633bd089" />


