### PR TITLE
feat(elicitation): add URL-mode elicitation passthrough (SEP-1036)

### DIFF
--- a/mcpgateway/cache/session_registry.py
+++ b/mcpgateway/cache/session_registry.py
@@ -2226,31 +2226,61 @@ class SessionRegistry(SessionBackend):
         async with self._lock:
             return self._client_capabilities.get(session_id)
 
-    async def has_elicitation_capability(self, session_id: str) -> bool:
+    @staticmethod
+    def _capabilities_support_elicitation(capabilities: Optional[Dict[str, Any]], mode: Optional[str]) -> bool:
+        """Return whether a client capabilities dict supports elicitation (optionally a mode).
+
+        Args:
+            capabilities: Stored client capabilities dictionary (or None)
+            mode: Optional elicitation mode to require ("form" or "url", per SEP-1036)
+
+        Returns:
+            True if the requested elicitation capability is supported, else False
+        """
+        if not capabilities:
+            return False
+        elicitation = capabilities.get("elicitation")
+        if mode is None:
+            # Preserve legacy behaviour: any truthy elicitation declaration counts.
+            return bool(elicitation)
+        if not elicitation:
+            return False
+        # Explicit SEP-1036 sub-capabilities take precedence when present.
+        if isinstance(elicitation, dict) and ("form" in elicitation or "url" in elicitation):
+            return elicitation.get(mode) is not None
+        # Legacy declaration without sub-capabilities: form mode only.
+        return mode == "form"
+
+    async def has_elicitation_capability(self, session_id: str, mode: Optional[str] = None) -> bool:
         """Check if a session has elicitation capability.
 
         Args:
             session_id: The session ID
+            mode: Optional elicitation mode to require ("form" or "url", per SEP-1036).
+                When None, returns True if the client declares any elicitation
+                support. When a mode is given, the client must declare that specific
+                sub-capability; a legacy bare declaration (e.g. ``{}`` or ``True``)
+                without explicit ``form``/``url`` keys is treated as form-mode only.
 
         Returns:
-            True if session supports elicitation, False otherwise
+            True if session supports the requested elicitation capability, else False
         """
         capabilities = await self.get_client_capabilities(session_id)
-        if not capabilities:
-            return False
-        # Check if elicitation capability exists in client capabilities
-        return bool(capabilities.get("elicitation"))
+        return self._capabilities_support_elicitation(capabilities, mode)
 
-    async def get_elicitation_capable_sessions(self) -> list[str]:
+    async def get_elicitation_capable_sessions(self, mode: Optional[str] = None) -> list[str]:
         """Get list of session IDs that support elicitation.
 
+        Args:
+            mode: Optional elicitation mode to require ("form" or "url", per SEP-1036).
+
         Returns:
-            List of session IDs with elicitation capability
+            List of session IDs with the requested elicitation capability
         """
         async with self._lock:
             capable_sessions = []
             for session_id, capabilities in self._client_capabilities.items():
-                if capabilities.get("elicitation"):
+                if self._capabilities_support_elicitation(capabilities, mode):
                     # Verify session still exists
                     if session_id in self._sessions:
                         capable_sessions.append(session_id)

--- a/mcpgateway/common/models.py
+++ b/mcpgateway/common/models.py
@@ -785,29 +785,72 @@ class ListResourceTemplatesResult(BaseModel):
     )
 
 
-# Elicitation types (MCP 2025-06-18)
-class ElicitationCapability(BaseModelWithConfigDict):
-    """Client capability for elicitation operations (MCP 2025-06-18).
+# Elicitation types (form mode: MCP 2025-06-18; URL mode: SEP-1036, MCP 2025-11-25)
 
-    Per MCP spec: Clients that support elicitation MUST declare this capability
-    during initialization. Elicitation allows servers to request structured
-    information from users through the client during interactive workflows.
+# JSON-RPC error code returned by a server when a request cannot proceed until one
+# or more URL-mode elicitations are completed (SEP-1036 "URLElicitationRequiredError").
+URL_ELICITATION_REQUIRED = -32042
 
-    Example:
-        {"capabilities": {"elicitation": {}}}
+
+class FormElicitationCapability(BaseModelWithConfigDict):
+    """Client sub-capability indicating support for form-mode elicitation.
+
+    Present (as ``{}``) inside the ``elicitation`` capability when the client can
+    render in-band structured-input forms (SEP-1036).
     """
 
-    # Empty object per MCP spec, follows MCP SDK pattern
+    model_config = ConfigDict(extra="allow")
+
+
+class UrlElicitationCapability(BaseModelWithConfigDict):
+    """Client sub-capability indicating support for URL-mode elicitation.
+
+    Present (as ``{}``) inside the ``elicitation`` capability when the client can
+    direct the user to an external URL for out-of-band interactions such as OAuth,
+    credential collection, or payments (SEP-1036).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ElicitationCapability(BaseModelWithConfigDict):
+    """Client capability for elicitation operations.
+
+    Per MCP spec, clients that support elicitation MUST declare this capability
+    during initialization. Elicitation allows servers to request information from
+    users through the client during interactive workflows.
+
+    Form mode (MCP 2025-06-18) was the only mode originally; SEP-1036 (MCP
+    2025-11-25) added URL mode and split the capability into ``form`` and ``url``
+    sub-capabilities. A client MUST support at least one mode. For backwards
+    compatibility, a bare ``{}`` (or any value lacking explicit sub-capabilities)
+    is treated as form-mode support.
+
+    Attributes:
+        form (Optional[FormElicitationCapability]): Present when the client supports
+                        form-mode elicitation (MCP 2025-06-18). None if not advertised.
+        url (Optional[UrlElicitationCapability]): Present when the client supports
+                        URL-mode elicitation (SEP-1036). None if not advertised.
+
+    Example:
+        {"capabilities": {"elicitation": {"form": {}, "url": {}}}}
+    """
+
+    form: Optional[FormElicitationCapability] = None
+    url: Optional[UrlElicitationCapability] = None
+
+    # extra="allow" keeps the legacy empty-object ({}) declaration valid.
     model_config = ConfigDict(extra="allow")
 
 
 class ElicitRequestParams(BaseModelWithConfigDict):
