### PR TITLE
fix: enforce Rust lockfile checks in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,9 @@ on:
     types: [opened, synchronize, ready_for_review]
     branches: [main, develop]
     paths:
+      - "a2a-agents/rust/**"
       - "crates/**"
+      - "mcp-servers/rust/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
@@ -87,6 +89,9 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup default stable
+
+      - name: Check Cargo.lock is current
+        run: cargo metadata --locked --format-version 1 >/dev/null
 
       - name: Cache Cargo
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "futures",
  "serde",
  "serde_json",
  "tokio",


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes #5380.

Adds a locked Cargo metadata check to the existing Rust build job so stale `Cargo.lock` metadata fails on the Rust change that introduced it, not on the next unrelated PR that happens to run Rust CI.

This PR also includes the one-line lockfile metadata repair from #5379 so the new check passes against current `main`.

## 🔁 Reproduction Steps

1. Check out commit `25f705361921b89ed76d5570ed4170993f00eb69`.
2. Run `cargo metadata --locked --format-version 1 >/dev/null`.
3. Cargo fails because `Cargo.lock` is stale.

## 🐞 Root Cause

The Rust workflow did not run for `a2a-agents/rust/**`, even though that directory contains a root workspace member. The build job also did not run a locked Cargo metadata check before continuing, so stale lockfile metadata was only exposed later by `make rust-vet` on an unrelated PR.

## 💡 Fix Description

- Updates `Cargo.lock` so `a2a-echo-agent` includes its declared `futures` dependency metadata.
- Adds `a2a-agents/rust/**` and `mcp-servers/rust/**` to the Rust CI path filters.
- Adds `cargo metadata --locked --format-version 1 >/dev/null` as an early step in the existing `Rust build` job.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Workflow syntax | `actionlint .github/workflows/rust.yml` | Pass |
| Lockfile check | `cargo metadata --locked --format-version 1 >/dev/null` | Pass |
| Existing supply-chain check | `make rust-vet` | Pass |
| Diff hygiene | `git diff --check` | Pass |
| Regression probe | `cargo metadata --locked --format-version 1 >/dev/null` at `25f7053` | Fails with stale lockfile error |

## 📐 MCP Compliance (if relevant)

- [ ] Matches current MCP spec
- [x] No breaking change to MCP clients

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
