### PR TITLE
fix: eliminate multi-worker session-affinity forward amplification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,7 +67,7 @@ CSRF_TRUSTED_ORIGINS=["http://localhost:4444","http://localhost:8080"]
 # WARNING: Setting this env var REPLACES the config.py default entirely — it does not append.
 # Leave unset to use the secure default maintained in mcpgateway/config.py (csrf_exempt_paths).
 # Only set explicitly if you need a fully custom list (you must include every path you want exempt).
-#CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc","/api/metrics/","/toolops/","/tokens","/teams/","/llmchat/","/api/logs/"]
+#CSRF_EXEMPT_PATHS=["/health","/auth/login","/auth/logout","/auth/refresh","/auth/email/login","/auth/email/register","/auth/email/forgot-password","/auth/email/reset-password","/admin","/admin/login","/admin/forgot-password","/admin/reset-password","/oauth/fetch-tools","/docs","/redoc","/openapi.json","/metrics","/mcp/","/sse","/message","/rpc","/api/metrics/","/toolops/","/tokens","/teams/","/llmchat/","/api/logs/","/_internal/mcp/"]
 
 # Bootstrap admin credentials (email auth)
 # PRODUCTION: Change these values

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-02T14:13:52Z",
+  "generated_at": "2026-07-03T08:17:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5140,7 +5140,7 @@
         "hashed_secret": "4f13f134744a2fadbbe2d624687246347d12fa63",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2770,
+        "line_number": 2830,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/gunicorn.config.py
+++ b/gunicorn.config.py
@@ -139,6 +139,32 @@ def post_fork(server, worker):
     except ImportError:
         pass
 
+    # Recompute the session-affinity WORKER_ID per worker, but only when the feature
+    # is enabled. Captured at import time, so under --preload every worker would
+    # otherwise inherit the master's id ({hostname}:1) and subscribe to the same Redis
+    # channel, collapsing point-to-point forwarding into a per-container broadcast that
+    # fans every request out to all workers and degrades throughput by an order of
+    # magnitude. With the affinity flag off, no request path reads WORKER_ID, so gating
+    # the rebind (and the session_affinity import at fork) keeps "flag off" a clean
+    # no-op for the affinity machinery.
+    if settings.mcpgateway_session_affinity_enabled:
+        try:
+            import socket
+
+            from mcpgateway.services import session_affinity
+
+            session_affinity.WORKER_ID = f"{socket.gethostname()}:{worker.pid}"
+        except Exception as exc:  # noqa: BLE001 - fail loud, never crash the worker
+            # Silent fallback would re-introduce the per-container broadcast amplification.
+            server.log.warning(
+                "post_fork(pid=%s): failed to rebind session_affinity.WORKER_ID (%s: %s) — "
+                "workers may share the master's WORKER_ID and session-affinity forwarding "
+                "may broadcast each request to every worker in the container.",
+                worker.pid,
+                type(exc).__name__,
+                exc,
+            )
+
 
 def post_worker_init(worker):
     worker.log.info("worker initialization completed")

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -223,6 +223,25 @@ def get_internal_mcp_auth_context(request: Request) -> Optional[Dict[str, Any]]:
     return None
 
 