-    """Parameters for elicitation/create requests (MCP spec-compliant).
+    """Parameters for form-mode ``elicitation/create`` requests (MCP 2025-06-18).
 
-    Elicitation requests allow servers to ask for user input with a structured
-    schema. The schema is restricted to flat objects with primitive types only.
+    Form-mode elicitation asks for user input with a structured schema. The schema
+    is restricted to flat objects with primitive types only.
 
     Attributes:
+        mode: Always "form" for this type (the default elicitation mode).
         message: Human-readable message to present to user
         requestedSchema: JSON Schema defining expected response structure.
                         Per MCP spec, must be type 'object' with primitive properties only:
@@ -831,8 +874,70 @@ class ElicitRequestParams(BaseModelWithConfigDict):
         }
     """
 
+    mode: Literal["form"] = "form"
     message: str
     requestedSchema: Dict[str, Any]  # JSON Schema (validated by ElicitationService)  # noqa: N815 (MCP spec requires camelCase)
+    model_config = ConfigDict(extra="allow")
+
+
+class ElicitRequestURLParams(BaseModelWithConfigDict):
+    """Parameters for URL-mode ``elicitation/create`` requests (SEP-1036).
+
+    URL mode directs the user to an external URL for sensitive out-of-band
+    interactions (OAuth flows, credential collection, payments). No schema is
+    requested; the client obtains consent to navigate and the server signals
+    completion via a ``notifications/elicitation/complete`` notification.
+
+    Attributes:
+        mode: Always "url" for this type.
+        message: Human-readable message explaining why the interaction is needed.
+        url: The URL the user should navigate to.
+        elicitationId: Server-unique, opaque identifier correlating the request,
+                       the client's consent response, and the later completion
+                       notification.
+
+    Example:
+        {
+            "mode": "url",
+            "message": "Sign in with your provider to continue",
+            "url": "https://auth.example.com/authorize?...",
+            "elicitationId": "elc_01H..."
+        }
+    """
+
+    mode: Literal["url"] = "url"
+    message: str
+    url: str
+    elicitationId: str  # noqa: N815 (MCP spec requires camelCase)
+    model_config = ConfigDict(extra="allow")
+
+
+class ElicitationRequiredErrorData(BaseModelWithConfigDict):
+    """Error ``data`` payload for a URLElicitationRequiredError (code -32042).
+
+    Returned by a server when a request cannot be processed until one or more
+    URL-mode elicitations are completed (SEP-1036). The gateway forwards this
+    payload through to the originating client unchanged.
+
+    Attributes:
+        elicitations: The URL-mode elicitations that must be completed first.
+    """
+
+    elicitations: List[ElicitRequestURLParams]
+    model_config = ConfigDict(extra="allow")
+
+
+class ElicitCompleteNotificationParams(BaseModelWithConfigDict):
+    """Params for a ``notifications/elicitation/complete`` notification (SEP-1036).
+
+    Sent server→client to inform it that a URL-mode elicitation has completed, so
+    the client may retry a request that previously received a -32042 error.
+
+    Attributes:
+        elicitationId: Identifier of the elicitation that was completed.
+    """
+
+    elicitationId: str  # noqa: N815 (MCP spec requires camelCase)
     model_config = ConfigDict(extra="allow")
 
 
@@ -841,22 +946,28 @@ class ElicitResult(BaseModelWithConfigDict):
 
     The MCP specification defines three distinct user actions to differentiate
     between explicit approval, explicit rejection, and dismissal without choice.
+    The same three-action model applies to both form and URL modes; in URL mode
+    "accept" means the user consented to navigate and ``content`` is omitted.
 
     Attributes:
         action: User's response action:
                 - "accept": User explicitly approved and submitted data
-                             (content field MUST be populated)
+                             (form mode: content populated; URL mode: consent given)
                 - "decline": User explicitly declined the request
                              (content typically None/omitted)
                 - "cancel": User dismissed without making an explicit choice
                             (content typically None/omitted)
         content: Submitted form data matching requestedSchema.
-                Only present when action is "accept".
-                Contains primitive values: str, int, float, bool, or None.
+                Only present when action is "accept" in form mode. Contains
+                primitive values: str, int, float, bool, list[str], or None.
+                Omitted for URL mode.
 
     Examples:
-        Accept response:
+        Accept response (form):
             {"action": "accept", "content": {"name": "John", "email": "john@example.com"}}
+
+        Accept response (url consent):
+            {"action": "accept"}
 
         Decline response:
             {"action": "decline"}
@@ -866,7 +977,7 @@ class ElicitResult(BaseModelWithConfigDict):
     """
 
     action: Literal["accept", "decline", "cancel"]
-    content: Optional[Dict[str, Union[str, int, float, bool, None]]] = None
+    content: Optional[Dict[str, Union[str, int, float, bool, List[str], None]]] = None
     model_config = ConfigDict(extra="allow")
 
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -1161,10 +1161,17 @@ class Settings(BaseSettings):
     mcpgateway_bootstrap_roles_in_db_enabled: bool = Field(default=False, description="Enable ContextForge add additional roles in db")
     mcpgateway_bootstrap_roles_in_db_file: str = Field(default="additional_roles_in_db.json", description="Path to add additional roles in db")
 
-    # Elicitation support (MCP 2025-06-18)
+    # Elicitation support (form mode: MCP 2025-06-18; URL mode: SEP-1036, MCP 2025-11-25)
     mcpgateway_elicitation_enabled: bool = Field(default=True, description="Enable elicitation passthrough support (MCP 2025-06-18)")
     mcpgateway_elicitation_timeout: int = Field(default=60, description="Default timeout for elicitation requests in seconds")
     mcpgateway_elicitation_max_concurrent: int = Field(default=100, description="Maximum concurrent elicitation requests")
