### PR TITLE
chore: migrate Rust server runtime images from debian:trixie-slim to ubi-minimal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-26T16:10:47Z",
+  "generated_at": "2026-06-26T19:31:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/a2a-agents/rust/a2a-echo-agent/Dockerfile
+++ b/a2a-agents/rust/a2a-echo-agent/Dockerfile
@@ -11,9 +11,9 @@ COPY mcp-servers/rust/slow-time-server ./mcp-servers/rust/slow-time-server
 COPY a2a-agents/rust/a2a-echo-agent ./a2a-agents/rust/a2a-echo-agent
 RUN cargo build --release -p a2a-echo-agent
 
-FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/* \
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app
 COPY --from=builder /app/target/release/a2a-echo-agent /app/a2a-echo-agent

--- a/mcp-servers/rust/benchmark-server/Containerfile
+++ b/mcp-servers/rust/benchmark-server/Containerfile
@@ -12,9 +12,9 @@ COPY mcp-servers/rust/benchmark-server/src ./mcp-servers/rust/benchmark-server/s
 RUN touch mcp-servers/rust/benchmark-server/src/main.rs \
     && cargo build --release -p benchmark-server
 
-FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/* \
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app
 COPY --from=builder /app/target/release/benchmark-server /app/benchmark-server

--- a/mcp-servers/rust/benchmark-server/Dockerfile
+++ b/mcp-servers/rust/benchmark-server/Dockerfile
@@ -12,9 +12,9 @@ COPY mcp-servers/rust/benchmark-server/src ./mcp-servers/rust/benchmark-server/s
 RUN touch mcp-servers/rust/benchmark-server/src/main.rs \
     && cargo build --release -p benchmark-server
 
-FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/* \
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app
 COPY --from=builder /app/target/release/benchmark-server /app/benchmark-server

--- a/mcp-servers/rust/fast-time-server/Containerfile
+++ b/mcp-servers/rust/fast-time-server/Containerfile
@@ -32,15 +32,12 @@ RUN touch src/main.rs && cargo build --release
 # =============================================================================
 # Runtime stage - Minimal distroless-like image
 # =============================================================================
-FROM docker.io/library/debian:trixie-slim
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
 
 # Install runtime deps (ca-certificates + curl for health checks) and create
 # the non-root mcpuser in a single layer.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean \
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all \
     && useradd -r -s /bin/false mcpuser
 
 WORKDIR /app

--- a/mcp-servers/rust/fast-time-server/Dockerfile
+++ b/mcp-servers/rust/fast-time-server/Dockerfile
@@ -25,12 +25,10 @@ COPY src ./src
 RUN touch src/main.rs && cargo build --release
 
 # Runtime stage - minimal image
-FROM docker.io/library/debian:trixie-slim
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all
 
 WORKDIR /app
 

--- a/mcp-servers/rust/slow-time-server/Containerfile
+++ b/mcp-servers/rust/slow-time-server/Containerfile
@@ -12,9 +12,9 @@ COPY mcp-servers/rust/slow-time-server/src ./mcp-servers/rust/slow-time-server/s
 RUN touch mcp-servers/rust/slow-time-server/src/main.rs \
     && cargo build --release -p slow-time-server
 
-FROM docker.io/library/debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/* \
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752
+RUN microdnf install -y ca-certificates curl shadow-utils \
+    && microdnf clean all \
     && useradd -r -s /bin/false mcpuser
 WORKDIR /app
 COPY --from=builder /app/target/release/slow-time-server /app/slow-time-server


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes https://github.com/IBM/mcp-context-forge/issues/5403

---

## 📝 Summary

Migrates the runtime stage of all Rust server container build files from `debian:trixie-slim` to `registry.access.redhat.com/ubi10/ubi-minimal:10.2-1777462752`.

Affected files:
- `a2a-agents/rust/a2a-echo-agent/Dockerfile`
- `mcp-servers/rust/benchmark-server/Dockerfile`
- `mcp-servers/rust/benchmark-server/Containerfile`
- `mcp-servers/rust/fast-time-server/Dockerfile`
- `mcp-servers/rust/fast-time-server/Containerfile`
- `mcp-servers/rust/slow-time-server/Containerfile`

The builder stages are unaffected — they remain on `rust:*-slim`. Only the runtime stages change. `apt-get` is replaced with `microdnf` and `shadow-utils` is added to provide `useradd`. Aligns them with the rest of the project (the main Containerfile, nginx, Go servers all already use UBI).

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| Build image | `docker build --no-cache -f a2a-agents/rust/a2a-echo-agent/Dockerfile .` | ✅ |
| Health endpoint | `curl -sf http://localhost:9199/health` | ✅ `{"name":"a2a-echo-agent","status":"healthy","version":"0.1.0"}` |
| Non-root user | `docker run --rm --entrypoint whoami <image>` | ✅ `mcpuser` |
| Lint suite | `make lint` | |
| Unit tests | `make test` | |
| Coverage ≥ 80% | `make coverage` | |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Will negate:
- [Internal issue](<https://github.ibm.com/contextforge-org/internal_issues/issues/56>)
- [Internal issue](<https://github.ibm.com/contextforge-org/internal_issues/issues/53>)