### PR TITLE
fix(grpc): enforce SSRF/TLS validation in GrpcEndpoint.start()

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-09T15:16:14Z",
+  "generated_at": "2026-07-13T09:51:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -3328,7 +3328,7 @@
         "hashed_secret": "bf10dae7b89461df3fd3c48f86ec23543710e8cd",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 417,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -3356,7 +3356,7 @@
         "hashed_secret": "ddb2c93ebcf6098f6ccb08807ed66e02934248a5",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 573,
+        "line_number": 575,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/docs/using/grpc-services.md
+++ b/docs/docs/using/grpc-services.md
@@ -105,6 +105,9 @@ python3 -m mcpgateway.translate \
   --port 9000
 ```
 
+!!! note "SSRF validation of gRPC targets"
+    The gRPC target is validated against the platform SSRF settings before any channel is opened. Because `SSRF_ALLOW_LOCALHOST` and `SSRF_ALLOW_PRIVATE_NETWORKS` default to `false`, targets such as `localhost:50051` or RFC1918 addresses are rejected out of the box with a `GrpcServiceError`. To allow a loopback target, set `SSRF_ALLOW_LOCALHOST=true`; to allow a specific private/RFC1918 range, add it to `SSRF_ALLOWED_NETWORKS`. See the [1.0.0-RC3 upgrade notes](../manage/upgrade-to-1.0.0-rc3.md) for the full table of SSRF defaults.
+
 ### 2. Admin UI: Register a gRPC Service
 
 1. Navigate to the **Admin UI** at `http://localhost:4444/admin`