+    # URL-mode elicitation (SEP-1036; out-of-band flows: OAuth, payments, credential collection)
+    mcpgateway_elicitation_url_mode_enabled: bool = Field(
+        default=True, description="Enable URL-mode elicitation passthrough (mode='url', SEP-1036). When false, URL-mode elicitation/create requests are rejected."
+    )
+    mcpgateway_elicitation_url_require_https: bool = Field(
+        default=True, description="Require URL-mode elicitation URLs to use https:// (SEP-1036 security guidance; rejects non-HTTPS URLs to prevent insecure out-of-band flows)."
+    )
 
     # Security
     skip_ssl_verify: bool = Field(

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -10892,6 +10892,31 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
                 params.get("logger"),
             )
             result = {}
+        elif method == "notifications/elicitation/complete":
+            # SEP-1036: server signals a URL-mode elicitation has completed so the
+            # client can retry a request that previously received a -32042 error.
+            # Route the notification to the client session owning the elicitation.
+            if settings.mcpgateway_elicitation_enabled and settings.mcpgateway_elicitation_url_mode_enabled:
+                # First-Party
+                from mcpgateway.services.elicitation_service import get_elicitation_service  # pylint: disable=import-outside-toplevel
+
+                elicitation_id = params.get("elicitationId")
+                target_session_id = params.get("session_id") or params.get("sessionId")
+                if not target_session_id and elicitation_id:
+                    pending = get_elicitation_service().get_pending_by_elicitation_id(elicitation_id)
+                    if pending:
+                        target_session_id = pending.downstream_session_id
+                if target_session_id:
+                    await session_registry.broadcast(
+                        target_session_id,
+                        {"jsonrpc": "2.0", "method": "notifications/elicitation/complete", "params": {"elicitationId": elicitation_id}},
+                    )
+                    logger.debug("Routed elicitation completion (elicitationId=%s) to session %s", elicitation_id, target_session_id)
+                else:
+                    # TODO: durable elicitationId->session mapping is needed for completions
+                    # that arrive after the consent response cleared the pending entry.
+                    logger.warning("Could not route elicitation completion for elicitationId=%s (no target session)", elicitation_id)
+            result = {}
         elif method.startswith("notifications/"):
             # Catch-all for other notifications/* methods (currently unsupported)
             result = {}
@@ -10905,86 +10930,132 @@ async def _handle_rpc_authenticated(request: Request, db: Session, user):
             # Catch-all for other sampling/* methods (currently unsupported)
             result = {}
         elif method == "elicitation/create":
-            # MCP spec 2025-06-18: Elicitation support (server-to-client requests)
-            # Elicitation allows servers to request structured user input through clients
+            # Elicitation: server-to-client request for user input.
+            # Form mode: MCP 2025-06-18. URL mode: SEP-1036 (MCP 2025-11-25).
 
             # Check if elicitation is enabled
             if not settings.mcpgateway_elicitation_enabled:
                 raise JSONRPCError(-32601, "Elicitation feature is disabled", {"feature": "elicitation", "config": "MCPGATEWAY_ELICITATION_ENABLED=false"})
 
-            # Validate params
             # First-Party
-            from mcpgateway.common.models import ElicitRequestParams  # pylint: disable=import-outside-toplevel
+            from mcpgateway.common.models import ElicitRequestParams, ElicitRequestURLParams  # pylint: disable=import-outside-toplevel
             from mcpgateway.services.elicitation_service import get_elicitation_service  # pylint: disable=import-outside-toplevel
 
-            try:
-                elicit_params = ElicitRequestParams(**params)
-            except Exception as e:
-                raise JSONRPCError(-32602, f"Invalid elicitation params: {e}", params)
-
-            # Get target session (from params or find elicitation-capable session)
-            target_session_id = params.get("session_id") or params.get("sessionId")
-            if not target_session_id:
-                # Find an elicitation-capable session
-                capable_sessions = await session_registry.get_elicitation_capable_sessions()
-                if not capable_sessions:
-                    raise JSONRPCError(-32000, "No elicitation-capable clients available", {"message": elicit_params.message})
-                target_session_id = capable_sessions[0]
-                logger.debug("Selected session %s for elicitation", target_session_id)
-
-            # Verify session has elicitation capability
-            if not await session_registry.has_elicitation_capability(target_session_id):
-                raise JSONRPCError(-32000, f"Session {target_session_id} does not support elicitation", {"session_id": target_session_id})
-
-            # Get elicitation service and create request
+            elicit_mode = params.get("mode", "form")
             elicitation_service = get_elicitation_service()
-
-            # Extract timeout from params or use default
             timeout = params.get("timeout", settings.mcpgateway_elicitation_timeout)
+            # In a full bidirectional proxy this is the upstream session that
+            # initiated the request; passthrough uses a placeholder.
+            upstream_session_id = "gateway"
 
-            try:
-                # Create elicitation request - this stores it and waits for response
-                # For now, use dummy upstream_session_id - in full bidirectional proxy,
-                # this would be the session that initiated the request
-                upstream_session_id = "gateway"
+            if elicit_mode == "url":
+                # ----- URL mode (SEP-1036) -----
+                if not settings.mcpgateway_elicitation_url_mode_enabled:
+                    raise JSONRPCError(-32601, "URL-mode elicitation is disabled", {"feature": "elicitation.url", "config": "MCPGATEWAY_ELICITATION_URL_MODE_ENABLED=false"})
 
