### PR TITLE
bugfix/5177-password-policy-sequential-characters

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-26T16:10:47Z",
+  "generated_at": "2026-06-26T09:59:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -642,7 +642,7 @@
         "hashed_secret": "25ab86bed149ca6ca9c1c0d5db7c9a91388ddeab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1000,
+        "line_number": 1001,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -650,7 +650,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1103,
+        "line_number": 1104,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -658,7 +658,7 @@
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1106,
+        "line_number": 1107,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -666,7 +666,7 @@
         "hashed_secret": "8674c9b302d20800e4ab3808f139704d8641a6e3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1272,
+        "line_number": 1273,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,7 +674,7 @@
         "hashed_secret": "cff0d14e4337fa8bdb68dfa906f04b0df6fad72f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1311,
+        "line_number": 1312,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -682,7 +682,7 @@
         "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1360,
+        "line_number": 1361,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -690,7 +690,7 @@
         "hashed_secret": "acde39840735314af1300688b6c2324ea89770a3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1455,
+        "line_number": 1456,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -698,7 +698,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1826,
+        "line_number": 1827,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/charts/mcp-stack/values.yaml
+++ b/charts/mcp-stack/values.yaml
@@ -870,6 +870,7 @@ mcpContextForge:
     REQUIRE_PASSWORD_CHANGE_FOR_DEFAULT_PASSWORD: "true" # require change for default password
     PASSWORD_POLICY_ENABLED: "true"         # enable password policy enforcement
     PASSWORD_PREVENT_REUSE: "true"          # prevent reuse of recent passwords
+    PASSWORD_PREVENT_SEQUENTIAL_CHARS: "true" # prevent sequential characters like '123' or 'abc'
     PASSWORD_MAX_AGE_DAYS: "90"             # maximum password age in days
     MAX_FAILED_LOGIN_ATTEMPTS: "5"         # maximum failed login attempts before lockout
     ACCOUNT_LOCKOUT_DURATION_MINUTES: "30" # account lockout duration in minutes

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1016,6 +1016,7 @@ class Settings(BaseSettings):
     require_password_change_for_default_password: bool = Field(default=True, description="Require password change when user is created with the default password")
     password_policy_enabled: bool = Field(default=True, description="Enable password complexity validation for new/changed passwords")
     password_prevent_reuse: bool = Field(default=True, description="Prevent reusing the current password when changing")
+    password_prevent_sequential_chars: bool = Field(default=True, description="Prevent sequential characters like '123' or 'abc' in passwords. Set false to allow sequential characters.")
     password_max_age_days: int = Field(default=90, description="Password maximum age in days before expiry forces a change")
     password_error_message_max_length: int = Field(default=200, description="Maximum length for password validation error messages in URL redirects (prevents URL overflow)")
     # Account Security Configuration

--- a/mcpgateway/services/password_policy_service.py
+++ b/mcpgateway/services/password_policy_service.py
@@ -184,9 +184,10 @@ class PasswordPolicyService:
                 raise PasswordPolicyError("Password must not be based on your username")
 
         # Check for sequential characters (e.g., "123", "abc")
-        has_sequential = self._has_sequential_chars(password)
-        if has_sequential:
-            raise PasswordPolicyError("Password contains too many sequential characters")
+        if getattr(settings, "password_prevent_sequential_chars", True):
+            has_sequential = self._has_sequential_chars(password)
+            if has_sequential:
+                raise PasswordPolicyError("Password contains too many sequential characters")
 
         return True
 
@@ -447,10 +448,11 @@ class PasswordPolicyService:
             score = min(score, 30)  # Cap score for common passwords
 
         # Check for sequential characters
-        if not self._has_sequential_chars(password):
-            score += 10
-        else:
-            feedback.append("Avoid sequential characters (e.g., '123', 'abc')")
+        if getattr(settings, "password_prevent_sequential_chars", True):
+            if not self._has_sequential_chars(password):
+                score += 10
+            else:
+                feedback.append("Avoid sequential characters (e.g., '123', 'abc')")
 
         # Entropy check
         if self._has_sufficient_entropy(password):