+def encode_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> str:
+    """Encode an edge-validated auth context for forwarding to a trusted internal dispatcher.
+
+    Mirror of :func:`decode_internal_mcp_auth_context`. Packages the auth context
+    so a trusted internal dispatcher (e.g. ``/_internal/mcp/rpc``) can use it
+    without re-running authentication. The unpadded base64url shape keeps the
+    value header-safe.
+
+    Args:
+        auth_context: Auth-context dict to encode.
+
+    Returns:
+        Unpadded base64url-encoded JSON payload for the
+        ``x-contextforge-auth-context`` header.
+    """
+    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
+    return encoded.rstrip("=")
+
+
 def decode_internal_mcp_auth_context(header_value: str) -> Dict[str, Any]:
     """Decode the trusted internal MCP auth header payload.
 
@@ -291,6 +310,184 @@ def has_valid_internal_mcp_runtime_auth_header(request: Request) -> bool:
     if not provided:
         return False
     return hmac.compare_digest(provided, _expected_internal_mcp_runtime_auth_header())
+
+
+# Redis-transit integrity for forwarded auth context.
+#
+# The header-borne auth context that reaches /_internal/mcp/rpc is gated by the
+# secret-derived runtime-auth token, so a caller must already hold the secret.
+# The session-affinity Redis pub/sub hop is different: a writer to the Redis
+# channel needs no secret, yet the owner worker re-stamps whatever auth context
+# it reads with a valid runtime-auth token before dispatching. That makes the
+# owner a signing oracle for forged contexts. Signing the auth context alone
+# closes the forged-identity oracle, but it does not prove that the verified
+# identity belongs to the *operation* being executed: an attacker with Redis
+# write access could pair a captured signature with a different method, path,
+# body, or response_channel (CWE-347). To close that, the publisher signs the
+# whole forwarded envelope (every operation field, including response_channel so
+# the response cannot be redirected) and the consumer verifies the envelope
+# before dispatch.
+#
+# These helpers are deliberately separate from the general header-encoding
+# contract (encode/decode_internal_mcp_auth_context), which must stay
+# byte-compatible for the Rust runtime. The forward signature is Redis-only
+# Python transit metadata: it is stripped by the owning worker before the
+# in-process dispatch and never reaches the Rust runtime, so it does not affect
+# the encoded auth-context wire format.
+FORWARD_SIG_FIELD = "forward_sig"
+_REDIS_FORWARD_ENVELOPE_SIG_DOMAIN = b"mcpgw.redis-fwd-envelope.v1"
+_REDIS_FORWARD_ENVELOPE_SIG_DELIMITER = b"\x1f"  # ASCII unit separator; never present in canonical JSON
+
+
+def _redis_forward_envelope_sig_material(envelope: Dict[str, Any]) -> bytes:
+    """Build the domain-separated HMAC input for a Redis-forwarded envelope.
+
+    The signature field itself is excluded, then the remaining envelope is
+    canonicalized with sorted keys so the publisher and the consumer (which has
+    round-tripped the payload through JSON) produce byte-identical material. The
+    domain tag plus a unit separator that cannot occur in the canonical JSON keep
+    the two segments unambiguous.
+
+    Args:
+        envelope: The forwarded Redis payload. The signature field, if present,
+            is ignored so signing and verification see the same input.
+
+    Returns:
+        The byte string fed to HMAC.
+    """
+    without_sig = {k: v for k, v in envelope.items() if k != FORWARD_SIG_FIELD}
+    canonical = orjson.dumps(without_sig, option=orjson.OPT_SORT_KEYS)
+    return _REDIS_FORWARD_ENVELOPE_SIG_DOMAIN + _REDIS_FORWARD_ENVELOPE_SIG_DELIMITER + canonical
+
+
+def sign_redis_forward_envelope(envelope: Dict[str, Any]) -> str:
+    """Sign a full forwarded envelope for transit over the session-affinity Redis hop.
+
+    Keyed with ``auth_encryption_secret`` and bound to every operation field in
+    the envelope (method, path, body, headers, response_channel, auth_context,
+    ...), so a captured signature cannot be replayed under a different operation
+    or to a different response channel.
+
+    Args:
+        envelope: The forwarded Redis payload to protect. Any existing signature
+            field is excluded from the signed material.
+
+    Returns:
+        Hex-encoded HMAC-SHA256 signature.
+    """
+    return hmac.new(
+        _auth_encryption_secret_value().encode("utf-8"),
+        _redis_forward_envelope_sig_material(envelope),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_redis_forward_envelope(envelope: Dict[str, Any]) -> bool:
+    """Verify a Redis-forwarded envelope signature in constant time.
+
+    Must be called on the untouched received envelope, before any field is
+    decoded or mutated, so the recomputed material matches what was signed.
+
+    Args:
+        envelope: The forwarded Redis payload, including its ``forward_sig``.
+
+    Returns:
+        ``True`` only when the envelope carries a non-empty ``forward_sig`` that
+        is a valid signature for the rest of the envelope under the current secret.
+    """
+    signature = envelope.get(FORWARD_SIG_FIELD)
+    if not isinstance(signature, str) or not signature:
+        return False
+    expected = sign_redis_forward_envelope(envelope)
+    return hmac.compare_digest(signature, expected)
+
+
+# Internal-dispatch trust gate, defined once and shared by all callers.
+INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
+INTERNAL_A2A_PATH_PREFIX = "/_internal/a2a"
+INTERNAL_RUNTIME_MARKER_HEADER = "x-contextforge-mcp-runtime"
+INTERNAL_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
+TRUSTED_INTERNAL_RUNTIME_MARKERS = frozenset({"rust", "affinity"})
+
+
+def _internal_path_requires_auth_context(path: str) -> bool:
+    """Whether an internal route requires an auth context.
+
+    Only ``*/authenticate`` is exempt, since it creates the context; every
+    other internal route must carry one.
+
+    Args:
+        path: The request path to classify.
+
+    Returns:
+        ``False`` for ``*/authenticate``, otherwise ``True``.
+    """
+    return not path.rstrip("/").endswith("/authenticate")
+
+
+def is_trusted_internal_runtime_request(
+    request: Request,
+    *,
+    allowed_prefixes: tuple[str, ...],
+    require_auth_context: bool,
+    path: Optional[str] = None,
+) -> bool:
+    """Return whether a request is a trusted in-process internal-runtime hop.
+
+    The trust boundary is the HMAC header and, when required, the encoded
+    ``x-contextforge-auth-context``. The loopback check is defense in depth,
+    not an independent gate: ProxyHeaders(trusted_hosts="*") lets a direct
+    external caller influence ``request.client.host`` (the replay is hardened
+    separately by stripping forwarded / client-IP headers).
+
+    Args:
+        request: Incoming request to inspect.
+        allowed_prefixes: Internal path prefixes this caller trusts.
+        require_auth_context: Require a non-empty ``x-contextforge-auth-context``.
+        path: Explicit path override for callers that strip a ``root_path``;
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` only when prefix, runtime marker, HMAC, optional auth context,
+        and loopback all hold; otherwise ``False``.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if not any(p == prefix or p.startswith(f"{prefix}/") for prefix in allowed_prefixes):
+        return False
+    if request.headers.get(INTERNAL_RUNTIME_MARKER_HEADER) not in TRUSTED_INTERNAL_RUNTIME_MARKERS:
+        return False
+    if not has_valid_internal_mcp_runtime_auth_header(request):
+        return False
+    if require_auth_context and not request.headers.get(INTERNAL_AUTH_CONTEXT_HEADER):
+        return False
+    client_host = getattr(getattr(request, "client", None), "host", None)
+    return client_host in ("127.0.0.1", "::1")
+
+
+def is_trusted_internal_mcp_request(request: Request, *, path: Optional[str] = None) -> bool:
+    """MCP + A2A internal trust gate with a path-aware auth-context requirement.
+
+    ``*/authenticate`` routes are exempt from the auth-context requirement;
+    every other internal route requires it. ``/_internal/a2a/*`` is trusted
+    only when the A2A feature is enabled.
+
+    Args:
+        request: Incoming request to inspect.
+        path: Explicit path override (e.g. a ``root_path``-stripped path);
+            defaults to ``request.url.path``.
+
+    Returns:
+        ``True`` when the request is a trusted internal MCP/A2A hop.
+    """
+    p = path if path is not None else (getattr(getattr(request, "url", None), "path", "") or "")
+    if p.startswith(f"{INTERNAL_A2A_PATH_PREFIX}/") and not settings.mcpgateway_a2a_enabled:
+        return False
+    return is_trusted_internal_runtime_request(
+        request,
+        allowed_prefixes=(INTERNAL_MCP_PATH_PREFIX, INTERNAL_A2A_PATH_PREFIX),
+        require_auth_context=_internal_path_requires_auth_context(p),
+        path=p,
+    )
 
 
 def get_token_teams_from_request(request: Request) -> Optional[List[str]]:

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -466,6 +466,7 @@ class Settings(BaseSettings):
             "/teams/",
             "/llmchat/",
             "/api/logs/",
+            "/_internal/mcp/",  # Exempt: loopback-only, HMAC-gated internal dispatch (affinity/Rust forwards); not browser-reachable
         ],
         description="Paths exempt from CSRF protection",
     )

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -78,14 +78,15 @@ from mcpgateway import version as version_module
 from mcpgateway.auth import get_current_user, get_user_team_roles, TokenValidationError, validate_token_user
 from mcpgateway.auth_context import (
     decode_internal_mcp_auth_context,
+    encode_internal_mcp_auth_context,
     get_internal_mcp_auth_context,
     get_request_identity,
     get_rpc_filter_context,
     get_scoped_resource_access_context,
     get_token_teams_from_request,
     get_user_email,
-    has_valid_internal_mcp_runtime_auth_header,
     INTERNAL_MCP_SESSION_VALIDATED_HEADER,
+    is_trusted_internal_mcp_request,
 )
 from mcpgateway.cache import ResourceCache, SessionRegistry
 from mcpgateway.common.models import InitializeResult
@@ -285,26 +286,26 @@ _INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
 
 
 def _is_trusted_internal_mcp_runtime_request(request: Request) -> bool:
-    """Return whether the request came from the local Rust runtime sidecar.
+    """Return whether the request came from a trusted local internal source.
+
+    Two callers are trusted today:
+
+    - ``"rust"`` — the local Rust runtime sidecar (over loopback).
+    - ``"affinity"`` — the in-process dispatch used by session-affinity
+      forwarding to reach the owner worker, carrying the identity the edge
+      already validated.
+
+    Both share the same gates: a shared-secret HMAC header AND a loopback client
+    address. Only the ``x-contextforge-mcp-runtime`` marker value differs.
 
     Args:
         request: Incoming request to inspect.
 
     Returns:
-        ``True`` when the request carries the trusted Rust runtime marker from
-        loopback, otherwise ``False``.
+        ``True`` when the request carries a trusted internal-runtime marker
+        from loopback, otherwise ``False``.
     """
-    runtime_marker = request.headers.get("x-contextforge-mcp-runtime")
-    client_host = getattr(getattr(request, "client", None), "host", None)
-    if runtime_marker != "rust" or not has_valid_internal_mcp_runtime_auth_header(request) or client_host not in ("127.0.0.1", "::1"):
-        return False
-    # Defense-in-depth: /_internal/a2a/* endpoints must refuse requests when
-    # A2A support is disabled, even from an otherwise-trusted local sidecar.
-    # A legitimate sidecar should not be running when the feature is off.
-    path = getattr(getattr(request, "url", None), "path", "") or ""
-    if path.startswith("/_internal/a2a/") and not settings.mcpgateway_a2a_enabled:
-        return False
-    return True
+    return is_trusted_internal_mcp_request(request)
 
 
 def _is_jwt_token(token: str) -> bool:
@@ -330,6 +331,48 @@ def _is_jwt_token(token: str) -> bool:
         except Exception:  # pylint: disable=broad-exception-caught
             return False
     return True
+
+
+def _validate_internal_mcp_auth_context(auth_context: Dict[str, Any]) -> None:
+    """Validate a decoded trusted-internal auth context, failing closed on malformed input.
+
+    The public-only RBAC skip in ``_ensure_rpc_permission`` trusts this context, so a
+    public-only context (``is_authenticated is False``) must not carry authenticated-only
+    or elevated attributes. Field types are checked first to avoid downstream confusion
+    (for example a string ``scoped_permissions`` would be iterated per-character).
+
+    Args:
+        auth_context: Decoded auth-context dict from ``decode_internal_mcp_auth_context``.
+
+    Raises:
+        HTTPException: 400 when the context is malformed or a public-only context claims
+            teams, admin, or an identity.
+    """
+    teams = auth_context.get("teams")
+    if teams is not None and not isinstance(teams, list):
+        raise HTTPException(status_code=400, detail="Invalid trusted MCP auth context: teams must be a list")
+
+    scoped_permissions = auth_context.get("scoped_permissions")
+    if scoped_permissions is not None and not isinstance(scoped_permissions, list):
+        raise HTTPException(status_code=400, detail="Invalid trusted MCP auth context: scoped_permissions must be a list")
+
+    # is_authenticated must be a real bool so the ``is False`` identity checks below (and the
+    # public-only RBAC skip in _ensure_rpc_permission) are reliable. A truthy non-bool like
+    # the string "false" or 0 would slip past ``is False`` and defeat the public-only flooring.
+    is_authenticated = auth_context.get("is_authenticated")
+    if is_authenticated is not None and not isinstance(is_authenticated, bool):
+        raise HTTPException(status_code=400, detail="Invalid trusted MCP auth context: is_authenticated must be a bool")
+
+    # A public-only (unauthenticated) context must map to exactly public privileges.
+    # The RBAC skip relies on this invariant, so reject any contradictory attributes
+    # rather than letting them ride an unauthenticated dispatch.
+    if is_authenticated is False:
+        if teams:
+            raise HTTPException(status_code=400, detail="Invalid public-only auth context: teams must be empty")
+        if auth_context.get("is_admin") is True or auth_context.get("permission_is_admin") is True:
+            raise HTTPException(status_code=400, detail="Invalid public-only auth context: admin not permitted")
+        if auth_context.get("email"):
+            raise HTTPException(status_code=400, detail="Invalid public-only auth context: email not permitted")
 
 
 def _build_internal_mcp_forwarded_user(request: Request) -> Dict[str, Any]:
@@ -358,6 +401,10 @@ def _build_internal_mcp_forwarded_user(request: Request) -> Dict[str, Any]:
         logger.debug("Invalid trusted MCP auth context: %s", exc)
         raise HTTPException(status_code=400, detail="Invalid trusted MCP auth context") from exc
 
+    # Fail closed on a malformed or self-contradictory context before it is stored
+    # and trusted by the public-only RBAC skip downstream.
+    _validate_internal_mcp_auth_context(auth_context)
+
     setattr(request.state, "_mcp_internal_auth_context", auth_context)
 
     if "teams" in auth_context and (auth_context["teams"] is None or isinstance(auth_context["teams"], list)):
@@ -383,6 +430,58 @@ def _build_internal_mcp_forwarded_user(request: Request) -> Dict[str, Any]:
         "auth_method": forwarded_auth_method,
         "token_use": auth_context.get("token_use"),
     }
+
+
+def _build_internal_mcp_auth_context_for_rpc(request: Request, user: Any) -> Dict[str, Any]:
+    """Build the trusted-internal auth context for an affinity-forwarded ``/rpc`` request.
+
+    Affinity forwarding of a JSON-RPC ``/rpc`` request must carry the caller's
+    already-validated identity to the owner worker's ``/_internal/mcp/rpc`` dispatch, so the
+    owner does not re-authenticate at the public route boundary (which would 401 OAuth and
+    ``MCP_REQUIRE_AUTH=false`` public-only callers).
+
+    The identity is derived from the verified request state via ``get_rpc_filter_context``
+    (the canonical Layer-1 policy source) and the cached verified JWT payload, never from
+    inbound headers, so token-team and admin semantics are preserved. The result has the
+    same shape ``get_streamable_http_auth_context()`` emits, so the owner-side
+    ``_build_internal_mcp_forwarded_user`` reconstructs both forward paths identically, and
+    it satisfies ``_validate_internal_mcp_auth_context``.
+
+    Args:
+        request: The incoming ``/rpc`` request (already authenticated by the route).
+        user: The user object produced by the auth dependency.
+
+    Returns:
+        Encodable auth-context dict for ``encode_internal_mcp_auth_context``.
+    """
+    email, token_teams, is_admin = get_rpc_filter_context(request, user)
+    # Genuine anonymous / MCP_REQUIRE_AUTH=false public-only callers have no email.
+    is_authenticated = email is not None
+
+    scoped = _extract_scoped_permissions(request)
+    scoped_permissions = sorted(scoped) if scoped else None
+
+    cached = getattr(request.state, "_jwt_verified_payload", None)
+    payload = cached[1] if (isinstance(cached, tuple) and len(cached) == 2 and isinstance(cached[1], dict)) else {}
+    scopes = payload.get("scopes") if isinstance(payload.get("scopes"), dict) else {}
+    scoped_server_id = scopes.get("server_id")
+
+    context: Dict[str, Any] = {
+        "email": email,
+        # Authenticated callers keep their token teams (None == admin bypass); public-only
+        # callers are floored to no teams so _validate_internal_mcp_auth_context accepts them.
+        "teams": token_teams if is_authenticated else [],
+        "is_authenticated": is_authenticated,
+        "is_admin": bool(is_admin) if is_authenticated else False,
+        "permission_is_admin": bool(is_admin) if is_authenticated else False,
+        "auth_method": payload.get("auth_method") or ("jwt" if is_authenticated else "anonymous"),
+        "token_use": payload.get("token_use"),
+    }
+    if scoped_permissions is not None:
+        context["scoped_permissions"] = scoped_permissions
+    if scoped_server_id:
+        context["scoped_server_id"] = scoped_server_id
+    return context
 
 
 def _enforce_internal_mcp_server_scope(request: Request, server_id: str) -> None:
@@ -714,6 +813,16 @@ async def _ensure_rpc_permission(user, db: Session, permission: str, method: str
     Raises:
         JSONRPCError: If the requester lacks the required permission.
     """
+    # Trusted-internal public-only dispatch: the originating edge already applied public-only
+    # visibility (and per-server OAuth), so an unauthenticated internal hop must not be re-denied
+    # by RBAC. Mirrors _authorize_internal_mcp_request(). This only fires for HMAC-trusted internal
+    # requests (the auth context is set on request.state only after the trust gate passes); the
+    # public /rpc path and authenticated internal callers (is_authenticated True) fall through.
+    if request is not None:
+        _internal_ctx = get_internal_mcp_auth_context(request)
+        if isinstance(_internal_ctx, dict) and _internal_ctx.get("is_authenticated", True) is False:
+            return
+
     # Layer 1: Token scope cap
     if request is not None:
         scoped = _extract_scoped_permissions(request)
@@ -9829,6 +9938,7 @@ async def _maybe_forward_affinitized_rpc_request(
     params: Dict[str, Any],
     req_id: Any,
     lowered_request_headers: Dict[str, str],
+    user: Any,
 ) -> Optional[Dict[str, Any]]:
     """Forward an MCP request to the owning worker when session affinity requires it.
 
@@ -9838,6 +9948,8 @@ async def _maybe_forward_affinitized_rpc_request(
         params: Parsed JSON-RPC params payload.
         req_id: JSON-RPC request identifier.
         lowered_request_headers: Lower-cased request headers used for forwarding.
+        user: Authenticated user from the route dependency, used to build the verified
+            edge auth context carried to the owner's trusted-internal dispatch.
 
     Returns:
         Forwarded JSON-RPC response payload when affinity forwarding handled the
@@ -9864,9 +9976,14 @@ async def _maybe_forward_affinitized_rpc_request(
             from mcpgateway.services.session_affinity import get_session_affinity  # pylint: disable=import-outside-toplevel
 
             pool = get_session_affinity()
+            # Carry the verified edge identity (built from request state, not headers) so the
+            # owner dispatches to the trusted internal endpoint without re-authenticating, so
+            # OAuth and MCP_REQUIRE_AUTH=false public-only callers survive the rpc forward.
+            encoded_auth_context = encode_internal_mcp_auth_context(_build_internal_mcp_auth_context_for_rpc(request, user))
             forwarded_response = await pool.forward_request_to_owner(
                 mcp_session_id,
                 {"method": method, "params": params, "headers": lowered_request_headers, "req_id": req_id},
+                encoded_auth_context,
             )
             if forwarded_response is not None:
                 logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded response received", WORKER_ID, session_short, method)
@@ -10124,6 +10241,7 @@ async def handle_internal_mcp_tools_call(request: Request):
             params=params,
             req_id=req_id,
             lowered_request_headers=lowered_request_headers,
+            user=user,
         )
         if forwarded_response is not None:
             return forwarded_response
@@ -10547,6 +10665,7 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             params=params,
             req_id=req_id,
             lowered_request_headers=_lowered_request_headers(),
+            user=user,
         )
         if forwarded_response is not None:
             return forwarded_response

--- a/mcpgateway/middleware/rate_limit_middleware.py
+++ b/mcpgateway/middleware/rate_limit_middleware.py
@@ -38,6 +38,7 @@ from starlette.responses import JSONResponse
 
 # First-Party
 from mcpgateway import auth
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.config import settings
 from mcpgateway.services.security_logger import SecurityEventType, SecurityLogger, SecuritySeverity
 
@@ -198,6 +199,10 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         """Process request with rate limiting."""
         if not self.enabled:
+            return await call_next(request)
+
+        # Skip rate limiting for the trusted-internal dispatch; the edge request was already counted.
+        if is_trusted_internal_mcp_request(request):
             return await call_next(request)
 
         tier = self.get_endpoint_tier(request.url.path)

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -13,8 +13,6 @@ and time-based restrictions.
 # Standard
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
-import hashlib
-import hmac
 import ipaddress
 import re
 from typing import List, Optional, Pattern, Tuple
@@ -64,11 +62,6 @@ _RESOURCE_PATTERNS: List[Tuple[Pattern[str], str]] = [
     (re.compile(r"/gateways/?([a-f0-9\-]+)"), "gateway"),
 ]
 _AUTH_COOKIE_NAMES = ("jwt_token", "access_token")
-_INTERNAL_MCP_PATH_PREFIX = "/_internal/mcp"
-_INTERNAL_MCP_RUNTIME_HEADER = "x-contextforge-mcp-runtime"
-_INTERNAL_MCP_AUTH_CONTEXT_HEADER = "x-contextforge-auth-context"
-_INTERNAL_MCP_RUNTIME_AUTH_HEADER = "x-contextforge-mcp-runtime-auth"
-_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT = "contextforge-internal-mcp-runtime-v1"
 
 # Permission map with precompiled patterns
 # Maps (HTTP method, path pattern) to required permission
@@ -1399,70 +1392,24 @@ class TokenScopingMiddleware:
             )
 
     def _is_trusted_internal_mcp_runtime_request(self, request: Request, normalized_path: str) -> bool:
-        """Return whether the request is a trusted loopback Rust MCP sidecar hop.
+        """Return whether the request is a trusted internal MCP/A2A runtime hop.
+
+        Delegates to the shared gate in ``auth_context`` so the trust decision is
+        defined in one place. Unlike the previous local check, this trusts both
+        the ``rust`` and ``affinity`` runtime markers — closing the gap where the
+        in-process session-affinity dispatch was still token-scoped.
 
         Args:
             request: Incoming HTTP request.
             normalized_path: Canonicalized request path used for route matching.
 
         Returns:
-            ``True`` when the request originated from the local Rust MCP runtime and
-            includes the expected trusted headers.
+            ``True`` when the request is a trusted internal MCP/A2A hop.
         """
-        if normalized_path != _INTERNAL_MCP_PATH_PREFIX and not normalized_path.startswith(f"{_INTERNAL_MCP_PATH_PREFIX}/"):
-            return False
+        # First-Party
+        from mcpgateway.auth_context import is_trusted_internal_mcp_request  # pylint: disable=import-outside-toplevel
 
-        if request.headers.get(_INTERNAL_MCP_RUNTIME_HEADER) != "rust":
-            return False
-
-        provided_auth = request.headers.get(_INTERNAL_MCP_RUNTIME_AUTH_HEADER)
-        if not provided_auth:
-            return False
-
-        expected_auth = self._expected_internal_mcp_runtime_auth_header()
-        if not hmac.compare_digest(provided_auth, expected_auth):
-            return False
-
-        if not request.headers.get(_INTERNAL_MCP_AUTH_CONTEXT_HEADER):
-            return False
-
-        client_host = getattr(getattr(request, "client", None), "host", None)
-        return client_host in ("127.0.0.1", "::1")
-
-    @staticmethod
-    def _auth_encryption_secret_value() -> str:
-        """Return the configured auth-encryption secret as a plain string.
-
-        Returns:
-            The auth-encryption secret, normalized to a regular string.
-        """
-        secret = settings.auth_encryption_secret
-        if hasattr(secret, "get_secret_value"):
-            return secret.get_secret_value()
-        return str(secret)
-
-    @staticmethod
-    @lru_cache(maxsize=8)
-    def _expected_internal_mcp_runtime_auth_header_for_secret(secret: str) -> str:
-        """Return the expected shared internal-auth header for a specific secret.
-
-        Args:
-            secret: Auth-encryption secret to derive the trust header from.
-
-        Returns:
-            Hex-encoded SHA-256 digest derived from the provided auth secret.
-        """
-        material = f"{secret}:{_INTERNAL_MCP_RUNTIME_AUTH_CONTEXT}".encode("utf-8")
-        return hashlib.sha256(material).hexdigest()
-
-    @staticmethod
-    def _expected_internal_mcp_runtime_auth_header() -> str:
-        """Return the expected shared internal-auth header for Rust MCP hops.
-
-        Returns:
-            Shared secret-derived digest expected on trusted internal Rust MCP calls.
-        """
-        return TokenScopingMiddleware._expected_internal_mcp_runtime_auth_header_for_secret(TokenScopingMiddleware._auth_encryption_secret_value())
+        return is_trusted_internal_mcp_request(request, path=normalized_path)
 
 
 # Create middleware instance

--- a/mcpgateway/middleware/token_usage_middleware.py
+++ b/mcpgateway/middleware/token_usage_middleware.py
@@ -30,6 +30,7 @@ from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import is_trusted_internal_mcp_request
 from mcpgateway.db import fresh_db_session
 from mcpgateway.middleware.path_filter import should_skip_auth_context
 from mcpgateway.services.token_catalog_service import TokenCatalogService
@@ -84,6 +85,11 @@ class TokenUsageMiddleware:
         # Skip health checks and static files
         path = scope.get("path", "")
         if should_skip_auth_context(path):
+            await self.app(scope, receive, send)
+            return
+
+        # Skip usage logging for the trusted-internal dispatch; the edge request is already recorded.
+        if is_trusted_internal_mcp_request(Request(scope), path=path):
             await self.app(scope, receive, send)
             return
 

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -1053,7 +1053,7 @@ class SessionAffinity:
             return {"result": response_data.get("result", {})}
 
         except httpx.TimeoutException:
-            logger.warning("Timeout executing forwarded request: %s", request.get('method'))
+            logger.warning("Timeout executing forwarded request: %s", request.get("method"))
             return {"error": {"code": -32603, "message": "Internal request timeout"}}
         except Exception as e:
             logger.warning("Error executing forwarded request: %s", e)
@@ -1348,7 +1348,7 @@ class SessionAffinity:
                             msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
                             if msg and msg["type"] == "message":
                                 response_data = orjson.loads(msg["data"])
-                                logger.debug("[HTTP_AFFINITY] Received HTTP response via Redis: status=%s", response_data.get('status'))
+                                logger.debug("[HTTP_AFFINITY] Received HTTP response via Redis: status=%s", response_data.get("status"))
 
                                 # Decode hex body back to bytes
                                 body_hex = response_data.get("body", "")

--- a/mcpgateway/services/session_affinity.py
+++ b/mcpgateway/services/session_affinity.py
@@ -50,12 +50,17 @@ from mcpgateway.services.upstream_session_registry import (  # re-exported as th
 )
 from mcpgateway.utils.internal_http import (
     internal_loopback_base_url,
-    internal_loopback_verify,
+    post_rpc_in_process,
 )
 
 # Shared session-id validation (downstream MCP session IDs used for affinity).
 # Intentionally strict: protects Redis key/channel construction and log lines.
 _MCP_SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+# Extract the virtual server id from a Streamable HTTP path (/servers/{id}/mcp)
+# so a forwarded request can be re-routed to the local /rpc dispatcher. Mirrors
+# _SERVER_ID_RE in streamablehttp_transport; kept local to avoid a transport import.
+_SERVER_ID_RE = re.compile(r"^/servers/(?P<server_id>[^/]+)/mcp")
 
 # Worker ID for multi-worker session affinity
 # Uses hostname + PID to be unique across Docker containers (each container has PID 1)
@@ -744,6 +749,7 @@ class SessionAffinity:
         self,
         mcp_session_id: str,
         request_data: Dict[str, Any],
+        auth_context: str,
         timeout: Optional[float] = None,
     ) -> Optional[Dict[str, Any]]:
         """Forward RPC request to the worker that owns the session owner.
@@ -755,6 +761,9 @@ class SessionAffinity:
         Args:
             mcp_session_id: The MCP session ID from x-mcp-session-id header.
             request_data: The RPC request data to forward.
+            auth_context: Encoded edge auth context (required, non-empty). Signed into
+                the Redis envelope and verified by the owner before the trusted-internal
+                dispatch, so the rpc forward hop carries a tamper-evident identity.
             timeout: Optional timeout in seconds (default from config).
 
         Returns:
@@ -769,6 +778,14 @@ class SessionAffinity:
 
         if not self.is_valid_mcp_session_id(mcp_session_id):
             return None
+
+        # Invariant: the rpc forward hop must always carry a signed auth context, so the
+        # owner can dispatch to the trusted internal endpoint without re-authenticating.
+        # Refuse rather than publish an unsigned envelope the consumer would reject.
+        if not auth_context:
+            logger.warning("[AFFINITY] Worker %s | Refusing to forward RPC request without an auth context", WORKER_ID)
+            self._forwarded_request_failures += 1
+            return {"error": {"code": -32003, "message": "Forwarded auth context is required"}}
 
         effective_timeout = timeout if timeout is not None else settings.mcpgateway_pool_rpc_forward_timeout
 
@@ -837,13 +854,20 @@ class SessionAffinity:
                 await pubsub.subscribe(response_channel)
 
                 try:
-                    # Prepare request with response channel
+                    # First-Party
+                    from mcpgateway.auth_context import FORWARD_SIG_FIELD, sign_redis_forward_envelope  # pylint: disable=import-outside-toplevel
+
+                    # Prepare request with response channel and the edge auth context.
                     forward_data = {
                         "type": "rpc_forward",
                         **request_data,
                         "response_channel": response_channel,
                         "mcp_session_id": mcp_session_id,
+                        "auth_context": auth_context,
                     }
+                    # HMAC over the whole envelope (identity + operation + response_channel);
+                    # verified by the owner before trust so nothing can be tampered or redirected.
+                    forward_data[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(forward_data)
 
                     # Publish request to owner's channel
                     await redis.publish(f"mcpgw:pool_rpc:{owner_id}", orjson.dumps(forward_data))
@@ -949,157 +973,251 @@ class SessionAffinity:
 
             logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Received forwarded request, executing locally", WORKER_ID, session_short, method)
 
-            # Make internal HTTP/HTTPS call to local /rpc endpoint.
-            # This reuses ALL existing method handling logic without duplication.
-            internal_base_url = internal_loopback_base_url()
-            async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                # Build headers for internal request - forward original headers
-                # but add x-forwarded-internally to prevent infinite loops.
-                # Relies on the originating transport having already filtered
-                # passthrough headers via extract_headers_for_loopback (#3640).
-                internal_headers = dict(headers)
-                internal_headers["x-forwarded-internally"] = "true"
-                # Ensure content-type is set
-                internal_headers["content-type"] = "application/json"
+            # Verify the forwarded envelope before trusting it: forward_request_to_owner
+            # signs the whole envelope (identity + operation + response_channel) with the
+            # auth-encryption secret. Verify the untouched received envelope first, then
+            # require a non-empty auth context, so a tampered, redirected, or unsigned
+            # request is refused rather than re-stamped onto the trusted-internal dispatch
+            # (the Redis signing oracle, here on the rpc channel). Fail closed: do not dispatch.
+            # First-Party
+            from mcpgateway.auth_context import verify_redis_forward_envelope  # pylint: disable=import-outside-toplevel
 
-                response = await client.post(
-                    f"{internal_base_url}/rpc",
-                    json={
+            if not verify_redis_forward_envelope(request):
+                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing or invalid envelope signature", WORKER_ID, session_short)
+                self._forwarded_request_failures += 1
+                return {"error": {"code": -32003, "message": "Forwarded auth context failed integrity verification"}}
+            auth_context = request.get("auth_context") or ""
+            if not auth_context:
+                logger.warning("[AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing auth context", WORKER_ID, session_short)
+                self._forwarded_request_failures += 1
+                return {"error": {"code": -32003, "message": "Forwarded auth context failed integrity verification"}}
+
+            # Build headers for the in-process internal dispatch - forward original headers
+            # but add x-forwarded-internally to prevent infinite loops. Relies on the
+            # originating transport having already filtered passthrough headers via
+            # extract_headers_for_loopback (#3640).
+            internal_headers = dict(headers)
+            internal_headers["x-forwarded-internally"] = "true"
+            internal_headers["content-type"] = "application/json"
+
+            # Dispatch IN-PROCESS to the trusted internal endpoint so it resolves the bound
+            # upstream session from this worker's registry instead of scattering over the
+            # shared socket. The verified edge identity rides in auth_context.
+            response = await post_rpc_in_process(
+                content=orjson.dumps(
+                    {
                         "jsonrpc": "2.0",
                         "method": method,
                         "params": params,
                         "id": req_id,
-                    },
-                    headers=internal_headers,
-                    timeout=settings.mcpgateway_pool_rpc_forward_timeout,
-                )
-
-                # Gate on HTTP status first: non-2xx responses are errors
-                # even if the body parses as JSON.
-                if not response.is_success:
-                    try:
-                        response_data = response.json()
-                    except ValueError:
-                        response_data = {}
-                    if not isinstance(response_data, dict):
-                        response_data = {}
-
-                    # If body is a JSON-RPC error ({"error": {...}}), propagate it
-                    if "error" in response_data and isinstance(response_data["error"], dict):
-                        logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error (HTTP %s)", WORKER_ID, session_short, method, response.status_code)
-                        return {"error": response_data["error"]}
-
-                    # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
-                    detail = response_data.get("detail", response.text[:200] or "Unknown error")
-                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution failed with HTTP %s", WORKER_ID, session_short, method, response.status_code)
-                    return {
-                        "error": {
-                            "code": -32603,
-                            "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
-                        }
                     }
+                ),
+                auth_context=auth_context,
+                headers=internal_headers,
+                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
+            )
 
-                # Parse successful response
-                response_data = response.json()
+            # Gate on HTTP status first: non-2xx responses are errors
+            # even if the body parses as JSON.
+            if not response.is_success:
+                try:
+                    response_data = response.json()
+                except ValueError:
+                    response_data = {}
+                if not isinstance(response_data, dict):
+                    response_data = {}
 
-                # Extract result or error from JSON-RPC response
-                if "error" in response_data:
-                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error", WORKER_ID, session_short, method)
+                # If body is a JSON-RPC error ({"error": {...}}), propagate it
+                if "error" in response_data and isinstance(response_data["error"], dict):
+                    logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error (HTTP %s)", WORKER_ID, session_short, method, response.status_code)
                     return {"error": response_data["error"]}
-                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed successfully", WORKER_ID, session_short, method)
-                return {"result": response_data.get("result", {})}
+
+                # Non-JSON-RPC error body (e.g. {"detail": "..."}): map to JSON-RPC error
+                detail = response_data.get("detail", response.text[:200] or "Unknown error")
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution failed with HTTP %s", WORKER_ID, session_short, method, response.status_code)
+                return {
+                    "error": {
+                        "code": -32603,
+                        "message": f"Forwarded request failed (HTTP {response.status_code}): {detail}",
+                    }
+                }
+
+            # Parse successful response
+            response_data = response.json()
+
+            # Extract result or error from JSON-RPC response
+            if "error" in response_data:
+                logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed with error", WORKER_ID, session_short, method)
+                return {"error": response_data["error"]}
+            logger.info("[AFFINITY] Worker %s | Session %s... | Method: %s | Forwarded execution completed successfully", WORKER_ID, session_short, method)
+            return {"result": response_data.get("result", {})}
 
         except httpx.TimeoutException:
-            logger.warning("Timeout executing forwarded request: %s", request.get("method"))
+            logger.warning("Timeout executing forwarded request: %s", request.get('method'))
             return {"error": {"code": -32603, "message": "Internal request timeout"}}
         except Exception as e:
             logger.warning("Error executing forwarded request: %s", e)
             return {"error": {"code": -32603, "message": str(e)}}
 
     async def _execute_forwarded_http_request(self, request: Dict[str, Any], redis: Any) -> None:
-        """Execute a forwarded HTTP request locally and return response via Redis.
+        """Execute a forwarded Streamable HTTP request on the owner worker and reply over Redis.
 
-        This method handles full HTTP requests forwarded from other workers for
-        Streamable HTTP transport session affinity. It reconstructs the HTTP request,
-        makes an internal call to the appropriate endpoint, and publishes the response
-        back through Redis.
+        The request lands on the worker that owns the downstream session, so the
+        bound upstream session in this process can serve it. It is dispatched
+        in-process to the trusted-internal ``/_internal/mcp/rpc`` endpoint rather
+        than the public ``/rpc``.
+
+        Public ``/rpc`` only understands ContextForge JWTs and cookies, so an
+        OAuth bearer or an ``MCP_REQUIRE_AUTH=false`` public-only request would
+        401 if re-authenticated there. Instead, the originating worker's
+        already-validated identity rides in ``auth_context`` (the encoded
+        ``x-contextforge-auth-context`` header); with the
+        ``x-contextforge-mcp-runtime: affinity`` marker, the shared-secret HMAC,
+        and the loopback client address, the trusted endpoint accepts the request
+        and reconstructs the same user the edge established.
 
         Args:
             request: Serialized HTTP request data from Redis Pub/Sub containing:
                 - type: "http_forward"
                 - response_channel: Redis channel to publish response to
                 - mcp_session_id: Session identifier
-                - method: HTTP method (GET, POST, DELETE)
-                - path: Request path (e.g., /mcp)
-                - query_string: Query parameters
-                - headers: Request headers dict
-                - body: Hex-encoded request body
-            redis: Redis client for publishing response
+                - method: HTTP method (POST primarily)
+                - path: Original request path (e.g., /servers/{id}/mcp)
+                - headers: Original request headers (lowercased keys)
+                - body: Hex-encoded JSON-RPC request body
+                - auth_context: base64url-encoded auth context from the
+                  originating worker's ``streamable_http_auth()`` result
+            redis: Redis client for publishing the response
         """
-        response_channel = None
+        response_channel = request.get("response_channel")
+
+        async def _publish(status: int, body: bytes, headers: Optional[Dict[str, str]] = None) -> None:
+            """Publish a serialized HTTP response back to the requesting worker."""
+            if redis and response_channel:
+                payload = {"status": status, "headers": headers or {"content-type": "application/json"}, "body": body.hex()}
+                await redis.publish(response_channel, orjson.dumps(payload))
+
         try:
-            response_channel = request.get("response_channel")
             method = request.get("method")
-            path = request.get("path")
-            query_string = request.get("query_string", "")
+            path = request.get("path") or ""
             headers = request.get("headers", {})
             body_hex = request.get("body", "")
             mcp_session_id = request.get("mcp_session_id")
-
-            # Decode hex body back to bytes
+            auth_context_header = request.get("auth_context") or ""
             body = bytes.fromhex(body_hex) if body_hex else b""
 
             session_short = mcp_session_id[:8] if mcp_session_id and len(mcp_session_id) >= 8 else "unknown"
             logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Received forwarded HTTP request: %s %s", WORKER_ID, session_short, method, path)
 
-            # Add internal forwarding headers to prevent loops.
-            # Relies on the originating transport having already filtered
-            # passthrough headers via extract_headers_for_loopback (#3640).
-            internal_headers = dict(headers)
-            internal_headers["x-forwarded-internally"] = "true"
-            internal_headers["x-original-worker"] = request.get("original_worker", "unknown")
+            # Verify the forwarded envelope before trusting anything about this request.
+            # forward_to_owner() signs the whole envelope (identity + operation +
+            # response_channel) with the auth-encryption secret; a Redis writer cannot
+            # produce a valid signature without it. Verify the untouched received envelope
+            # first, before any field is decoded or the body is rewritten, and require a
+            # non-empty auth context. Without this the owner would re-stamp an injected or
+            # tampered context with a valid runtime-auth token and dispatch it (a signing
+            # oracle), or honor a redirected response_channel (CWE-347). Fail closed.
+            # First-Party
+            from mcpgateway.auth_context import verify_redis_forward_envelope  # pylint: disable=import-outside-toplevel
 
-            # Make internal HTTP/HTTPS request to local endpoint
-            url = f"{internal_loopback_base_url()}{path}"
-            if query_string:
-                url = f"{url}?{query_string}"
+            if not verify_redis_forward_envelope(request) or not auth_context_header:
+                logger.warning(
+                    "[HTTP_AFFINITY] Worker %s | Session %s... | Rejected forwarded request: missing or invalid envelope signature",
+                    WORKER_ID,
+                    session_short,
+                )
+                self._forwarded_request_failures += 1
+                await _publish(403, orjson.dumps({"jsonrpc": "2.0", "error": {"code": -32003, "message": "Forwarded auth context failed integrity verification"}, "id": None}))
+                return
 
-            async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                response = await client.request(
-                    method=method,
-                    url=url,
-                    headers=internal_headers,
+            # Only POST carries a JSON-RPC body that needs upstream dispatch.
+            # DELETE/other lifecycle methods are handled by the originating worker; ack them.
+            if method != "POST":
+                await _publish(200, b'{"jsonrpc":"2.0","result":{}}')
+                return
+            if not body:
+                await _publish(202, b"")
+                return
+
+            json_body = orjson.loads(body)
+            rpc_method = json_body.get("method", "") if isinstance(json_body, dict) else ""
+
+            # Notifications need no upstream round-trip.
+            if isinstance(rpc_method, str) and rpc_method.startswith("notifications/"):
+                await _publish(202, b"")
+                return
+
+            # Inject the virtual server id (from the path) into params so the
+            # dispatcher routes to the right virtual server.
+            server_match = _SERVER_ID_RE.search(path)
+            if server_match and isinstance(json_body, dict):
+                if not isinstance(json_body.get("params"), dict):
+                    json_body["params"] = {}
+                json_body["params"]["server_id"] = server_match.group("server_id")
+                body = orjson.dumps(json_body)
+
+            # First-Party - lazy imports avoid a circular dependency with main/transport.
+            # The forwarded envelope was already verified above, before any field was decoded.
+            from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header  # pylint: disable=import-outside-toplevel,protected-access
+            from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+            from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+            from mcpgateway.utils.verify_credentials import _resolve_auth_header_name  # pylint: disable=import-outside-toplevel,protected-access
+
+            # Trust headers for the internal /_internal/mcp/rpc endpoint:
+            # - x-contextforge-mcp-runtime: "affinity" caller marker
+            # - x-contextforge-mcp-runtime-auth: shared-secret HMAC
+            # - x-contextforge-auth-context: the encoded edge auth context, so the
+            #   endpoint reconstructs the same user without re-authenticating.
+            rpc_headers = {
+                "content-type": "application/json",
+                "x-mcp-session-id": mcp_session_id or "",
+                "x-contextforge-mcp-runtime": "affinity",
+                "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                "x-contextforge-auth-context": auth_context_header,
+            }
+            # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+            # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+            # the configured header, so a custom header would otherwise be dropped.
+            # This is defense-in-depth; the endpoint trusts the auth-context above.
+            auth_header_name = _resolve_auth_header_name(settings).lower()
+            original_auth = headers.get(auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+            if original_auth:
+                rpc_headers[auth_header_name] = original_auth
+            # Preserve passthrough headers destined for upstream MCP servers (#3640).
+            rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+
+            # Dispatch IN-PROCESS to the trusted internal endpoint. The explicit
+            # client=("127.0.0.1", 0) tells ASGITransport to set scope["client"]
+            # to a loopback address so the trust check accepts the request.
+            transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+            async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+                response = await client.post(
+                    "/_internal/mcp/rpc",
                     content=body,
+                    headers=rpc_headers,
                     timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                 )
 
-                logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Executed locally: %s", WORKER_ID, session_short, response.status_code)
+            logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | Executed in-process via /_internal/mcp/rpc: %s", WORKER_ID, session_short, response.status_code)
 
-                # Serialize response for Redis transport
-                response_data = {
-                    "status": response.status_code,
-                    "headers": dict(response.headers),
-                    "body": response.content.hex(),  # Hex encode binary response
-                }
-
-                # Publish response back to requesting worker
-                if redis and response_channel:
-                    await redis.publish(response_channel, orjson.dumps(response_data))
-                    logger.debug("[HTTP_AFFINITY] Published HTTP response to Redis channel: %s", response_channel)
+            resp_headers = {"content-type": "application/json"}
+            if mcp_session_id:
+                resp_headers["mcp-session-id"] = mcp_session_id
+            await _publish(response.status_code, response.content, resp_headers)
 
         except Exception as e:
-            logger.error("Error executing forwarded HTTP request: %s", e)
-            # Try to send error response if possible
-            if redis and response_channel:
-                error_response = {
-                    "status": 500,
-                    "headers": {"content-type": "application/json"},
-                    "body": orjson.dumps({"error": "Internal forwarding error"}).hex(),
-                }
-                try:
-                    await redis.publish(response_channel, orjson.dumps(error_response))
-                except Exception as publish_error:
-                    logger.debug("Failed to publish error response via Redis: %s", publish_error)
+            # Sanitise + truncate the exception message: this except catches anything from the
+            # inner /rpc dispatch (FastAPI handlers, middleware, services), so the exception may
+            # carry request fragments or newlines that would forge log entries (CWE-117).
+            logger.error(
+                "Error executing forwarded HTTP request: %s: %s",
+                type(e).__name__,
+                SecurityValidator.sanitize_log_message(str(e), max_length=500),
+            )
+            try:
+                await _publish(500, orjson.dumps({"error": "Internal forwarding error"}))
+            except Exception as publish_error:
+                logger.debug("Failed to publish error response via Redis: %s", publish_error)
 
     async def get_session_owner(self, mcp_session_id: str) -> Optional[str]:
         """Get the worker ID that owns a Streamable HTTP session.
@@ -1123,6 +1241,7 @@ class SessionAffinity:
         path: str,
         headers: Dict[str, str],
         body: bytes,
+        auth_context: str,
         query_string: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Forward a Streamable HTTP request to the worker that owns the session via Redis Pub/Sub.
@@ -1139,6 +1258,12 @@ class SessionAffinity:
             path: Request path (e.g., /mcp).
             headers: Request headers.
             body: Request body bytes.
+            auth_context: Encoded ``x-contextforge-auth-context`` value carrying the
+                originating worker's already-validated identity, so the owner can
+                dispatch to the trusted internal endpoint without re-authenticating
+                (OAuth bearers and ``MCP_REQUIRE_AUTH=false`` public-only survive).
+                Required and must be non-empty: the Redis hop must always carry a
+                signed auth context.
             query_string: Query string if any.
 
         Returns:
@@ -1150,6 +1275,19 @@ class SessionAffinity:
 
         if not self.is_valid_mcp_session_id(mcp_session_id):
             return None
+
+        # Invariant: a Redis http_forward must always carry a signed auth context. Refuse to
+        # publish an unsigned/missing one rather than relying on the consumer to reject it
+        # (or, worse, accept it). The real Streamable HTTP caller always encodes a context
+        # (an empty {} encodes to a non-empty value), so this only trips on a contract bug.
+        if not auth_context:
+            logger.warning("[HTTP_AFFINITY] Worker %s | Refusing to forward HTTP request without an auth context", WORKER_ID)
+            self._forwarded_request_failures += 1
+            return {
+                "status": 403,
+                "headers": {"content-type": "application/json"},
+                "body": orjson.dumps({"jsonrpc": "2.0", "error": {"code": -32003, "message": "Forwarded auth context is required"}, "id": None}),
+            }
 
         session_short = mcp_session_id[:8] if len(mcp_session_id) >= 8 else mcp_session_id
         logger.debug("[HTTP_AFFINITY] Worker %s | Session %s... | %s %s | Forwarding to worker %s", WORKER_ID, session_short, method, path, owner_worker_id)
@@ -1169,6 +1307,9 @@ class SessionAffinity:
             response_uuid = uuid.uuid4().hex
             response_channel = f"mcpgw:pool_http_response:{response_uuid}"
 
+            # First-Party
+            from mcpgateway.auth_context import FORWARD_SIG_FIELD, sign_redis_forward_envelope  # pylint: disable=import-outside-toplevel
+
             # Serialize HTTP request for Redis transport
             forward_data = {
                 "type": "http_forward",
@@ -1181,7 +1322,14 @@ class SessionAffinity:
                 "body": body.hex() if body else "",  # Hex encode binary body
                 "original_worker": WORKER_ID,
                 "timestamp": time.time(),
+                # Encoded edge identity; lets the owner dispatch without re-authenticating.
+                "auth_context": auth_context,
             }
+            # Sign the whole envelope (identity + operation + response_channel) so the owner
+            # can verify nothing was forged, tampered, or redirected in Redis transit before
+            # re-stamping it with the runtime-auth token (closes the signing-oracle on the
+            # pub/sub hop, CWE-347). auth_context is non-empty here (guarded above).
+            forward_data[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(forward_data)
 
             # Subscribe to response channel BEFORE publishing request (prevent race)
             async with redis.pubsub() as pubsub:
@@ -1200,7 +1348,7 @@ class SessionAffinity:
                             msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0.1)
                             if msg and msg["type"] == "message":
                                 response_data = orjson.loads(msg["data"])
-                                logger.debug("[HTTP_AFFINITY] Received HTTP response via Redis: status=%s", response_data.get("status"))
+                                logger.debug("[HTTP_AFFINITY] Received HTTP response via Redis: status=%s", response_data.get('status'))
 
                                 # Decode hex body back to bytes
                                 body_hex = response_data.get("body", "")

--- a/mcpgateway/transports/rust_mcp_runtime_proxy.py
+++ b/mcpgateway/transports/rust_mcp_runtime_proxy.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 # Standard
 import asyncio
-import base64
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
 
 # Third-Party
 import httpx
-import orjson
 from sqlalchemy import exists as sa_exists
 from starlette.types import Receive, Scope, Send
 
 # First-Party
+from mcpgateway.auth_context import encode_internal_mcp_auth_context
 from mcpgateway.config import settings
 from mcpgateway.db import fresh_db_session
 from mcpgateway.db import Server as DbServer
@@ -368,5 +367,4 @@ def _build_forwarded_auth_context_header() -> str | None:
     auth_context = get_streamable_http_auth_context()
     if not auth_context:
         return None
-    encoded = base64.urlsafe_b64encode(orjson.dumps(auth_context)).decode("ascii")
-    return encoded.rstrip("=")
+    return encode_internal_mcp_auth_context(auth_context)

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -91,7 +91,7 @@ from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
 from mcpgateway.utils.gateway_access import build_gateway_auth_headers, check_gateway_access, extract_gateway_id_from_headers, GATEWAY_ID_HEADER
 from mcpgateway.utils.identity_propagation import build_identity_headers
-from mcpgateway.utils.internal_http import internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import post_rpc_in_process
 from mcpgateway.utils.log_sanitizer import sanitize_for_log
 from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.passthrough_headers import compute_passthrough_headers_cached
@@ -1742,9 +1742,16 @@ async def call_tool(
             except Exception as e:
                 logger.error("Failed to pre-register session mapping for Streamable HTTP: %s", e)
 
+            # First-Party
+            from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+            # Carry the verified edge identity so the owner dispatches to the trusted internal
+            # endpoint without re-authenticating (OAuth / public-only survive the rpc forward).
+            encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
             forwarded_response = await pool.forward_request_to_owner(
                 mcp_session_id,
                 {"method": "tools/call", "params": {"name": name, "arguments": arguments, "_meta": meta_data}, "headers": dict(request_headers) if request_headers else {}},
+                encoded_auth_context,
             )
             if forwarded_response is not None:
                 # Request was handled by another worker - convert response to expected format
@@ -4150,55 +4157,57 @@ class SessionManagerWrapper:
                     body = orjson.dumps(json_body)
                     logger.debug("[HTTP_AFFINITY_FORWARDED] Injected server_id %s into /rpc params", server_id)
 
-                async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                    rpc_headers = {
-                        "content-type": "application/json",
-                        "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
-                        "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                rpc_headers = {
+                    "content-type": "application/json",
+                    "x-mcp-session-id": mcp_session_id,  # Pass session for upstream affinity
+                    "x-forwarded-internally": "true",  # Prevent infinite forwarding loops
+                }
+                # Preserve the inbound gateway auth header (default: Authorization,
+                # or AUTH_HEADER_NAME when customized) so the CSRF bearer short-circuit
+                # keys on it. The trusted endpoint itself authenticates via the encoded
+                # auth context, not this header; hardcoding "authorization" would drop
+                # auth on deployments using a custom AUTH_HEADER_NAME.
+                _gw_auth_lower = _resolve_auth_header_name(settings).lower()
+                if _gw_auth_lower in headers:
+                    rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
+                # Forward passthrough headers for upstream MCP servers (see #3640).
+                # First-Party
+                from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+                from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+
+                rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+
+                # Dispatch IN-PROCESS to the trusted internal endpoint so it executes in
+                # this worker (the session owner) rather than scattering over the shared
+                # socket. The edge identity established on this request is encoded and
+                # carried as the auth context; this is in-process (no Redis hop), so no
+                # signature is required.
+                encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
+                response = await post_rpc_in_process(content=body, headers=rpc_headers, timeout=30.0, auth_context=encoded_auth_context)
+
+                # Return response to client
+                response_headers = [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(response.content)).encode()),
+                ]
+                if mcp_session_id != "not-provided":
+                    response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
+
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": response.status_code,
+                        "headers": response_headers,
                     }
-                    # Forward the inbound gateway auth header (default: Authorization,
-                    # or AUTH_HEADER_NAME when customized) so /rpc can re-authenticate
-                    # the same caller. Hardcoding "authorization" here would silently
-                    # drop auth on deployments using a custom AUTH_HEADER_NAME.
-                    _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                    if _gw_auth_lower in headers:
-                        rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                    # Forward passthrough headers for upstream MCP servers (see #3640).
-                    # First-Party
-                    from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
-
-                    rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
-
-                    response = await client.post(
-                        f"{internal_loopback_base_url()}/rpc",
-                        content=body,
-                        headers=rpc_headers,
-                        timeout=30.0,
-                    )
-
-                    # Return response to client
-                    response_headers = [
-                        (b"content-type", b"application/json"),
-                        (b"content-length", str(len(response.content)).encode()),
-                    ]
-                    if mcp_session_id != "not-provided":
-                        response_headers.append((b"mcp-session-id", mcp_session_id.encode()))
-
-                    await send(
-                        {
-                            "type": "http.response.start",
-                            "status": response.status_code,
-                            "headers": response_headers,
-                        }
-                    )
-                    await send(
-                        {
-                            "type": "http.response.body",
-                            "body": response.content,
-                        }
-                    )
-                    logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
-                    return
+                )
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": response.content,
+                    }
+                )
+                logger.debug("[HTTP_AFFINITY_FORWARDED] Response sent | Status: %s", response.status_code)
+                return
             except Exception as e:
                 logger.error("[HTTP_AFFINITY_FORWARDED] Error routing to /rpc: %s", e)
                 # Fall through to SDK handling as fallback
@@ -4216,6 +4225,14 @@ class SessionManagerWrapper:
                 if owner and owner != WORKER_ID:
                     # Session owned by another worker - forward the entire HTTP request
                     logger.info("[HTTP_AFFINITY] Worker %s | Session %s... | Owner: %s | Forwarding HTTP request", WORKER_ID, mcp_session_id[:8], owner)
+
+                    # Package the edge-validated identity so the owner can dispatch via
+                    # the trusted internal /_internal/mcp/rpc endpoint without
+                    # re-authenticating, letting OAuth and public-only sessions survive.
+                    # First-Party
+                    from mcpgateway.auth_context import encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel
+
+                    encoded_auth_context = encode_internal_mcp_auth_context(get_streamable_http_auth_context())
 
                     # Read request body
                     body_parts = []
@@ -4238,6 +4255,7 @@ class SessionManagerWrapper:
                         headers=headers,
                         body=body,
                         query_string=query_string,
+                        auth_context=encoded_auth_context,
                     )
 
                     if response:
@@ -4321,49 +4339,67 @@ class SessionManagerWrapper:
                             body = orjson.dumps(json_body)
                             logger.debug("[HTTP_AFFINITY_LOCAL] Injected server_id %s into /rpc params", server_id)
 
-                        async with httpx.AsyncClient(verify=internal_loopback_verify()) as client:
-                            rpc_headers = {
-                                "content-type": "application/json",
-                                "x-mcp-session-id": mcp_session_id,
-                                "x-forwarded-internally": "true",
-                            }
-                            _gw_auth_lower = _resolve_auth_header_name(settings).lower()
-                            if _gw_auth_lower in headers:
-                                rpc_headers[_gw_auth_lower] = headers[_gw_auth_lower]
-                            # Forward passthrough headers for upstream MCP servers (see #3640).
-                            # First-Party
-                            from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
+                        # Owner-direct path: dispatch to the trusted internal
+                        # /_internal/mcp/rpc endpoint carrying the edge-validated auth
+                        # context, so OAuth and public-only sessions are honored without
+                        # re-authenticating against public /rpc (JWTs/cookies only).
+                        # First-Party
+                        from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header, encode_internal_mcp_auth_context  # pylint: disable=import-outside-toplevel,protected-access
+                        from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+                        from mcpgateway.utils.internal_http import internal_loopback_base_url  # pylint: disable=import-outside-toplevel
+                        from mcpgateway.utils.passthrough_headers import safe_extract_and_filter_for_loopback  # pylint: disable=import-outside-toplevel
 
-                            rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
+                        rpc_headers = {
+                            "content-type": "application/json",
+                            "x-mcp-session-id": mcp_session_id,
+                            "x-contextforge-mcp-runtime": "affinity",
+                            "x-contextforge-mcp-runtime-auth": _expected_internal_mcp_runtime_auth_header(),
+                            "x-contextforge-auth-context": encode_internal_mcp_auth_context(get_streamable_http_auth_context()),
+                        }
+                        # Preserve the bearer under the configured auth header (AUTH_HEADER_NAME),
+                        # not a hardcoded "authorization": the CSRF bearer short-circuit keys on
+                        # the configured header, so a custom header would otherwise be dropped.
+                        # This is defense-in-depth; the endpoint trusts the auth-context above.
+                        _auth_header_name = _resolve_auth_header_name(settings).lower()
+                        _original_auth = headers.get(_auth_header_name) or headers.get(_resolve_auth_header_name(settings))
+                        if _original_auth:
+                            rpc_headers[_auth_header_name] = _original_auth
+                        # Forward passthrough headers for upstream MCP servers (see #3640).
+                        rpc_headers.update(safe_extract_and_filter_for_loopback(headers))
 
+                        # Dispatch in-process so the request runs on this worker, the
+                        # session owner that holds the bound upstream session, instead of
+                        # looping back over the shared socket to a random worker.
+                        transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+                        async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
                             response = await client.post(
-                                f"{internal_loopback_base_url()}/rpc",
+                                "/_internal/mcp/rpc",
                                 content=body,
                                 headers=rpc_headers,
-                                timeout=30.0,
+                                timeout=settings.mcpgateway_pool_rpc_forward_timeout,
                             )
 
-                            response_headers = [
-                                (b"content-type", b"application/json"),
-                                (b"content-length", str(len(response.content)).encode()),
-                                (b"mcp-session-id", mcp_session_id.encode()),
-                            ]
+                        response_headers = [
+                            (b"content-type", b"application/json"),
+                            (b"content-length", str(len(response.content)).encode()),
+                            (b"mcp-session-id", mcp_session_id.encode()),
+                        ]
 
-                            await send(
-                                {
-                                    "type": "http.response.start",
-                                    "status": response.status_code,
-                                    "headers": response_headers,
-                                }
-                            )
-                            await send(
-                                {
-                                    "type": "http.response.body",
-                                    "body": response.content,
-                                }
-                            )
-                            logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
-                            return
+                        await send(
+                            {
+                                "type": "http.response.start",
+                                "status": response.status_code,
+                                "headers": response_headers,
+                            }
+                        )
+                        await send(
+                            {
+                                "type": "http.response.body",
+                                "body": response.content,
+                            }
+                        )
+                        logger.debug("[HTTP_AFFINITY_LOCAL] Response sent | Status: %s", response.status_code)
+                        return
                     except Exception as e:
                         logger.error("[HTTP_AFFINITY_LOCAL] Error routing to /rpc: %s", e)
                         # Fall through to SDK handling as fallback

--- a/mcpgateway/utils/internal_http.py
+++ b/mcpgateway/utils/internal_http.py
@@ -13,6 +13,9 @@ self-calls to local endpoints like /rpc.
 # Standard
 import os
 
+# Third-Party
+import httpx
+
 # First-Party
 from mcpgateway.config import settings
 
@@ -48,3 +51,62 @@ def internal_loopback_verify() -> bool:
         bool: ``False`` when the loopback URL is HTTPS, ``True`` otherwise.
     """
     return not _is_ssl_enabled()
+
+
+async def post_rpc_in_process(*, content: bytes, headers: dict, timeout: float, auth_context: str) -> httpx.Response:
+    """POST to the trusted-internal ``/_internal/mcp/rpc`` route via an in-process ASGI transport.
+
+    Affinity-owned requests must execute on the worker that actually holds the
+    bound upstream session. A real loopback to ``127.0.0.1`` hits the shared
+    gunicorn socket, and the kernel routes it to an arbitrary worker that does
+    not hold the session, which breaks upstream-session reuse (and the #4205
+    isolation invariant for stateful upstreams). ``httpx.ASGITransport`` invokes
+    the FastAPI app in *this* process instead, so the dispatch resolves the
+    session from this worker's ``UpstreamSessionRegistry``.
+
+    Targets the trusted-internal endpoint rather than the public ``/rpc`` so that
+    OAuth and ``MCP_REQUIRE_AUTH=false`` public-only sessions are not
+    re-authenticated (and 401'd) at the public route boundary. The already
+    validated edge identity rides in ``auth_context``; this helper attaches the
+    runtime-auth trust headers and the encoded context, and pins the ASGI client
+    to loopback so the trust gate accepts the call. It is trust-agnostic: a
+    Redis-forwarded request MUST have had its signature verified by the caller
+    before reaching here.
+
+    ``app`` is imported lazily to avoid a circular import at module load.
+
+    Args:
+        content: Serialized JSON-RPC request body.
+        headers: Request headers. Must include ``x-forwarded-internally: true``
+            so the re-entered handler does not forward again.
+        timeout: Per-call timeout in seconds.
+        auth_context: Encoded ``x-contextforge-auth-context`` value (required,
+            non-empty) carrying the edge-validated identity. Attached verbatim;
+            this helper does not verify it.
+
+    Returns:
+        httpx.Response: The response from the in-process ``/_internal/mcp/rpc`` dispatch.
+
+    Raises:
+        ValueError: If ``auth_context`` is empty (internal dispatch must always carry one).
+    """
+    if not auth_context:
+        raise ValueError("post_rpc_in_process requires a non-empty auth_context for trusted-internal dispatch")
+
+    # First-Party
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header  # pylint: disable=import-outside-toplevel,protected-access
+    from mcpgateway.main import app  # pylint: disable=import-outside-toplevel,cyclic-import
+
+    # Trust headers for the internal endpoint: the "affinity" runtime marker, the
+    # shared-secret HMAC, and the encoded edge auth context (so the endpoint
+    # reconstructs the caller without re-authenticating).
+    rpc_headers = dict(headers)
+    rpc_headers["x-contextforge-mcp-runtime"] = "affinity"
+    rpc_headers["x-contextforge-mcp-runtime-auth"] = _expected_internal_mcp_runtime_auth_header()
+    rpc_headers["x-contextforge-auth-context"] = auth_context
+
+    # client=("127.0.0.1", 0) sets scope["client"] to a loopback address so the
+    # trust gate's defense-in-depth loopback check accepts the in-process call.
+    transport = httpx.ASGITransport(app=app, client=("127.0.0.1", 0))
+    async with httpx.AsyncClient(transport=transport, base_url=internal_loopback_base_url()) as client:
+        return await client.post("/_internal/mcp/rpc", content=content, headers=rpc_headers, timeout=timeout)

--- a/mcpgateway/utils/passthrough_headers.py
+++ b/mcpgateway/utils/passthrough_headers.py
@@ -606,6 +606,25 @@ _LOOPBACK_SKIP_HEADERS: frozenset[str] = frozenset(
         "upgrade",
         "x-mcp-session-id",
         "x-forwarded-internally",
+        # Gateway-internal trust headers for the /_internal/mcp/* dispatch: the
+        # server-established auth context, runtime marker, and HMAC. A client
+        # passthrough header must never overwrite them, or a caller could spoof
+        # the trusted identity while the server's valid HMAC still rides along.
+        "x-contextforge-auth-context",
+        "x-contextforge-mcp-runtime",
+        "x-contextforge-mcp-runtime-auth",
+        "x-contextforge-session-validated",
+        # Forwarded / client-IP headers: strip so a caller cannot spoof the loopback
+        # client address that ProxyHeaders(trusted_hosts="*") would otherwise trust.
+        "forwarded",
+        "x-forwarded-for",
+        "x-forwarded-host",
+        "x-forwarded-proto",
+        "x-forwarded-port",
+        "x-forwarded-prefix",
+        "x-real-ip",
+        "cf-connecting-ip",
+        "true-client-ip",
     }
 )
 

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -231,6 +231,39 @@ async def test_exempt_path_passes_without_token():
 
 
 @pytest.mark.asyncio
+async def test_internal_mcp_dispatch_is_csrf_exempt_by_default():
+    """``/_internal/mcp/*`` is CSRF-exempt by default (loopback-only, HMAC-gated).
+
+    The affinity dispatch posts to the trusted-internal endpoint, which must not
+    require a CSRF token. Without the exemption, custom AUTH_HEADER_NAME
+    deployments (whose bearer the CSRF short-circuit can't find) would 403 on the
+    inner dispatch.
+    """
+    # First-Party
+    from mcpgateway.config import settings as real_settings
+
+    # The shipped default must cover the internal MCP dispatch prefix.
+    assert "/_internal/mcp/" in real_settings.csrf_exempt_paths
+
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/_internal/mcp/rpc"
+    request.headers = {}  # no CSRF token, no bearer
+
+    with patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings:
+        mock_settings.csrf_enabled = True
+        mock_settings.csrf_exempt_paths = real_settings.csrf_exempt_paths
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
 async def test_bearer_token_request_passes_without_csrf():
     """Test that requests with Authorization: Bearer header pass without CSRF token."""
     middleware = CSRFMiddleware(app=AsyncMock())

--- a/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_rate_limit_middleware.py
@@ -16,6 +16,30 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _trusted_internal_request(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a real loopback internal request for trust-gate exemption tests."""
+    from starlette.requests import Request
+
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+    return Request(scope)
+
+
 class TestRateLimiterRedisUrl:
     """Test rate limit middleware uses dedicated Redis function."""
 
@@ -97,6 +121,29 @@ class TestRateLimitMiddlewareTiers:
         request.state = MagicMock()
         request.scope = {"client": ("192.168.1.100", 12345)}
         return request
+
+    @pytest.mark.asyncio
+    async def test_trusted_internal_dispatch_skips_rate_limiting(self, middleware):
+        """A trusted-internal hop is not rate-limited; the edge request already was."""
+        request = _trusted_internal_request("/_internal/mcp/rpc")
+        call_next = AsyncMock(return_value="passthrough")
+        # If the exemption fires, tier computation is never reached.
+        middleware.get_endpoint_tier = MagicMock(side_effect=AssertionError("trusted internal must not be rate-limited"))
+
+        result = await middleware.dispatch(request, call_next)
+
+        assert result == "passthrough"
+        call_next.assert_awaited_once_with(request)
+
+    @pytest.mark.asyncio
+    async def test_forged_internal_request_is_still_rate_limited(self, middleware):
+        """A forged HMAC fails the trust gate, so the rate-limit path runs."""
+        request = _trusted_internal_request("/_internal/mcp/rpc", hmac_value="forged")
+        call_next = AsyncMock(return_value="passthrough")
+        middleware.get_endpoint_tier = MagicMock(side_effect=RuntimeError("reached rate-limit path"))
+
+        with pytest.raises(RuntimeError, match="reached rate-limit path"):
+            await middleware.dispatch(request, call_next)
 
     def test_endpoint_tier_critical(self, middleware):
         """Test CRITICAL tier detection for auth endpoints."""

--- a/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_token_usage_middleware.py
@@ -27,6 +27,60 @@ async def _make_asgi_call(middleware, scope, receive=None, send=None):
     return send
 
 
+def _trusted_internal_scope(path, *, marker="rust", hmac_value=None, ctx="ctx", client="127.0.0.1"):
+    """Build a loopback internal ASGI scope for trust-gate exemption tests."""
+    # First-Party
+    from mcpgateway.auth_context import _expected_internal_mcp_runtime_auth_header
+
+    headers = [
+        (b"x-contextforge-mcp-runtime", marker.encode()),
+        (b"x-contextforge-mcp-runtime-auth", (hmac_value or _expected_internal_mcp_runtime_auth_header()).encode()),
+    ]
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": headers,
+        "client": (client, 12345),
+    }
+
+
+@pytest.mark.asyncio
+async def test_trusted_internal_dispatch_skips_usage_logging():
+    """A trusted-internal hop is not recorded; the edge request already was.
+
+    The skip path forwards the original ``send`` unwrapped (no status capture, no
+    logging), which distinguishes it from the normal metered path.
+    """
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    app.assert_awaited_once_with(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_forged_internal_request_is_not_skipped_for_usage():
+    """A forged HMAC fails the trust gate, so the usage path runs (wrapped send)."""
+    app = AsyncMock()
+    middleware = TokenUsageMiddleware(app=app)
+    scope = _trusted_internal_scope("/_internal/mcp/rpc", hmac_value="forged")
+    receive, send = AsyncMock(), AsyncMock()
+
+    await middleware(scope, receive, send)
+
+    assert app.await_count == 1
+    forwarded_send = app.await_args.args[2]
+    assert forwarded_send is not send
+
+
 @pytest.mark.asyncio
 async def test_skips_health_check_paths():
     """Middleware should skip health check and static paths."""

--- a/tests/unit/mcpgateway/services/test_session_affinity.py
+++ b/tests/unit/mcpgateway/services/test_session_affinity.py
@@ -34,6 +34,26 @@ def _reset_affinity_singleton():
     sa._mcp_session_pool = None
 
 
+def _sign_forward(request: dict) -> dict:
+    """Attach a valid ``forward_sig`` over the whole forwarded envelope.
+
+    The consumers now verify the entire envelope (identity + operation +
+    response_channel), not just the auth context, so tests that exercise the happy
+    path build the same signature the publishers (``forward_to_owner`` /
+    ``forward_request_to_owner``) would. Must be called after the payload is fully
+    built: any field mutated afterwards invalidates the signature.
+    """
+    # First-Party
+    from mcpgateway.auth_context import FORWARD_SIG_FIELD, sign_redis_forward_envelope  # pylint: disable=import-outside-toplevel
+
+    if request.get("auth_context") is None:
+        # Envelopes that don't set a context get a placeholder so the consumer's
+        # required-auth-context check passes on the happy path.
+        request["auth_context"] = "ctx"
+    request[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(request)
+    return request
+
+
 class _FakeRedis:
     """Minimal mock for the redis asyncio client surface SessionAffinity uses.
 
@@ -752,7 +772,7 @@ async def test_forward_request_to_owner_noop_when_feature_disabled():
     affinity = SessionAffinity()
     with patch("mcpgateway.services.session_affinity.settings") as mock_settings:
         mock_settings.mcpgateway_session_affinity_enabled = False
-        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}) is None
+        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx") is None
 
 
 @pytest.mark.asyncio
@@ -765,7 +785,7 @@ async def test_forward_request_to_owner_invalid_session_id_returns_none():
     with patch("mcpgateway.services.session_affinity.settings") as mock_settings:
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        assert await affinity.forward_request_to_owner("bad id", {"method": "x"}) is None
+        assert await affinity.forward_request_to_owner("bad id", {"method": "x"}, "ctx") is None
 
 
 @pytest.mark.asyncio
@@ -781,7 +801,7 @@ async def test_forward_request_to_owner_none_when_redis_unavailable():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        assert await affinity.forward_request_to_owner("sess-1", {"method": "x"}) is None
+        assert await affinity.forward_request_to_owner("sess-1", {"method": "x"}, "ctx") is None
 
 
 @pytest.mark.asyncio
@@ -798,7 +818,7 @@ async def test_forward_request_to_owner_no_owner_returns_none():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}) is None
+        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx") is None
 
 
 @pytest.mark.asyncio
@@ -817,7 +837,7 @@ async def test_forward_request_to_owner_returns_none_when_we_own_the_session():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}) is None
+        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx") is None
 
 
 @pytest.mark.asyncio
@@ -837,7 +857,7 @@ async def test_forward_request_to_owner_swallows_unexpected_errors_as_none():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}) is None
+        assert await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx") is None
     assert affinity._forwarded_request_failures == 1  # pylint: disable=protected-access
 
 
@@ -1031,7 +1051,7 @@ async def test_forward_to_owner_noop_when_feature_disabled():
     affinity = SessionAffinity()
     with patch("mcpgateway.services.session_affinity.settings") as mock_settings:
         mock_settings.mcpgateway_session_affinity_enabled = False
-        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"")
+        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"", auth_context="ctx")
     assert result is None
 
 
@@ -1045,7 +1065,7 @@ async def test_forward_to_owner_invalid_session_id_returns_none():
     with patch("mcpgateway.services.session_affinity.settings") as mock_settings:
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity.forward_to_owner("w-1", "bad id", "POST", "/mcp", {}, b"")
+        result = await affinity.forward_to_owner("w-1", "bad id", "POST", "/mcp", {}, b"", auth_context="ctx")
     assert result is None
 
 
@@ -1062,7 +1082,7 @@ async def test_forward_to_owner_returns_none_when_redis_unavailable():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity.forward_to_owner("w-1", "sess-1", "POST", "/mcp", {}, b"")
+        result = await affinity.forward_to_owner("w-1", "sess-1", "POST", "/mcp", {}, b"", auth_context="ctx")
     assert result is None
 
 
@@ -1086,7 +1106,7 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {"h": "v"}, b"req-body")
+        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {"h": "v"}, b"req-body", auth_context="ctx")
 
     assert result is not None
     assert result["status"] == 200
@@ -1096,6 +1116,134 @@ async def test_forward_to_owner_decodes_hex_body_from_response():
     # Forward metrics bumped.
     assert affinity._forwarded_requests == 1  # pylint: disable=protected-access
     assert fake.last_pubsub.closed is True, "PubSub was not closed"
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_includes_auth_context_in_redis_payload():
+    """The encoded auth context from the originating worker is carried in the forwarded Redis payload.
+
+    Without this, the owner worker cannot reconstruct the StreamableHTTP user
+    that ``streamable_http_auth()`` already validated at the edge, so forwarded
+    OAuth and ``MCP_REQUIRE_AUTH=false`` requests would re-authenticate against
+    the public ``/rpc`` and fail with 401.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    # Make the pubsub wait return immediately so we focus on the published payload.
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    encoded_ctx = "base64url-encoded-auth-ctx-from-edge"
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner(
+            owner_worker_id="other-worker",
+            mcp_session_id="sess-auth",
+            method="POST",
+            path="/servers/srv-9/mcp",
+            headers={"Authorization": "Bearer x"},
+            body=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            auth_context=encoded_ctx,
+        )
+
+    # Locate the forward payload published to the owner's HTTP channel.
+    owner_channels = [(chan, payload) for chan, payload in fake.published if chan == "mcpgw:pool_http:other-worker"]
+    assert owner_channels, "forward payload was not published to the owner channel"
+    forward_data = orjson.loads(owner_channels[0][1])
+    assert forward_data["type"] == "http_forward"
+    assert forward_data["auth_context"] == encoded_ctx
+
+
+@pytest.mark.asyncio
+async def test_forward_to_owner_refuses_to_publish_without_auth_context():
+    """Sender side: a missing/empty auth_context is refused before publishing.
+
+    The Redis http_forward hop must always carry a signed auth context, so
+    forward_to_owner returns a 403 (and publishes nothing) when handed an empty
+    context, rather than emitting an unsigned payload the consumer would reject.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=fake)),
+    ):
+        mock_settings.mcpgateway_session_affinity_enabled = True
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        result = await affinity.forward_to_owner("other-worker", "sess-no-ctx", "POST", "/mcp", {}, b"", auth_context="")
+
+    # Refused with a 403, and nothing was published to Redis.
+    assert result is not None and result["status"] == 403
+    assert fake.published == []
+    assert affinity._forwarded_request_failures == 1  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_public_only_forward_signs_and_consumer_accepts():
+    """Public-only path: publisher encodes a non-empty context and signs it; consumer verifies and dispatches (no integrity 403).
+
+    Directly disproves the ``auth_context=None for public-only`` premise: a permissive-mode
+    (``is_authenticated`` False) context still encodes non-empty, is signed on the Redis hop,
+    and is accepted by the owner-side consumer, which dispatches to ``/_internal/mcp/rpc``.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    sid = "sess-public-rt"
+    encoded = encode_internal_mcp_auth_context({"email": None, "teams": [], "is_authenticated": False})
+    assert encoded  # public-only context is non-empty once encoded
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+
+    # Publisher side: sign + publish.
+    pub_fake = _FakeRedisWithPubSub(response_payload=orjson.dumps({"status": 200, "headers": {}, "body": b"".hex()}))
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as ms,
+        patch("mcpgateway.utils.redis_client.get_redis_client", AsyncMock(return_value=pub_fake)),
+    ):
+        ms.mcpgateway_session_affinity_enabled = True
+        ms.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity.forward_to_owner("other-worker", sid, "POST", "/mcp", {}, jsonrpc_body, auth_context=encoded)
+
+    forward_data = orjson.loads(pub_fake.published[0][1])
+    assert forward_data["auth_context"] == encoded  # non-empty context forwarded
+    assert forward_data["forward_sig"]  # and the whole envelope is signed
+
+    # Consumer side: verify + dispatch (mocked internal endpoint).
+    consumer_fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as ms2,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        ms2.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(forward_data, consumer_fake)  # pylint: disable=protected-access
+
+    # Accepted and dispatched to the trusted-internal endpoint, NOT an integrity 403.
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    assert orjson.loads(consumer_fake.published[0][1])["status"] != 403
 
 
 @pytest.mark.asyncio
@@ -1113,7 +1261,7 @@ async def test_forward_to_owner_times_out_and_returns_none_with_metric_bump():
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 0.05  # short timeout
-        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"")
+        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"", auth_context="ctx")
 
     assert result is None
     assert affinity._forwarded_request_timeouts == 1  # pylint: disable=protected-access
@@ -1335,7 +1483,7 @@ async def test_forward_request_to_owner_happy_path_via_pubsub():
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         mock_settings.mcpgateway_session_affinity_ttl = 300
-        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
 
     assert result == {"jsonrpc": "2.0", "result": {"ok": True}, "id": 1}
     assert affinity._forwarded_requests == 1  # pylint: disable=protected-access
@@ -1362,7 +1510,7 @@ async def test_forward_request_to_owner_raises_and_counts_timeout_when_no_respon
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 0.05  # short
         mock_settings.mcpgateway_session_affinity_ttl = 300
         with pytest.raises(asyncio.TimeoutError):
-            await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+            await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
 
     assert affinity._forwarded_request_timeouts == 1  # pylint: disable=protected-access
 
@@ -1385,7 +1533,7 @@ async def test_forward_request_to_owner_reclaims_session_from_dead_worker():
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         mock_settings.mcpgateway_session_affinity_ttl = 300
-        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
 
     # We reclaimed + now own it → execute locally (None).
     assert result is None
@@ -1433,14 +1581,25 @@ class _FakeHttpxClient:
     async def __aexit__(self, *_exc):
         return False
 
-    async def post(self, url, *, json=None, headers=None, timeout=None):
-        self.last_post_kwargs = {"url": url, "json": json, "headers": headers, "timeout": timeout}
+    async def post(self, url, *, json=None, content=None, headers=None, timeout=None):
+        self.last_post_kwargs = {"url": url, "json": json, "content": content, "headers": headers, "timeout": timeout}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
 
     async def request(self, *, method, url, headers=None, content=None, timeout=None):
         self.last_request_kwargs = {"method": method, "url": url, "headers": headers, "content": content, "timeout": timeout}
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+    async def as_post_rpc(self, *, content=None, headers=None, timeout=None, auth_context=None):
+        """Adapter so this fake can stand in for ``utils.internal_http.post_rpc_in_process``.
+
+        Patching the helper to this method lets the fake capture
+        ``content``/``headers``/``timeout``/``auth_context`` for the call-site assertions.
+        """
+        self.last_post_kwargs = {"content": content, "headers": headers, "timeout": timeout, "auth_context": auth_context}
         if self._raise_exc is not None:
             raise self._raise_exc
         return self._response
@@ -1457,18 +1616,61 @@ async def test_execute_forwarded_request_success_returns_result():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
-            {"method": "tools/list", "params": {}, "headers": {"Authorization": "Bearer x"}, "req_id": 1, "mcp_session_id": "sess-12345678"}
+            _sign_forward({"method": "tools/list", "params": {}, "headers": {"Authorization": "Bearer x"}, "req_id": 1, "mcp_session_id": "sess-12345678"})
         )
 
     assert result == {"result": {"tools": []}}
     # x-forwarded-internally header is added to prevent loops.
     assert client.last_post_kwargs["headers"].get("x-forwarded-internally") == "true"  # type: ignore[index]
+    # The verified edge context is passed through to the trusted-internal dispatch.
+    assert client.last_post_kwargs["auth_context"]  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_request_rejects_forged_signature():
+    """An rpc forward with an invalid envelope signature is rejected, never dispatched."""
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, json_body={"jsonrpc": "2.0", "result": {}, "id": 1}))
+    request = {
+        "method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess-forged",
+        "auth_context": "forged-admin-ctx", "forward_sig": "deadbeef" * 8,  # not a valid envelope HMAC
+    }
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        result = await affinity._execute_forwarded_request(request)  # pylint: disable=protected-access
+
+    assert result["error"]["code"] == -32003  # integrity rejection
+    assert client.last_post_kwargs is None  # never dispatched
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_request_rejects_missing_signature():
+    """An rpc forward with no auth context / signature is rejected, never dispatched (fail closed)."""
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, json_body={"jsonrpc": "2.0", "result": {}, "id": 1}))
+    request = {"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess-nosig"}
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        result = await affinity._execute_forwarded_request(request)  # pylint: disable=protected-access
+
+    assert result["error"]["code"] == -32003
+    assert client.last_post_kwargs is None
 
 
 @pytest.mark.asyncio
@@ -1483,13 +1685,11 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_in_response():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         result = await affinity._execute_forwarded_request(  # pylint: disable=protected-access
-            {"method": "tools/call", "params": {"name": "x"}, "headers": {}, "req_id": 1, "mcp_session_id": "sess-abcd"}
+            _sign_forward({"method": "tools/call", "params": {"name": "x"}, "headers": {}, "req_id": 1, "mcp_session_id": "sess-abcd"})
         )
 
     assert result == {"error": {"code": -32603, "message": "internal"}}
@@ -1506,12 +1706,10 @@ async def test_execute_forwarded_request_maps_non_2xx_http_to_jsonrpc_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"}))  # pylint: disable=protected-access
 
     assert "error" in result
     assert result["error"]["code"] == -32603
@@ -1533,12 +1731,10 @@ async def test_execute_forwarded_request_timeout_returns_timeout_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"}))  # pylint: disable=protected-access
 
     assert result == {"error": {"code": -32603, "message": "Internal request timeout"}}
 
@@ -1554,12 +1750,10 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"}))  # pylint: disable=protected-access
 
     assert result == {"error": {"code": -32603, "message": "boom"}}
 
@@ -1571,7 +1765,10 @@ async def test_execute_forwarded_request_generic_error_returns_wrapped_error():
 
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_response_via_redis():
-    """Happy path: make the internal HTTP call, hex-encode the response body, publish to Redis."""
+    """Happy path: dispatch in-process to the trusted internal endpoint and publish the response back."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1581,34 +1778,45 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
     response.headers = {"content-type": "application/json"}
     client = _FakeHttpxClient(response=response)
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-1",
         "method": "POST",
-        "path": "/mcp",
+        "path": "/servers/srv-9/mcp",
         "query_string": "",
         "headers": {"Authorization": "Bearer x"},
-        "body": b"upstream-body".hex(),
+        "body": jsonrpc_body.hex(),
         "original_worker": "origin-worker",
         "mcp_session_id": "sess-123456789",
+        "auth_context": "encoded-ctx",
     }
+    _sign_forward(request)
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Dispatched to the trusted-internal endpoint, NOT the public /rpc.
+    assert client.last_post_kwargs is not None
+    assert client.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+    headers = client.last_post_kwargs["headers"]
+    assert headers["x-contextforge-mcp-runtime"] == "affinity"
+    assert headers["x-contextforge-mcp-runtime-auth"] == "HMAC-SHA256"
+    assert headers["x-contextforge-auth-context"] == "encoded-ctx"
+    assert headers["x-mcp-session-id"] == "sess-123456789"
+    # server_id from the path is injected into JSON-RPC params before dispatch.
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"]["server_id"] == "srv-9"
 
     # Response published to the requester's channel.
     assert fake.published
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-1"
-    # Orjson round-trips the dict — body is hex-encoded.
-    # Third-Party
-    import orjson
-
     decoded = orjson.loads(payload)
     assert decoded["status"] == 200
     assert bytes.fromhex(decoded["body"]) == b"response-body"
@@ -1617,6 +1825,9 @@ async def test_execute_forwarded_http_request_publishes_response_via_redis():
 @pytest.mark.asyncio
 async def test_execute_forwarded_http_request_publishes_500_error_on_exception():
     """If the internal HTTP call raises, a 500 error envelope is still published to Redis."""
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -1624,28 +1835,28 @@ async def test_execute_forwarded_http_request_publishes_500_error_on_exception()
     fake = _FakeRedis()
     client = _FakeHttpxClient(raise_exc=RuntimeError("internal crash"))
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
         "response_channel": "mcpgw:pool_http_response:req-2",
         "method": "POST",
         "path": "/mcp",
         "headers": {},
-        "body": "",
+        "body": jsonrpc_body.hex(),
         "mcp_session_id": "sess-abcdef",
+        "auth_context": "ctx-err",
     }
+    _sign_forward(request)
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
     # Error response still published so the requester doesn't hang.
-    # Third-Party
-    import orjson
-
     chan, payload = fake.published[0]
     assert chan == "mcpgw:pool_http_response:req-2"
     decoded = orjson.loads(payload)
@@ -1925,7 +2136,7 @@ async def test_forward_to_owner_logs_warning_and_returns_none_on_unexpected_erro
     ):
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 1.0
-        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"")
+        result = await affinity.forward_to_owner("other-worker", "sess-1", "POST", "/mcp", {}, b"", auth_context="ctx")
     assert result is None
     assert affinity._forwarded_request_failures == 1  # pylint: disable=protected-access
 
@@ -2004,7 +2215,7 @@ async def test_forward_request_to_owner_forwards_to_new_owner_when_reclaim_lost(
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         mock_settings.mcpgateway_session_affinity_ttl = 300
-        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
 
     assert result == {"result": {"race": "forwarded"}}
     # Forwarded to the new owner's channel (not the dead one).
@@ -2054,12 +2265,10 @@ async def test_execute_forwarded_request_propagates_jsonrpc_error_from_non_2xx_r
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "sess"}))  # pylint: disable=protected-access
 
     assert result == {"error": {"code": -32601, "message": "method not found"}}
 
@@ -2077,12 +2286,10 @@ async def test_execute_forwarded_request_handles_non_dict_non_2xx_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"}))  # pylint: disable=protected-access
 
     assert "error" in result
     assert result["error"]["code"] == -32603
@@ -2100,12 +2307,10 @@ async def test_execute_forwarded_request_handles_non_2xx_with_non_json_body():
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
-        result = await affinity._execute_forwarded_request({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"})  # pylint: disable=protected-access
+        result = await affinity._execute_forwarded_request(_sign_forward({"method": "tools/list", "params": {}, "headers": {}, "req_id": 1, "mcp_session_id": "s"}))  # pylint: disable=protected-access
 
     assert "error" in result
     assert result["error"]["code"] == -32603
@@ -2138,9 +2343,7 @@ async def test_execute_forwarded_http_request_skips_publish_when_redis_is_none()
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         # Should complete without raising and without a redis.publish call.
@@ -2185,7 +2388,7 @@ async def test_forward_request_to_owner_returns_none_when_reclaimed_key_vanishes
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         mock_settings.mcpgateway_session_affinity_ttl = 300
-        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
     assert result is None
 
 
@@ -2226,13 +2429,121 @@ async def test_forward_request_to_owner_returns_none_when_reclaim_race_makes_us_
         mock_settings.mcpgateway_session_affinity_enabled = True
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         mock_settings.mcpgateway_session_affinity_ttl = 300
-        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"})
+        result = await affinity.forward_request_to_owner("sess-1", {"method": "tools/list"}, "ctx")
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_execute_forwarded_http_request_appends_query_string():
-    """Query string from forwarded request is appended to the internal URL."""
+async def test_execute_forwarded_http_request_preserves_authorization_for_csrf_bypass():
+    """The originating ``Authorization`` bearer is copied onto the trusted-internal dispatch.
+
+    The CSRF middleware short-circuits on bearer-tokened requests; without
+    preserving the original ``Authorization`` header, the affinity dispatch to
+    ``/_internal/mcp/rpc`` 403s on CSRF even though the trusted-internal gate
+    itself is satisfied. Mirrors the Rust runtime forward path.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-auth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"authorization": "Bearer original-jwt"},  # lowercased like the wire
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-auth-bypass",
+        "auth_context": "ctx",
+    }
+    _sign_forward(request)
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    sent_headers = client.last_post_kwargs["headers"]
+    assert sent_headers.get("authorization") == "Bearer original-jwt"
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_rejects_unsigned_context():
+    """Executor side: a forwarded payload without a valid auth-context signature is rejected, not dispatched.
+
+    Closes the Redis signing oracle: a writer to the pub/sub channel needs no
+    secret, so the owner must not re-stamp an unverified context with a valid
+    runtime-auth token. A missing ``auth_context`` (and thus a missing
+    ``forward_sig``) fails closed: a 403 is published and the trusted
+    endpoint is never called.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-noctx",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-ctx",
+        # No "auth_context"/"forward_sig" on purpose: must fail closed.
+    }
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC-SHA256"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Never dispatched: the trusted endpoint was not called.
+    assert client.last_post_kwargs is None
+    # A 403 was published back to the requester.
+    chan, payload = fake.published[0]
+    assert chan == "mcpgw:pool_http_response:req-noctx"
+    decoded = orjson.loads(payload)
+    assert decoded["status"] == 403
+    # Failure counter incremented.
+    assert affinity._forwarded_request_failures == 1  # pylint: disable=protected-access
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_rejects_forged_signature():
+    """The core oracle case: an arbitrary injected context with an invalid signature is refused.
+
+    A Redis writer can supply any ``auth_context`` (e.g. an admin context) but
+    cannot produce a valid signature without the secret. The owner must refuse to
+    re-stamp it with a valid runtime-auth token: 403 published, never dispatched.
+    """
+    # Third-Party
+    import orjson
+
     # First-Party
     from mcpgateway.services.session_affinity import SessionAffinity
 
@@ -2240,26 +2551,312 @@ async def test_execute_forwarded_http_request_appends_query_string():
     fake = _FakeRedis()
     client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
 
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
     request = {
-        "response_channel": "r",
-        "method": "GET",
+        "response_channel": "mcpgw:pool_http_response:req-forged",
+        "method": "POST",
         "path": "/mcp",
-        "query_string": "foo=bar&baz=qux",
         "headers": {},
-        "body": "",
-        "mcp_session_id": "sess-qs",
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-forged",
+        "auth_context": "forged-admin-ctx",
+        "forward_sig": "deadbeef" * 8,  # not a valid HMAC for this envelope
     }
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
         patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
         patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
         await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
 
-    assert client.last_request_kwargs["url"] == "http://localhost:4444/mcp?foo=bar&baz=qux"  # type: ignore[index]
+    assert client.last_post_kwargs is None  # never dispatched
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 403
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_rejects_signature_bound_to_other_session():
+    """A signature valid for a different session id is rejected, blocking cross-session replay.
+
+    ``mcp_session_id`` is part of the signed envelope, so lifting a valid envelope
+    onto another session (by rewriting ``mcp_session_id``) invalidates the signature.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.auth_context import FORWARD_SIG_FIELD, sign_redis_forward_envelope  # pylint: disable=import-outside-toplevel
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    ctx = "victim-ctx"
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-replay",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "victim-session",
+        "auth_context": ctx,
+    }
+    # Sign for victim-session, then replay under a different session id without re-signing.
+    request[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(request)
+    request["mcp_session_id"] = "attacker-session"
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is None  # cross-session replay refused
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 403
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_preserves_custom_auth_header():
+    """Executor side: the bearer is preserved under the CONFIGURED auth header.
+
+    On a deployment with ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the CSRF bearer
+    short-circuit keys on that header, so hardcoding ``authorization`` would drop
+    the bearer and risk a 403 on the inner dispatch.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-customauth",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {"x-mcp-gateway-auth": "Bearer custom-tok"},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-custom",
+        "auth_context": "encoded-ctx",
+    }
+    _sign_forward(request)
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        mock_settings.auth_header_name = "X-MCP-Gateway-Auth"
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    assert client.last_post_kwargs is not None
+    headers = client.last_post_kwargs["headers"]
+    # Configured header preserved (lowercased); hardcoded "authorization" is NOT used.
+    assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+    assert "authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_non_post_lifecycle_requests():
+    """Lifecycle methods (DELETE, GET) don't carry a JSON-RPC body, so the owner just acks 200 without dispatching."""
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+
+    request = _sign_forward({
+        "response_channel": "r",
+        "method": "DELETE",
+        "path": "/mcp",
+        "query_string": "",
+        "headers": {},
+        "body": "",
+        "mcp_session_id": "sess-delete",
+    })
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # Acked without invoking the in-process dispatch.
+    assert client.last_post_kwargs is None
+    decoded = orjson.loads(fake.published[0][1])
+    assert decoded["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_acks_notification_method_without_dispatch():
+    """``notifications/*`` methods need no upstream round-trip — owner acks 202 without dispatching.
+
+    MCP notification messages are fire-and-forget; the originating worker
+    already accepted the notification. The owner just acknowledges receipt.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    client = _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="should-not-be-used"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+    request = _sign_forward({
+        "response_channel": "mcpgw:pool_http_response:req-notif",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-notif",
+    })
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch helper was never invoked.
+    assert client.last_post_kwargs is None
+    # A 202 ack was published for the notification.
+    chan, payload = fake.published[0]
+    assert chan == "mcpgw:pool_http_response:req-notif"
+    decoded = orjson.loads(payload)
+    assert decoded["status"] == 202
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_initialises_params_when_missing_for_server_id_injection():
+    """When the JSON-RPC body has no ``params`` key, the executor synthesises one before injecting ``server_id``.
+
+    Pins the defensive branch in the server-id-injection path: a request body
+    that arrives without ``params`` (or with a non-dict params) still routes
+    to the correct virtual server because the executor populates an empty
+    dict and writes the server_id into it.
+    """
+    # Third-Party
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    response = _FakeHttpResponse(200, text_body="ok")
+    response.headers = {"content-type": "application/json"}
+    client = _FakeHttpxClient(response=response)
+
+    # Body has NO "params" key — the executor must initialise it before writing server_id.
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "id": 1})
+    request = {
+        "response_channel": "mcpgw:pool_http_response:req-no-params",
+        "method": "POST",
+        "path": "/servers/srv-17/mcp",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-no-params",
+        "auth_context": "ctx-params",
+    }
+    _sign_forward(request)
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # The dispatch ran and the synthesised params carries the parsed server_id.
+    assert client.last_post_kwargs is not None
+    sent_body = orjson.loads(client.last_post_kwargs["content"])
+    assert sent_body["params"] == {"server_id": "srv-17"}
+
+
+@pytest.mark.asyncio
+async def test_execute_forwarded_http_request_dispatches_in_process_via_asgi_transport():
+    """The forward is dispatched IN-PROCESS via ``httpx.ASGITransport(app=app)``, not over the loopback socket.
+
+    This is the load-bearing change behind the #4557 fix. A real
+    ``httpx.AsyncClient`` to ``http://127.0.0.1:4444/_internal/mcp/rpc`` would
+    hit the shared gunicorn socket and let the kernel route it to an arbitrary
+    worker that didn't hold the upstream session. Dispatching in-process via
+    ASGITransport keeps the re-entered ``/_internal/mcp/rpc`` handler in *this*
+    worker, so the bound ``UpstreamSessionRegistry`` entry actually serves the
+    request.
+    """
+    # Third-Party
+    import httpx
+    import orjson
+
+    # First-Party
+    from mcpgateway.services.session_affinity import SessionAffinity
+
+    affinity = SessionAffinity()
+    fake = _FakeRedis()
+    captured_transport: list[Any] = []
+
+    def _capture_async_client(*args: Any, **kwargs: Any) -> _FakeHttpxClient:
+        captured_transport.append(kwargs.get("transport"))
+        return _FakeHttpxClient(response=_FakeHttpResponse(200, text_body="ok"))
+
+    jsonrpc_body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    request = {
+        "response_channel": "r",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": "",
+        "headers": {},
+        "body": jsonrpc_body.hex(),
+        "mcp_session_id": "sess-asgi",
+        "auth_context": "ctx-asgi",
+    }
+    _sign_forward(request)
+
+    with (
+        patch("mcpgateway.services.session_affinity.settings") as mock_settings,
+        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", side_effect=_capture_async_client),
+        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
+        patch("mcpgateway.auth_context._expected_internal_mcp_runtime_auth_header", return_value="HMAC"),
+    ):
+        mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0
+        await affinity._execute_forwarded_http_request(request, fake)  # pylint: disable=protected-access
+
+    # AsyncClient was constructed with an ASGITransport — the in-process dispatch path.
+    assert captured_transport, "httpx.AsyncClient was never called"
+    assert isinstance(captured_transport[0], httpx.ASGITransport), (
+        f"expected ASGITransport for in-process dispatch, got {type(captured_transport[0]).__name__}"
+    )
 
 
 @pytest.mark.asyncio
@@ -2286,9 +2883,7 @@ async def test_execute_forwarded_http_request_logs_debug_when_error_publish_also
 
     with (
         patch("mcpgateway.services.session_affinity.settings") as mock_settings,
-        patch("mcpgateway.services.session_affinity.httpx.AsyncClient", return_value=client),
-        patch("mcpgateway.services.session_affinity.internal_loopback_base_url", return_value="http://localhost:4444"),
-        patch("mcpgateway.services.session_affinity.internal_loopback_verify", return_value=False),
+        patch("mcpgateway.services.session_affinity.post_rpc_in_process", new=client.as_post_rpc),
         caplog.at_level("DEBUG", logger="mcpgateway.services.session_affinity"),
     ):
         mock_settings.mcpgateway_pool_rpc_forward_timeout = 5.0

--- a/tests/unit/mcpgateway/test_auth_context_redis_signing.py
+++ b/tests/unit/mcpgateway/test_auth_context_redis_signing.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_auth_context_redis_signing.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Pratik Gandhi
+
+Unit tests for the Redis-transit forward-envelope signing helpers in ``auth_context``.
+
+These protect the session-affinity Redis pub/sub hop: the publisher signs the
+*whole* forwarded envelope (identity + operation + response_channel) and the
+consumer verifies it before dispatch. Signing only the identity would let a Redis
+writer replay a valid signature with a different method/path/body/response_channel
+(CWE-347), so the tests pin that every operation field is bound and that a
+redirected response channel is rejected.
+"""
+
+# Third-Party
+import orjson
+import pytest
+
+# First-Party
+from mcpgateway.auth_context import (
+    encode_internal_mcp_auth_context,
+    FORWARD_SIG_FIELD,
+    sign_redis_forward_envelope,
+    verify_redis_forward_envelope,
+)
+
+_CTX = encode_internal_mcp_auth_context({"email": "u@example.com", "is_authenticated": True, "is_admin": False})
+_SID = "abc123def456"
+
+
+def _rpc_envelope():
+    """A representative signed rpc_forward envelope (matches forward_request_to_owner)."""
+    env = {
+        "type": "rpc_forward",
+        "method": "tools/call",
+        "params": {"name": "do", "arguments": {"a": 1}},
+        "req_id": 7,
+        "headers": {"x-mcp-session-id": _SID},
+        "response_channel": "mcpgw:pool_rpc_response:chan-1",
+        "mcp_session_id": _SID,
+        "auth_context": _CTX,
+    }
+    env[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(env)
+    return env
+
+
+def _http_envelope():
+    """A representative signed http_forward envelope (matches forward_to_owner)."""
+    env = {
+        "type": "http_forward",
+        "response_channel": "mcpgw:pool_http_response:chan-1",
+        "mcp_session_id": _SID,
+        "method": "POST",
+        "path": "/servers/abc123/mcp",
+        "query_string": "",
+        "headers": {"content-type": "application/json"},
+        "body": b'{"jsonrpc":"2.0","method":"tools/list","id":1}'.hex(),
+        "original_worker": "worker-1",
+        "timestamp": 123.0,
+        "auth_context": _CTX,
+    }
+    env[FORWARD_SIG_FIELD] = sign_redis_forward_envelope(env)
+    return env
+
+
+def _wire(env):
+    """Round-trip the envelope through JSON exactly as Redis pub/sub does."""
+    return orjson.loads(orjson.dumps(env))
+
+
+def test_rpc_envelope_round_trips():
+    """A signed rpc envelope verifies after an orjson round-trip (canonicalization holds)."""
+    assert verify_redis_forward_envelope(_wire(_rpc_envelope())) is True
+
+
+def test_http_envelope_round_trips():
+    """A signed http envelope verifies after an orjson round-trip (canonicalization holds)."""
+    assert verify_redis_forward_envelope(_wire(_http_envelope())) is True
+
+
+@pytest.mark.parametrize(
+    "field,new_value",
+    [
+        ("method", "resources/read"),
+        ("params", {"name": "evil", "arguments": {}}),
+        ("req_id", 9999),
+        ("headers", {"x-mcp-session-id": "attacker"}),
+        ("response_channel", "mcpgw:pool_rpc_response:attacker"),  # response redirection
+        ("mcp_session_id", "attacker-session"),
+        ("auth_context", encode_internal_mcp_auth_context({"is_admin": True, "is_authenticated": True})),
+    ],
+)
+def test_rpc_field_tamper_is_rejected(field, new_value):
+    """Mutating any rpc operation field (incl. response_channel) invalidates the signature."""
+    env = _wire(_rpc_envelope())
+    env[field] = new_value
+    assert verify_redis_forward_envelope(env) is False
+
+
+@pytest.mark.parametrize(
+    "field,new_value",
+    [
+        ("method", "DELETE"),
+        ("path", "/servers/other/mcp"),
+        ("query_string", "x=1"),
+        ("headers", {"content-type": "text/plain"}),
+        ("body", b'{"jsonrpc":"2.0","method":"tools/call","id":1}'.hex()),
+        ("response_channel", "mcpgw:pool_http_response:attacker"),  # response redirection
+        ("mcp_session_id", "attacker-session"),
+        ("auth_context", encode_internal_mcp_auth_context({"is_admin": True, "is_authenticated": True})),
+    ],
+)
+def test_http_field_tamper_is_rejected(field, new_value):
+    """Mutating any http operation field (incl. response_channel) invalidates the signature."""
+    env = _wire(_http_envelope())
+    env[field] = new_value
+    assert verify_redis_forward_envelope(env) is False
+
+
+def test_missing_forward_sig_is_rejected():
+    """An envelope with no forward_sig fails closed."""
+    env = _wire(_rpc_envelope())
+    del env[FORWARD_SIG_FIELD]
+    assert verify_redis_forward_envelope(env) is False
+
+
+def test_non_string_forward_sig_is_rejected():
+    """A non-string forward_sig fails closed rather than raising."""
+    env = _wire(_rpc_envelope())
+    env[FORWARD_SIG_FIELD] = 12345
+    assert verify_redis_forward_envelope(env) is False
+
+
+def test_empty_forward_sig_is_rejected():
+    """An empty forward_sig fails closed."""
+    env = _wire(_rpc_envelope())
+    env[FORWARD_SIG_FIELD] = ""
+    assert verify_redis_forward_envelope(env) is False
+
+
+def test_garbage_forward_sig_is_rejected():
+    """A well-formed-looking but wrong signature is rejected."""
+    env = _wire(_rpc_envelope())
+    env[FORWARD_SIG_FIELD] = "deadbeef" * 8
+    assert verify_redis_forward_envelope(env) is False
+
+
+def test_legacy_auth_context_sig_alone_is_rejected():
+    """An old identity-only ``auth_context_sig`` (no forward_sig) does not verify.
+
+    Guards against silently accepting a pre-envelope publisher during a mixed-version
+    rollout: the narrow signature is gone and must not be honored.
+    """
+    env = {
+        "type": "rpc_forward",
+        "method": "tools/call",
+        "params": {},
+        "mcp_session_id": _SID,
+        "response_channel": "mcpgw:pool_rpc_response:chan-1",
+        "auth_context": _CTX,
+        "auth_context_sig": "deadbeef" * 8,
+    }
+    assert verify_redis_forward_envelope(_wire(env)) is False
+
+
+def test_wrong_secret_is_rejected(monkeypatch):
+    """A signature made under a different secret does not verify (pins the keying)."""
+    env = _rpc_envelope()  # signed under the current secret
+    monkeypatch.setattr("mcpgateway.auth_context._auth_encryption_secret_value", lambda: "a-different-secret")
+    assert verify_redis_forward_envelope(_wire(env)) is False
+
+
+def test_signature_is_deterministic_for_same_inputs():
+    """Same envelope yields the same signature under the same secret."""
+    base = {"type": "rpc_forward", "method": "tools/call", "mcp_session_id": _SID, "auth_context": _CTX}
+    assert sign_redis_forward_envelope(dict(base)) == sign_redis_forward_envelope(dict(base))
+
+
+def test_signature_is_key_order_independent():
+    """Key insertion order does not change the signature (sorted-keys canonicalization)."""
+    a = {"type": "rpc_forward", "method": "tools/call", "mcp_session_id": _SID, "auth_context": _CTX}
+    b = {"auth_context": _CTX, "mcp_session_id": _SID, "method": "tools/call", "type": "rpc_forward"}
+    assert sign_redis_forward_envelope(a) == sign_redis_forward_envelope(b)

--- a/tests/unit/mcpgateway/test_auth_context_redis_signing.py
+++ b/tests/unit/mcpgateway/test_auth_context_redis_signing.py
@@ -27,7 +27,7 @@ from mcpgateway.auth_context import (
 )
 
 _CTX = encode_internal_mcp_auth_context({"email": "u@example.com", "is_authenticated": True, "is_admin": False})
-_SID = "abc123def456"
+_SID = "abc123def456"  # pragma: allowlist secret
 
 
 def _rpc_envelope():

--- a/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
+++ b/tests/unit/mcpgateway/test_internal_a2a_endpoints.py
@@ -1162,7 +1162,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1173,7 +1173,7 @@ class TestInternalA2ADenyPaths:
             "x-contextforge-mcp-runtime": "rust",
             "x-contextforge-mcp-runtime-auth": "stub",  # pragma: allowlist secret
         }
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             resp = client.post(url, json={}, headers=headers)
         assert resp.status_code == 403
 
@@ -1210,11 +1210,11 @@ class TestInternalA2ADenyPaths:
         # First-Party
         from mcpgateway.main import _is_trusted_internal_mcp_runtime_request
 
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(request) is True
 
         # And the equivalent /_internal/a2a/ path with the same headers
         # MUST still be rejected (the feature flag narrows correctly).
         a2a_scope = {**scope, "path": "/_internal/a2a/authenticate", "raw_path": b"/_internal/a2a/authenticate"}
-        with patch("mcpgateway.main.has_valid_internal_mcp_runtime_auth_header", return_value=True):
+        with patch("mcpgateway.auth_context.has_valid_internal_mcp_runtime_auth_header", return_value=True):
             assert _is_trusted_internal_mcp_runtime_request(Request(a2a_scope)) is False

--- a/tests/unit/mcpgateway/test_internal_mcp_auth_context_validation.py
+++ b/tests/unit/mcpgateway/test_internal_mcp_auth_context_validation.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/test_internal_mcp_auth_context_validation.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Pratik Gandhi
+
+Unit tests for ``_validate_internal_mcp_auth_context``.
+
+The public-only RBAC early-return in ``_ensure_rpc_permission`` trusts the decoded
+trusted-internal auth context. These tests pin the fail-closed contract: a public-only
+context (``is_authenticated is False``) must carry only public privileges, and field
+types must be well-formed, otherwise the dispatch is rejected with HTTP 400.
+"""
+
+# Standard
+from unittest.mock import MagicMock, patch
+
+# Third-Party
+from fastapi import HTTPException
+import pytest
+
+# First-Party
+from mcpgateway.main import _build_internal_mcp_auth_context_for_rpc, _validate_internal_mcp_auth_context
+
+
+def test_valid_public_only_context_passes():
+    """A well-formed public-only context (no identity, no teams, not admin) is accepted."""
+    _validate_internal_mcp_auth_context({"email": None, "teams": [], "is_authenticated": False, "is_admin": False, "permission_is_admin": False})
+
+
+def test_valid_authenticated_context_may_carry_privileges():
+    """An authenticated context is allowed to carry teams, admin, and an identity."""
+    _validate_internal_mcp_auth_context({"email": "u@example.com", "teams": ["t1"], "is_authenticated": True, "is_admin": True, "scoped_permissions": ["tools.read"]})
+
+
+@pytest.mark.parametrize(
+    "ctx",
+    [
+        {"is_authenticated": False, "teams": ["t1"]},  # public-only must not carry teams
+        {"is_authenticated": False, "is_admin": True},  # public-only must not be admin
+        {"is_authenticated": False, "permission_is_admin": True},  # nor via permission_is_admin
+        {"is_authenticated": False, "email": "attacker@evil.com"},  # public-only must not carry an identity
+    ],
+)
+def test_contradictory_public_only_context_is_rejected(ctx):
+    """A public-only context that claims teams, admin, or an identity is rejected with 400."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_internal_mcp_auth_context(ctx)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "ctx",
+    [
+        {"is_authenticated": True, "teams": "t1"},  # teams must be a list
+        {"is_authenticated": True, "scoped_permissions": "tools.read"},  # scoped_permissions must be a list
+    ],
+)
+def test_malformed_types_are_rejected(ctx):
+    """Non-list ``teams`` / ``scoped_permissions`` are rejected with 400 (avoids downstream type confusion)."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_internal_mcp_auth_context(ctx)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("bad", ["false", "true", "False", 0, 1])
+def test_non_bool_is_authenticated_is_rejected(bad):
+    """A non-bool ``is_authenticated`` (e.g. ``"false"`` or ``0``) is rejected so the downstream ``is False`` checks stay reliable."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_internal_mcp_auth_context({"is_authenticated": bad})
+    assert exc.value.status_code == 400
+
+
+def test_public_only_with_none_teams_is_accepted():
+    """``teams: None`` on a public-only context is fine (normalised to no teams downstream)."""
+    _validate_internal_mcp_auth_context({"is_authenticated": False, "teams": None, "is_admin": False, "email": None})
+
+
+# ---------------------------------------------------------------------------
+# _build_internal_mcp_auth_context_for_rpc — the /rpc forward edge-context builder
+# ---------------------------------------------------------------------------
+
+
+def _rpc_request(payload=None):
+    """A request stand-in carrying an optional cached verified JWT payload."""
+    req = MagicMock()
+    req.state._jwt_verified_payload = ("tok", payload) if payload is not None else None
+    return req
+
+
+def test_rpc_builder_authenticated_shape_passes_validator():
+    """An authenticated /rpc context carries email/teams/scopes and satisfies the validator."""
+    with patch("mcpgateway.main.get_rpc_filter_context", return_value=("u@example.com", ["t1"], False)), patch("mcpgateway.main._extract_scoped_permissions", return_value={"tools.read"}):
+        ctx = _build_internal_mcp_auth_context_for_rpc(_rpc_request({"scopes": {"server_id": "srv-1"}}), {"email": "u@example.com"})
+    assert ctx["email"] == "u@example.com"
+    assert ctx["is_authenticated"] is True
+    assert ctx["teams"] == ["t1"]
+    assert ctx["scoped_permissions"] == ["tools.read"]
+    assert ctx["scoped_server_id"] == "srv-1"
+    _validate_internal_mcp_auth_context(ctx)  # must not raise
+
+
+def test_rpc_builder_anonymous_is_floored_and_passes_validator():
+    """A public-only /rpc context (no email) is floored to public privileges and satisfies the validator."""
+    with patch("mcpgateway.main.get_rpc_filter_context", return_value=(None, None, False)), patch("mcpgateway.main._extract_scoped_permissions", return_value=None):
+        ctx = _build_internal_mcp_auth_context_for_rpc(_rpc_request(None), {})
+    assert ctx["is_authenticated"] is False
+    assert ctx["email"] is None
+    assert ctx["teams"] == []
+    assert ctx["is_admin"] is False
+    _validate_internal_mcp_auth_context(ctx)
+
+
+def test_rpc_builder_admin_bypass_passes_validator():
+    """An admin /rpc context (token_teams None == bypass) keeps is_admin and satisfies the validator."""
+    with patch("mcpgateway.main.get_rpc_filter_context", return_value=("admin@example.com", None, True)), patch("mcpgateway.main._extract_scoped_permissions", return_value=None):
+        ctx = _build_internal_mcp_auth_context_for_rpc(_rpc_request(None), {"email": "admin@example.com", "is_admin": True})
+    assert ctx["is_authenticated"] is True
+    assert ctx["is_admin"] is True
+    assert ctx["teams"] is None
+    _validate_internal_mcp_auth_context(ctx)

--- a/tests/unit/mcpgateway/test_internal_runtime_trust.py
+++ b/tests/unit/mcpgateway/test_internal_runtime_trust.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the consolidated internal-runtime trust gate.
+
+Covers the shared helper in ``auth_context`` (``is_trusted_internal_runtime_request`` /
+``is_trusted_internal_mcp_request``), the path-aware auth-context rule, the A2A
+feature guard, the affinity marker, the HMAC-is-the-trust-boundary property, and
+that the forwarded/client-IP headers are stripped from loopback passthrough.
+"""
+
+# Third-Party
+import pytest
+from starlette.requests import Request
+
+# First-Party
+from mcpgateway.auth_context import (
+    _expected_internal_mcp_runtime_auth_header,
+    _internal_path_requires_auth_context,
+    is_trusted_internal_mcp_request,
+    is_trusted_internal_runtime_request,
+)
+
+def _req(path, *, marker="rust", hmac="valid", ctx="ctx", client="127.0.0.1", extra=None):
+    """Build a synthetic internal request."""
+    headers = []
+    if marker is not None:
+        headers.append((b"x-contextforge-mcp-runtime", marker.encode()))
+    if hmac is not None:
+        # Derive the expected HMAC at call time, not module-import time. Other tests in the suite
+        # mutate ``settings.auth_encryption_secret`` (the HMAC's input), so a value captured at import
+        # would go stale and the gate would correctly reject the now-mismatched header.
+        valid_hmac = _expected_internal_mcp_runtime_auth_header()
+        headers.append((b"x-contextforge-mcp-runtime-auth", (valid_hmac if hmac == "valid" else hmac).encode()))
+    if ctx is not None:
+        headers.append((b"x-contextforge-auth-context", ctx.encode()))
+    for k, v in (extra or []):
+        headers.append((k, v))
+    scope = {"type": "http", "method": "POST", "path": path, "raw_path": path.encode(),
+             "query_string": b"", "headers": headers, "client": (client, 12345) if client else None}
+    return Request(scope)
+
+
+# --- path-aware auth-context rule ------------------------------------------
+
+@pytest.mark.parametrize("path,expected", [
+    ("/_internal/mcp/authenticate", False),
+    ("/_internal/mcp/authenticate/", False),
+    ("/_internal/a2a/authenticate", False),
+    ("/_internal/mcp/rpc", True),
+    ("/_internal/mcp/initialize", True),
+    ("/_internal/a2a/tasks/get", True),
+])
+def test_path_requires_auth_context(path, expected):
+    assert _internal_path_requires_auth_context(path) is expected
+
+
+# --- MCP gate: allow --------------------------------------------------------
+
+def test_rpc_trusted_with_rust_marker_hmac_and_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc")) is True
+
+
+def test_rpc_trusted_with_affinity_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="affinity")) is True
+
+
+def test_authenticate_trusted_without_ctx():
+    # /authenticate creates the context, so no ctx required.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/authenticate", ctx=None)) is True
+
+
+# --- MCP gate: deny ---------------------------------------------------------
+
+def test_deny_bad_hmac_even_on_loopback_with_ctx():
+    # The HMAC is the trust boundary: loopback + marker + ctx but a bad HMAC is denied.
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", hmac="not-the-real-hmac")) is False
+
+
+def test_deny_wrong_marker():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", marker="bogus")) is False
+
+
+def test_deny_non_loopback_client():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", client="10.0.0.9")) is False
+
+
+def test_deny_rpc_missing_ctx():
+    assert is_trusted_internal_mcp_request(_req("/_internal/mcp/rpc", ctx=None)) is False
+
+
+def test_deny_non_internal_prefix():
+    assert is_trusted_internal_mcp_request(_req("/servers/x/mcp")) is False
+
+
+def test_xff_cannot_make_untrusted_request_trusted():
+    # Even with a spoofed X-Forwarded-For and a loopback client, a bad HMAC is denied:
+    # loopback is defense-in-depth, the HMAC is the boundary.
+    req = _req("/_internal/mcp/rpc", hmac="forged", extra=[(b"x-forwarded-for", b"127.0.0.1")])
+    assert is_trusted_internal_mcp_request(req) is False
+
+
+# --- A2A feature guard ------------------------------------------------------
+
+def test_a2a_trusted_when_enabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", True)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is True
+
+
+def test_a2a_denied_when_disabled(monkeypatch):
+    monkeypatch.setattr("mcpgateway.auth_context.settings.mcpgateway_a2a_enabled", False)
+    assert is_trusted_internal_mcp_request(_req("/_internal/a2a/tasks/get")) is False
+
+
+# --- generic helper: explicit require_auth_context + prefixes ---------------
+
+def test_generic_helper_respects_prefix_allowlist():
+    req = _req("/_internal/mcp/rpc")
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/a2a",), require_auth_context=True) is False
+    assert is_trusted_internal_runtime_request(req, allowed_prefixes=("/_internal/mcp",), require_auth_context=True) is True
+
+
+# --- token_scoping now trusts the affinity marker ---------------------------
+
+def test_token_scoping_trusts_affinity_hop():
+    # First-Party
+    from mcpgateway.middleware.token_scoping import token_scoping_middleware
+
+    req = _req("/_internal/mcp/rpc", marker="affinity")
+    assert token_scoping_middleware._is_trusted_internal_mcp_runtime_request(req, "/_internal/mcp/rpc") is True
+
+
+# --- forwarded / client-IP headers are stripped from loopback passthrough ---
+
+@pytest.mark.parametrize("header", [
+    "forwarded", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
+    "x-forwarded-port", "x-forwarded-prefix", "x-real-ip", "cf-connecting-ip", "true-client-ip",
+])
+def test_loopback_passthrough_strips_forwarded_headers(header):
+    # First-Party
+    from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+    out = filter_loopback_skip_headers({header: "1.2.3.4", "x-keep": "ok"})
+    assert header not in {k.lower() for k in out}
+    assert out.get("x-keep") == "ok"

--- a/tests/unit/mcpgateway/test_main_extended.py
+++ b/tests/unit/mcpgateway/test_main_extended.py
@@ -846,7 +846,11 @@ class TestInternalTrustedMcpTransportBridge:
 
         await bridge.handle_streamable_http(scope, receive, send)
 
-        assert events[0]["status"] == 400
+        # A missing auth context now fails the internal trust gate itself
+        # (require_auth_context is folded into is_trusted_internal_mcp_request),
+        # so the request is rejected as untrusted (403) before reaching the
+        # "missing auth context" (400) branch.
+        assert events[0]["status"] == 403
 
     def test_build_internal_mcp_auth_scope_uses_public_request_shape(self):
         """Synthetic auth scope should preserve the public MCP path and client IP."""
@@ -1443,6 +1447,62 @@ class TestInternalMcpHelperCoverage:
 
         with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(side_effect=AssertionError("RBAC should be skipped"))):
             await _ensure_rpc_permission({"permission_is_admin": True}, MagicMock(), "admin.system_config", "roots/list", request)
+
+    @pytest.mark.asyncio
+    async def test_ensure_rpc_permission_skips_rbac_for_public_only_internal_dispatch(self):
+        """Public-only trusted-internal dispatch (is_authenticated=False) must skip RBAC.
+
+        Mirrors ``_authorize_internal_mcp_request()``: the originating edge already applied
+        public-only visibility, so the forwarded internal hop must not be re-denied. The
+        auth context is only present on ``request.state`` for HMAC-trusted internal requests,
+        so the skip cannot be triggered by a forged/untrusted request.  If the skip fires the
+        RBAC checker is never reached.
+        """
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        request.state = SimpleNamespace(_mcp_internal_auth_context={"is_authenticated": False, "teams": []})
+
+        with patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(side_effect=AssertionError("RBAC must be skipped for public-only internal dispatch"))):
+            # No raise == skip fired; the method's own visibility filtering then proceeds.
+            await _ensure_rpc_permission({"email": None, "is_admin": False}, MagicMock(), "tools.read", "tools/list", request)
+
+    @pytest.mark.asyncio
+    async def test_ensure_rpc_permission_enforces_rbac_for_authenticated_internal_dispatch(self):
+        """An authenticated forwarded caller (is_authenticated=True) still goes through RBAC and is denied without permission."""
+        # First-Party
+        from mcpgateway.main import JSONRPCError  # pylint: disable=import-outside-toplevel
+
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        request.state = SimpleNamespace(_mcp_internal_auth_context={"is_authenticated": True, "teams": ["t1"]})
+
+        with (
+            patch("mcpgateway.main._extract_scoped_permissions", return_value=None),
+            patch("mcpgateway.main._build_rpc_permission_user", return_value=MagicMock()),
+            patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=False)),
+        ):
+            with pytest.raises(JSONRPCError) as exc:
+                await _ensure_rpc_permission({"email": "u@example.com", "is_admin": False}, MagicMock(), "tools.read", "tools/list", request)
+        assert exc.value.code == -32003
+
+    @pytest.mark.asyncio
+    async def test_ensure_rpc_permission_enforces_rbac_without_trusted_internal_context(self):
+        """A request with no trusted internal auth context (forged HMAC never sets it, or a normal public /rpc request) gets no public-only skip — RBAC is enforced."""
+        # First-Party
+        from mcpgateway.main import JSONRPCError  # pylint: disable=import-outside-toplevel
+
+        request = MagicMock(spec=Request)
+        request.headers = {}
+        request.state = SimpleNamespace()  # no _mcp_internal_auth_context -> not a trusted internal dispatch
+
+        with (
+            patch("mcpgateway.main._extract_scoped_permissions", return_value=None),
+            patch("mcpgateway.main._build_rpc_permission_user", return_value=MagicMock()),
+            patch("mcpgateway.main.PermissionChecker.has_permission", new=AsyncMock(return_value=False)),
+        ):
+            with pytest.raises(JSONRPCError) as exc:
+                await _ensure_rpc_permission({"email": "u@example.com", "is_admin": False}, MagicMock(), "tools.read", "tools/list", request)
+        assert exc.value.code == -32003
 
 
 class TestEndpointErrorHandling:
@@ -10088,6 +10148,7 @@ class TestRpcHandling:
             params={"name": "echo"},
             req_id="aff-local",
             lowered_request_headers={"mcp-session-id": "sess-123"},
+            user={"email": "u@example.com"},
         )
 
         assert forwarded is None

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -8835,6 +8835,146 @@ async def test_local_affinity_post_injects_server_id_regression(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_local_affinity_post_dispatches_to_internal_endpoint_with_auth_context(monkeypatch):
+    """Owner-direct affinity POST dispatches to the trusted-internal /_internal/mcp/rpc.
+
+    Closes the coverage gap for the local-owner path: instead of re-authenticating
+    against public /rpc (which only understands ContextForge JWTs/cookies and would
+    401 virtual-server OAuth or MCP_REQUIRE_AUTH=false public-only sessions), the
+    owner dispatches to the trusted-internal endpoint carrying the affinity runtime
+    marker, the HMAC, and the edge-validated auth context. The originating
+    Authorization header is preserved for the CSRF bearer short-circuit.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    # Deterministic auth context regardless of request-scoped state.
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"authorization", b"Bearer tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        # Routed to the trusted-internal endpoint, NOT public /rpc.
+        assert mock_client.post.call_args.args[0] == "/_internal/mcp/rpc"
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["x-contextforge-mcp-runtime"] == "affinity"
+        assert headers["x-contextforge-mcp-runtime-auth"]
+        assert headers["x-contextforge-auth-context"]
+        # Authorization preserved for the CSRF bearer short-circuit.
+        assert headers["authorization"] == "Bearer tok"
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_local_affinity_post_preserves_custom_auth_header(monkeypatch):
+    """Owner-direct dispatch preserves the bearer under the CONFIGURED auth header.
+
+    On ``AUTH_HEADER_NAME=X-MCP-Gateway-Auth`` the bearer rides that header and
+    the CSRF short-circuit keys on it, so hardcoding ``authorization`` would drop it.
+    """
+    # Third-Party
+    import orjson
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            pass
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.auth_header_name", "X-MCP-Gateway-Auth")
+    monkeypatch.setattr("mcpgateway.services.server_service.ServerService.entity_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr(tr, "get_streamable_http_auth_context", lambda: {"email": "u@example.com"})
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    server_id = "abc-def-123-456"
+    body = orjson.dumps({"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 1})
+    scope = _make_scope(f"/servers/{server_id}/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-1"), (b"x-mcp-gateway-auth", b"Bearer custom-tok")])
+    receive = _make_receive(body)
+    send, messages = _make_send_collector()
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-1")
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{},"id":1}'
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+        patch("mcpgateway.transports.streamablehttp_transport.httpx.AsyncClient") as mock_client_cls,
+    ):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        await wrapper.handle_streamable_http(scope, receive, send)
+
+        mock_client.post.assert_called_once()
+        headers = mock_client.post.call_args.kwargs["headers"]
+        # Configured header preserved (lowercased); hardcoded "authorization" not used.
+        assert headers["x-mcp-gateway-auth"] == "Bearer custom-tok"
+        assert "authorization" not in headers
+
+    await wrapper.shutdown()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "params_value,params_json",
     [
@@ -9014,6 +9154,65 @@ async def test_affinity_forward_to_owner_worker_multipart_body(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_affinity_forward_to_owner_propagates_encoded_auth_context(monkeypatch):
+    """The sender encodes the live ``get_streamable_http_auth_context()`` result and passes it through ``forward_to_owner``.
+
+    Without this, OAuth-enabled virtual servers and ``MCP_REQUIRE_AUTH=false``
+    public-only mode would 401 after a cross-worker forward, because the owner
+    would have nothing to reconstruct the edge-authenticated user from.
+    """
+    # First-Party
+    from mcpgateway.auth_context import encode_internal_mcp_auth_context
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    # Stand-in for the authenticated identity the edge worker already established.
+    edge_auth_ctx = {"email": "alice@example.com", "is_admin": False, "teams": ["t1"]}
+    expected_encoded = encode_internal_mcp_auth_context(edge_auth_ctx)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_streamable_http_auth_context", lambda: edge_auth_ctx)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    scope = _make_scope("/mcp", method="POST", headers=[(b"mcp-session-id", b"sess-auth")])
+
+    mock_pool = MagicMock()
+    mock_pool.get_session_owner = AsyncMock(return_value="worker-2")
+    mock_pool.forward_to_owner = AsyncMock(
+        return_value={
+            "status": 200,
+            "headers": {"content-type": "application/json"},
+            "body": b'{"jsonrpc":"2.0","result":{}}',
+        }
+    )
+
+    mock_session_class = MagicMock()
+    mock_session_class.is_valid_mcp_session_id = MagicMock(return_value=True)
+
+    with (
+        patch("mcpgateway.services.session_affinity.get_session_affinity", return_value=mock_pool),
+        patch("mcpgateway.services.session_affinity.WORKER_ID", "worker-1"),
+        patch("mcpgateway.services.session_affinity.SessionAffinity", mock_session_class),
+    ):
+        await wrapper.handle_streamable_http(scope, _make_receive(b'{"jsonrpc":"2.0"}'), send)
+
+    await wrapper.shutdown()
+    # auth_context kwarg is supplied and equals the encoded edge identity.
+    assert mock_pool.forward_to_owner.call_args.kwargs["auth_context"] == expected_encoded
+
+
+@pytest.mark.asyncio
 async def test_affinity_forward_failure_falls_through(monkeypatch):
     """Test affinity forward failure falls through to local handling (line 1525-1527)."""
 
@@ -9187,6 +9386,67 @@ async def test_local_affinity_post_routes_to_rpc(monkeypatch):
 
     await wrapper.shutdown()
     assert messages[0]["status"] == 200
+
+
+
+
+@pytest.mark.asyncio
+async def test_http_affinity_forwarded_path_dispatches_via_post_rpc_in_process(monkeypatch):
+    """``[HTTP_AFFINITY_FORWARDED]`` re-entry also goes through ``post_rpc_in_process`` (PR #4987).
+
+    When a worker receives a forwarded request (carrying
+    ``x-forwarded-internally: true``), it re-enters the /rpc dispatch. Before
+    PR #4987 that re-entry built its own ``httpx.AsyncClient`` and bounced
+    back through the shared socket — splitting the session across yet
+    another random worker. Routing through the helper keeps the dispatch
+    in-process on the worker that already owns the session, closing the last
+    remaining scatter point in the forward chain.
+    """
+
+    class DummySessionManager:
+        @asynccontextmanager
+        async def run(self):
+            yield self
+
+        async def handle_request(self, scope, receive, send_func):
+            raise AssertionError("Should not reach SDK")
+
+    monkeypatch.setattr(tr, "StreamableHTTPSessionManager", lambda **kwargs: DummySessionManager())
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.mcpgateway_session_affinity_enabled", True)
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.settings.use_stateful_sessions", True)
+
+    wrapper = SessionManagerWrapper()
+    await wrapper.initialize()
+
+    send, _messages = _make_send_collector()
+    body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+    # x-forwarded-internally: true triggers the [HTTP_AFFINITY_FORWARDED] re-entry branch.
+    # Use a server-less path so the handler doesn't try to validate server_id against the (un-initialised) DB.
+    scope = _make_scope(
+        "/mcp",
+        method="POST",
+        headers=[
+            (b"mcp-session-id", b"sess-fwd"),
+            (b"x-forwarded-internally", b"true"),
+            (b"authorization", b"Bearer original-jwt"),
+        ],
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"jsonrpc":"2.0","result":{}}'
+
+    mock_post_rpc = AsyncMock(return_value=mock_response)
+
+    with patch("mcpgateway.transports.streamablehttp_transport.post_rpc_in_process", mock_post_rpc):
+        await wrapper.handle_streamable_http(scope, _make_receive(body), send)
+
+    await wrapper.shutdown()
+    mock_post_rpc.assert_awaited_once()
+    sent_headers = mock_post_rpc.await_args.kwargs["headers"]
+    assert sent_headers["x-forwarded-internally"] == "true"
+    assert sent_headers["x-mcp-session-id"] == "sess-fwd"
+    assert sent_headers["authorization"] == "Bearer original-jwt"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/utils/test_internal_http.py
+++ b/tests/unit/mcpgateway/utils/test_internal_http.py
@@ -7,11 +7,16 @@ Authors: Mihai Criveti
 Unit tests for internal loopback HTTP helpers.
 """
 
+# Standard
+from typing import Any
+from unittest.mock import patch
+
 # Third-Party
+import httpx
 import pytest
 
 # First-Party
-from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify
+from mcpgateway.utils.internal_http import _is_ssl_enabled, internal_loopback_base_url, internal_loopback_verify, post_rpc_in_process
 
 
 class TestIsSSLEnabled:
@@ -99,3 +104,114 @@ class TestInternalLoopbackVerify:
         monkeypatch.delenv("SSL", raising=False)
         monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
         assert internal_loopback_verify() is True
+
+
+class _CapturingAsyncClient:
+    """Async-CM ``httpx.AsyncClient`` stand-in that captures construction + post kwargs.
+
+    Records the ``transport`` and ``base_url`` passed to the constructor and the
+    ``url``/``content``/``headers``/``timeout`` of the inner ``.post`` call so
+    tests can assert on the in-process dispatch contract without touching the
+    real FastAPI app.
+    """
+
+    last_init_kwargs: dict[str, Any] = {}
+    last_post_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).last_init_kwargs = kwargs
+
+    async def __aenter__(self) -> "_CapturingAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+    async def post(self, url: str, **kwargs: Any) -> Any:
+        type(self).last_post_kwargs = {"url": url, **kwargs}
+        # Return a minimal Response-like sentinel; the executor under test
+        # never inspects this object in the unit-test path.
+        return object()
+
+
+class TestPostRpcInProcess:
+    """Tests for ``post_rpc_in_process`` (PR #4987).
+
+    The helper centralises in-process ``/rpc`` dispatch so all four affinity
+    sites (cross-worker forward + cross-worker SSE/RPC + local-owned + the
+    HTTP-affinity-forwarded re-entry) execute on the worker that holds the
+    bound upstream session, instead of looping back over the shared gunicorn
+    socket and scattering to a random worker. The load-bearing details pinned
+    here: the transport is ``httpx.ASGITransport`` (proves in-process, not
+    network loopback), the path is exactly ``/_internal/mcp/rpc`` (the
+    trusted-internal route, not the public ``/rpc`` and not the original request
+    path), ``content``/``timeout`` pass through unchanged, and the caller's
+    ``headers`` are preserved while the trust markers are attached on top.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dispatches_via_asgi_transport_in_process(self):
+        """Asserts the AsyncClient is constructed with an ``httpx.ASGITransport``.
+
+        This is the whole point of #4987 — a real ``httpx.AsyncClient(verify=...)``
+        to ``127.0.0.1`` would hit the shared gunicorn socket and the kernel
+        would route the call to an arbitrary worker that does not hold the
+        bound upstream session.
+        """
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0, auth_context="ctx")
+        assert isinstance(_CapturingAsyncClient.last_init_kwargs.get("transport"), httpx.ASGITransport)
+
+    @pytest.mark.asyncio
+    async def test_posts_to_rpc_endpoint(self):
+        """The helper targets exactly ``/_internal/mcp/rpc`` — the trusted-internal JSON-RPC route."""
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={"x-forwarded-internally": "true"}, timeout=1.0, auth_context="ctx")
+        assert _CapturingAsyncClient.last_post_kwargs["url"] == "/_internal/mcp/rpc"
+
+    @pytest.mark.asyncio
+    async def test_propagates_content_headers_and_timeout(self):
+        """``content`` and ``timeout`` reach the inner ``.post`` unchanged, and the
+        caller's ``headers`` are preserved with the trust markers attached on top.
+
+        Each caller builds its own loop-stop header set; the helper must not drop
+        or replace them, but it does add the trusted-internal runtime markers and
+        the encoded auth context.
+        """
+        headers = {"x-forwarded-internally": "true", "x-mcp-session-id": "abc", "authorization": "Bearer x"}
+        body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=body, headers=headers, timeout=7.5, auth_context="edge-ctx")
+
+        captured = _CapturingAsyncClient.last_post_kwargs
+        assert captured["content"] == body
+        assert captured["timeout"] == 7.5
+        # Caller headers preserved untouched...
+        for key, value in headers.items():
+            assert captured["headers"][key] == value
+        # ...and the trust markers attached on top.
+        assert captured["headers"]["x-contextforge-mcp-runtime"] == "affinity"
+        assert captured["headers"]["x-contextforge-auth-context"] == "edge-ctx"
+        assert captured["headers"]["x-contextforge-mcp-runtime-auth"]
+
+    @pytest.mark.asyncio
+    async def test_requires_non_empty_auth_context(self):
+        """An empty ``auth_context`` is rejected before any dispatch is attempted."""
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            with pytest.raises(ValueError):
+                await post_rpc_in_process(content=b"{}", headers={}, timeout=1.0, auth_context="")
+
+    @pytest.mark.asyncio
+    async def test_uses_loopback_base_url(self, monkeypatch):
+        """The AsyncClient's ``base_url`` is the gateway's loopback URL.
+
+        ASGITransport ignores ``base_url`` for routing — the FastAPI app sees
+        the request directly — but the base URL still appears in logs and in
+        observability scopes, so it must be the loopback.
+        """
+        monkeypatch.setattr("mcpgateway.utils.internal_http.settings.port", 4444)
+        monkeypatch.delenv("SSL", raising=False)
+        with patch("mcpgateway.utils.internal_http.httpx.AsyncClient", _CapturingAsyncClient):
+            await post_rpc_in_process(content=b"{}", headers={}, timeout=1.0, auth_context="ctx")
+        assert _CapturingAsyncClient.last_init_kwargs.get("base_url") == "http://127.0.0.1:4444"

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -497,3 +497,40 @@ class TestPassthroughHeaders:
 
         # Should log warning about conflict
         assert any("conflicts with pre-defined headers" in record.message for record in caplog.records)
+
+
+class TestLoopbackSkipTrustedInternalHeaders:
+    """Deny-path: client passthrough must never carry the gateway-internal trust headers.
+
+    The ``/_internal/mcp/*`` dispatch sets ``x-contextforge-auth-context`` (the
+    server-established identity), ``x-contextforge-mcp-runtime``, and the HMAC.
+    If the loopback passthrough echoed a client-supplied copy of those, a caller
+    could spoof the trusted identity while the server's valid HMAC still rode
+    along. The loopback skip set must strip them.
+    """
+
+    def test_filter_strips_trusted_internal_headers(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        spoofed = {
+            "x-contextforge-auth-context": "SPOOFED",
+            "x-contextforge-mcp-runtime": "affinity",
+            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",
+            "x-contextforge-session-validated": "rust",
+            "x-business-header": "kept",
+        }
+        out = filter_loopback_skip_headers(spoofed)
+        assert "x-contextforge-auth-context" not in out
+        assert "x-contextforge-mcp-runtime" not in out
+        assert "x-contextforge-mcp-runtime-auth" not in out
+        assert "x-contextforge-session-validated" not in out
+        # Non-trusted business headers are unaffected.
+        assert out.get("x-business-header") == "kept"
+
+    def test_filter_strips_trusted_headers_case_insensitively(self):
+        # First-Party
+        from mcpgateway.utils.passthrough_headers import filter_loopback_skip_headers
+
+        out = filter_loopback_skip_headers({"X-ContextForge-Auth-Context": "SPOOFED"})
+        assert not any(k.lower() == "x-contextforge-auth-context" for k in out)

--- a/tests/unit/mcpgateway/utils/test_passthrough_headers.py
+++ b/tests/unit/mcpgateway/utils/test_passthrough_headers.py
@@ -516,7 +516,7 @@ class TestLoopbackSkipTrustedInternalHeaders:
         spoofed = {
             "x-contextforge-auth-context": "SPOOFED",
             "x-contextforge-mcp-runtime": "affinity",
-            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",
+            "x-contextforge-mcp-runtime-auth": "SPOOFED-HMAC",  # pragma: allowlist secret
             "x-contextforge-session-validated": "rust",
             "x-business-header": "kept",
         }

--- a/tests/unit/test_gunicorn_config.py
+++ b/tests/unit/test_gunicorn_config.py
@@ -2,15 +2,40 @@
 """Location: ./tests/unit/test_gunicorn_config.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
+Authors: Mihai Criveti, Pratik Gandhi
 
-Tests for gunicorn.config.py hooks.
+Tests for the ``gunicorn.config.py`` ``post_fork`` hook.
+
+Covers two concerns of the hook:
+
+- **Engine / Redis pool reset on fork** (``TestPostForkHook``): each worker
+  disposes the inherited SQLAlchemy engine pool and resets the Redis client.
+
+- **Per-worker WORKER_ID rebind (#4557)**: the load-bearing fix behind PR #4981.
+  With ``--preload``, ``mcpgateway.services.session_affinity.WORKER_ID`` is
+  captured at import time in the master process, so every forked worker would
+  otherwise inherit ``{hostname}:1`` (the master's PID). A shared WORKER_ID
+  collapses the per-worker pub/sub channels and makes every forwarded request
+  execute on all workers in the container (24x broadcast amplification observed
+  in #4557). The ``post_fork`` hook recomputes WORKER_ID per worker to restore
+  single-executor forwarding, and wraps the rebind in a broad ``except`` that
+  logs a ``warning`` referencing #4557 so silent fallback can't drift production
+  back into the amplification state.
 """
 
+# Future
+from __future__ import annotations
+
+# Standard
 import importlib.util
+import socket
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+# Third-Party
+import pytest
 
 # Load gunicorn.config.py as a module (it has a dot in the name, so we need importlib)
 project_root = Path(__file__).parent.parent.parent
@@ -20,6 +45,36 @@ spec = importlib.util.spec_from_file_location("gunicorn_config", gunicorn_config
 gunicorn_config = importlib.util.module_from_spec(spec)
 sys.modules["gunicorn_config"] = gunicorn_config
 spec.loader.exec_module(gunicorn_config)
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GUNICORN_CONFIG_PATH = _REPO_ROOT / "gunicorn.config.py"
+
+
+def _load_gunicorn_config():
+    """Import ``gunicorn.config`` from the repo root by file path.
+
+    ``gunicorn.config.py`` sits at the repo root, not on ``sys.path``, so
+    a plain ``import gunicorn.config`` doesn't reach it. Loading via spec
+    keeps the test hermetic and avoids polluting ``sys.modules`` with a
+    name that collides with the real ``gunicorn`` package.
+    """
+    spec = importlib.util.spec_from_file_location("_gunicorn_config_under_test", _GUNICORN_CONFIG_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_fake_server() -> SimpleNamespace:
+    """Build a minimal gunicorn-server stand-in exposing ``log.info/warning/error``."""
+    return SimpleNamespace(log=MagicMock())
+
+
+@pytest.fixture
+def fake_worker() -> SimpleNamespace:
+    """A gunicorn-worker stand-in with a stable PID."""
+    return SimpleNamespace(pid=4242)
 
 
 class TestPostForkHook:
@@ -67,10 +122,13 @@ class TestPostForkHook:
             # Should not raise - exception is caught
             gunicorn_config.post_fork(mock_server, mock_worker)
 
-        # Verify warning was logged
-        mock_server.log.warning.assert_called_once()
-        warning_call = mock_server.log.warning.call_args[0]
-        assert "Failed to reset SQLAlchemy engine pool" in warning_call[0]
+        # Verify the engine-pool warning was logged. Search among all warning calls
+        # rather than asserting it was the only one: post_fork may emit other warnings
+        # (e.g. the affinity rebind) depending on configuration, so assert_called_once()
+        # would be brittle.
+        engine_warnings = [c for c in mock_server.log.warning.call_args_list if c.args and "Failed to reset SQLAlchemy engine pool" in str(c.args[0])]
+        assert engine_warnings, "expected a warning about engine pool reset failure"
+        warning_call = engine_warnings[0].args
         assert "Connection pool error" in str(warning_call[1])
 
     def test_post_fork_resets_redis_client(self):
@@ -111,3 +169,94 @@ class TestPostForkHook:
         # Should still complete successfully
         mock_server.log.info.assert_any_call("Worker spawned (pid: %s)", 12345)
         mock_server.log.info.assert_any_call("SQLAlchemy engine pool reset for worker %s", 12345)
+
+
+def test_post_fork_rebinds_worker_id_per_worker(fake_worker, monkeypatch):
+    """Happy path: with the affinity flag on, ``post_fork`` overrides the master-frozen ``WORKER_ID`` with ``{hostname}:{worker.pid}``.
+
+    Without this, every forked gunicorn worker carries the master's
+    ``{hostname}:1``, so a forwarded request published to the owner's
+    pub/sub channel reaches every worker in the container.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services import session_affinity
+
+    monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", True)
+    cfg = _load_gunicorn_config()
+    original = session_affinity.WORKER_ID
+    try:
+        cfg.post_fork(_make_fake_server(), fake_worker)
+        assert session_affinity.WORKER_ID == f"{socket.gethostname()}:{fake_worker.pid}"
+    finally:
+        # Restore the module-level constant so other tests aren't affected.
+        session_affinity.WORKER_ID = original
+
+
+def test_post_fork_skips_worker_id_rebind_when_affinity_disabled(fake_worker, monkeypatch):
+    """With the affinity flag off, ``post_fork`` must NOT touch ``WORKER_ID``.
+
+    The kill-switch contract: flag off means the affinity machinery is a clean
+    no-op, so the per-worker rebind (and the ``session_affinity`` import at fork)
+    is skipped and ``WORKER_ID`` keeps whatever value it already had.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services import session_affinity
+
+    monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", False)
+    cfg = _load_gunicorn_config()
+    sentinel = "sentinel-host:0"
+    original = session_affinity.WORKER_ID
+    session_affinity.WORKER_ID = sentinel
+    try:
+        cfg.post_fork(_make_fake_server(), fake_worker)
+        # Unchanged: the rebind block was gated out by the disabled flag.
+        assert session_affinity.WORKER_ID == sentinel
+    finally:
+        session_affinity.WORKER_ID = original
+
+
+def test_post_fork_logs_warning_when_rebind_fails(fake_worker, monkeypatch):
+    """If the rebind raises, the hook must log a ``warning`` referencing #4557 and NOT crash the worker.
+
+    Regression test for the F2 follow-up: the original ``except ImportError: pass``
+    silently fell back to the master's frozen ``WORKER_ID``, so #4557's broadcast
+    amplification could return into production unnoticed. The fix broadens the
+    catch and surfaces the failure via ``server.log.warning(...)``.
+
+    To reproduce a rebind failure deterministically without depending on the
+    real module's internals, monkeypatch ``socket.gethostname`` (called inside
+    the try block) to raise.
+    """
+    # First-Party
+    from mcpgateway.config import settings
+    from mcpgateway.services import session_affinity
+
+    monkeypatch.setattr(settings, "mcpgateway_session_affinity_enabled", True)
+
+    original_worker_id = session_affinity.WORKER_ID
+
+    def _boom() -> str:
+        raise RuntimeError("simulated rebind failure")
+
+    monkeypatch.setattr(socket, "gethostname", _boom)
+
+    cfg = _load_gunicorn_config()
+    server = _make_fake_server()
+    try:
+        # Must not raise — the hook is expected to swallow + log, never propagate.
+        cfg.post_fork(server, fake_worker)
+    finally:
+        session_affinity.WORKER_ID = original_worker_id
+
+    # WORKER_ID was NOT silently rebound (the failure was real, not papered over).
+    assert session_affinity.WORKER_ID == original_worker_id
+
+    # A warning was emitted, mentioning the failing operation (rebind) and the consequence.
+    assert server.log.warning.called, "expected post_fork to log a warning on rebind failure"
+    call_args = server.log.warning.call_args
+    # First arg is the format string; subsequent args are the format params.
+    fmt = call_args.args[0] if call_args.args else ""
+    assert "WORKER_ID" in fmt
+    assert "broadcast" in fmt, "warning should describe the consequence (per-container broadcast) so operators can act on it"


### PR DESCRIPTION
## Summary

Rebased, single-commit version of the multi-worker session-affinity forward-amplification fix (#4557), cleanly on top of current `main`. This supersedes the long-running #4981 branch, which had drifted 107 commits behind `main`.

Fixes the #4557 regression where stateful MCP requests (carrying `Mcp-Session-Id`) collapsed from ~180 RPS to single digits on multi-worker deployments, via two fixes:

- **Per-worker `WORKER_ID`** recomputed in the gunicorn `post_fork` hook. Under `--preload`, every worker inherited the master's `{host}:1`, so a forward fanned out to all workers in the container (N× duplicate execution).
- **In-process dispatch** of the affinity-owned forward. The owner now serves the request in its own process against the bound upstream session, instead of a loopback `/rpc` call that the kernel scattered to a random worker.

## Validation

- Rebased onto `main`; conflicts resolved (5 files), no logic changes vs the reviewed #4981 work.
- `make test`: **19664 passed, 605 skipped, 2 xfailed**.
- Re-validated end-to-end on a 16-core / 32 GB host (3 gateway replicas behind nginx): **461.88 RPS @ 0.00% failures** and the #4205 counter reproducers pass **5/5** — details below.

<details>
<summary><b>Load benchmark — Streamable HTTP tools throughput (16-core host, 462 RPS @ 0.00% failures)</b></summary>

Image built from this branch (`make docker-prod`), stack up via `make testing-up`, then
`make benchmark-mcp-tools` — tools-only MCP Streamable HTTP, 125 concurrent users, 30/s
spawn rate, 60s, against the registered `fast_time` virtual server through nginx on `:8080`.

| Metric | Value |
|---|---|
| Total requests | 27,734 |
| Failures | 0 (0.00%) |
| Throughput | 461.88 RPS |
| Avg latency | 200.2 ms |
| p50 / p90 / p95 / p99 | 140 / 320 / 490 / 1,400 ms |
| Max | 3,003 ms |

| Endpoint | Reqs | Fails | RPS | Avg (ms) | p99 (ms) |
|---|---|---|---|---|---|
| `tools/call` [rapid] | 26,294 | 0 | 437.9 | 200.7 | 1,400 |
| `tools/list` [rapid] | 1,315 | 0 | 21.9 | 193.0 | 1,200 |
| `initialize` | 125 | 0 | 2.1 | 163.9 | 1,800 |

</details>

<details>
<summary><b>#4205 counter reproducers — statefulness &amp; isolation under multi-worker affinity (5/5 PASS)</b></summary>

A minimal per-session counter MCP server (state keyed by the upstream `ServerSession`) is
registered behind the gateway; a session is incremented N times and must read back N. If
forwarding scattered onto a fresh upstream session, the counter would drop.

**Counter server** (run on the host; a 2nd instance on `:9401` for Test 4):

```python
# counter_server.py — per-session counter, state keyed by the upstream ServerSession
from mcp.server.fastmcp import Context, FastMCP
mcp = FastMCP("repro-counter", host="0.0.0.0", port=9400)
_counters: dict[int, int] = {}

