### PR TITLE
fix(startup): fail-fast on AUTH_ENCRYPTION_SECRET mismatch before gateway init

### DIFF
--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -1457,6 +1457,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # Validate UAID security configuration
         validate_uaid_security_config()
 
+        # Validate AUTH_ENCRYPTION_SECRET can decrypt existing auth data.
+        # Must run before gateway_service.initialize() schedules worker tasks
+        # that call decode_auth — otherwise InvalidTag surfaces as a noisy
+        # per-gateway error log rather than a single actionable fatal.
+        validate_auth_encryption_key()
+
         # Initialize the plugin manager factory whenever the YAML config is
         # available. We used to gate this on ``settings.plugins.enabled`` but
         # that broke runtime enable-from-disabled: a node that boots with the
@@ -1918,6 +1924,88 @@ app = FastAPI(
 
 # Setup metrics instrumentation
 setup_metrics(app)
+
+
+def validate_auth_encryption_key() -> None:
+    """Verify AUTH_ENCRYPTION_SECRET can decrypt existing AES-GCM auth blobs.
+
+    Samples one encrypted auth blob from each AES-GCM-backed column
+    (gateways.auth_value, tools.auth_value) and attempts decryption with
+    the current secret.  Aborts startup with a targeted diagnostic on failure
+    rather than letting individual gateway workers surface the error as
+    per-gateway ``InvalidTag`` log noise.
+
+    Column coverage:
+        - ``gateways.auth_value`` — bearer/basic/authheader credentials for
+          each registered upstream MCP gateway (decoded by
+          ``utils/services_auth.decode_auth`` at connection time).
+        - ``tools.auth_value`` — per-tool auth overrides stored in the same
+          AES-GCM format.
+
+    Skips rows whose stored value is not a genuine encrypted blob:
+        - SQL NULL
+        - JSON null (→ Python None after psycopg3 JSON parsing)
+        - Empty JSON object (→ Python ``{}``) used for "no OAuth configured"
+        - Empty string
+
+    Only ``cryptography.exceptions.InvalidTag`` triggers the abort — that is
+    the specific exception raised by AES-GCM when the decryption key is wrong.
+    Other errors (DB connection issues, import errors) are not suppressed.
+
+    Raises:
+        SystemExit: If any sampled auth blob cannot be decrypted with the
+            current AUTH_ENCRYPTION_SECRET.
+    """
+    # pylint: disable=import-outside-toplevel
+    from cryptography.exceptions import InvalidTag  # type: ignore[import-untyped]
+
+    from mcpgateway.utils.services_auth import decode_auth
+
+    secret = settings.auth_encryption_secret.get_secret_value()
+
+    # Columns using services_auth AES-GCM encoding.  One sample per column is
+    # sufficient — all rows share the same key derivation.
+    PROBE_QUERIES = [
+        ("gateways", "auth_value"),
+        ("tools", "auth_value"),
+    ]
+
+    db = SessionLocal()
+    try:
+        for table, column in PROBE_QUERIES:
+            result = db.execute(
+                # text() is intentional — table/column names are literals, not user input
+                text(f"SELECT {column} FROM {table} WHERE {column} IS NOT NULL LIMIT 50")  # noqa: S608
+            )
+            for (raw_val,) in result:
+                # Skip structural non-values that are never encrypted.
+                if raw_val is None:
+                    continue
+                if isinstance(raw_val, dict):
+                    continue  # JSON null → {} or empty oauth_config
+                if not isinstance(raw_val, str) or not raw_val:
+                    continue
+                if len(raw_val) < 20:
+                    continue  # too short to be a valid AES-GCM blob
+                if raw_val.startswith("v2:") or raw_val.startswith('"'):
+                    continue  # Fernet-wrapped or JSON-quoted — wrong layer
+
+                try:
+                    decode_auth(raw_val, secret=secret)
+                    break  # one successful decode is enough for this column
+                except InvalidTag:
+                    logger.critical(
+                        "FATAL: AUTH_ENCRYPTION_SECRET cannot decrypt %s.%s auth data. "
+                        "If you rotated AUTH_ENCRYPTION_SECRET, run the rekey migration before restarting. "
+                        "Validator: python3 scripts/validate_rekey.py OLD_SECRET NEW_SECRET DATABASE_URL",
+                        table,
+                        column,
+                    )
+                    sys.exit(1)
+    finally:
+        db.close()
+
+    logger.info("Auth encryption key verified against live gateway/tool auth data")
 
 
 def validate_security_configuration():

--- a/scripts/rotate-encryption-secret.sh
+++ b/scripts/rotate-encryption-secret.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# rotate-encryption-secret.sh — safe AUTH_ENCRYPTION_SECRET rotation for RouterCore
+#
+# Encodes the full procedure from the 2026-06-26 incident postmortem:
+#   1. Accept the old + new secret values
+#   2. Run the rekey migration inside the running container
+#   3. Run validate_rekey.py — MUST exit 0
+#   4. Restart routercore only on validation pass
+#
+# Usage:
+#   scripts/rotate-encryption-secret.sh OLD_SECRET NEW_SECRET [--restart]
+#
+# Arguments:
+#   OLD_SECRET   Current AUTH_ENCRYPTION_SECRET (the one the container is running with)
+#   NEW_SECRET   Replacement AUTH_ENCRYPTION_SECRET (already stored in KeePass)
+#   --restart    Restart the container after successful validation (default: dry-run only)
+#
+# The rekey migration and validation both run INSIDE the container so they share
+# the same mcpgateway Python environment. Never run them on the host directly.
+#
+# Prerequisites:
+#   - routercore container must be running
+#   - The compose.yml AUTH_ENCRYPTION_SECRET env var must already reference the new
+#     KeePass entry (so the restarted container picks up the new value automatically)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER="routercore"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+die() { printf "${RED}FATAL: %s${NC}\n" "$*" >&2; exit 1; }
+info() { printf "${GREEN}>> %s${NC}\n" "$*"; }
+warn() { printf "${YELLOW}WARN: %s${NC}\n" "$*"; }
+
+[[ "$#" -ge 2 ]] || { echo "Usage: $0 OLD_SECRET NEW_SECRET [--restart]"; exit 2; }
+
+OLD_SECRET="$1"
+NEW_SECRET="$2"
+DO_RESTART=false
+[[ "${3:-}" == "--restart" ]] && DO_RESTART=true
+
+[[ "$OLD_SECRET" == "$NEW_SECRET" ]] && die "OLD_SECRET and NEW_SECRET are identical — rotation did nothing"
+[[ -z "$OLD_SECRET" ]] && die "OLD_SECRET is empty"
+[[ -z "$NEW_SECRET" ]] && die "NEW_SECRET is empty"
+
+# Verify container is up
+docker inspect "$CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true \
+  || die "Container '$CONTAINER' is not running"
+
+# Pull DATABASE_URL from the live container (avoids duplicating connection config here)
+DB_URL=$(docker exec "$CONTAINER" printenv DATABASE_URL 2>/dev/null) \
+  || die "Could not read DATABASE_URL from container — is mcpgateway running?"
+[[ -n "$DB_URL" ]] || die "DATABASE_URL is empty inside container"
+
+info "Container:    $CONTAINER"
+info "Database:     ${DB_URL%%@*}@***"  # redact credentials in log
+info "Old secret:   ${OLD_SECRET:0:4}*** (${#OLD_SECRET} chars)"
+info "New secret:   ${NEW_SECRET:0:4}*** (${#NEW_SECRET} chars)"
+echo
+
+# ── Step 1: copy scripts into container ───────────────────────────────────────
+info "Copying migration and validation scripts into container..."
+
+REKEY_SCRIPT="$SCRIPT_DIR/../scripts/validate_rekey.py"
+[[ -f "$REKEY_SCRIPT" ]] || die "validate_rekey.py not found at $REKEY_SCRIPT"
+
+# The migration script lives at a well-known path; operator must have run it
+# separately (it is destructive and requires explicit invocation), but we verify
+# whether the DB has already been migrated by running validation directly.
+docker cp "$SCRIPT_DIR/validate_rekey.py" "$CONTAINER:/tmp/validate_rekey.py"
+
+# ── Step 2: run validation against the DB ────────────────────────────────────
+info "Running pre-restart validation..."
+echo
+
+set +e
+docker exec "$CONTAINER" python3 /tmp/validate_rekey.py \
+  "$OLD_SECRET" "$NEW_SECRET" "$DB_URL"
+VALIDATE_EXIT=$?
+set -e
+echo
+
+if [[ "$VALIDATE_EXIT" -ne 0 ]]; then
+  die "Validation FAILED (exit $VALIDATE_EXIT). DB migration is incomplete.
+
+  If you have not run the rekey migration yet, do so first:
+    docker exec $CONTAINER python3 /tmp/rekey.py OLD_SECRET NEW_SECRET DATABASE_URL
+
+  Then re-run this script."
+fi
+
+info "Validation passed."
+
+# ── Step 3: restart ───────────────────────────────────────────────────────────
+if [[ "$DO_RESTART" == "true" ]]; then
+  info "Restarting container..."
+  docker restart "$CONTAINER"
+  echo
+  info "Waiting for health check..."
+  DEADLINE=$(( $(date +%s) + 60 ))
+  until docker exec "$CONTAINER" python3 -c \
+      "import urllib.request; urllib.request.urlopen('http://localhost:4444/health')" \
+      &>/dev/null; do
+    [[ "$(date +%s)" -lt "$DEADLINE" ]] || die "Container did not become healthy within 60s"
+    sleep 3
+  done
+  info "Container healthy. Rotation complete."
+else
+  warn "Dry run — container NOT restarted."
+  warn "Re-run with --restart to apply:  $0 OLD_SECRET NEW_SECRET --restart"
+fi

--- a/scripts/validate_rekey.py
+++ b/scripts/validate_rekey.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Post-rotation validation for AUTH_ENCRYPTION_SECRET.
+
+Run this script after every key rotation, before restarting the routercore container.
+All checks must pass. Any failure means the rekey migration is incomplete or incorrect.
+
+Usage:
+    python3 scripts/validate_rekey.py OLD_SECRET NEW_SECRET DATABASE_URL
+
+    OLD_SECRET  The previous AUTH_ENCRYPTION_SECRET value (what was in the container before rotation)
+    NEW_SECRET  The new AUTH_ENCRYPTION_SECRET value (what will be in the container after restart)
+    DATABASE_URL postgresql+psycopg://user:pass@host:port/dbname
+
+Exit codes:
+    0  All checks passed — safe to restart
+    1  One or more checks failed — do not restart until repaired
+
+Background:
+    ContextForge stores encrypted auth credentials in two distinct schemes that must
+    never be conflated during a rekey:
+
+    A. services_auth  (gateway/tool auth_value columns)
+       key    = SHA256(AUTH_ENCRYPTION_SECRET.encode())
+       format = base64url(nonce[12] + aesgcm_ciphertext)
+       used   = mcpgateway/utils/services_auth.py decode_auth / encode_auth
+
+    B. encryption_service  (other encrypted fields, e.g. oauth_config secrets)
+       key    = Argon2id(AUTH_ENCRYPTION_SECRET)
+       format = "v2:{...json...}"
+       used   = mcpgateway/services/encryption_service.py
+
+    Mixing these layers (e.g. passing an AES-GCM blob through encrypt_secret) produces
+    double-wrapped values that look valid in the DB but raise InvalidTag at runtime.
+    See the 2026-06-26 incident postmortem in the session audit log for details.
+"""
+import sys
+import re
+import base64
+import hashlib
+import json as json_mod
+
+FAIL = "\033[31mFAIL\033[0m"
+OK   = "\033[32m OK \033[0m"
+
+
+def die(msg: str) -> None:
+    print(f"\n{FAIL}  {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+if len(sys.argv) != 4:
+    print(__doc__)
+    sys.exit(2)
+
+OLD_SECRET, NEW_SECRET, DATABASE_URL = sys.argv[1], sys.argv[2], sys.argv[3]
+
+if OLD_SECRET == NEW_SECRET:
+    die("OLD_SECRET and NEW_SECRET are identical — rotation did not change the key")
+
+# Parse DSN
+dsn = re.sub(r"postgresql\+psycopg://([^:]+):([^@]+)@([^/]+)/(.+)", r"host=\3 dbname=\4 user=\1 password=\2", DATABASE_URL)
+dsn = re.sub(r"host=([^:]+):(\d+)", r"host=\1 port=\2", dsn)
+
+sys.path.insert(0, "/app")
+from mcpgateway.services.encryption_service import get_encryption_service
+from mcpgateway.utils.services_auth import decode_auth, encode_auth
+import psycopg
+
+old_fernet = get_encryption_service(OLD_SECRET)
+new_fernet = get_encryption_service(NEW_SECRET)
+
+# Tables using AES-GCM (services_auth) for their auth columns
+AESGCM_COLS = [
+    ("gateways",  "id", "name", ["auth_value", "oauth_config", "auth_query_params"]),
+    ("tools",     "id", "name", ["auth_value"]),
+    ("servers",   "id", "name", ["oauth_config"]),
+    ("a2a_agents","id", "name", ["auth_value", "oauth_config"]),
+]
+
+failures = 0
+warnings = 0
+
+
+def check(label: str, passed: bool, detail: str = "") -> None:
+    global failures
+    tag = OK if passed else FAIL
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  [{tag}] {label}{suffix}")
+    if not passed:
+        failures += 1
+
+
+def is_v2_fernet(val: str) -> bool:
+    return isinstance(val, str) and val.startswith("v2:")
+
+
+def is_json_quoted(val: str) -> bool:
+    """Detect accidentally JSON-encoded strings: '"v2:{...}"' or '"base64..."'."""
+    return isinstance(val, str) and val.startswith('"') and val.endswith('"')
+
+
+def is_encrypted_auth_blob(val) -> bool:
+    """Return True only if val looks like an actual AES-GCM auth blob.
+
+    JSON columns can legitimately hold {} (no OAuth), json null (→ Python None),
+    or other non-encrypted values. Only base64url strings of sufficient length
+    are candidate encrypted blobs.
+    """
+    if not isinstance(val, str):
+        return False
+    if not val or val in ("{}", "null", "[]"):
+        return False
+    # AES-GCM blobs are base64url: alphabet A-Z a-z 0-9 - _ (no spaces, no colons)
+    # v2: Fernet blobs start with "v2:" and are detected separately
+    if val.startswith("v2:") or val.startswith('"'):
+        return False  # Fernet or JSON-quoted — not a raw AES-GCM blob
+    return len(val) >= 20  # minimum: 12-byte nonce + 1 byte data + 16-byte tag → 29 bytes → ~39 base64 chars
+
+
+def probe_aesgcm(val, secret: str) -> bool:
+    if not is_encrypted_auth_blob(val):
+        return False
+    try:
+        result = decode_auth(val, secret=secret)
+        return isinstance(result, dict) and bool(result)
+    except Exception:
+        return False
+
+
+with psycopg.connect(dsn) as conn:
+    print("\n=== 1. Invariant: no column contains a value decodable by the OLD secret ===")
+    print("    (all AES-GCM auth columns must have been re-keyed away from OLD_SECRET)\n")
+
+    for table, pk, name_col, columns in AESGCM_COLS:
+        for col in columns:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT {pk}, {name_col}, {col} FROM {table} WHERE {col} IS NOT NULL")
+                rows = cur.fetchall()
+            blobs = [(row[0], row[1], row[2]) for row in rows if is_encrypted_auth_blob(row[2])]
+            if not blobs:
+                print(f"  [ OK ] {table}.{col}: 0 encrypted rows — skip")
+                continue
+            bad = [(rid, name) for rid, name, val in blobs if probe_aesgcm(val, OLD_SECRET)]
+            check(
+                f"{table}.{col}: {len(blobs)} encrypted rows, none decodable with old secret",
+                len(bad) == 0,
+                f"still old-key: {[n for _,n in bad[:3]]}" if bad else "",
+            )
+
+    print("\n=== 2. Invariant: all encrypted AES-GCM rows decode with the NEW secret ===\n")
+
+    for table, pk, name_col, columns in AESGCM_COLS:
+        for col in columns:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT {pk}, {name_col}, {col} FROM {table} WHERE {col} IS NOT NULL")
+                rows = cur.fetchall()
+            blobs = [(row[0], row[1], row[2]) for row in rows if is_encrypted_auth_blob(row[2])]
+            if not blobs:
+                print(f"  [ OK ] {table}.{col}: 0 encrypted rows — skip")
+                continue
+            bad = [(rid, name) for rid, name, val in blobs if not probe_aesgcm(val, NEW_SECRET)]
+            check(
+                f"{table}.{col}: {len(blobs)} encrypted rows, all decode with new secret",
+                len(bad) == 0,
+                f"undecryptable: {[n for _,n in bad[:3]]}" if bad else "",
+            )
+
+    print("\n=== 3. Invariant: AES-GCM columns are never Fernet-wrapped (v2: prefix) ===\n")
+
+    for table, pk, name_col, columns in AESGCM_COLS:
+        for col in columns:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT {pk}, {name_col}, {col} FROM {table} WHERE {col} IS NOT NULL")
+                rows = cur.fetchall()
+            str_rows = [(row[0], row[1], row[2]) for row in rows if isinstance(row[2], str) and row[2]]
+            if not str_rows:
+                continue
+            wrapped = [(rid, name) for rid, name, val in str_rows if is_v2_fernet(val)]
+            check(
+                f"{table}.{col}: no rows are Fernet-wrapped (v2: prefix)",
+                len(wrapped) == 0,
+                f"fernet-wrapped: {[n for _,n in wrapped[:3]]}" if wrapped else "",
+            )
+
+    print("\n=== 4. Invariant: VARCHAR auth columns are not accidentally JSON-quoted ===\n")
+    print("    (first rekey incident wrote \"v2:{...}\" with outer quotes into VARCHAR columns)\n")
+
+    for table, pk, name_col, columns in AESGCM_COLS:
+        for col in columns:
+            with conn.cursor() as cur:
+                # Get column type
+                cur.execute(
+                    "SELECT data_type FROM information_schema.columns "
+                    "WHERE table_name=%s AND column_name=%s",
+                    (table, col),
+                )
+                row = cur.fetchone()
+                if not row or row[0].lower() not in ("character varying", "text"):
+                    continue  # JSON columns handled differently
+                cur.execute(f"SELECT {pk}, {name_col}, {col} FROM {table} WHERE {col} IS NOT NULL")
+                rows = cur.fetchall()
+            if not rows:
+                continue
+            quoted = [(row[0], row[1]) for row in rows if is_json_quoted(str(row[2]))]
+            check(
+                f"{table}.{col} (varchar): no rows have JSON-quoted outer wrapping",
+                len(quoted) == 0,
+                f"json-quoted: {[n for _,n in quoted[:3]]}" if quoted else "",
+            )
+
+    print("\n=== 5. Invariant: decode_auth result is a non-empty dict for all encrypted rows ===\n")
+
+    for table, pk, name_col, columns in AESGCM_COLS:
+        for col in columns:
+            with conn.cursor() as cur:
+                cur.execute(f"SELECT {pk}, {name_col}, {col} FROM {table} WHERE {col} IS NOT NULL")
+                rows = cur.fetchall()
+            blobs = [(row[0], row[1], row[2]) for row in rows if is_encrypted_auth_blob(row[2])]
+            if not blobs:
+                continue
+            non_dict = []
+            for rid, name, val in blobs:
+                try:
+                    result = decode_auth(val, secret=NEW_SECRET)
+                    if not isinstance(result, dict) or not result:
+                        non_dict.append(name)
+                except Exception:
+                    pass  # already caught by check 2
+            check(
+                f"{table}.{col}: decode_auth returns non-empty dict for all encrypted rows",
+                len(non_dict) == 0,
+                f"non-dict/empty: {non_dict[:3]}" if non_dict else "",
+            )
+
+
+print(f"\n{'='*60}")
+if failures == 0:
+    print(f"  [{OK}] All checks passed. Safe to restart the container.")
+    print(f"{'='*60}\n")
+    sys.exit(0)
+else:
+    print(f"  [{FAIL}] {failures} check(s) failed. Repair before restarting.")
+    print(f"{'='*60}\n")
+    sys.exit(1)


### PR DESCRIPTION
## Summary

- Adds `validate_auth_encryption_key()` to the `lifespan()` startup path in `main.py`, running before `gateway_service.initialize()`.
- Probes `gateways.auth_value` and `tools.auth_value` using `decode_auth()`. If `InvalidTag` is raised (wrong key), logs a single actionable FATAL message and calls `sys.exit(1)` — before any worker task has started.
- Adds `scripts/validate_rekey.py`: a standalone post-rotation gate that enforces five invariants (old secret decrypts nothing, new secret decrypts everything, no AES-GCM column holds a Fernet `v2:` blob, no JSON-quoted VARCHAR values, decoded payloads are non-empty dicts). Exit 0 = safe to restart.
- Adds `scripts/rotate-encryption-secret.sh`: wrapper that runs `validate_rekey.py` as a mandatory gate before restarting the container, with a dry-run default and `--restart` flag to apply.

## Problem

ContextForge stores gateway and tool auth credentials in two distinct encryption layers:

| Layer | Module | Key derivation | Format |
|---|---|---|---|
| AES-GCM | `utils/services_auth.py` | `SHA256(secret)` | `base64url(nonce[12] + ciphertext)` |
| Fernet/Argon2id | `services/encryption_service.py` | Argon2id | `v2:{...json...}` |

When an operator rotates `AUTH_ENCRYPTION_SECRET` and the rekey migration conflates these layers, the DB ends up with blobs that pass structural validation but raise `cryptography.exceptions.InvalidTag` at runtime. Without this patch, that error surfaces as a per-gateway 500 from the health worker — noisy, delayed, and not actionable.

## Behavior change

**Before**: wrong `AUTH_ENCRYPTION_SECRET` causes `InvalidTag` on first gateway health check cycle, logged per-gateway, no startup abort.

**After**: wrong `AUTH_ENCRYPTION_SECRET` causes a single FATAL log at startup with explicit repair instructions and `sys.exit(1)` before any worker task starts.

No behavior change when auth data is valid — `validate_auth_encryption_key()` logs one INFO line and returns.

## Non-encrypted values are filtered

The probe skips NULL, JSON null (→ Python `None`), empty dict (`{}`), Fernet `v2:` blobs, JSON-quoted VARCHAR values, and strings shorter than 20 chars. Only real AES-GCM blobs that `decode_auth()` must handle at runtime are tested.

## Closes

N/A — standalone operator-safety improvement.