@@ -506,7 +508,7 @@ class PasswordPolicyService:
                 {"name": "special", "description": "Special characters (!@#$%^&*()_+-=[]{};:'\"\\|,.<>?)"},
             ],
             "restrictions": [
-                "Cannot contain more than 3 sequential characters (e.g., '123', 'abc')",
+                *(("Cannot contain more than 3 sequential characters (e.g., '123', 'abc')",) if getattr(settings, "password_prevent_sequential_chars", True) else ()),
                 "Cannot be a common password",
                 "Cannot contain your username",
             ],

--- a/tests/unit/mcpgateway/test_password_policy.py
+++ b/tests/unit/mcpgateway/test_password_policy.py
@@ -87,6 +87,19 @@ class TestPasswordPolicyService:
         with pytest.raises(PasswordPolicyError, match="sequential characters"):
             policy_service.validate_user_password("Abcd!Password1", "user@example.com")
 
+    def test_validate_user_password_sequential_chars_disabled(self, policy_service):
+        """Test that sequential character check can be disabled via settings."""
+        from mcpgateway.config import settings
+
+        original_value = getattr(settings, "password_prevent_sequential_chars", True)
+        try:
+            settings.password_prevent_sequential_chars = False
+            # These passwords contain sequential chars but should pass when check is disabled
+            assert policy_service.validate_user_password("Pass123word!", "user@example.com")
+            assert policy_service.validate_user_password("Abcd!Password1", "user@example.com")
+        finally:
+            settings.password_prevent_sequential_chars = original_value
+
     def test_validate_privileged_password_length(self, policy_service):
         """Test that privileged accounts require 22+ characters."""
         # 22 characters - should pass

--- a/tests/unit/mcpgateway/test_password_policy.py
+++ b/tests/unit/mcpgateway/test_password_policy.py
@@ -191,6 +191,11 @@ class TestPasswordPolicyService:
         assert result["score"] <= 40  # Common passwords get penalized but still have some base score
         assert any("common" in fb.lower() for fb in result["feedback"])
 
+    def test_get_password_strength_score_sequential(self, policy_service):
+        """Test that sequential char detection in strength score adds feedback."""
+        result = policy_service.get_password_strength_score("Pass123word!")
+        assert any("sequential" in fb.lower() for fb in result["feedback"])
+
     # Helper Method Tests
 
     def test_has_sequential_chars_numbers(self, policy_service):


### PR DESCRIPTION
Signed-off-by: NAYANA.R <nayana.r7813@gmail.com>

closes #5177 

new configuration flag PASSWORD_PREVENT_SEQUENTIAL_CHARS that allows disabling the sequential character validation.


Changes Made
config.py (mcpgateway/config.py:999)
- Added password_prevent_sequential_chars: bool = True — new env var to control the sequential character check.
password_policy_service.py (3 changes):
- validate_user_password() (line 187) — sequential check now guarded by getattr(settings, "password_prevent_sequential_chars", True)
- get_password_strength_score() (line 451) — sequential penalty/feedback only applied when the setting is enabled
- get_password_requirements() (line 511) — the sequential restriction is only listed when the setting is enabled
test_password_policy.py (tests/unit/mcpgateway/test_password_policy.py:90)
- Added test_validate_user_password_sequential_chars_disabled — verifies that "Pass123word!" and "Abcd!Password1" pass when password_prevent_sequential_chars = False
values.yaml (charts/mcp-stack/values.yaml:873)
- Added PASSWORD_PREVENT_SEQUENTIAL_CHARS: "true" to the Helm chart config section
To disable the sequential character check, set PASSWORD_PREVENT_SEQUENTIAL_CHARS=false in your environment or Helm values.

