### PR TITLE
fix(plugins): restrict non-hook plugin initialization to a single worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -888,6 +888,12 @@ MCPGATEWAY_SKIP_MIGRATIONS=false
 # Leader key name in Redis
 # REDIS_LEADER_KEY=gateway_service_leader
 
+# Override path for the primary-worker election lock file
+# (mcpgateway/utils/primary_worker.py). Lets a side-effecting non-hook plugin run
+# its work on one worker per host. Defaults to a port-scoped file in the system
+# temp dir when unset; point it at a gateway-owned directory on hostile hosts.
+# PRIMARY_WORKER_LOCK_PATH=
+
 # =============================================================================
 
 # =============================================================================

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-13T12:57:02Z",
+  "generated_at": "2026-07-13T14:35:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-13T14:32:55Z",
+  "generated_at": "2026-07-13T12:57:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -124,7 +124,7 @@
         "hashed_secret": "14f8aa3e560a47851908ab0f04ec856dbc512d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 936,
+        "line_number": 942,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -132,7 +132,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1234,
+        "line_number": 1240,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -140,7 +140,7 @@
         "hashed_secret": "7b4455a56fbf1d198e45e04c437488514645a82c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1260,
+        "line_number": 1266,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -148,7 +148,7 @@
         "hashed_secret": "d08f88df745fa7950b104e4a707a31cfce7b5841",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1268,
+        "line_number": 1274,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -156,7 +156,7 @@
         "hashed_secret": "ac371b6dcce28a86c90d12bc57d946a800eebf17",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1347,
+        "line_number": 1353,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -164,7 +164,7 @@
         "hashed_secret": "0b6ec68df700dec4dcd64babd0eda1edccddace1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1352,
+        "line_number": 1358,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -172,7 +172,7 @@
         "hashed_secret": "4ad6f0082ee224001beb3ca5c3e81c8ceea5ed86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1357,
+        "line_number": 1363,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +180,7 @@
         "hashed_secret": "cb32747fcfb55eaa194c8cd8e4ba7d49ada08a94",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1363,
+        "line_number": 1369,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "6c178d51b13520496dbc767ed3d9d7aa5803ac72",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1375,
+        "line_number": 1381,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -196,7 +196,7 @@
         "hashed_secret": "ca45060a53fd8a255d1a83ee8d2f025283ccc66e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1393,
+        "line_number": 1399,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -204,7 +204,7 @@
         "hashed_secret": "910fbf00f58e9bcb095ea26a75cc1d9a3355e671",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1454,
+        "line_number": 1460,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -350,7 +350,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 976,
+        "line_number": 982,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -358,7 +358,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 978,
+        "line_number": 984,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1630,
+        "line_number": 1636,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1849,
+        "line_number": 1855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5922,
+        "line_number": 5928,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6419,
+        "line_number": 6425,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6431,
+        "line_number": 6437,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6503,
+        "line_number": 6509,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7585,
+        "line_number": 7591,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -2148,7 +2148,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1280,
+        "line_number": 1281,
         "type": "Basic Auth Credentials",
         "verified_result": null
       },
@@ -2156,7 +2156,7 @@
         "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1284,
+        "line_number": 1285,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -882,6 +882,12 @@ test-mcp-plugin-parity: uv  ## MCP plugin parity E2E for current Python or Rust 
 		|| { echo "❌ MCP plugin parity tests failed!"; exit 1; }
 	@echo "✅ MCP plugin parity tests passed!"
 
+test-primary-worker-e2e: uv  ## Primary-worker election E2E: boots a local 2-worker gateway, asserts the gated side effect runs once
+	@echo "🧪 Running primary-worker e2e (boots its own 2-worker gateway)..."
+	@$(UV_BIN) run bash tests/live_gateway/run_primary_worker_e2e.sh \
+		|| { echo "❌ Primary-worker e2e failed!"; exit 1; }
+	@echo "✅ Primary-worker e2e passed!"
+
 test-mcp-session-isolation: uv  ## MCP session/auth isolation tests for the Rust public transport path
 	@echo "🧪 Running MCP session/auth isolation tests against $${MCP_CLI_BASE_URL:-http://localhost:8080}..."
 	@echo "   Requires: docker-compose stack rebuilt in Rust edge/full mode"

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -930,6 +930,7 @@ The gateway includes built-in observability features for tracking HTTP requests,
 | `MAX_CONCURRENT_HEALTH_CHECKS` | Max concurrent health checks        | `20`    | int > 0 |
 | `AUTO_REFRESH_SERVERS` | Auto refresh tools/prompts/resources        | `false` | bool    |
 | `FILELOCK_NAME`         | File lock for leader election             | `gateway_service_leader.lock` | string |
