### PR TITLE
fix(auth): propagate end-user identity on the cached virtual-server invocation path

### DIFF
--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -114,6 +114,33 @@ _REGISTRY_CACHE = None
 _TOOL_LOOKUP_CACHE = None
 
 
+def _resolve_propagation_identity(global_context):
+    """Resolve the end-user identity to propagate to upstream MCP servers.
+
+    Prefers the plugin global context's ``user_context``; falls back to the
+    per-request ``user_identity_var`` set by the transport auth layer
+    (``streamablehttp_transport._set_user_identity_from_dict``).
+
+    The cached virtual-server invocation path calls :meth:`ToolService.invoke_tool`
+    without a ``plugin_global_context`` (see the ``streamablehttp_transport``
+    tool-call handler), so without this fallback identity propagation silently
+    no-ops for virtual-server tool calls while still working on the direct_proxy
+    path. See https://github.com/IBM/mcp-context-forge (vServer identity gap).
+
+    Args:
+        global_context: Optional plugin ``GlobalContext`` carrying ``user_context``.
+
+    Returns:
+        A ``UserContext`` to propagate, or ``None`` if no identity is available.
+    """
+    if global_context is not None and getattr(global_context, "user_context", None):
+        return global_context.user_context
+    # Local import to avoid import cycles at module load time.
+    from mcpgateway.transports.context import user_identity_var  # pylint: disable=import-outside-toplevel
+
+    return user_identity_var.get()
+
+
 def _get_registry_cache():
     """Get registry cache singleton lazily.
 
@@ -4988,8 +5015,9 @@ class ToolService(BaseService):
                             logger.debug("[AFFINITY] Worker %s | Session %s... | Tool: %s | Normalized MCP-Session-Id → x-mcp-session-id for pool affinity", worker_id, session_short, name)
 
                     # Inject identity propagation headers for REST tools
-                    if global_context and global_context.user_context:
-                        headers.update(build_identity_headers(global_context.user_context))
+                    _propagation_identity = _resolve_propagation_identity(global_context)
+                    if _propagation_identity:
+                        headers.update(build_identity_headers(_propagation_identity))
 
                     if plugin_manager and plugin_manager.has_hooks_for(ToolHookType.TOOL_PRE_INVOKE) and not skip_pre_invoke:
                         # Use pre-created Pydantic model from Phase 2 (no ORM access)
@@ -5299,9 +5327,10 @@ class ToolService(BaseService):
                             )
 
                     # Inject identity propagation headers and meta for MCP tools
-                    if global_context and global_context.user_context:
-                        headers.update(build_identity_headers(global_context.user_context))
-                        meta_data = build_identity_meta(global_context.user_context, meta_data)
+                    _propagation_identity = _resolve_propagation_identity(global_context)
+                    if _propagation_identity:
+                        headers.update(build_identity_headers(_propagation_identity))
+                        meta_data = build_identity_meta(_propagation_identity, meta_data)
 
                     # mTLS client cert/key: resolve from payload, then override with runtime gateway if available
                     client_cert_from_payload = gateway_payload.get("client_cert") if has_gateway else None

--- a/tests/unit/mcpgateway/services/test_tool_service_vserver_identity.py
+++ b/tests/unit/mcpgateway/services/test_tool_service_vserver_identity.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/services/test_tool_service_vserver_identity.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+Tests for identity propagation on the cached virtual-server invocation path.
+
+The cached tool-call path (``streamablehttp_transport`` -> ``ToolService.invoke_tool``)
+does not pass a ``plugin_global_context``. Identity propagation must therefore fall
+back to the per-request ``user_identity_var`` set by the transport auth layer,
+otherwise ``X-<prefix>-*`` identity headers are silently dropped for vServer calls.
+"""
+
+# Standard
+from datetime import datetime, timezone
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.services.tool_service import _resolve_propagation_identity
+from mcpgateway.transports.context import UserContext, user_identity_var
+
+
+class _GC:
+    """Minimal stand-in for the plugin GlobalContext (only ``user_context`` is read)."""
+
+    def __init__(self, user_context):
+        self.user_context = user_context
+
+
+@pytest.fixture(autouse=True)
+def _clear_identity_var():
+    """Reset the identity contextvar around each test."""
+    token = user_identity_var.set(None)
+    try:
+        yield
+    finally:
+        user_identity_var.reset(token)
+
+
+def _uc(email):
+    return UserContext(user_id=email, email=email, teams=["team-it"], auth_method="bearer", authenticated_at=datetime.now(timezone.utc))
+
+
+def test_prefers_global_context_user_context():
+    """When a plugin global context carries a user_context, it wins."""
+    gc_uc = _uc("from-gc@example.com")
+    user_identity_var.set(_uc("from-var@example.com"))
+    assert _resolve_propagation_identity(_GC(gc_uc)) is gc_uc
+
+
+def test_falls_back_to_contextvar_when_no_global_context():
+    """Cached vServer path: global_context is None -> use user_identity_var."""
+    var_uc = _uc("from-var@example.com")
+    user_identity_var.set(var_uc)
+    assert _resolve_propagation_identity(None) is var_uc
+
+
+def test_falls_back_when_global_context_has_no_user_context():
+    """A global context without user_context still falls back to the contextvar."""
+    var_uc = _uc("from-var@example.com")
+    user_identity_var.set(var_uc)
+    assert _resolve_propagation_identity(_GC(None)) is var_uc
+
+
+def test_returns_none_when_no_identity_anywhere():
+    """No global context and no contextvar -> nothing to propagate."""
+    assert _resolve_propagation_identity(None) is None
+    assert _resolve_propagation_identity(_GC(None)) is None


