### PR TITLE
chore: upgrade dpkg in debian:trixie-slim runtime stages

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-25T16:43:37Z",
+  "generated_at": "2026-06-26T10:58:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/a2a-agents/rust/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/rust/a2a-echo-agent/Dockerfile
@@ -12,7 +12,9 @@ COPY a2a-agents/rust/a2a-echo-agent ./a2a-agents/rust/a2a-echo-agent
 RUN cargo build --release -p a2a-echo-agent
 
 FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+RUN apt-get update \
+    && apt-get install -y --only-upgrade dpkg \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app

--- a/mcp-servers/rust/benchmark-server/Dockerfile
+++ b/mcp-servers/rust/benchmark-server/Dockerfile
@@ -13,7 +13,9 @@ RUN touch mcp-servers/rust/benchmark-server/src/main.rs \
     && cargo build --release -p benchmark-server
 
 FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+RUN apt-get update \
+    && apt-get install -y --only-upgrade dpkg \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app

--- a/mcp-servers/rust/fast-time-server/Dockerfile
+++ b/mcp-servers/rust/fast-time-server/Dockerfile
@@ -27,7 +27,9 @@ RUN touch src/main.rs && cargo build --release
 # Runtime stage - minimal image
 FROM docker.io/library/debian:trixie-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y --only-upgrade dpkg \
+    && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes [Issue 53](<https://github.ibm.com/contextforge-org/internal_issues/issues/53>)

---

## 📝 Summary

Adds `apt-get install -y --only-upgrade dpkg` to the runtime stage of the three `debian:trixie-slim`-based Rust server Dockerfiles. This ensures every image build pulls the patched dpkg version regardless of the cached base image layer in CI.

Affected files:
- `a2a-agents/rust/a2a-echo-agent/Dockerfile`
- `mcp-servers/rust/benchmark-server/Dockerfile`
- `mcp-servers/rust/fast-time-server/Dockerfile`

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Dockerfile-only change. Does not affect the builder stage, only the runtime stage of each multi-stage build.