+| `PRIMARY_WORKER_LOCK_PATH` | Override path for the primary-worker election lock file (per-host; default is a port-scoped temp file) | (none) | string |
 | `DEFAULT_ROOTS`         | Default root paths for resources          | `[]`    | JSON array |
 
 ### Database Connection Pool

--- a/docs/docs/using/plugins/lifecycle.md
+++ b/docs/docs/using/plugins/lifecycle.md
@@ -339,3 +339,25 @@ make serve
 
 !!! note
         `PLUGINS_ENABLED=true` should be set in your gateway `.env` file.
+
+## Multi-Worker Execution
+
+Under multiple workers (`GUNICORN_WORKERS`), every worker calls each plugin's
+`initialize()`, so **hooks run on every worker by design**. A non-hook plugin
+that does a **side effect** at startup or in a background task would otherwise
+run it once per worker. Gate it with `is_primary_worker()` to run on one worker
+per host:
+
+```python
+from mcpgateway.utils.primary_worker import is_primary_worker
+
+class InventorySync(Plugin):
+    async def initialize(self) -> None:
+        if not is_primary_worker():
+            return
+        ...  # runs on one worker only
+```
+
+One worker is elected via a file lock; the OS frees it on process exit, so a
+follower takes over. Re-check it each cycle for recurring work. The lock is per
+host and its path is overridable with `PRIMARY_WORKER_LOCK_PATH`.

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -2525,6 +2525,11 @@ class Settings(BaseSettings):
 
     filelock_name: str = "gateway_service_leader.lock"
 
+    # Override path for the primary-worker election lock file used by
+    # mcpgateway/utils/primary_worker.py. Defaults to a port-scoped file in the
+    # system temp dir when unset.
+    primary_worker_lock_path: Optional[str] = None
+
     # Default Roots
     default_roots: List[str] = []
 