-                # Start the elicitation (creates pending request and future)
-                elicitation_task = asyncio.create_task(
-                    elicitation_service.create_elicitation(
-                        upstream_session_id=upstream_session_id, downstream_session_id=target_session_id, message=elicit_params.message, requested_schema=elicit_params.requestedSchema, timeout=timeout
+                try:
+                    url_params = ElicitRequestURLParams(**params)
+                except Exception as e:
+                    raise JSONRPCError(-32602, f"Invalid URL elicitation params: {e}", params)
+
+                target_session_id = params.get("session_id") or params.get("sessionId")
+                if not target_session_id:
+                    capable_sessions = await session_registry.get_elicitation_capable_sessions(mode="url")
+                    if not capable_sessions:
+                        raise JSONRPCError(-32000, "No URL-elicitation-capable clients available", {"message": url_params.message})
+                    target_session_id = capable_sessions[0]
+                    logger.debug("Selected session %s for URL elicitation", target_session_id)
+
+                if not await session_registry.has_elicitation_capability(target_session_id, mode="url"):
+                    raise JSONRPCError(-32000, f"Session {target_session_id} does not support URL-mode elicitation", {"session_id": target_session_id})
+
+                try:
+                    elicitation_task = asyncio.create_task(
+                        elicitation_service.create_url_elicitation(
+                            upstream_session_id=upstream_session_id,
+                            downstream_session_id=target_session_id,
+                            message=url_params.message,
+                            url=url_params.url,
+                            elicitation_id=url_params.elicitationId,
+                            timeout=timeout,
+                            require_https=settings.mcpgateway_elicitation_url_require_https,
+                        )
                     )
-                )
 
-                # Get the pending elicitation to extract request_id
-                # Wait a moment for it to be created
-                await asyncio.sleep(0.01)
-                pending_elicitations = [e for e in elicitation_service._pending.values() if e.downstream_session_id == target_session_id]  # pylint: disable=protected-access
-                if not pending_elicitations:
-                    raise JSONRPCError(-32000, "Failed to create elicitation request", {})
+                    # Wait for the pending entry to materialize so we can read request_id
+                    await asyncio.sleep(0.01)
+                    pending = elicitation_service.get_pending_by_elicitation_id(url_params.elicitationId)
+                    if not pending:
+                        raise JSONRPCError(-32000, "Failed to create URL elicitation request", {})
 
-                pending = pending_elicitations[-1]  # Get most recent
+                    elicitation_request = {
+                        "jsonrpc": "2.0",
+                        "id": pending.request_id,
+                        "method": "elicitation/create",
+                        "params": {"mode": "url", "message": url_params.message, "url": url_params.url, "elicitationId": url_params.elicitationId},
+                    }
+                    await session_registry.broadcast(target_session_id, elicitation_request)
+                    logger.debug("Sent URL elicitation %s (elicitationId=%s) to session %s", pending.request_id, url_params.elicitationId, target_session_id)
 
-                # Send elicitation request to client via broadcast
-                elicitation_request = {
-                    "jsonrpc": "2.0",
-                    "id": pending.request_id,
-                    "method": "elicitation/create",
-                    "params": {"message": elicit_params.message, "requestedSchema": elicit_params.requestedSchema},
-                }
+                    elicit_result = await elicitation_task
+                    result = elicit_result.model_dump(by_alias=True, exclude_none=True)
+                except asyncio.TimeoutError:
+                    raise JSONRPCError(-32000, f"Elicitation timed out after {timeout}s", {"message": url_params.message, "timeout": timeout})
+                except ValueError as e:
+                    # Includes URL validation failures and concurrency limits
+                    raise JSONRPCError(-32602, str(e), {"message": url_params.message})
+            else:
+                # ----- Form mode (MCP 2025-06-18) -----
+                try:
+                    elicit_params = ElicitRequestParams(**params)
+                except Exception as e:
+                    raise JSONRPCError(-32602, f"Invalid elicitation params: {e}", params)
 
-                await session_registry.broadcast(target_session_id, elicitation_request)
-                logger.debug("Sent elicitation request %s to session %s", pending.request_id, target_session_id)
+                target_session_id = params.get("session_id") or params.get("sessionId")
+                if not target_session_id:
+                    capable_sessions = await session_registry.get_elicitation_capable_sessions(mode="form")
+                    if not capable_sessions:
+                        raise JSONRPCError(-32000, "No elicitation-capable clients available", {"message": elicit_params.message})
+                    target_session_id = capable_sessions[0]
+                    logger.debug("Selected session %s for elicitation", target_session_id)
 
-                # Wait for response
-                elicit_result = await elicitation_task
+                if not await session_registry.has_elicitation_capability(target_session_id, mode="form"):
+                    raise JSONRPCError(-32000, f"Session {target_session_id} does not support elicitation", {"session_id": target_session_id})
 
-                # Return result
-                result = elicit_result.model_dump(by_alias=True, exclude_none=True)
+                try:
+                    elicitation_task = asyncio.create_task(
+                        elicitation_service.create_elicitation(
+                            upstream_session_id=upstream_session_id,
+                            downstream_session_id=target_session_id,
+                            message=elicit_params.message,
+                            requested_schema=elicit_params.requestedSchema,
+                            timeout=timeout,
+                        )
+                    )
 
-            except asyncio.TimeoutError:
-                raise JSONRPCError(-32000, f"Elicitation timed out after {timeout}s", {"message": elicit_params.message, "timeout": timeout})
-            except ValueError as e:
-                raise JSONRPCError(-32000, str(e), {"message": elicit_params.message})
+                    # Wait a moment for the pending entry to be created
+                    await asyncio.sleep(0.01)
+                    pending_elicitations = [e for e in elicitation_service._pending.values() if e.downstream_session_id == target_session_id]  # pylint: disable=protected-access
+                    if not pending_elicitations:
+                        raise JSONRPCError(-32000, "Failed to create elicitation request", {})
+
+                    pending = pending_elicitations[-1]  # Get most recent
+
+                    elicitation_request = {
+                        "jsonrpc": "2.0",
+                        "id": pending.request_id,
+                        "method": "elicitation/create",
+                        "params": {"mode": "form", "message": elicit_params.message, "requestedSchema": elicit_params.requestedSchema},
+                    }
+                    await session_registry.broadcast(target_session_id, elicitation_request)
+                    logger.debug("Sent elicitation request %s to session %s", pending.request_id, target_session_id)
+
+                    elicit_result = await elicitation_task
+                    result = elicit_result.model_dump(by_alias=True, exclude_none=True)
+                except asyncio.TimeoutError:
+                    raise JSONRPCError(-32000, f"Elicitation timed out after {timeout}s", {"message": elicit_params.message, "timeout": timeout})
+                except ValueError as e:
+                    raise JSONRPCError(-32000, str(e), {"message": elicit_params.message})
         elif method.startswith("elicitation/"):
             # Catch-all for other elicitation/* methods
             result = {}

--- a/mcpgateway/services/elicitation_service.py
+++ b/mcpgateway/services/elicitation_service.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 import logging
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 from uuid import uuid4
 
 # First-Party
@@ -39,8 +40,12 @@ class PendingElicitation:
         created_at: Unix timestamp when request was created
         timeout: Maximum wait time in seconds
         message: User-facing message describing what input is needed
-        schema: JSON Schema defining expected response structure
+        schema: JSON Schema defining expected response structure (form mode only)
         future: AsyncIO future that resolves to ElicitResult when complete
+        mode: Elicitation mode, "form" (default) or "url" (SEP-1036)
+        url: Target URL for URL-mode elicitation (None for form mode)
+        elicitation_id: Server-provided opaque correlation id for URL-mode
+            elicitations; used to route the later completion notification.
     """
 
     request_id: str
@@ -49,8 +54,11 @@ class PendingElicitation:
     created_at: float
     timeout: float
     message: str
-    schema: Dict[str, Any]
+    schema: Optional[Dict[str, Any]] = None
     future: asyncio.Future = field(default_factory=asyncio.Future)
+    mode: str = "form"
+    url: Optional[str] = None
+    elicitation_id: Optional[str] = None
 
 
 class ElicitationService:
@@ -170,6 +178,97 @@ class ElicitationService:
         finally:
             # Cleanup
             self._pending.pop(request_id, None)
+
+    async def create_url_elicitation(
+        self,
+        upstream_session_id: str,
+        downstream_session_id: str,
+        message: str,
+        url: str,
+        elicitation_id: str,
+        timeout: Optional[float] = None,
+        require_https: bool = True,
+    ) -> ElicitResult:
+        """Create and track a URL-mode elicitation request (SEP-1036).
+
+        URL mode directs the user to an external URL for out-of-band interactions
+        (OAuth, credential collection, payments). No schema is validated; instead
+        the URL is validated and the request awaits the client's consent action.
+
+        Args:
+            upstream_session_id: Session that initiated the request (server)
+            downstream_session_id: Session that will handle the request (client)
+            message: Message to present to the user
+            url: URL the user should navigate to
+            elicitation_id: Server-provided opaque correlation id
+            timeout: Optional timeout override (default: self.default_timeout)
+            require_https: Reject non-HTTPS URLs when True
+
+        Returns:
+            ElicitResult from the client containing the consent action
+
+        Raises:
+            ValueError: If max concurrent limit reached or URL is invalid
+            asyncio.TimeoutError: If request times out waiting for response
+        """
+        # Check concurrent limit
+        if len(self._pending) >= self.max_concurrent:
+            logger.warning("Max concurrent elicitations reached: %s", self.max_concurrent)
+            raise ValueError(f"Maximum concurrent elicitations ({self.max_concurrent}) reached")
+
+        # Validate URL (scheme / https requirement) per SEP-1036 security guidance
+        self._validate_url(url, require_https=require_https)
+
+        # Create tracking entry
+        request_id = str(uuid4())
+        timeout_val = timeout if timeout is not None else self.default_timeout
+        future: asyncio.Future = asyncio.Future()
+
+        elicitation = PendingElicitation(
+            request_id=request_id,
+            upstream_session_id=upstream_session_id,
+            downstream_session_id=downstream_session_id,
+            created_at=time.time(),
+            timeout=timeout_val,
+            message=message,
+            schema=None,
+            future=future,
+            mode="url",
+            url=url,
+            elicitation_id=elicitation_id,
+        )
+
+        self._pending[request_id] = elicitation
+        logger.info(
+            "Created URL elicitation request %s (elicitationId=%s): upstream=%s, downstream=%s, timeout=%ss", request_id, elicitation_id, upstream_session_id, downstream_session_id, timeout_val
+        )
+
+        try:
+            result = await asyncio.wait_for(future, timeout=timeout_val)
+            logger.info("URL elicitation %s completed: action=%s", request_id, result.action)
+            return result
+        except asyncio.TimeoutError:
+            logger.warning("URL elicitation %s timed out after %ss", request_id, timeout_val)
+            raise
+        finally:
+            self._pending.pop(request_id, None)
+
+    def get_pending_by_elicitation_id(self, elicitation_id: str) -> Optional[PendingElicitation]:
+        """Look up a pending URL-mode elicitation by its server-provided id.
+
+        Used to route a ``notifications/elicitation/complete`` notification back to
+        the client session that owns the matching elicitation.
+
+        Args:
+            elicitation_id: The server-provided opaque correlation id
+
+        Returns:
+            PendingElicitation if a matching URL-mode request is pending, else None
+        """
+        for elicitation in self._pending.values():
+            if elicitation.elicitation_id == elicitation_id:
+                return elicitation
+        return None
 
     def complete_elicitation(self, request_id: str, result: ElicitResult) -> bool:
         """Complete a pending elicitation with a result from the client.
@@ -309,6 +408,37 @@ class ElicitationService:
                     logger.warning(f"Property '{prop_name}' has non-standard format '{fmt}'. Allowed formats: {allowed_formats}")
 
         logger.debug("Schema validation passed: %s properties", len(properties))
+
+    def _validate_url(self, url: str, require_https: bool = True):
+        """Validate a URL-mode elicitation target URL (SEP-1036).
+
+        SEP-1036 directs URL mode at sensitive out-of-band flows, so the URL must
+        be absolute and (in production) use HTTPS. ``localhost``/loopback hosts are
+        permitted over HTTP to support local development.
+
+        Args:
+            url: The URL to validate
+            require_https: Reject non-HTTPS URLs (except loopback hosts) when True
+
+        Raises:
+            ValueError: If the URL is empty, not absolute, or violates the scheme policy
+        """
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError("URL-mode elicitation requires a non-empty 'url'")
+
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError(f"Invalid elicitation URL '{url}': must be an absolute URL with scheme and host")
+
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Invalid elicitation URL scheme '{parsed.scheme}': only http/https are allowed")
+
+        if require_https and parsed.scheme != "https":
+            host = (parsed.hostname or "").lower()
+            if host not in ("localhost", "127.0.0.1", "::1"):
+                raise ValueError(f"Insecure elicitation URL '{url}': https is required (set MCPGATEWAY_ELICITATION_URL_REQUIRE_HTTPS=false to allow http)")
+
+        logger.debug("URL validation passed: %s", url)
 
 
 # Global singleton instance

--- a/tests/unit/mcpgateway/cache/test_session_registry_coverage.py
+++ b/tests/unit/mcpgateway/cache/test_session_registry_coverage.py
@@ -2212,6 +2212,38 @@ class TestClientCapabilitiesAndElicitation:
         result = await registry.get_elicitation_capable_sessions()
         assert "orphan" not in result
 
+    @pytest.mark.asyncio
+    async def test_has_elicitation_legacy_declaration_is_form_only(self, registry):
+        """SEP-1036: a legacy bare declaration counts as form mode, not url mode."""
+        await registry.store_client_capabilities("legacy", {"elicitation": True})
+        assert await registry.has_elicitation_capability("legacy") is True
+        assert await registry.has_elicitation_capability("legacy", mode="form") is True
+        assert await registry.has_elicitation_capability("legacy", mode="url") is False
+
+    @pytest.mark.asyncio
+    async def test_has_elicitation_subcapabilities(self, registry):
+        """SEP-1036: explicit form/url sub-capabilities are honored per-mode."""
+        await registry.store_client_capabilities("both", {"elicitation": {"form": {}, "url": {}}})
+        assert await registry.has_elicitation_capability("both", mode="form") is True
+        assert await registry.has_elicitation_capability("both", mode="url") is True
+
+        await registry.store_client_capabilities("urlonly", {"elicitation": {"url": {}}})
+        assert await registry.has_elicitation_capability("urlonly") is True
+        assert await registry.has_elicitation_capability("urlonly", mode="url") is True
+        assert await registry.has_elicitation_capability("urlonly", mode="form") is False
+
+    @pytest.mark.asyncio
+    async def test_get_elicitation_capable_sessions_by_mode(self, registry):
+        """SEP-1036: capable-session filtering respects the requested mode."""
+        for sid in ("uf", "uu", "ul"):
+            await registry.add_session(sid, FakeSSETransport(sid))
+        await registry.store_client_capabilities("uf", {"elicitation": {"form": {}}})
+        await registry.store_client_capabilities("uu", {"elicitation": {"url": {}}})
+        await registry.store_client_capabilities("ul", {"elicitation": True})  # legacy = form
+
+        assert set(await registry.get_elicitation_capable_sessions(mode="url")) == {"uu"}
+        assert set(await registry.get_elicitation_capable_sessions(mode="form")) == {"uf", "ul"}
+
 
 # ---------------------------------------------------------------------------
 # generate_response edge cases (lines 1926, 1951, 1955, 1962-1968)

--- a/tests/unit/mcpgateway/common/test_elicitation_models.py
+++ b/tests/unit/mcpgateway/common/test_elicitation_models.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/common/test_elicitation_models.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Stefano Amorelli
+
+Unit tests for elicitation Pydantic models, including URL-mode (SEP-1036).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from mcpgateway.common.models import (
+    ElicitationCapability,
+    ElicitationRequiredErrorData,
+    ElicitCompleteNotificationParams,
+    ElicitRequestParams,
+    ElicitRequestURLParams,
+    ElicitResult,
+    URL_ELICITATION_REQUIRED,
+)
+
+
+def test_url_elicitation_required_error_code():
+    """SEP-1036 defines URLElicitationRequiredError as JSON-RPC code -32042."""
+    assert URL_ELICITATION_REQUIRED == -32042
+
+
+# --------------------------------------------------------------------------- #
+# FORM MODE
+# --------------------------------------------------------------------------- #
+
+
+def test_form_params_default_mode_and_requires_schema():
+    """Form params default to mode='form' and require requestedSchema."""
+    params = ElicitRequestParams(message="hi", requestedSchema={"type": "object", "properties": {}})
+    assert params.mode == "form"
+    assert params.requestedSchema == {"type": "object", "properties": {}}
+
+    with pytest.raises(ValidationError):
+        ElicitRequestParams(message="hi")  # requestedSchema is required
+
+
+# --------------------------------------------------------------------------- #
+# URL MODE (SEP-1036)
+# --------------------------------------------------------------------------- #
+
+
+def test_url_params_valid_and_alias_roundtrip():
+    """URL params expose mode='url' and round-trip the camelCase elicitationId alias."""
+    params = ElicitRequestURLParams(message="Sign in", url="https://auth.example.com/x", elicitationId="elc_1")
+    assert params.mode == "url"
+    assert params.url == "https://auth.example.com/x"
+    assert params.elicitationId == "elc_1"
+
+    dumped = params.model_dump(by_alias=True)
+    assert dumped["mode"] == "url"
+    assert dumped["elicitationId"] == "elc_1"
+
+
+def test_url_params_require_url_and_id():
+    """URL params must carry both url and elicitationId."""
+    with pytest.raises(ValidationError):
+        ElicitRequestURLParams(message="Sign in")  # missing url + elicitationId
+    with pytest.raises(ValidationError):
+        ElicitRequestURLParams(message="Sign in", url="https://e.example.com/x")  # missing elicitationId
+
+
+def test_elicitation_required_error_data_holds_url_params():
+    """ElicitationRequiredErrorData carries a list of URL-mode elicitations."""
+    data = ElicitationRequiredErrorData(elicitations=[ElicitRequestURLParams(message="m", url="https://e.example.com/x", elicitationId="e1")])
+    assert len(data.elicitations) == 1
+    assert data.elicitations[0].mode == "url"
+
+
+def test_elicit_complete_notification_params():
+    """Completion-notification params surface the elicitationId being completed."""
+    params = ElicitCompleteNotificationParams(elicitationId="elc_99")
+    assert params.elicitationId == "elc_99"
+
+
+# --------------------------------------------------------------------------- #
+# CAPABILITY + RESULT
+# --------------------------------------------------------------------------- #
+
+
+def test_elicitation_capability_subcapabilities():
+    """Capability honours form/url sub-capabilities and the legacy empty declaration."""
+    cap = ElicitationCapability(form={}, url={})
+    assert cap.form is not None
+    assert cap.url is not None
+
+    # Legacy empty declaration still validates (form/url default to None).
+    legacy = ElicitationCapability()
+    assert legacy.form is None
+    assert legacy.url is None
+
+
+def test_elicit_result_actions_and_list_content():
+    """ElicitResult accepts list[str] content, allows url-mode consent without content, and rejects unknown actions."""
+    accept = ElicitResult(action="accept", content={"tags": ["a", "b"], "name": "x"})
+    assert accept.content["tags"] == ["a", "b"]
+
+    # URL-mode consent: accept with no content is valid.
+    consent = ElicitResult(action="accept")
+    assert consent.content is None
+
+    with pytest.raises(ValidationError):
+        ElicitResult(action="bogus")

--- a/tests/unit/mcpgateway/services/test_elicitation_service.py
+++ b/tests/unit/mcpgateway/services/test_elicitation_service.py
@@ -187,3 +187,112 @@ def test_global_singleton(monkeypatch):
     s2 = svc.ElicitationService()
     svc.set_elicitation_service(s2)
     assert svc.get_elicitation_service() is s2
+
+
+# --------------------------------------------------------------------------- #
+# URL MODE ELICITATION (SEP-1036)
+# --------------------------------------------------------------------------- #
+
+
+def test_pending_elicitation_url_mode_fields():
+    """PendingElicitation tracks url-mode metadata with form-mode defaults."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        form = svc.PendingElicitation("r1", "u", "d", time.time(), 1, "m", {"type": "object", "properties": {}}, loop.create_future())
+        assert form.mode == "form"
+        assert form.url is None
+        assert form.elicitation_id is None
+
+        url = svc.PendingElicitation(
+            request_id="r2",
+            upstream_session_id="u",
+            downstream_session_id="d",
+            created_at=time.time(),
+            timeout=1,
+            message="m",
+            schema=None,
+            future=loop.create_future(),
+            mode="url",
+            url="https://auth.example.com/authorize",
+            elicitation_id="elc_1",
+        )
+        assert url.mode == "url"
+        assert url.url == "https://auth.example.com/authorize"
+        assert url.elicitation_id == "elc_1"
+    finally:
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_create_url_elicitation_and_complete():
+    service = svc.ElicitationService(default_timeout=0.5)
+
+    async def consent_later(req_id):
+        await asyncio.sleep(0.05)
+        service.complete_elicitation(req_id, DummyElicitResult("accept"))
+
+    task = asyncio.create_task(service.create_url_elicitation("u", "d", "sign in", "https://auth.example.com/authorize", "elc_42", timeout=0.5))
+
+    for _ in range(30):
+        if service._pending:
+            break
+        await asyncio.sleep(0.02)
+    assert service._pending, "Expected a pending url elicitation"
+
+    pending = service.get_pending_by_elicitation_id("elc_42")
+    assert pending is not None
+    assert pending.mode == "url"
+    assert pending.url == "https://auth.example.com/authorize"
+
+    asyncio.create_task(consent_later(pending.request_id))
+    result = await task
+    assert result.action == "accept"
+
+
+@pytest.mark.asyncio
+async def test_create_url_elicitation_limit_and_timeout():
+    service = svc.ElicitationService(max_concurrent=1, default_timeout=0.01)
+    service._pending = {"1": MagicMock()}
+    with pytest.raises(ValueError):
+        await service.create_url_elicitation("u", "d", "m", "https://e.example.com", "elc_lim")
+
+    service._pending.clear()
+    with pytest.raises(asyncio.TimeoutError):
+        await service.create_url_elicitation("u", "d", "m", "https://e.example.com", "elc_to", timeout=0.001)
+
+
+@pytest.mark.asyncio
+async def test_create_url_elicitation_rejects_insecure_url():
+    service = svc.ElicitationService(default_timeout=0.5)
+    with pytest.raises(ValueError, match="https is required"):
+        await service.create_url_elicitation("u", "d", "m", "http://insecure.example.com", "elc_http", require_https=True)
+    # No pending entry should linger after a validation failure.
+    assert service.get_pending_by_elicitation_id("elc_http") is None
+
+
+def test_get_pending_by_elicitation_id_missing():
+    service = svc.ElicitationService()
+    assert service.get_pending_by_elicitation_id("nope") is None
+
+
+def test_validate_url_success():
+    s = svc.ElicitationService()
+    s._validate_url("https://auth.example.com/authorize?state=abc")
+    # Loopback hosts are allowed over http for local development.
+    s._validate_url("http://localhost:8080/callback", require_https=True)
+    s._validate_url("http://127.0.0.1/callback", require_https=True)
+    # http allowed when https not required.
+    s._validate_url("http://example.com/x", require_https=False)
+
+
+def test_validate_url_failures():
+    s = svc.ElicitationService()
+    with pytest.raises(ValueError, match="non-empty"):
+        s._validate_url("")
+    with pytest.raises(ValueError, match="absolute URL"):
+        s._validate_url("not-a-url")
+    with pytest.raises(ValueError, match="only http/https"):
+        s._validate_url("ftp://example.com/file")
+    with pytest.raises(ValueError, match="https is required"):
+        s._validate_url("http://example.com/insecure", require_https=True)

--- a/tests/unit/mcpgateway/test_main.py
+++ b/tests/unit/mcpgateway/test_main.py
@@ -2979,6 +2979,55 @@ class TestRPCEndpoints:
         body = response.json()
         assert body["error"]["code"] == -32601
 
+    def test_rpc_elicitation_url_mode_disabled(self, test_client, auth_headers, monkeypatch):
+        """URL-mode elicitation/create returns -32601 when url mode disabled (SEP-1036)."""
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_enabled", True)
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_url_mode_enabled", False)
+        req = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "method": "elicitation/create",
+            "params": {"mode": "url", "message": "Sign in", "url": "https://auth.example.com/x", "elicitationId": "e1"},
+        }
+        response = test_client.post("/rpc/", json=req, headers=auth_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["error"]["code"] == -32601
+
+    def test_rpc_elicitation_url_invalid_params(self, test_client, auth_headers, monkeypatch):
+        """URL-mode elicitation/create with missing url/elicitationId returns -32602."""
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_enabled", True)
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_url_mode_enabled", True)
+        req = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "method": "elicitation/create",
+            "params": {"mode": "url", "message": "Sign in"},  # missing url + elicitationId
+        }
+        response = test_client.post("/rpc/", json=req, headers=auth_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["error"]["code"] == -32602
+
+    def test_rpc_elicitation_url_no_capable_clients(self, test_client, auth_headers, monkeypatch):
+        """URL-mode elicitation/create with no url-capable client returns -32000."""
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_enabled", True)
+        monkeypatch.setattr(settings, "mcpgateway_elicitation_url_mode_enabled", True)
+        req = {
+            "jsonrpc": "2.0",
+            "id": "test-id",
+            "method": "elicitation/create",
+            "params": {"mode": "url", "message": "Sign in", "url": "https://auth.example.com/x", "elicitationId": "e1"},
+        }
+        response = test_client.post("/rpc/", json=req, headers=auth_headers)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["error"]["code"] == -32000
+        assert "URL-elicitation-capable" in body["error"]["message"]
+
     @patch("mcpgateway.main.logging_service.notify", new_callable=AsyncMock)
     def test_rpc_notifications_initialized(self, mock_notify, test_client, auth_headers):
         """Test notifications/initialized JSON-RPC method."""


### PR DESCRIPTION
_(draft)_

## 🔗 Epic / Issue

Relates to #5168 (RC 2026-07-28 pass-through, the "Elicitation Pass-Through (URL Mode)" acceptance criteria) and #5166 (MCP Release Candidate 2026-07-28 epic).

This is a scoped slice rather than a full resolution of either issue, so it intentionally does not use `Closes`.

---

## 🚀 Summary (1-2 sentences)

This adds URL-mode elicitation pass-through (SEP-1036, incorporated into MCP 2025-11-25), where a server can direct the user to an external URL for out-of-band interactions such as OAuth, credential collection, or payments instead of an in-band form. It extends the existing form-mode `elicitation/create` path rather than replacing it, so form-mode behaviour is unchanged.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

Note: #5168 and #5166 are currently labeled `triage`, so per CONTRIBUTING this is opened as a draft for early feedback and scoping rather than as ready-for-review. I am happy to split, reshape, or hold it depending on how maintainers want the RC 2026-07-28 elicitation work sequenced against the protocol-translation piece in #5167.

---

## 🧪 Checks

Targeted verification run locally against the changed code:

- `pytest` on the elicitation service, session-registry capability, model, and RPC-handler suites: `245 passed`.
- `ruff check` on the changed modules: clean.
- `black --check` (line length 200) on the changed modules: clean (no diff on the added lines).

- [ ] `make lint` passes (not yet run end-to-end here)
- [ ] `make test` passes (full suite not yet run; the targeted suites above are green)
- [ ] CHANGELOG updated (pending: this is user-facing and will need an entry before ready-for-review)

---

## 📓 Notes

Scope: this is the pass-through slice that fits the existing `elicitation/create` architecture and the `mcp` SDK types the repo already pins. It is deliberately narrower than the full #5166 epic, and does not touch the Tasks/Apps extensions, the 2025-11-25 to RC 2026-07-28 protocol translation in #5167, or the Admin-UI version negotiation.

What it adds:

- URL-mode request models and the `form`/`url` client-capability split (SEP-1036), the named `URL_ELICITATION_REQUIRED` (`-32042`) code, and the `notifications/elicitation/complete` notification type.
- Mode-aware capability negotiation in the session registry. A legacy bare `elicitation` declaration is treated as form-only, so existing form-mode clients are unaffected.
- `elicitation/create` dispatch on `mode`, URL validation (HTTPS required, loopback exempt), and routing of the completion notification back to the owning client session.
- Two settings: `MCPGATEWAY_ELICITATION_URL_MODE_ENABLED` and `MCPGATEWAY_ELICITATION_URL_REQUIRE_HTTPS`.

Known follow-up, left as a `TODO` in the handler: a durable `elicitationId` to session map is needed for completion notifications that arrive after the consent response has already cleared the pending entry. This matches the fidelity of the existing form-mode pass-through, which also uses a placeholder upstream session.
