### PR TITLE
ci: add compose production smoke check

### DIFF
--- a/.github/workflows/compose-prod-smoke.yml
+++ b/.github/workflows/compose-prod-smoke.yml
@@ -1,0 +1,159 @@
+name: Compose Production Smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: ["main"]
+    paths:
+      - ".dockerignore"
+      - "Containerfile.lite"
+      - "Makefile"
+      - "docker-compose*.yml"
+      - "docker-entrypoint.sh"
+      - "gunicorn.config.py"
+      - "infra/nginx/**"
+      - "run-gunicorn.sh"
+      - "a2a-agents/rust/a2a-echo-agent/**"
+      - "mcpgateway/**"
+      - "mcp-servers/rust/fast-time-server/**"
+      - "plugins/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/compose-prod-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-prod-smoke:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: compose-prod-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      DOCKER_BUILDKIT: "1"
+      GATEWAY_REPLICAS: "1"
+      GUNICORN_WORKERS: "2"
+      GATEWAY_CPU_LIMIT: "4"
+      GATEWAY_CPU_RESERVATION: "1"
+      TESTING_LOCUST_WORKERS: "1"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Build production image
+        run: make docker-prod
+
+      - name: Smoke default compose stack
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          make compose-up
+
+          for i in {1..90}; do
+            if curl -fsS http://localhost:8080/health >/tmp/compose-health.json; then
+              break
+            fi
+            echo "Waiting for gateway health through nginx (${i}/90)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8080/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8080/admin/login -o /tmp/admin-login.html
+          grep -q "Sign In - ContextForge" /tmp/admin-login.html
+          docker compose -f docker-compose.yml logs --no-color gateway > /tmp/default-gateway.log
+          if grep -E "Control server error|Read-only file system|SIGKILL|Perhaps out of memory" /tmp/default-gateway.log; then
+            echo "Gateway logged startup/runtime errors in default compose stack"
+            exit 1
+          fi
+
+      - name: Restart with testing profile and smoke endpoints
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          make compose-down
+          make testing-up
+
+          for i in {1..90}; do
+            if curl -fsS http://localhost:8080/health >/tmp/testing-health.json; then
+              break
+            fi
+            echo "Waiting for testing gateway health through nginx (${i}/90)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8080/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8080/admin/login -o /tmp/testing-admin-login.html
+          grep -q "Sign In - ContextForge" /tmp/testing-admin-login.html
+
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8880/health >/tmp/fast-test-health.json; then
+              break
+            fi
+            echo "Waiting for fast test server (${i}/60)"
+            sleep 2
+          done
+          for i in {1..60}; do
+            if curl -fsS http://localhost:9100/health >/tmp/a2a-echo-health.json; then
+              break
+            fi
+            echo "Waiting for A2A echo agent (${i}/60)"
+            sleep 2
+          done
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8089/ >/tmp/locust.html; then
+              break
+            fi
+            echo "Waiting for Locust UI (${i}/60)"
+            sleep 2
+          done
+
+          curl -fsS http://localhost:8880/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:9100/health | jq -e '.status == "healthy"'
+          curl -fsS http://localhost:8089/ >/tmp/locust.html
+          docker compose -f docker-compose.yml logs --no-color gateway > /tmp/testing-gateway.log
+          if grep -E "Control server error|Read-only file system|SIGKILL|Perhaps out of memory" /tmp/testing-gateway.log; then
+            echo "Gateway logged startup/runtime errors in testing compose stack"
+            exit 1
+          fi
+
+      - name: Show compose status
+        if: always()
+        run: docker compose -f docker-compose.yml ps -a || true
+
+      - name: Collect compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.yml logs --no-color > /tmp/compose-prod-smoke.log || true
+
+      - name: Upload compose logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: compose-prod-smoke-logs
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            /tmp/compose-health.json
+            /tmp/testing-health.json
+            /tmp/fast-test-health.json
+            /tmp/a2a-echo-health.json
+            /tmp/admin-login.html
+            /tmp/testing-admin-login.html
+            /tmp/locust.html
+            /tmp/default-gateway.log
+            /tmp/testing-gateway.log
+            /tmp/compose-prod-smoke.log
+
+      - name: Stop compose stack
+        if: always()
+        run: make compose-down || true


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5419

---

## 📝 Summary

This PR adds a dedicated production compose smoke workflow. The workflow builds the production image, starts the default compose stack with CI-sized local resources, verifies nginx-routed `/health` and `/admin/login`, then restarts with the testing profile and checks the gateway plus fast test, A2A echo, and Locust endpoints.

Rationale: current CI can be green while missing failures in the real production compose path. Existing checks build images or run `make serve` directly, but they do not combine `make docker-prod`, `make compose-up`, nginx routing on port 8080, and admin login verification. This gap allowed a read-only container filesystem issue in Gunicorn startup to escape CI.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Workflow lint | `actionlint .github/workflows/compose-prod-smoke.yml` | Pass |
| Compose testing profile config | `GATEWAY_REPLICAS=1 GUNICORN_WORKERS=2 GATEWAY_CPU_LIMIT=4 GATEWAY_CPU_RESERVATION=1 TESTING_LOCUST_WORKERS=1 docker compose -f docker-compose.yml --profile testing --profile inspector --profile sso config --quiet` | Pass |

---

## ✅ Checklist

- [x] Tests added/updated for changes
- [x] No secrets or credentials committed
- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Documentation updated (if applicable)

---

## 📓 Notes (optional)

The workflow intentionally uses lower CI runtime values (`GATEWAY_REPLICAS=1`, `GUNICORN_WORKERS=2`, `GATEWAY_CPU_LIMIT=4`, `GATEWAY_CPU_RESERVATION=1`) so GitHub-hosted runners can exercise the compose path without changing repository defaults.

It also fails when gateway logs contain startup/runtime signals that can otherwise be easy to miss: `Control server error`, `Read-only file system`, `SIGKILL`, or `Perhaps out of memory`.