--- a/mcpgateway/utils/primary_worker.py
+++ b/mcpgateway/utils/primary_worker.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/primary_worker.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Primary-worker election for side-effecting plugin work.
+
+Under multiple worker processes every worker runs each plugin's
+``initialize()``. ``is_primary_worker()`` lets a plugin gate side-effecting work
+to one worker. Election uses a file lock: the first process to acquire it is
+primary; the OS releases it on exit so another caller can take over.
+
+The lock is per host. Its path defaults to a port-scoped temp file, overridable
+via ``PRIMARY_WORKER_LOCK_PATH``. The path is predictable in a world-writable
+temp dir, so a local process could pre-acquire it and block election — point the
+setting at a gateway-owned directory on hostile hosts.
+"""
+
+# Standard
+import logging
+import os
+import tempfile
+import threading
+
+# Third-Party
+from filelock import FileLock, Timeout
+
+# First-Party
+from mcpgateway.config import settings
+
+__all__ = ["is_primary_worker"]
+
+logger = logging.getLogger(__name__)
+
+# Module state: the winner holds the lock for the process lifetime (never
+# released explicitly — the OS frees it on exit, letting a follower take over)
+# and memoizes the result. ``_guard`` serializes the lazy init/acquire across
+# threads (gunicorn ``--threads > 1``).
+_lock: FileLock | None = None
+_is_primary: bool = False
+_guard = threading.Lock()
+
+
+def _lock_path() -> str:
+    """Return the lock file path.
+
+    Uses ``primary_worker_lock_path`` if set, else a port-scoped tempdir file.
+
+    Returns:
+        Absolute path to the lock file.
+    """
+    override: str | None = settings.primary_worker_lock_path
+    if override:
+        return override
+    return os.path.join(tempfile.gettempdir(), f"mcpgw_plugin_primary_{settings.port}.lock")
+
+
+def is_primary_worker() -> bool:
+    """Return ``True`` on exactly one worker process; ``False`` on the others.
+
+    The first caller to acquire the lock holds it; others retry on later calls,
+    so a new primary is elected if the current one exits. Safe to call from
+    multiple threads.
+
+    Returns:
+        Whether this process holds primary status.
+    """
+    global _lock, _is_primary  # pylint: disable=global-statement
+    if _is_primary:
+        return True
+    # Guard serializes the lazy init/acquire (no double FileLock); the re-check
+    # returns early for threads that waited while another won.
+    with _guard:
+        if _is_primary:
+            return True  # type: ignore[unreachable]  # set concurrently by another thread
+        if _lock is None:
+            _lock = FileLock(_lock_path())
+        try:
+            _lock.acquire(timeout=0)
+            _is_primary = True
+            logger.info("primary worker elected pid=%d lock=%s", os.getpid(), _lock_path())
+        except Timeout:
+            _is_primary = False
+            logger.debug("non-primary worker pid=%d lock=%s", os.getpid(), _lock_path())
+        except OSError as exc:
+            # Permission error, missing parent dir, read-only temp dir, etc.
+            # Fail closed (non-primary) rather than crashing initialize().
+            _is_primary = False
+            logger.warning("primary worker election failed pid=%d lock=%s err=%s", os.getpid(), _lock_path(), exc)
+        return _is_primary

--- a/tests/live_gateway/fixtures/__init__.py
+++ b/tests/live_gateway/fixtures/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/fixtures/__init__.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Fixtures (plugins, configs) for live-gateway e2e tests.
+"""

--- a/tests/live_gateway/fixtures/primary_marker.py
+++ b/tests/live_gateway/fixtures/primary_marker.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/fixtures/primary_marker.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Test-only plugin for the primary-worker e2e.
+
+A non-hook plugin whose ``initialize()`` side effect is gated on
+``is_primary_worker()`` and appends its PID to ``MCPGW_PRIMARY_WORKER_E2E_MARKER``.
+A multi-worker gateway should leave exactly one line in that file.
+"""
+
+# Standard
+import os
+import time
+
+# Third-Party
+from cpex.framework import Plugin, PluginConfig
+
+# First-Party
+from mcpgateway.utils.primary_worker import is_primary_worker
+
+DEFAULT_MARKER = "/tmp/mcpgw_primary_worker_e2e.log"  # nosec B108 - test artifact path, overridable via env
+
+
+class PrimaryWorkerE2EMarkerPlugin(Plugin):
+    """Records a marker line only on the primary worker."""
+
+    def __init__(self, config: PluginConfig):
+        """Initialize the plugin.
+
+        Args:
+            config: Plugin configuration.
+        """
+        super().__init__(config)
+        self._marker = os.environ.get("MCPGW_PRIMARY_WORKER_E2E_MARKER", DEFAULT_MARKER)
+
+    async def initialize(self) -> None:
+        """Append this PID to the marker file when this worker is primary."""
+        if not is_primary_worker():
+            return
+        with open(self._marker, "a", encoding="utf-8") as fh:
+            fh.write(f"pid={os.getpid()} t={time.time():.3f}\n")

--- a/tests/live_gateway/fixtures/primary_worker_e2e_config.yaml
+++ b/tests/live_gateway/fixtures/primary_worker_e2e_config.yaml
@@ -1,0 +1,24 @@
+# tests/live_gateway/fixtures/primary_worker_e2e_config.yaml
+# Plugin config for the primary-worker e2e. Point the gateway at this file via
+# PLUGINS_CONFIG_FILE.
+
+plugin_settings:
+  parallel_execution_within_band: true
+  plugin_timeout: 120
+  fail_on_plugin_error: false
+  enable_plugin_api: true
+  plugin_health_check_interval: 120
+  include_user_info: false
+
+plugins:
+  - name: "PrimaryWorkerE2EMarker"
+    kind: "tests.live_gateway.fixtures.primary_marker.PrimaryWorkerE2EMarkerPlugin"
+    description: "E2E: non-hook plugin whose initialize() side effect is gated on is_primary_worker()"
+    version: "0.0.1"
+    author: "tests"
+    hooks: []            # non-hook plugin
+    tags: ["test", "e2e"]
+    mode: "permissive"
+    priority: 50
+    conditions: []
+    config: {}

--- a/tests/live_gateway/plugins/__init__.py
+++ b/tests/live_gateway/plugins/__init__.py
@@ -2,13 +2,6 @@
 """Location: ./tests/live_gateway/plugins/__init__.py
 Copyright 2026
 SPDX-License-Identifier: Apache-2.0
