### PR TITLE
fix(deps): bump prometheus-fastapi-instrumentator to 8.0.1 (fixes admin login 500 crash)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ cpex-secrets-detection = "2026-06-24T23:59:59Z"
 granian = "2026-06-18T23:59:59Z"
 tornado = "2026-06-10T23:59:59Z"
 langsmith = "2026-06-20T23:59:59Z"
+# 8.0.1 fixes AttributeError: '_IncludedRouter' object has no attribute 'path'
+# raised on every request once FastAPI 0.137 / Starlette 0.42+ introduced
+# _IncludedRouter (upstream issue trallnag/prometheus-fastapi-instrumentator#370).
+prometheus-fastapi-instrumentator = "2026-06-22T23:59:59Z"
 
 
 [tool.uv.sources]
@@ -96,7 +100,7 @@ dependencies = [
     "msgpack>=1.2.1",
     "orjson>=3.11.9",
     "parse>=1.22.1",
-    "prometheus-fastapi-instrumentator>=8.0.0",
+    "prometheus-fastapi-instrumentator>=8.0.1",  # 8.0.1: fix _IncludedRouter crash (issue #370)
     "prometheus_client>=0.25.0", # 0.25.0 exceeds 10-day min-release-age policy
     "psutil>=7.2.2",
     "pydantic>=2.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -8,24 +8,25 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-14T08:52:22.113688Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P10D"
 
 [options.exclude-newer-package]
-cpex-encoded-exfil-detection = "2026-06-24T23:59:59Z"
-langsmith = "2026-06-20T23:59:59Z"
+tornado = "2026-06-10T23:59:59Z"
 sqlalchemy = "2026-06-18T23:59:59Z"
-grpcio-reflection = "2026-06-18T23:59:59Z"
 cpex = "2026-06-18T23:59:59Z"
 cpex-retry-with-backoff = "2026-06-24T23:59:59Z"
-msgpack = "2026-06-18T23:59:59Z"
 starlette = "2026-06-18T23:59:59Z"
 cpex-url-reputation = "2026-06-24T23:59:59Z"
 cpex-rate-limiter = "2026-06-24T23:59:59Z"
 cpex-pii-filter = "2026-06-24T23:59:59Z"
+langsmith = "2026-06-20T23:59:59Z"
+prometheus-fastapi-instrumentator = "2026-06-22T23:59:59Z"
+grpcio-reflection = "2026-06-18T23:59:59Z"
+msgpack = "2026-06-18T23:59:59Z"
 cpex-secrets-detection = "2026-06-24T23:59:59Z"
 granian = "2026-06-18T23:59:59Z"
-tornado = "2026-06-10T23:59:59Z"
+cpex-encoded-exfil-detection = "2026-06-24T23:59:59Z"
 
 [[package]]
 name = "a2a-sdk"
@@ -3279,7 +3280,7 @@ requires-dist = [
     { name = "orjson", specifier = ">=3.11.9" },
     { name = "parse", specifier = ">=1.22.1" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=8.0.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=8.0.1" },
     { name = "protobuf", marker = "extra == 'grpc'", specifier = ">=6.33.6" },
     { name = "psutil", specifier = ">=7.2.2" },
     { name = "psycopg", extras = ["c", "binary"], marker = "extra == 'postgres'", specifier = ">=3.3.4" },
@@ -4189,15 +4190,15 @@ wheels = [
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "8.0.0"
+version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prometheus-client" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/8a/c78d184a6d8fc2f17cb8ec13b6fd7519ca575aeb5de198d08d309330a351/prometheus_fastapi_instrumentator-8.0.1.tar.gz", hash = "sha256:da495a52da38ac5cfae0f88103306199fd14ba552a549839b3abc7bd0db192d1", size = 21464, upload-time = "2026-06-22T19:22:46.589Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/ad/b14ed2fe73bb1d37bcc947e75afae018f795526415d5b849aeb99c403cd1/prometheus_fastapi_instrumentator-8.0.0-py3-none-any.whl", hash = "sha256:e3c967c402124dfe81cf5aad35208d9f96db5452c6cb752350d9358ca0a96198", size = 19411, upload-time = "2026-05-29T13:04:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c9/9614284a2641d38a65b3b2d8bae0b9d2fb659308e3b4dcb599b9724703cd/prometheus_fastapi_instrumentator-8.0.1-py3-none-any.whl", hash = "sha256:eeb16cde7446f15bf0260da042da8dbcb70ec4c9ceaa154a2c5409bd6a7f9b8d", size = 20618, upload-time = "2026-06-22T19:22:47.564Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Symptom

Every authenticated request to the gateway crashes with `HTTP 500`:

```
GET /admin/login -> 500
{"detail":"An internal error occurred. Please try again."}
```

The admin login form is unreachable; `register_fast_time`, `register_fast_test`, and any compose-driven gateway registration exit non-zero after timing out on `/ready` with 500 responses; the entire `make testing-up` flow can't reach a usable state.

## Root cause

`prometheus-fastapi-instrumentator 8.0.0` iterates `app.routes` and unconditionally reads `route.path` in [`_get_route_name`](https://github.com/trallnag/prometheus-fastapi-instrumentator/blob/v8.0.0/src/prometheus_fastapi_instrumentator/routing.py#L55):

```python
File "/app/.venv/lib64/python3.12/site-packages/prometheus_fastapi_instrumentator/routing.py", line 55, in _get_route_name
    route_name = route.path
                 ^^^^^^^^^^
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

FastAPI 0.137 / Starlette 0.42+ introduced `_IncludedRouter` — a wrapper that `app.include_router(prefix=...)` now appends to `app.routes` *instead of* flattening child routes. `_IncludedRouter` does not expose `.path`, so the instrumentator's `_get_route_name` raises `AttributeError` every time it sees one. The error is swallowed by Starlette's `ExceptionGroup` and surfaces only as a generic 500.

Upstream issue: [trallnag/prometheus-fastapi-instrumentator#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370)
Upstream fix: [v8.0.1 release notes](https://github.com/trallnag/prometheus-fastapi-instrumentator/releases/tag/v8.0.1) (2026-06-22)

Same bug is hitting other projects: vLLM ([#45597](https://github.com/vllm-project/vllm/issues/45597)), sglang ([#28887](https://github.com/sgl-project/sglang/issues/28887)), opentelemetry-instrumentation-fastapi.

## Fix

Bump the dependency floor and add a UV per-package override:

```toml
[tool.uv.exclude-newer-package]
...
prometheus-fastapi-instrumentator = "2026-06-22T23:59:59Z"

[project]
dependencies = [
    ...
    "prometheus-fastapi-instrumentator>=8.0.1",
]
```

The per-package override is required because the repo runs UV with a 10-day `exclude-newer` policy (`[tool.uv] exclude-newer = "10 days"`). Without the override, 8.0.1 (released 2026-06-22) would be excluded today (2026-06-26) until ~2026-07-02. The pattern mirrors the existing `langsmith`, `granian`, `tornado` overrides.

## Verification (end-to-end on `make testing-up`)

Before:
```
GET /admin/login                            -> 500
authenticated /ready                         -> 500
register_fast_time, register_fast_test       -> Exited (1)
container env ANYIO_CANCEL_DELIVERY_PATCH... -> set to false in PR #5396
AttributeError '_IncludedRouter' ...         -> raised on every request
```

After (with this PR):
```
GET /admin/login                            -> 200
authenticated /ready (3 attempts)            -> 200, 200, 200
register_fast_time, register_fast_test       -> Exited (0)
  - fast_time gateway registered with 6 Rust MCP tools
  - fast_test gateway registered with 6 Rust MCP tools
  - virtual servers created end-to-end
prometheus-fastapi-instrumentator version    -> 8.0.1 in container
'_IncludedRouter' AttributeErrors in 30s     -> 0
```

I traced the bug by temporarily instrumenting `mcpgateway/middleware/client_disconnect.py:163`'s `except` block to log `traceback.format_exception(..., chain=True)` (which walks `ExceptionGroup` sub-exceptions in Python 3.11+). That revealed the upstream frame inside `prometheus_fastapi_instrumentator/routing.py:55`. The instrumentation was reverted before commit — this PR contains only the dependency bump.

## Cross-reference

PR #5396 (`fix(fast-time-server): build Rust container from workspace root, complete Go→Rust replacement`) flagged this exact `_IncludedRouter` symptom in its "Known follow-up (out of scope)" section. This PR resolves that follow-up.