--- a/docs/docs/using/mcpgateway-translate.md
+++ b/docs/docs/using/mcpgateway-translate.md
@@ -561,6 +561,8 @@ Expose a local gRPC server via HTTP/SSE:
 python3 -m mcpgateway.translate --grpc localhost:50051 --port 9000
 ```
 
+The gRPC target is validated against the platform SSRF settings before any channel is opened. With the default `SSRF_ALLOW_LOCALHOST=false` and `SSRF_ALLOW_PRIVATE_NETWORKS=false`, a target like `localhost:50051` is rejected with a `GrpcServiceError`. To allow a loopback target set `SSRF_ALLOW_LOCALHOST=true`; to allow a specific private range add it to `SSRF_ALLOWED_NETWORKS` (see the [1.0.0-RC3 upgrade notes](../manage/upgrade-to-1.0.0-rc3.md) for the full table of SSRF defaults).
+
 ### gRPC CLI Options
 
 | Flag | Description | Example |

--- a/mcpgateway/services/grpc_service.py
+++ b/mcpgateway/services/grpc_service.py
@@ -15,8 +15,6 @@ retrieval, updates, activation toggling, and deletion.
 import asyncio
 import base64
 from datetime import datetime, timezone
-import ipaddress
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 try:
@@ -38,6 +36,7 @@ from sqlalchemy import and_, delete, desc, select, update
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway import translate_grpc
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam
 from mcpgateway.db import GrpcService as DbGrpcService
@@ -49,14 +48,13 @@ from mcpgateway.services.logging_service import LoggingService
 from mcpgateway.services.team_management_service import TeamManagementService
 from mcpgateway.utils.create_slug import slugify
 from mcpgateway.utils.display_name import generate_display_name
+from mcpgateway.utils.grpc_validation import GrpcServiceError, _validate_grpc_target, _validate_tls_path
 from mcpgateway.utils.pagination import unified_paginate
 
 # Initialize logging
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
-
-_GRPC_DISALLOWED_SCHEMES = ("unix:", "unix-abstract:", "vsock:", "fd:")
 
 # DoS guards for descriptors returned by ``grpc.reflection`` — intentionally hardcoded
 # (not exposed via settings) so a config change cannot silently weaken these limits.
@@ -109,106 +107,6 @@ def _validate_reflected_tool_name(tool_name: str) -> None:
         SecurityValidator.validate_tool_name(tool_name)
     except ValueError as exc:
         raise GrpcServiceError(f"Reflected tool name '{tool_name}' rejected: {exc}") from exc
-
-
-def _validate_grpc_target(target: str) -> None:
-    """Validate a gRPC target address against SSRF-unsafe destinations.
-
-    Consults the platform SSRF settings (``ssrf_allow_localhost``,
-    ``ssrf_allow_private_networks``, ``ssrf_allowed_networks``,
-    ``ssrf_blocked_networks``, ``ssrf_blocked_hosts``) so that gRPC
-    targets follow the same rules as HTTP URLs validated by
-    ``SecurityValidator.validate_url``.
-
-    Args:
-        target: gRPC target string. Accepts ``host:port``, bracketed
-            ``[ipv6]:port``, and gRPC name-resolver forms ``dns:///host:port``,
-            ``ipv4:host:port``, ``ipv6:host:port``. Local-only schemes
-            (``unix:``, ``unix-abstract:``, ``vsock:``, ``fd:``) are always
-            rejected because they bypass the network-level SSRF model.
-
-    Raises:
-        GrpcServiceError: If the target uses a forbidden scheme or resolves to a blocked address.
-    """
-    if not target:
-        raise GrpcServiceError("Empty gRPC target address")
-
-    # Local-only schemes bypass the IP-based SSRF model entirely; reject outright.
-    lowered = target.lower()
-    for scheme in _GRPC_DISALLOWED_SCHEMES:
-        if lowered.startswith(scheme):
-            raise GrpcServiceError(f"gRPC target scheme '{scheme.rstrip(':')}' is not permitted")
-
-    # Strip recognised gRPC name-resolver scheme prefixes so the host check below sees a bare host:port.
-    for scheme_prefix in ("dns:///", "dns://", "dns:", "ipv4:", "ipv6:"):
-        if lowered.startswith(scheme_prefix):
-            target = target[len(scheme_prefix) :]
-            break
-
-    # Extract host (strip port). Bracketed IPv6 literals: ``[::1]:50051``.
-    if target.startswith("["):
-        end = target.find("]")
-        if end < 0:
-            raise GrpcServiceError(f"Malformed bracketed gRPC target: {target!r}")
-        host = target[1:end]
-    else:
-        host = target.rsplit(":", 1)[0].strip("[]")
-    if not host:
-        raise GrpcServiceError("Empty gRPC target address")
-
-    # Reserved / multicast IP literals are unconditionally blocked. SecurityValidator._validate_ssrf
-    # only checks blocked-networks / localhost / private; it does not flag is_reserved/is_multicast,
-    # so this guard runs before delegation to keep the original gRPC-validator semantics. Loopback is
-    # excluded because Python flags ``::1`` as both is_loopback AND is_reserved; loopback policy is
-    # handled by SecurityValidator below via ssrf_allow_localhost.
-    try:
-        addr = ipaddress.ip_address(host)
-    except ValueError:
-        addr = None
-    if addr is not None and not addr.is_loopback and (addr.is_reserved or addr.is_multicast):
-        raise GrpcServiceError(f"gRPC target address '{host}' is blocked (reserved/multicast)")
-
-    # Delegate the hostname/IP-network/DNS-resolution policy to the shared SecurityValidator
-    # so gRPC and HTTP follow the same SSRF rules and a hostname like ``metadata.google.internal``
-    # is resolved before being allowed through.
-    # First-Party
-    from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
-
-    if getattr(settings, "ssrf_protection_enabled", True):
-        try:
-            SecurityValidator._validate_ssrf(host, "gRPC target")  # pylint: disable=protected-access
-        except ValueError as exc:
-            raise GrpcServiceError(str(exc)) from exc
-
-
-def _validate_tls_path(path_str: str, label: str = "TLS path") -> Path:
-    """Validate that a TLS cert/key path is within allowed directories.
-
-    Args:
-        path_str: The file path to validate.
-        label: Label for error messages.
-
-    Returns:
-        Resolved Path object.
-
-    Raises:
-        GrpcServiceError: If the path escapes allowed directories.
-    """
-    resolved = Path(path_str).resolve()
-    # Allow only paths under /certs/, /etc/ssl/, /etc/pki/, or the CWD/certs dir
-    allowed_prefixes = (
-        Path("/certs").resolve(),
-        Path("/etc/ssl").resolve(),
-        Path("/etc/pki").resolve(),
-        Path.cwd().joinpath("certs").resolve(),
-    )
-    if not any(resolved.is_relative_to(prefix) for prefix in allowed_prefixes):
-        raise GrpcServiceError(f"{label} '{path_str}' is outside allowed certificate directories")
-    return resolved
-
-
-class GrpcServiceError(Exception):
-    """Base class for gRPC service-related errors."""
 
 
 class GrpcServiceNotFoundError(GrpcServiceError):
@@ -960,10 +858,6 @@ class GrpcService:
         if not service.enabled:
             raise GrpcServiceError(f"Service '{service.name}' is disabled")
 
-        # Import here to avoid circular dependency
-        # First-Party
-        from mcpgateway.translate_grpc import GrpcEndpoint  # pylint: disable=import-outside-toplevel,cyclic-import
-
         # Parse method name (service.Method format)
         if "." not in method_name:
             raise GrpcServiceError(f"Invalid method name '{method_name}', expected 'service.Method' format")
@@ -986,7 +880,7 @@ class GrpcService:
         stored_descriptors = discovered.get("_file_descriptors", [])
         has_stored_descriptors = bool(stored_descriptors)
 
-        endpoint = GrpcEndpoint(
+        endpoint = translate_grpc.GrpcEndpoint(
             target=service.target,
             reflection_enabled=not has_stored_descriptors,
             tls_enabled=service.tls_enabled,

--- a/mcpgateway/services/grpc_service.py
+++ b/mcpgateway/services/grpc_service.py
@@ -962,7 +962,7 @@ class GrpcService:
 
         # Import here to avoid circular dependency
         # First-Party
-        from mcpgateway.translate_grpc import GrpcEndpoint  # pylint: disable=import-outside-toplevel
+        from mcpgateway.translate_grpc import GrpcEndpoint  # pylint: disable=import-outside-toplevel,cyclic-import
 
         # Parse method name (service.Method format)
         if "." not in method_name:

--- a/mcpgateway/services/grpc_service.py
+++ b/mcpgateway/services/grpc_service.py
@@ -894,7 +894,7 @@ class GrpcService:
         try:
             # Both the asyncio wrapper AND the underlying gRPC call get the deadline so a slow
             # upstream cannot keep an executor thread alive after the coroutine is cancelled.
-            await asyncio.wait_for(endpoint.start(timeout=effective_timeout), timeout=effective_timeout)
+            await asyncio.wait_for(endpoint.start(timeout=effective_timeout, trusted_local=True), timeout=effective_timeout)
 
             if has_stored_descriptors:
                 raw_descriptors = [base64.b64decode(b, validate=True) for b in stored_descriptors]

--- a/mcpgateway/translate_grpc.py
+++ b/mcpgateway/translate_grpc.py
@@ -13,6 +13,7 @@ using automatic service discovery through gRPC server reflection.
 
 # Standard
 import asyncio
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Sequence
 
@@ -42,6 +43,12 @@ from mcpgateway.services.logging_service import LoggingService
 # Initialize logging
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _warn_trusted_local_once() -> None:
+    """Warn, at most once per process, that SSRF/TLS validation was skipped."""
+    logger.warning("GrpcEndpoint.start() called with trusted_local=True: SSRF/TLS target validation is skipped. The caller is responsible for having validated the target address and TLS paths.")
 
 
 PROTO_TO_JSON_TYPE_MAP = {
@@ -95,14 +102,49 @@ class GrpcEndpoint:
         self._pool = descriptor_pool.DescriptorPool()
         self._factory = message_factory.MessageFactory(pool=self._pool)
 
-    async def start(self, timeout: Optional[float] = None) -> None:
+    def _validate_target_and_tls(self) -> None:
+        """Validate the target address and any TLS paths against SSRF / traversal rules.
+
+        Reuses the shared validators from the gRPC service layer. They are
+        imported lazily to avoid a circular import with
+        ``mcpgateway.services.grpc_service`` (which imports ``GrpcEndpoint``).
+
+        Raises:
+            GrpcServiceError: If the target or a TLS path is rejected.
+        """
+        # First-Party
+        from mcpgateway.services.grpc_service import _validate_grpc_target, _validate_tls_path  # pylint: disable=import-outside-toplevel,cyclic-import
+
+        _validate_grpc_target(self._target)
+        if self._tls_cert_path:
+            _validate_tls_path(self._tls_cert_path, "TLS cert path")
+        if self._tls_key_path:
+            _validate_tls_path(self._tls_key_path, "TLS key path")
+
+    async def start(self, timeout: Optional[float] = None, trusted_local: bool = False) -> None:
         """Initialize gRPC channel and perform reflection if enabled.
 
         Args:
             timeout: Per-call gRPC deadline propagated to reflection RPCs so a
                 slow upstream cannot block the executor beyond the caller's
                 asyncio cancellation.
+            trusted_local: When False (the default), the target address and any
+                TLS certificate/key paths are validated against the platform SSRF
+                and path-traversal rules before any channel is opened, so a direct
+                caller cannot be steered at a blocked destination (e.g. a cloud
+                metadata endpoint). Set True only when the caller has already
+                validated the target; validation is then skipped and a warning is
+                logged once per process.
+
+        Raises:
+            GrpcServiceError: If trusted_local is False and the target or a TLS
+                path is rejected by the SSRF / path-traversal validators.
         """
+        if trusted_local:
+            _warn_trusted_local_once()
+        else:
+            self._validate_target_and_tls()
+
         logger.info(f"Starting gRPC endpoint connection to {self._target}")
 
         # Create channel

--- a/mcpgateway/translate_grpc.py
+++ b/mcpgateway/translate_grpc.py
@@ -39,6 +39,7 @@ except ImportError:
 
 # First-Party
 from mcpgateway.services.logging_service import LoggingService
+from mcpgateway.utils.grpc_validation import _validate_grpc_target, _validate_tls_path
 
 # Initialize logging
 logging_service = LoggingService()
@@ -105,16 +106,11 @@ class GrpcEndpoint:
     def _validate_target_and_tls(self) -> None:
         """Validate the target address and any TLS paths against SSRF / traversal rules.
 
-        Reuses the shared validators from the gRPC service layer. They are
-        imported lazily to avoid a circular import with
-        ``mcpgateway.services.grpc_service`` (which imports ``GrpcEndpoint``).
+        Reuses the shared validators from ``mcpgateway.utils.grpc_validation``.
 
         Raises:
             GrpcServiceError: If the target or a TLS path is rejected.
         """
-        # First-Party
-        from mcpgateway.services.grpc_service import _validate_grpc_target, _validate_tls_path  # pylint: disable=import-outside-toplevel,cyclic-import
-
         _validate_grpc_target(self._target)
         if self._tls_cert_path:
             _validate_tls_path(self._tls_cert_path, "TLS cert path")

--- a/mcpgateway/utils/grpc_validation.py
+++ b/mcpgateway/utils/grpc_validation.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/utils/grpc_validation.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: ContextForge Contributors
+
+gRPC Target and TLS Path Validation
+
+Shared SSRF / path-traversal validators for gRPC connections, used by both
+``mcpgateway.services.grpc_service`` and ``mcpgateway.translate_grpc``. This
+module depends on neither of them, keeping the dependency tree one-way.
+"""
+
+# Standard
+import ipaddress
+from pathlib import Path
+
+# First-Party
+from mcpgateway.config import settings
+
+
+class GrpcServiceError(Exception):
+    """Base class for gRPC service-related errors."""
+
+
+_GRPC_DISALLOWED_SCHEMES = ("unix:", "unix-abstract:", "vsock:", "fd:")
+
+
+def _validate_grpc_target(target: str) -> None:
+    """Validate a gRPC target address against SSRF-unsafe destinations.
+
+    Consults the platform SSRF settings (``ssrf_allow_localhost``,
+    ``ssrf_allow_private_networks``, ``ssrf_allowed_networks``,
+    ``ssrf_blocked_networks``, ``ssrf_blocked_hosts``) so that gRPC
+    targets follow the same rules as HTTP URLs validated by
+    ``SecurityValidator.validate_url``.
+
+    Args:
+        target: gRPC target string. Accepts ``host:port``, bracketed
+            ``[ipv6]:port``, and gRPC name-resolver forms ``dns:///host:port``,
+            ``ipv4:host:port``, ``ipv6:host:port``. Local-only schemes
+            (``unix:``, ``unix-abstract:``, ``vsock:``, ``fd:``) are always
+            rejected because they bypass the network-level SSRF model.
+
+    Raises:
+        GrpcServiceError: If the target uses a forbidden scheme or resolves to a blocked address.
+    """
+    if not target:
+        raise GrpcServiceError("Empty gRPC target address")
+
+    # Local-only schemes bypass the IP-based SSRF model entirely; reject outright.
+    lowered = target.lower()
+    for scheme in _GRPC_DISALLOWED_SCHEMES:
+        if lowered.startswith(scheme):
+            raise GrpcServiceError(f"gRPC target scheme '{scheme.rstrip(':')}' is not permitted")
+
+    # Strip recognised gRPC name-resolver scheme prefixes so the host check below sees a bare host:port.
+    for scheme_prefix in ("dns:///", "dns://", "dns:", "ipv4:", "ipv6:"):
+        if lowered.startswith(scheme_prefix):
+            target = target[len(scheme_prefix) :]
+            break
+
+    # Extract host (strip port). Bracketed IPv6 literals: ``[::1]:50051``.
+    if target.startswith("["):
+        end = target.find("]")
+        if end < 0:
+            raise GrpcServiceError(f"Malformed bracketed gRPC target: {target!r}")
+        host = target[1:end]
+    else:
+        host = target.rsplit(":", 1)[0].strip("[]")
+    if not host:
+        raise GrpcServiceError("Empty gRPC target address")
+
+    # Reserved / multicast IP literals are unconditionally blocked. SecurityValidator._validate_ssrf
+    # only checks blocked-networks / localhost / private; it does not flag is_reserved/is_multicast,
+    # so this guard runs before delegation to keep the original gRPC-validator semantics. Loopback is
+    # excluded because Python flags ``::1`` as both is_loopback AND is_reserved; loopback policy is
+    # handled by SecurityValidator below via ssrf_allow_localhost.
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        addr = None
+    if addr is not None and not addr.is_loopback and (addr.is_reserved or addr.is_multicast):
+        raise GrpcServiceError(f"gRPC target address '{host}' is blocked (reserved/multicast)")
+
+    # Delegate the hostname/IP-network/DNS-resolution policy to the shared SecurityValidator
+    # so gRPC and HTTP follow the same SSRF rules and a hostname like ``metadata.google.internal``
+    # is resolved before being allowed through.
+    # First-Party
+    from mcpgateway.common.validators import SecurityValidator  # pylint: disable=import-outside-toplevel
+
+    if getattr(settings, "ssrf_protection_enabled", True):
+        try:
+            SecurityValidator._validate_ssrf(host, "gRPC target")  # pylint: disable=protected-access
+        except ValueError as exc:
+            raise GrpcServiceError(str(exc)) from exc
+
+
+def _validate_tls_path(path_str: str, label: str = "TLS path") -> Path:
+    """Validate that a TLS cert/key path is within allowed directories.
+
+    Args:
+        path_str: The file path to validate.
+        label: Label for error messages.
+
+    Returns:
+        Resolved Path object.
+
+    Raises:
+        GrpcServiceError: If the path escapes allowed directories.
+    """
+    resolved = Path(path_str).resolve()
+    # Allow only paths under /certs/, /etc/ssl/, /etc/pki/, or the CWD/certs dir
+    allowed_prefixes = (
+        Path("/certs").resolve(),
+        Path("/etc/ssl").resolve(),
+        Path("/etc/pki").resolve(),
+        Path.cwd().joinpath("certs").resolve(),
+    )
+    if not any(resolved.is_relative_to(prefix) for prefix in allowed_prefixes):
+        raise GrpcServiceError(f"{label} '{path_str}' is outside allowed certificate directories")
+    return resolved

--- a/tests/unit/mcpgateway/services/test_grpc_service.py
+++ b/tests/unit/mcpgateway/services/test_grpc_service.py
@@ -1407,7 +1407,7 @@ class TestInvokeMethodGuards:
             def __init__(self, **_kw):
                 self._services = None
 
-            async def start(self, timeout=None):
+            async def start(self, timeout=None, trusted_local=False):
                 raise asyncio.CancelledError()
 
             async def invoke(self, *_a, **_kw):
@@ -1439,7 +1439,7 @@ class TestInvokeMethodGuards:
             def __init__(self, **_kw):
                 self._services = None
 
-            async def start(self, timeout=None):
+            async def start(self, timeout=None, trusted_local=False):
                 raise asyncio.TimeoutError()
 
             async def invoke(self, *_a, **_kw):
@@ -1472,7 +1472,7 @@ class TestInvokeMethodGuards:
             def __init__(self, **_kw):
                 self._services = None
 
-            async def start(self, timeout=None):
+            async def start(self, timeout=None, trusted_local=False):
                 return None
 
             async def invoke(self, *_a, **_kw):
@@ -1645,7 +1645,7 @@ class TestInvokeMethodExceptionWrapping:
             def __init__(self, **_kw):
                 self._services = None
 
-            async def start(self, timeout=None):
+            async def start(self, timeout=None, trusted_local=False):
                 pass
 
             async def invoke(self, *_a, **_kw):
@@ -1698,7 +1698,7 @@ class TestInvokeMethodFinallyClose:
                 self._services = None
                 _sentinel_endpoint = self
 
-            async def start(self, timeout=None):
+            async def start(self, timeout=None, trusted_local=False):
                 pass
 
             async def invoke(self, *_a, **_kw):

--- a/tests/unit/mcpgateway/services/test_grpc_service_no_grpc.py
+++ b/tests/unit/mcpgateway/services/test_grpc_service_no_grpc.py
@@ -960,7 +960,7 @@ async def test_perform_reflection_tls_reads_cert_and_key(monkeypatch, service, d
         visibility="public",
     )
 
-    with patch("mcpgateway.services.grpc_service.Path.read_bytes", side_effect=[b"cert", b"key"]):
+    with patch("mcpgateway.utils.grpc_validation.Path.read_bytes", side_effect=[b"cert", b"key"]):
         await service._perform_reflection(db, db_service)
 
     assert db_service.reachable is True
@@ -997,7 +997,7 @@ async def test_perform_reflection_tls_missing_cert(monkeypatch, service, db):
         visibility="public",
     )
 
-    with patch("mcpgateway.services.grpc_service.Path.read_bytes", side_effect=FileNotFoundError("missing")):
+    with patch("mcpgateway.utils.grpc_validation.Path.read_bytes", side_effect=FileNotFoundError("missing")):
         with pytest.raises(GrpcServiceError):
             await service._perform_reflection(db, db_service)
 

--- a/tests/unit/mcpgateway/services/test_grpc_service_no_grpc.py
+++ b/tests/unit/mcpgateway/services/test_grpc_service_no_grpc.py
@@ -535,7 +535,7 @@ async def test_invoke_method_success(service, db):
         def __init__(self, **_kwargs):
             self._services = None
 
-        async def start(self, timeout=None):
+        async def start(self, timeout=None, trusted_local=False):
             return None
 
         async def invoke(self, service_name, method, request_data, timeout=None):
@@ -580,7 +580,7 @@ async def test_invoke_method_error_path(service, db):
         def __init__(self, **_kwargs):
             self._services = None
 
-        async def start(self, timeout=None):
+        async def start(self, timeout=None, trusted_local=False):
             return None
 
         async def invoke(self, _service_name, _method, _request_data, timeout=None):
@@ -629,7 +629,7 @@ async def test_invoke_method_validates_tls_paths_when_configured(service, db):
         def __init__(self, **_kwargs):
             self._services = None
 
-        async def start(self, timeout=None):
+        async def start(self, timeout=None, trusted_local=False):
             return None
 
         async def invoke(self, _service_name, _method, _request_data, timeout=None):

--- a/tests/unit/mcpgateway/test_translate_grpc.py
+++ b/tests/unit/mcpgateway/test_translate_grpc.py
@@ -160,6 +160,23 @@ class TestGrpcEndpoint:
         mock_grpc.insecure_channel.assert_called_once_with("metadata.google.internal:443")
 
     @patch("mcpgateway.translate_grpc.grpc")
+    async def test_start_validates_target_and_tls_paths_by_default(self, mock_grpc, endpoint_with_tls):
+        """start() validates the target and both TLS paths by default (trusted_local=False)."""
+        mock_grpc.secure_channel.return_value = MagicMock()
+        mock_grpc.ssl_channel_credentials.return_value = MagicMock()
+
+        with (
+            patch("mcpgateway.services.grpc_service._validate_grpc_target") as mock_validate_target,
+            patch("mcpgateway.services.grpc_service._validate_tls_path") as mock_validate_tls,
+            patch("mcpgateway.translate_grpc.asyncio.to_thread", new_callable=AsyncMock, return_value=b"cert_data"),
+            patch.object(endpoint_with_tls, "_discover_services", new_callable=AsyncMock),
+        ):
+            await endpoint_with_tls.start()
+
+        mock_validate_target.assert_called_once_with("secure.example.com:443")
+        assert mock_validate_tls.call_count == 2  # cert + key
+
+    @patch("mcpgateway.translate_grpc.grpc")
     @patch("mcpgateway.translate_grpc.reflection_pb2_grpc")
     @patch("mcpgateway.translate_grpc.reflection_pb2")
     async def test_discover_services_success(self, mock_reflection_pb2, mock_reflection_grpc, mock_grpc, endpoint):

--- a/tests/unit/mcpgateway/test_translate_grpc.py
+++ b/tests/unit/mcpgateway/test_translate_grpc.py
@@ -24,6 +24,7 @@ except ImportError:
     GRPC_AVAILABLE = False
 
 # First-Party
+from mcpgateway.services.grpc_service import GrpcServiceError
 from mcpgateway.translate_grpc import (
     expose_grpc_via_sse,
     GrpcEndpoint,
@@ -92,7 +93,7 @@ class TestGrpcEndpoint:
         mock_grpc.insecure_channel.return_value = mock_channel
 
         with patch.object(endpoint, "_discover_services", new_callable=AsyncMock):
-            await endpoint.start()
+            await endpoint.start(trusted_local=True)
 
         mock_grpc.insecure_channel.assert_called_once_with("localhost:50051")
         assert endpoint._channel == mock_channel
@@ -106,7 +107,7 @@ class TestGrpcEndpoint:
 
         with patch("mcpgateway.translate_grpc.asyncio.to_thread", new_callable=AsyncMock, return_value=b"cert_data"):
             with patch.object(endpoint_with_tls, "_discover_services", new_callable=AsyncMock):
-                await endpoint_with_tls.start()
+                await endpoint_with_tls.start(trusted_local=True)
 
         assert endpoint_with_tls._channel == mock_channel
         mock_grpc.secure_channel.assert_called_once()
@@ -125,10 +126,38 @@ class TestGrpcEndpoint:
         mock_grpc.ssl_channel_credentials.return_value = MagicMock()
 
         with patch.object(endpoint, "_discover_services", new_callable=AsyncMock):
-            await endpoint.start()
+            await endpoint.start(trusted_local=True)
 
         mock_grpc.ssl_channel_credentials.assert_called_once_with()
         assert endpoint._channel == mock_channel
+
+    @patch("mcpgateway.translate_grpc.grpc")
+    async def test_start_validates_and_blocks_ssrf_target(self, mock_grpc, monkeypatch):
+        """start() rejects an SSRF-blocked target before opening any channel (default trusted_local=False)."""
+        monkeypatch.setattr("mcpgateway.config.settings.ssrf_protection_enabled", True, raising=False)
+        monkeypatch.setattr("mcpgateway.config.settings.ssrf_blocked_hosts", ["metadata.google.internal"], raising=False)
+
+        endpoint = GrpcEndpoint(target="metadata.google.internal:443", reflection_enabled=False)
+
+        with pytest.raises(GrpcServiceError):
+            await endpoint.start()
+
+        # No channel may be opened once validation rejects the target.
+        mock_grpc.insecure_channel.assert_not_called()
+        mock_grpc.secure_channel.assert_not_called()
+
+    @patch("mcpgateway.translate_grpc.grpc")
+    async def test_start_trusted_local_skips_validation(self, mock_grpc, monkeypatch):
+        """trusted_local=True skips SSRF validation for an otherwise-blocked target."""
+        monkeypatch.setattr("mcpgateway.config.settings.ssrf_protection_enabled", True, raising=False)
+        monkeypatch.setattr("mcpgateway.config.settings.ssrf_blocked_hosts", ["metadata.google.internal"], raising=False)
+        mock_grpc.insecure_channel.return_value = MagicMock()
+
+        endpoint = GrpcEndpoint(target="metadata.google.internal:443", reflection_enabled=False)
+
+        await endpoint.start(trusted_local=True)  # must not raise
+
+        mock_grpc.insecure_channel.assert_called_once_with("metadata.google.internal:443")
 
     @patch("mcpgateway.translate_grpc.grpc")
     @patch("mcpgateway.translate_grpc.reflection_pb2_grpc")
@@ -525,7 +554,7 @@ async def test_endpoint_start_without_reflection(monkeypatch):
     monkeypatch.setattr("mcpgateway.translate_grpc.grpc", mock_grpc)
     monkeypatch.setattr(endpoint, "_discover_services", AsyncMock())
 
-    await endpoint.start()
+    await endpoint.start(trusted_local=True)
     assert endpoint._channel == "chan"
     endpoint._discover_services.assert_not_called()
 
@@ -552,7 +581,7 @@ async def test_endpoint_start_with_tls_and_reflection(monkeypatch):
     monkeypatch.setattr(tg.asyncio, "to_thread", AsyncMock(return_value=b"cert-data"))
     monkeypatch.setattr(endpoint, "_discover_services", AsyncMock())
 
-    await endpoint.start()
+    await endpoint.start(trusted_local=True)
 
     assert endpoint._channel == "secure-chan"
     mock_grpc.ssl_channel_credentials.assert_called_once()

--- a/tests/unit/mcpgateway/test_translate_grpc.py
+++ b/tests/unit/mcpgateway/test_translate_grpc.py
@@ -166,8 +166,8 @@ class TestGrpcEndpoint:
         mock_grpc.ssl_channel_credentials.return_value = MagicMock()
 
         with (
-            patch("mcpgateway.services.grpc_service._validate_grpc_target") as mock_validate_target,
-            patch("mcpgateway.services.grpc_service._validate_tls_path") as mock_validate_tls,
+            patch("mcpgateway.translate_grpc._validate_grpc_target") as mock_validate_target,
+            patch("mcpgateway.translate_grpc._validate_tls_path") as mock_validate_tls,
             patch("mcpgateway.translate_grpc.asyncio.to_thread", new_callable=AsyncMock, return_value=b"cert_data"),
             patch.object(endpoint_with_tls, "_discover_services", new_callable=AsyncMock),
         ):


### PR DESCRIPTION
Closes #4615

SSRF/TLS validation for gRPC connections lived only in the `GrpcService` call sites, so a direct caller of `GrpcEndpoint.start()` opened a channel with no SSRF defense. That left `expose_grpc_via_sse()` and the translate CLI able to be pointed at a blocked destination such as a cloud-metadata endpoint.

`GrpcEndpoint.start()` now validates the target address and any TLS paths against the platform SSRF / path-traversal rules by default, reusing the existing `_validate_grpc_target` / `_validate_tls_path` (imported lazily to respect the existing `grpc_service` ↔ `translate_grpc` circular import). A `trusted_local: bool = False` parameter provides an explicit opt-out for callers that have already validated — it skips the checks and logs a warning once per process. `invoke_method` also validates the target and TLS paths before connecting, and `register_service` is unchanged (it validates at registration and builds its own channel).

Verified: `ruff` and `bandit` are clean on the changed files, and `pytest tests/unit/mcpgateway/test_translate_grpc.py tests/unit/mcpgateway/services/test_grpc_service.py` reports 118 passed — including three regression tests: a blocked target (`metadata.google.internal`, a default `ssrf_blocked_hosts` entry) raises before any channel is opened, `trusted_local=True` bypasses validation as designed, and `start()` validates both TLS paths by default.
