### PR TITLE
fix: update Rust lockfile dependency metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "futures",
  "serde",
  "serde_json",
  "tokio",


### PR DESCRIPTION
# Bug-fix PR

## Summary

Fixes the Rust supply-chain vet failure caused by stale Cargo.lock package metadata for the a2a-echo-agent workspace package.

Related: #4907

## Reproduction Steps

1. Check out current main.
2. Run `cargo metadata --locked --format-version 1`.
3. Cargo fails because `Cargo.lock` would need an update while `--locked` is set.

## Root Cause

`a2a-agents/rust/a2a-echo-agent/Cargo.toml` declares `futures.workspace = true`, but the generated `Cargo.lock` entry for `a2a-echo-agent` did not include `"futures"` in its dependency list. `cargo vet check` reaches Cargo metadata in locked mode, so it fails instead of updating the lockfile.

## Fix Description

Regenerated the lockfile metadata so the `a2a-echo-agent` package entry includes its declared `futures` dependency. No Rust source code or dependency versions changed.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|---|---|---|
| Lockfile metadata | `cargo metadata --locked --format-version 1 >/dev/null` | Pass |
| Diff hygiene | `git diff --check` | Pass |
| Manual regression no longer fails | `make rust-vet` | Pass |

## MCP Compliance (if relevant)

- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed

--------

> edits by Jitesh

Related to https://github.com/IBM/mcp-context-forge/pull/5360