### PR DESCRIPTION
### Problem

End-user identity propagation (#3152) injects `X-<prefix>-*` identity headers (and `_meta`) into upstream MCP requests in `ToolService.invoke_tool`, guarded by:

```python
if global_context and global_context.user_context:
    headers.update(build_identity_headers(global_context.user_context))
```

But the **cached** tool-call path used by **virtual servers** does not pass a `plugin_global_context`: the `streamablehttp_transport` tool-call handler calls `tool_service.invoke_tool(db=..., name=..., user_email=..., token_teams=..., ...)` **without** `plugin_global_context`. So for any client connecting via `/servers/<vserver-id>/mcp`, `global_context` is `None` and identity injection is **silently skipped** — the upstream server never receives the identity headers.

The `direct_proxy` path works (it resolves identity from `user_identity_var` / passes `user_context`), but it only activates when the client sends the `X-Context-Forge-Gateway-Id` header, which virtual-server clients never do.

Net effect: signed team/identity routing in a downstream MCP works on the direct_proxy path but is impossible over the normal virtual-server path.

### Root cause

`invoke_tool` reads identity **only** from `global_context.user_context`, while the transport auth layer already sets the per-request `user_identity_var` (via `_set_user_identity_from_dict`) on the cached path — `invoke_tool` just never consults it.

### Fix

Resolve the propagation identity from `global_context.user_context` **or** fall back to `user_identity_var` (symmetric with the `_proxy_*_to_gateway` helpers). Extracted into a small helper `_resolve_propagation_identity()` used at both injection sites (REST + MCP). `+34/-5` in one file.

### Reproduction

1. Federate a STREAMABLEHTTP gateway, expose its tools via a virtual server.
2. Connect a client to `/servers/<id>/mcp` with a JWT carrying a `teams` claim.
3. Call a tool; observe the upstream receives **no** `X-<prefix>-*` headers.
4. With the fix, the upstream receives `X-<prefix>-Id/-Email/-Teams/-Claims-Signature`.

### Tests

- New `tests/unit/mcpgateway/services/test_tool_service_vserver_identity.py` — unit tests for `_resolve_propagation_identity` (prefers global context; falls back to the contextvar when `plugin_global_context` is absent or carries no `user_context`; `None` when neither is set).
- Existing `tests/unit/mcpgateway/test_identity_propagation.py` and the full `tests/unit/mcpgateway/services/test_tool_service.py` suite pass unchanged (regression).

### Notes / possible follow-up

The MCP injection site does not pass the resolved `gateway` to `build_identity_headers/meta`, so per-gateway `identity_propagation` overrides are ignored on this path (direct_proxy passes it). Left out to keep this PR minimal; happy to add if preferred.