@mcp.tool()
def increment(ctx: Context) -> int:
    _counters[id(ctx.session)] = _counters.get(id(ctx.session), 0) + 1
    return _counters[id(ctx.session)]

@mcp.tool()
def get_value(ctx: Context) -> int:
    return _counters.get(id(ctx.session), 0)

mcp.run(transport="streamable-http")
```

**Prefer the automated version:** these reproducers are scripted (with a README) on a companion branch — [compare `fix/session-affinity-forward-amplification...test/session-affinity-counter-reproducers`](https://github.com/IBM/mcp-context-forge/compare/fix/session-affinity-forward-amplification...test/session-affinity-counter-reproducers). It brings up the stack, registers the counter, runs Tests 1-5, and prints PASS/FAIL — easier than the manual steps below.

<details><summary><b>Manual counter-server registration (optional — the script does this for you, but here's how to do it by hand)</b></summary>

Run everything from the repo root, with the testing stack already up (`make testing-up`).

**1. Start the counter server on the host (binds `0.0.0.0`):**
```bash
.venv/bin/python tests/e2e/session_affinity/counter_server.py > /tmp/counter9400.log 2>&1 &
# confirm it's listening on 0.0.0.0:
ss -ltn | grep ':9400'
```

**2. Mint an admin token:**
```bash
export JWT_SECRET_KEY=$(grep -E '^JWT_SECRET_KEY=' .env | cut -d= -f2-)
export MCPGATEWAY_BEARER_TOKEN=$(.venv/bin/python -m mcpgateway.utils.create_jwt_token \
    --username admin@example.com --admin --exp 10080 --secret "$JWT_SECRET_KEY" --algo HS256 2>/dev/null)
