### PR TITLE
fix failed to shutdown plugin

### DIFF
--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -145,7 +145,7 @@ class TenantPluginManagerFactory:
             try:
                 await expired.manager.shutdown()
             except Exception:
-                logger.warning("Failed to shutdown expired manager for context_id=%s", context_id)
+                logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
 
         async with self._lock:
             inflight = self._inflight.get(context_id)

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -130,15 +130,24 @@ class TenantPluginManagerFactory:
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context."""
         context_id = context_id or "__global__"
-
+        expired = None
+        
         async with self._lock:
             entry = self._managers.get(context_id)
             if entry is not None:
                 if entry.is_expired(self._cache_ttl):
-                    self._managers.pop(context_id, None)
+                    expired = self._managers.pop(context_id, None)
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
                     return entry.manager
+        
+        if expired is not None:
+            try:
+                await expired.manager.shutdown()
+            except Exception:
+                logger.warning("Failed to shutdown expired manager for context_id=%s", context_id)
+
+        async with self._lock:
 
             inflight = self._inflight.get(context_id)
             if inflight is None:

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -147,7 +147,6 @@ class TenantPluginManagerFactory:
                 except Exception:
                     logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
 
-        async with self._lock:
             inflight = self._inflight.get(context_id)
             if inflight is None:
                 inflight = asyncio.create_task(self._build_manager(context_id))

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -141,11 +141,11 @@ class TenantPluginManagerFactory:
                 else:
                     return entry.manager
 
-        if expired is not None:
-            try:
-                await expired.manager.shutdown()
-            except Exception:
-                logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
+            if expired is not None:
+                try:
+                    await expired.manager.shutdown()
+                except Exception:
+                    logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
 
         async with self._lock:
             inflight = self._inflight.get(context_id)

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -131,7 +131,7 @@ class TenantPluginManagerFactory:
         """Get or create a TenantPluginManager for the given context."""
         context_id = context_id or "__global__"
         expired = None
-        
+
         async with self._lock:
             entry = self._managers.get(context_id)
             if entry is not None:
@@ -140,7 +140,7 @@ class TenantPluginManagerFactory:
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
                     return entry.manager
-        
+
         if expired is not None:
             try:
                 await expired.manager.shutdown()
@@ -148,7 +148,6 @@ class TenantPluginManagerFactory:
                 logger.warning("Failed to shutdown expired manager for context_id=%s", context_id)
 
         async with self._lock:
-
             inflight = self._inflight.get(context_id)
             if inflight is None:
                 inflight = asyncio.create_task(self._build_manager(context_id))

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -619,6 +619,7 @@ class TestGetManager:
     @pytest.mark.asyncio
     async def test_get_manager_rebuilds_expired(self, factory):
         old_manager = AsyncMock()
+        old_manager.shutdown = AsyncMock()
         factory._managers["ctx"] = _CachedManager(manager=old_manager, created_at=0)
 
         new_manager = AsyncMock()
@@ -631,6 +632,8 @@ class TestGetManager:
         ):
             result = await factory.get_manager("ctx")
         assert result is new_manager
+        old_manager.shutdown.assert_awaited_once()
+
 
     @pytest.mark.asyncio
     async def test_get_manager_race_returns_cached_entry(self, factory):


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

Closes #5140

---

## 📝 Summary

_What does this PR do and why?_

When the plugin manager is reloaded, new plugin object are created. However, the plugins in the old manager are not shutdown and can create memory leak when multiple instances of the same plugin are started and never stopped.

This change call shutdown on the plugin manager that expired (not in use).

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |   ✅   |
| Unit tests                | `make test`     |   ✅   |
| Coverage ≥ 80%            | `make coverage` |   ✅   |

---

## ✅ Checklist

- [x] Code formatted (`make pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