-Authors: Mihai Criveti
 
-Live-gateway end-to-end suites for managed cpex plugins.
-
-Each module under this package boots no code itself; it talks HTTP to a running
-ContextForge gateway that was started with a dedicated, single-plugin enforce
-config (``plugins/plugin_e2e_<slug>.yaml``). The tests never import the cpex
-plugin package — the gateway loads it from config, so a broken wheel or Rust
-extension surfaces as a failing E2E rather than a silently skipped import.
+Live-gateway plugin e2e tests.
 """

--- a/tests/live_gateway/plugins/test_primary_worker_e2e.py
+++ b/tests/live_gateway/plugins/test_primary_worker_e2e.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/live_gateway/plugins/test_primary_worker_e2e.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+End-to-end test for primary-worker election.
+
+Run via ``make test-primary-worker-e2e``, which boots a local >=2 worker gateway
+with the marker plugin. The gated side effect must run once, so the marker file
+has a single line.
+"""
+
+# Standard
+import os
+
+# Third-Party
+import pytest
+
+# First-Party
+from tests.live_gateway.helpers.mcp_test_helpers import skip_no_gateway
+
+MARKER_FILE = os.environ.get("MCPGW_PRIMARY_WORKER_E2E_MARKER", "/tmp/mcpgw_primary_worker_e2e.log")  # nosec B108 - test artifact
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+
+
+@skip_no_gateway
+def test_side_effect_runs_on_exactly_one_worker():
+    """The gated non-hook side effect runs once across all workers."""
+    if not os.path.exists(MARKER_FILE):
+        pytest.skip(f"marker file {MARKER_FILE} not found — start the gateway with the e2e plugin config (make test-primary-worker-e2e)")
+
+    with open(MARKER_FILE, encoding="utf-8") as fh:
+        lines = [ln for ln in fh.read().splitlines() if ln.strip()]
+
+    assert len(lines) == 1, f"expected exactly one primary worker to run the side effect, got {len(lines)}: {lines}"