```

**3. (Optional) Confirm the gateway container can reach the counter** — this is the step that catches the `localhost` mistake:
```bash
docker compose exec gateway python3 -c "import urllib.request; print(urllib.request.urlopen('http://host.docker.internal:9400/mcp', timeout=5).status)"
```
Any HTTP status back (e.g. `406`) = reachable ✅. A connection error = the server isn't on `0.0.0.0` or you'd be using `localhost`.

**4. Register the counter as a gateway** — note `host.docker.internal`, not `localhost`:
```bash
curl -sS -X POST http://localhost:8080/gateways \
  -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"counter-manual","url":"http://host.docker.internal:9400/mcp","transport":"STREAMABLEHTTP"}'
```
Look for `"status":"active"` and `"reachable":true` in the response = it connected. ✅

**5. Confirm the tools synced (a few seconds later):**
```bash
sleep 5
curl -sS http://localhost:8080/tools -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN" \
  | python3 -c "import sys,json; print([t['name'] for t in json.load(sys.stdin) if 'counter' in t['name'].lower()])"
```
You should see `counter-manual-increment` and `counter-manual-get-value`.

**Gotchas:**
- `{"message":"Gateway already exists"}` = a gateway is already registered at that URL (unique by URL). List them with `curl -sS http://localhost:8080/gateways -H "Authorization: Bearer $MCPGATEWAY_BEARER_TOKEN"` and delete the one on `:9400` first.
- Before running `run_reproducers.py`, delete this manual gateway — the script registers its own at `:9400` and would hit the same URL conflict. (The counter server keeps running; you're only removing the registration.)

</details>

**Steps:**

1. Run the counter on the host — reachable from the gateway containers via
   `host.docker.internal` (compose maps `extra_hosts: host.docker.internal:host-gateway`).
2. `POST /gateways` → `{"name":"repro-counter","url":"http://host.docker.internal:9400/mcp","transport":"STREAMABLEHTTP"}`.
3. Wait for tool sync (`GET /tools` filtered by `gatewayId`), then
   `POST /servers` → `{"server":{"name":"repro-counter-vs","associated_tools":[…]}}`.
4. Admin token: `python -m mcpgateway.utils.create_jwt_token --username admin@example.com --admin --secret $JWT_SECRET_KEY`.
5. Drive sessions against `/servers/{id}/mcp`: `initialize` → `notifications/initialized` →
   `tools/call increment` ×N → `tools/call get_value` (concurrent sessions via a thread pool).

| Test | Steps | Result |
|---|---|---|
| 1 — single session | one session, `increment` ×25, then `get_value` | `increments=[1…25]`, `get_value=25` — **PASS** |
| 2 — same-user multi-session | 3 concurrent sessions, one token, ×10 each | 3 distinct sids, each `[1…10]` / `get_value=10` — **PASS** |
| 3 — two tokens | two distinct tokens (same admin), parallel, ×10 | both `[1…10]`, no cross-talk — **PASS** |
| 4 — multi-upstream | one session across two counters (`:9400`+`:9401`): A×5, B×3, A×2 | A `[1,2,3,4,5]` then `[6,7]` (=7), B `[1,2,3]` (=3) — **PASS** |
| 5 — owner-worker kill | bind + ×5, read owner from Redis, `kill -9` the owning worker, hit stale sid, then fresh `initialize` | stale sid → **HTTP 404 / `-32600 "Session not found"` in 30.0s**; killed worker respawns; fresh init `[1,2,3]` — **PASS** |

Test 5 trace:

```
[1] bound sid=fa0fff53…  increments=[1, 2, 3, 4, 5]
[2] pool_owner -> 31d47cea2698:32        # owner pid 32 (not :1 -> per-worker WORKER_ID active)
[4] kill -9 32 -> worker dead (gunicorn respawns)
[5] stale-sid request -> HTTP 404 in 30.0s | {"error":{"code":-32600,"message":"Session not found"}}
[6] fresh initialize d0ab68fd… increments=[1, 2, 3]
```

Per-session upstream state survives the cross-worker affinity forwarding (one upstream
session per downstream session), isolation holds across sessions/tokens/upstreams, and the
owner-death failure mode returns a clean structured error rather than a hang.

</details>


 ([pr-5393-no-regression-logs.zip](https://github.com/user-attachments/files/29615610/pr-5393-no-regression-logs.zip)): RBAC, a 10-min load test, and MCP protocol e2e on a live 3-worker stack, showing this PR matches `main` with no regressions.


The only non-passing results are pre-existing on `main` and independent of this PR (a #4341 admin-visibility test assertion, stateless-mode default-endpoint execution, and load-test harness artifacts).

Relates to #4981, #4557, #5384.