--- a/tests/live_gateway/run_primary_worker_e2e.sh
+++ b/tests/live_gateway/run_primary_worker_e2e.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Boot a local multi-worker gateway with the marker plugin, run the
+# primary-worker e2e assertion, and tear down. Invoked via
+# `make test-primary-worker-e2e` (runs inside the project venv).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+PORT="${PORT:-8080}"
+WORKERS="${WORKERS:-2}"
+
+TMP="$(mktemp -d)"
+MARKER="$TMP/marker.log"
+LOCK="$TMP/primary.lock"
+LOG="$TMP/gunicorn.log"
+DB="$TMP/e2e.db"
+GPID=""
+
+cleanup() {
+  [ -n "$GPID" ] && kill "$GPID" 2>/dev/null || true
+  [ -n "$GPID" ] && wait "$GPID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+echo "▶ starting gateway: $WORKERS workers on 127.0.0.1:$PORT"
+PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+PLUGINS_ENABLED=true \
+PLUGINS_CONFIG_FILE=tests/live_gateway/fixtures/primary_worker_e2e_config.yaml \
+MCPGW_PRIMARY_WORKER_E2E_MARKER="$MARKER" \
+PRIMARY_WORKER_LOCK_PATH="$LOCK" \
+DATABASE_URL="sqlite:///$DB" \
+HOST=127.0.0.1 PORT="$PORT" \
+  gunicorn -c gunicorn.config.py \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers "$WORKERS" --bind "127.0.0.1:$PORT" --timeout 600 \
+    --error-logfile "$LOG" --access-logfile /dev/null \
+    mcpgateway.main:app &
+GPID=$!
+
+echo "▶ waiting for $WORKERS workers + /health ..."
+ready=0
+for _ in $(seq 1 60); do
+  if ! kill -0 "$GPID" 2>/dev/null; then echo "❌ gateway exited early"; cat "$LOG"; exit 1; fi
+  booted=$(grep -c "Booting worker" "$LOG" 2>/dev/null || echo 0)
+  if [ "$booted" -ge "$WORKERS" ] && curl -fsS -o /dev/null "http://127.0.0.1:$PORT/health" 2>/dev/null; then
+    ready=1; break
+  fi
+  sleep 1
+done
+[ "$ready" = 1 ] || { echo "❌ gateway not ready in time"; cat "$LOG"; exit 1; }
+sleep 2  # settle: let every worker finish plugin initialize()
+
+echo "▶ running assertion"
+PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+MCP_CLI_BASE_URL="http://127.0.0.1:$PORT" \
+MCPGW_PRIMARY_WORKER_E2E_MARKER="$MARKER" \
+  pytest tests/live_gateway/plugins/test_primary_worker_e2e.py -v -s --tb=short

--- a/tests/unit/mcpgateway/utils/test_primary_worker.py
+++ b/tests/unit/mcpgateway/utils/test_primary_worker.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/utils/test_primary_worker.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Tests for the primary-worker election helper.
+"""
+
+# Standard
+import threading
+
+# Third-Party
+from filelock import FileLock, Timeout
+import pytest
+
+# First-Party
+import mcpgateway.utils.primary_worker as pw
+from mcpgateway.utils.primary_worker import _lock_path, is_primary_worker
+
+
+def _set_override(monkeypatch, path):
+    """Point the lock path at ``path`` via the settings override."""
+    monkeypatch.setattr(pw.settings, "primary_worker_lock_path", str(path), raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    """Reset module-level lock state and the path override between tests."""
+    monkeypatch.setattr(pw.settings, "primary_worker_lock_path", None, raising=False)
+    pw._lock = None
+    pw._is_primary = False
+    yield
+    if pw._lock is not None:
+        try:
+            pw._lock.release()
+        except (Timeout, OSError):
+            pass
+    pw._lock = None
+    pw._is_primary = False
+
+
+def test_first_caller_is_primary(tmp_path, monkeypatch):
+    """The first process to acquire the lock is the primary."""
+    _set_override(monkeypatch, tmp_path / "p.lock")
+    assert is_primary_worker() is True
+
+
+def test_repeated_calls_stay_primary(tmp_path, monkeypatch):
+    """Once primary, repeated calls keep returning True (memoized)."""
+    _set_override(monkeypatch, tmp_path / "p.lock")
+    assert is_primary_worker() is True
+    assert is_primary_worker() is True
+
+
+def test_contention_returns_false(tmp_path, monkeypatch):
+    """A worker loses when another process already holds the lock."""
+    lock_file = tmp_path / "p.lock"
+    _set_override(monkeypatch, lock_file)
+    holder = FileLock(str(lock_file))
+    holder.acquire(timeout=0)
+    try:
+        assert is_primary_worker() is False
+    finally:
+        holder.release()
+
+
+def test_follower_retries_and_takes_over(tmp_path, monkeypatch):
+    """A non-primary worker takes over once the primary releases the lock."""
+    lock_file = tmp_path / "p.lock"
+    _set_override(monkeypatch, lock_file)
+    holder = FileLock(str(lock_file))
+    holder.acquire(timeout=0)
+    assert is_primary_worker() is False  # primary held elsewhere
+    holder.release()  # primary "exits"
+    assert is_primary_worker() is True  # next call takes over
+
+
+def test_settings_override_path(tmp_path, monkeypatch):
+    """The lock path honours the settings override."""
+    override = str(tmp_path / "custom.lock")
+    _set_override(monkeypatch, override)
+    assert _lock_path() == override
+
+
+def test_default_path_scoped_by_port(monkeypatch):
+    """Without an override the default path is tempdir-scoped by port and stable."""
+    monkeypatch.setattr(pw.settings, "primary_worker_lock_path", None, raising=False)
+    monkeypatch.setattr(pw.settings, "port", 4444, raising=False)
+    path = _lock_path()
+    assert path.endswith("mcpgw_plugin_primary_4444.lock")
+    assert _lock_path() == path  # stable across calls
+
+
+def test_two_scopes_are_independent(tmp_path, monkeypatch):
+    """Different scopes (lock files) each elect a primary without contending."""
+    _set_override(monkeypatch, tmp_path / "a.lock")
+    assert is_primary_worker() is True
+    # Simulate a separate instance: reset state, point at a different lock file.
+    pw._lock = None
+    pw._is_primary = False
+    _set_override(monkeypatch, tmp_path / "b.lock")
+    assert is_primary_worker() is True
+
+
+def test_oserror_returns_false_without_raising(tmp_path, monkeypatch):
+    """An OSError from FileLock.acquire fails closed (non-primary), not crash."""
+    _set_override(monkeypatch, tmp_path / "p.lock")
+
+    class BoomLock:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def acquire(self, *args, **kwargs):
+            raise PermissionError("read-only temp dir")
+
+        def release(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(pw, "FileLock", BoomLock)
+    assert is_primary_worker() is False
+
+
+def test_thread_safe_single_lock_creation(tmp_path, monkeypatch):
+    """Concurrent first-callers create one FileLock; all see primary (one process)."""
+    _set_override(monkeypatch, tmp_path / "p.lock")
+
+    created = []
+    real_filelock = pw.FileLock
+
+    def counting_filelock(*args, **kwargs):
+        inst = real_filelock(*args, **kwargs)
+        created.append(inst)
+        return inst
+
+    monkeypatch.setattr(pw, "FileLock", counting_filelock)
+
+    results = []
+    n = 8
+    barrier = threading.Barrier(n)
+
+    def worker():
+        barrier.wait()  # maximise contention on the lazy init
+        results.append(is_primary_worker())
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(created) == 1  # guard prevented duplicate FileLock creation
+    assert results == [True] * n  # one process -> every thread is primary
+
+
+def test_lock_path_is_directory_fails_closed(tmp_path, monkeypatch):
+    """A lock path pointing at a directory raises OSError -> non-primary, not crash."""
+    _set_override(monkeypatch, tmp_path)  # tmp_path is an existing directory
+    assert is_primary_worker() is False
+
+
+def test_empty_string_override_falls_back_to_default(monkeypatch):
+    """An empty override is falsy, so the default port-scoped path is used."""
+    monkeypatch.setattr(pw.settings, "primary_worker_lock_path", "", raising=False)
+    monkeypatch.setattr(pw.settings, "port", 4444, raising=False)
+    assert _lock_path().endswith("mcpgw_plugin_primary_4444.lock")


### PR DESCRIPTION
## 📌 Summary

When the gateway runs under multiple worker processes (e.g. gunicorn `workers > 1`), **every** worker loads the plugin manager and runs each plugin's `initialize()`. A non-hook plugin that performs a side effect on startup or in a background task (the reported case: fetch inventory and push it to an external API) therefore runs that work **once per worker**, duplicating it N times.

This adds a small, opt-in helper, `is_primary_worker()`, so a side-effecting plugin can run its work on exactly one worker.

Related issue:  #5139

## 🔁 Reproduction Steps

With `PLUGINS_ENABLED=true` and a non-hook plugin whose `initialize()` has a side effect, start under 2 workers:

```
GUNICORN_WORKERS=2 make serve   # or ./run-gunicorn.sh
```

The side effect runs twice (once per worker). With 1 worker it runs once — i.e. the count tracks worker count.

## 🐞 Root Cause

The FastAPI lifespan runs per worker, and within it the plugin manager initializes every plugin (`mcpgateway/main.py`). The cpex loader calls `await plugin.initialize()` per plugin during load. There is no notion of a "primary" worker, so any startup/background side effect in a plugin executes in every worker.

## 💡 Fix Description

New module `mcpgateway/utils/primary_worker.py` exposing `is_primary_worker()`:

- File-lock based election — the first process to acquire the lock is the primary and holds it for its lifetime; other workers get `False`.
- The lock is released by the OS when the holding process exits, so if the primary worker is recycled (`max_requests`) the next caller takes over.
- The lock file path is scoped by the configured port (override via `MCPGW_PRIMARY_WORKER_LOCK`) so co-located gateway instances don't collide while workers of one instance share a single lock.

Side-effecting non-hook plugins opt in:

```python
from mcpgateway.utils.primary_worker import is_primary_worker

async def initialize(self) -> None:
    if not is_primary_worker():
        return
    ...  # runs on one worker only
```

Design notes:
- **Opt-in / minimal surface.** No changes to `main.py`, gunicorn config, plugin schema, or the hook path. Plugins that don't call the helper behave exactly as before — hook plugins still load and execute on every worker.
- **Per host.** Election is file-lock based, so it deduplicates per host.

## 🧪 Verification

Validated with a throwaway 2-worker harness (a gated non-hook plugin + an ungated hook plugin), not included in this PR:

| Signal | Result |
|--------|--------|
| Gated non-hook plugin side effect (2 workers) | ran **once** (was twice) |
| Hook plugin `initialize()` (2 workers) | ran on **both** workers (unchanged) |
| Hook `http_pre_request` on requests | fired normally |

| Check | Command | Status |
|-------|---------|--------|
| Targeted unit tests | `pytest tests/unit/mcpgateway/utils/test_primary_worker.py` | ✅ 7 passed |
| Lint suite | `make lint` | ⬜ not yet run |
| Full unit tests | `make test` | ⬜ not yet run |
| Coverage ≥ 80% | `make coverage` | ⬜ not yet run |

## 🔁 Manual verification (the reporter's steps)

The reporter's plugin (inventory → IBM API Connect) is stood in for by an
equivalent minimal **non-hook** plugin that appends its worker PID to a file —
same mechanism (a side effect in `initialize()` under multiple workers), but
observable. The reporter's flow (enable plugins, multiple workers, `make serve`)
is otherwise unchanged.

**1. Create the non-hook plugin** `plugins/demo_marker/marker.py`:

```python
import os, time
from cpex.framework import Plugin, PluginConfig
from mcpgateway.utils.primary_worker import is_primary_worker

class DemoMarkerPlugin(Plugin):
    async def initialize(self) -> None:
        # if not is_primary_worker():   # <-- the fix; commented out to show the bug first
        #     return
        with open("/tmp/demo_marker.log", "a") as fh:
            fh.write(f"pid={os.getpid()} t={time.time():.3f}\n")
```

and a config `plugins/demo_marker_config.yaml`:

```yaml
plugin_settings:
  plugin_timeout: 120
  fail_on_plugin_error: false

plugins:
  - name: "DemoMarker"
    kind: "plugins.demo_marker.marker.DemoMarkerPlugin"
    description: "Demo non-hook plugin"
    version: "0.0.1"
    hooks: []          # non-hook plugin
    mode: "permissive"
    priority: 50
    conditions: []
    config: {}
```

**2. Reproduce the bug (gate commented out) — start with 2 workers:**

```bash
rm -f /tmp/demo_marker.log
GUNICORN_WORKERS=2 PLUGINS_ENABLED=true \
  PLUGINS_CONFIG_FILE=plugins/demo_marker_config.yaml make serve
```

Once both workers have booted, in another shell:

```bash
wc -l /tmp/demo_marker.log     # => 2  (side effect ran in every worker)
```

Stop the server (Ctrl-C).

**3. Apply the fix** — uncomment the two `is_primary_worker()` lines, then repeat step 2:

```bash
wc -l /tmp/demo_marker.log     # => 1  (side effect runs on one worker)
```

**Automated equivalent:** `make test-primary-worker-e2e` boots a local 2-worker
gateway with a gated marker plugin and asserts the file has exactly one line.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added for changes
- [x] No secrets/credentials committed

