### PR TITLE
Reuse default plugin manager

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1154,7 +1154,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1437,
+        "line_number": 1559,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1154,7 +1154,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1559,
+        "line_number": 1563,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-15T19:21:59Z",
+  "generated_at": "2026-07-15T22:11:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1154,7 +1154,7 @@
         "hashed_secret": "7373eb3c8f036e7f058bfc66fc27870f01231645",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1563,
+        "line_number": 1559,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/architecture-plugin-multi-tenancy.md
+++ b/docs/architecture-plugin-multi-tenancy.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The plugin subsystem supports **context-scoped isolation** through a shared `TenantPluginManagerFactory`. Each resolved context gets its own `TenantPluginManager` instance with an independently merged plugin configuration, while the default `__global__` context continues to serve non-context-aware call sites.
+The plugin subsystem supports **context-scoped isolation** through a shared `TenantPluginManagerFactory`. Each resolved context gets its own `TenantPluginManager` instance with an independently merged plugin configuration, while the default `##global##` context continues to serve non-context-aware call sites.
 
 The factory is intentionally **context-agnostic**. The identifier passed to `get_manager()` can represent a virtual server, tenant, tool, user, or another scoping key. The factory does not interpret the value; it only uses it to:
 - look up an existing cached manager,
@@ -11,7 +11,7 @@ The factory is intentionally **context-agnostic**. The identifier passed to `get
 - cache the result for reuse.
 
 In the current gateway wiring, the primary runtime usage is:
-- `get_plugin_manager()` or `get_plugin_manager("__global__")` for shared/global plugin execution
+- `get_plugin_manager()` or `get_plugin_manager("##global##")` for shared/global plugin execution
 - `get_plugin_manager(server_id)` for server-scoped execution in services such as tools, prompts, and resources
 
 ---
@@ -83,7 +83,7 @@ flowchart TD
 flowchart TD
     APP["Application lifespan\n(mcpgateway.main)"]
     F["TenantPluginManagerFactory\n(singleton, holds base YAML config)"]
-    G["TenantPluginManager\ncontext = '__global__'\n(backward-compat global manager)"]
+    G["TenantPluginManager\ncontext = '##global##'\n(backward-compat global manager)"]
     S1["TenantPluginManager\ncontext = 'server-id-1'"]
     S2["TenantPluginManager\ncontext = 'server-id-2'"]
     DB["get_config_from_db(context_id)\n(fetch per-context overrides)"]
@@ -118,7 +118,7 @@ At startup, `mcpgateway.main.lifespan()`:
    - plugin timeout,
    - hook payload policies,
    - optional observability provider,
-3. calls `await get_plugin_manager()` to resolve the default `__global__` manager,
+3. calls `await get_plugin_manager()` to resolve the default `##global##` manager,
 4. leaves additional context-specific managers to be created lazily on first use.
 
 This means the factory is initialized eagerly, but most tenant/server managers are initialized on demand.
@@ -166,7 +166,7 @@ Defined in `mcpgateway/plugins/framework/manager.py`.
 
 | Method | Current behavior |
 | --- | --- |
-| `get_manager(context_id=None)` | Returns cached manager or creates one; defaults to `__global__` |
+| `get_manager(context_id=None)` | Returns cached manager or creates one; defaults to `##global##` |
 | `_build_manager(context_id)` | Fetches overrides, merges config, initializes manager, swaps cache entry |
 | `_merge_tenant_config(overrides)` | Applies per-plugin override values on top of base YAML config |
 | `reload_tenant(context_id)` | Evicts cached manager, rebuilds it, and shuts down the old one |
@@ -183,7 +183,7 @@ The public accessor lives in `mcpgateway/plugins/framework/__init__.py`.
 | --- | --- |
 | `enable_plugins(toggle)` | Enables or disables the plugin subsystem globally |
 | `init_plugin_manager_factory(...)` | Creates the singleton factory explicitly during startup |
-| `get_plugin_manager(server_id="__global__")` | Returns a context manager when plugins are enabled and the factory exists |
+| `get_plugin_manager(server_id="##global##")` | Returns a context manager when plugins are enabled and the factory exists |
 | `shutdown_plugin_manager_factory()` | Shuts down the factory and clears the singleton reference |
 | `reset_plugin_manager_factory()` | Clears the singleton reference for tests |
 
@@ -289,7 +289,7 @@ The current design preserves compatibility in a few important ways:
 
 - `PluginManager` still exists for Borg-based shared-state behavior.
 - `TenantPluginManager` keeps the same public lifecycle and hook invocation API as `PluginManager`.
-- `get_plugin_manager()` without arguments still resolves the global `__global__` manager.
+- `get_plugin_manager()` without arguments still resolves the global `##global##` manager.
 - Call sites that are not context-aware continue to function against the global manager.
 
 What changed is the wiring: the system now routes plugin access through the factory instead of a single shared manager instance.

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -845,20 +845,24 @@ async def test_plugin_config_change():
 
 #### Shared Manager Optimization
 
-When no tenant-specific configuration is provided, the factory reuses a shared default plugin manager:
+When no tool-specific configuration is provided, the factory reuses a shared default plugin manager per team:
 
 ```python
-# Tenants without custom configs share the default manager
-manager_a = await factory.get_manager("tenant-a")  # No config → uses shared default
-manager_b = await factory.get_manager("tenant-b")  # No config → reuses same instance
+# Tools within the same team share the team's default manager
+manager_a1 = await factory.get_manager("team-a::tool1")  # No config → uses team-a::##global##
+manager_a2 = await factory.get_manager("team-a::tool2")  # No config → reuses team-a::##global##
 
-# Tenants with custom configs get dedicated managers
-manager_c = await factory.get_manager("tenant-c")  # Has config → dedicated instance
+# Different teams have separate default managers
+manager_b1 = await factory.get_manager("team-b::tool1")  # No config → uses team-b::##global##
+
+# Tools with custom configs get dedicated managers
+manager_a3 = await factory.get_manager("team-a::tool3")  # Has config → dedicated instance
 ```
 
 This optimization:
-- Reduces memory footprint when most tenants use default configuration
-- Maintains isolation through tenant-specific contexts during execution
+- Reduces memory footprint when most tools within a team use default configuration
+- Maintains team isolation with separate default managers per team
+- Maintains isolation through tool-specific contexts during execution
 - Automatically handles cleanup without double-shutdown errors during factory shutdown
 
 

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -752,41 +752,41 @@ In multi-tenant deployments, each tenant can have a separate plugin configuratio
 ```python
 class TenantPluginManagerFactory:
     """Factory for creating and caching tenant-specific plugin managers"""
-    
+
     def __init__(self, cache_ttl: int = 300):
         """
         Initialize factory with configurable cache TTL.
-        
+
         Args:
             cache_ttl: Cache time-to-live in seconds (default: 300 = 5 minutes)
         """
         self._managers: Dict[str, Tuple[PluginManager, float]] = {}
         self._cache_ttl = cache_ttl
-    
+
     async def get_manager(self, tenant_id: str) -> PluginManager:
         """
         Get or create a plugin manager for the specified tenant.
-        
+
         Managers are cached with TTL-based expiration. If a cached manager
         exists and hasn't expired, it is returned. Otherwise, a new manager
         is created from the tenant's plugin configuration.
-        
+
         Args:
             tenant_id: Unique tenant identifier
-            
+
         Returns:
             PluginManager instance for the tenant
         """
         ...
-    
+
     def reload_tenant(self, tenant_id: str) -> None:
         """
         Invalidate cached plugin manager for a tenant.
-        
+
         This forces the next get_manager() call to create a fresh manager
         with the latest configuration. Must be called when a tenant's
         plugin configuration changes.
-        
+
         Args:
             tenant_id: Tenant whose cache should be invalidated
         """
@@ -834,10 +834,10 @@ For deployments with many tenants, monitor memory usage and consider:
 async def test_plugin_config_change():
     # Update configuration
     await update_tenant_plugins(tenant_id, new_config)
-    
+
     # CRITICAL: Reload to simulate production behavior
     factory.reload_tenant(tenant_id)
-    
+
     # Verify new configuration is active
     manager = await factory.get_manager(tenant_id)
     assert manager.plugin_count == expected_count

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -741,6 +741,128 @@ class PluginInstanceRegistry:
     def unregister(self, name: str) -> None:
         """Unregister a plugin by name"""
 
+```
+
+# Multi-Tenant Plugin Manager
+
+In multi-tenant deployments, each tenant can have a separate plugin configuration. The `TenantPluginManagerFactory` manages per-tenant plugin manager instances with automatic caching and lifecycle management.
+
+#### Architecture
+
+```python
+class TenantPluginManagerFactory:
+    """Factory for creating and caching tenant-specific plugin managers"""
+    
+    def __init__(self, cache_ttl: int = 300):
+        """
+        Initialize factory with configurable cache TTL.
+        
+        Args:
+            cache_ttl: Cache time-to-live in seconds (default: 300 = 5 minutes)
+        """
+        self._managers: Dict[str, Tuple[PluginManager, float]] = {}
+        self._cache_ttl = cache_ttl
+    
+    async def get_manager(self, tenant_id: str) -> PluginManager:
+        """
+        Get or create a plugin manager for the specified tenant.
+        
+        Managers are cached with TTL-based expiration. If a cached manager
+        exists and hasn't expired, it is returned. Otherwise, a new manager
+        is created from the tenant's plugin configuration.
+        
+        Args:
+            tenant_id: Unique tenant identifier
+            
+        Returns:
+            PluginManager instance for the tenant
+        """
+        ...
+    
+    def reload_tenant(self, tenant_id: str) -> None:
+        """
+        Invalidate cached plugin manager for a tenant.
+        
+        This forces the next get_manager() call to create a fresh manager
+        with the latest configuration. Must be called when a tenant's
+        plugin configuration changes.
+        
+        Args:
+            tenant_id: Tenant whose cache should be invalidated
+        """
+        if tenant_id in self._managers:
+            del self._managers[tenant_id]
+```
+
+#### Cache Behavior
+
+**Cache TTL**: Plugin managers are cached for 300 seconds (5 minutes) by default. This balances:
+- **Performance**: Avoids recreating managers on every request
+- **Configuration freshness**: Changes propagate within reasonable time
+- **Memory efficiency**: Stale managers are automatically cleaned up
+
+**Cache Invalidation**: The cache must be explicitly invalidated when plugin configuration changes:
+
+```python
+# Example: After updating tenant plugin configuration
+await plugin_service.update_tenant_config(tenant_id, new_config)
+
+# CRITICAL: Invalidate cache so changes take effect immediately
+factory.reload_tenant(tenant_id)
+```
+
+#### Production Considerations
+
+**Memory Management**: Each cached plugin manager holds:
+- Plugin instances and their state
+- Configuration objects
+- Registry entries
+
+For deployments with many tenants, monitor memory usage and consider:
+- Reducing `cache_ttl` for tenants with infrequent requests
+- Implementing LRU eviction for least-recently-used managers
+- Setting up alerts for cache size growth
+
+**Configuration Propagation**: In distributed deployments:
+- Each gateway instance maintains its own cache
+- Configuration changes must propagate to all instances
+- Consider using Redis or similar for shared cache invalidation signals
+
+**Testing**: When writing tests that modify plugin configuration:
+
+```python
+async def test_plugin_config_change():
+    # Update configuration
+    await update_tenant_plugins(tenant_id, new_config)
+    
+    # CRITICAL: Reload to simulate production behavior
+    factory.reload_tenant(tenant_id)
+    
+    # Verify new configuration is active
+    manager = await factory.get_manager(tenant_id)
+    assert manager.plugin_count == expected_count
+```
+
+#### Shared Manager Optimization
+
+When no tenant-specific configuration is provided, the factory reuses a shared default plugin manager:
+
+```python
+# Tenants without custom configs share the default manager
+manager_a = await factory.get_manager("tenant-a")  # No config → uses shared default
+manager_b = await factory.get_manager("tenant-b")  # No config → reuses same instance
+
+# Tenants with custom configs get dedicated managers
+manager_c = await factory.get_manager("tenant-c")  # Has config → dedicated instance
+```
+
+This optimization:
+- Reduces memory footprint when most tenants use default configuration
+- Maintains isolation through tenant-specific contexts during execution
+- Automatically handles cleanup without double-shutdown errors during factory shutdown
+
+
+
     def get_plugin(self, name: str) -> Optional[PluginRef]:
         """Get plugin reference by name"""
 

--- a/docs/docs/architecture/plugins.md
+++ b/docs/docs/architecture/plugins.md
@@ -741,11 +741,26 @@ class PluginInstanceRegistry:
     def unregister(self, name: str) -> None:
         """Unregister a plugin by name"""
 
+    def get_plugin(self, name: str) -> Optional[PluginRef]:
+        """Get plugin reference by name"""
+
+    def get_plugins_for_hook(self, hook_type: HookType) -> list[PluginRef]:
+        """Get all plugins registered for a specific hook"""
+
+    def get_all_plugins(self) -> list[PluginRef]:
+        """Get all registered plugins"""
+
+    @property
+    def plugin_count(self) -> int:
+        """Number of registered plugins"""
+
+    async def shutdown(self) -> None:
+        """Shutdown all registered plugins"""
 ```
 
-# Multi-Tenant Plugin Manager
+### Multi-Tenant Plugin Manager
 
-In multi-tenant deployments, each tenant can have a separate plugin configuration. The `TenantPluginManagerFactory` manages per-tenant plugin manager instances with automatic caching and lifecycle management.
+In multi-tenant deployments, each context (tenant, server, tool) can have a separate plugin configuration. The `TenantPluginManagerFactory` manages context-specific plugin manager instances with automatic caching and lifecycle management. When no context-specific configuration is provided, the factory reuses a shared default manager per team to optimize memory usage.
 
 #### Architecture
 
@@ -864,25 +879,6 @@ This optimization:
 - Maintains team isolation with separate default managers per team
 - Maintains isolation through tool-specific contexts during execution
 - Automatically handles cleanup without double-shutdown errors during factory shutdown
-
-
-
-    def get_plugin(self, name: str) -> Optional[PluginRef]:
-        """Get plugin reference by name"""
-
-    def get_plugins_for_hook(self, hook_type: HookType) -> list[PluginRef]:
-        """Get all plugins registered for a specific hook"""
-
-    def get_all_plugins(self) -> list[PluginRef]:
-        """Get all registered plugins"""
-
-    @property
-    def plugin_count(self) -> int:
-        """Number of registered plugins"""
-
-    async def shutdown(self) -> None:
-        """Shutdown all registered plugins"""
-```
 
 ### Plugin Reference System
 

--- a/mcpgateway/middleware/http_auth_middleware.py
+++ b/mcpgateway/middleware/http_auth_middleware.py
@@ -167,7 +167,7 @@ class HttpAuthMiddleware(BaseHTTPMiddleware):
         Returns:
             The response from the application
         """
-        # Note: HTTP hooks always use global config (__global__ context) because
+        # Note: HTTP hooks always use global config (##global## context) because
         # this middleware runs before virtual server routing. Per-tenant HTTP hooks
         # would require extracting server_id from the request path, which is not
         # currently implemented. This is acceptable for auth-layer middleware.

--- a/mcpgateway/plugins/__init__.py
+++ b/mcpgateway/plugins/__init__.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 _PLUGINS_ENABLED = False
 _plugin_manager_factory: Optional[TenantPluginManagerFactory] = None
 _observability_service: Optional[ObservabilityProvider] = None
-DEFAULT_SERVER_ID = "__global__"
+DEFAULT_SERVER_ID = "##global##"
 
 _REDIS_PLUGINS_ENABLED_KEY = "plugin:global:enabled"
 _REDIS_INVALIDATION_CHANNEL = "plugin:invalidation"

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -40,6 +40,7 @@ from mcpgateway.services.tool_plugin_binding_service import get_bindings_for_too
 logger = logging.getLogger(__name__)
 
 CONTEXT_ID_SEPARATOR = "::"
+DEFAULT_CONTEXT_ID = "__global__"
 
 _LEGACY_MODE_TO_PLUGIN_MODE: dict[str, tuple[PluginMode, Optional[OnError]]] = {
     "enforce": (PluginMode.SEQUENTIAL, None),
@@ -129,13 +130,13 @@ class TenantPluginManagerFactory:
 
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context."""
-        context_id = context_id or "__global__"
+        context_id = context_id or DEFAULT_CONTEXT_ID
         expired = None
 
         async with self._lock:
             entry = self._managers.get(context_id)
             if entry is not None:
-                if entry.is_expired(self._cache_ttl):
+                if entry.is_expired(self._cache_ttl) and context_id != DEFAULT_CONTEXT_ID:
                     expired = self._managers.pop(context_id, None)
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
@@ -165,10 +166,33 @@ class TenantPluginManagerFactory:
                     self._inflight.pop(context_id, None)
 
     async def _build_manager(self, context_id: str) -> TenantPluginManager:
-        """Create, initialise, and cache a new manager for *context_id*."""
+        """Create, initialise, and cache a new manager for *context_id*.
+
+        Fallback: When no DB config exists for a team context, reuses the team's
+        default manager (team_id::__global__). Multiple contexts may share the
+        same manager instance. Invalidating a shared default affects all contexts
+        referencing it.
+        """
         manager = None
+        new_config = None
+        team_id = None
+
+        if CONTEXT_ID_SEPARATOR in context_id and DEFAULT_CONTEXT_ID not in context_id:
+            team_id = get_team_id_from_context(context_id)
+            async with self._lock:
+                new_config = await self.get_config_from_db(context_id)
+
+        if new_config is None:
+            async with self._lock:
+                default_team_context = make_context_id(team_id, DEFAULT_CONTEXT_ID) if team_id else DEFAULT_CONTEXT_ID
+                default = self._managers.get(default_team_context)
+                if default is not None:
+                    self._managers[context_id] = default
+                    return default.manager
+                else:
+                    context_id = default_team_context
+
         try:
-            new_config = await self.get_config_from_db(context_id)
             config = self._merge_tenant_config(new_config)
             config = await self._apply_redis_mode_overrides(config)
 
@@ -331,7 +355,8 @@ class TenantPluginManagerFactory:
     async def shutdown(self) -> None:
         """Shut down all cached managers and cancel in-flight build tasks."""
         async with self._lock:
-            entries = list(self._managers.values())
+            # Deduplicate managers to avoid multiple shutdowns when shared
+            unique_managers = {entry.manager for entry in self._managers.values()}
             inflight = list(self._inflight.values())
             self._managers.clear()
             self._inflight.clear()
@@ -342,9 +367,9 @@ class TenantPluginManagerFactory:
         if inflight:
             await asyncio.gather(*inflight, return_exceptions=True)
 
-        for entry in entries:
+        for manager in unique_managers:
             try:
-                await entry.manager.shutdown()
+                await manager.shutdown()
             except Exception:
                 logger.exception("Failed to shutdown plugin manager")
 
@@ -409,7 +434,7 @@ class TenantPluginManagerFactory:
     async def invalidate_all(self) -> None:
         """Reload every cached manager concurrently, logging failures."""
         async with self._lock:
-            context_ids = list(self._managers.keys())
+            context_ids = [ctx_id for ctx_id in self._managers]
         results = await asyncio.gather(
             *(self.reload_tenant(ctx_id) for ctx_id in context_ids),
             return_exceptions=True,
@@ -446,3 +471,12 @@ GatewayTenantPluginManagerFactory = TenantPluginManagerFactory
 def make_context_id(team_id: str, tool_name: str) -> str:
     """Build the context_id string expected by TenantPluginManagerFactory."""
     return f"{team_id}{CONTEXT_ID_SEPARATOR}{tool_name}"
+
+
+def get_team_id_from_context(context_id: str) -> Optional[str]:
+    """Get team_id from context_id"""
+    if CONTEXT_ID_SEPARATOR in context_id:
+        team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR)
+        return team_id
+    else:
+        return None

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -339,10 +339,18 @@ class TenantPluginManagerFactory:
 
         old = old_entry.manager if old_entry is not None else None
         if old is not None:
-            try:
-                await old.shutdown()
-            except Exception:
-                logger.exception("Failed to shutdown old manager for context_id=%s", context_id)
+            # Check if this manager is shared by other contexts before shutting down
+            is_shared = False
+            async with self._lock:
+                is_shared = any(entry.manager is old for entry in self._managers.values())
+
+            if is_shared:
+                logger.debug("reload_tenant: manager for context_id=%s is shared, skipping shutdown", context_id)
+            else:
+                try:
+                    await old.shutdown()
+                except Exception:
+                    logger.exception("Failed to shutdown old manager for context_id=%s", context_id)
 
         try:
             return await inflight
@@ -475,6 +483,6 @@ def make_context_id(team_id: str, tool_name: str) -> str:
 def get_team_id_from_context(context_id: str) -> Optional[str]:
     """Get team_id from context_id"""
     if CONTEXT_ID_SEPARATOR in context_id:
-        team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR)
+        team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR, 1)
         return team_id
     return None

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -40,7 +40,7 @@ from mcpgateway.services.tool_plugin_binding_service import get_bindings_for_too
 logger = logging.getLogger(__name__)
 
 CONTEXT_ID_SEPARATOR = "::"
-DEFAULT_CONTEXT_ID = "__global__"
+DEFAULT_CONTEXT_ID = "##global##"
 
 _LEGACY_MODE_TO_PLUGIN_MODE: dict[str, tuple[PluginMode, Optional[OnError]]] = {
     "enforce": (PluginMode.SEQUENTIAL, None),
@@ -169,7 +169,7 @@ class TenantPluginManagerFactory:
         """Create, initialise, and cache a new manager for *context_id*.
 
         Fallback: When no DB config exists for a team context, reuses the team's
-        default manager (team_id::__global__). Multiple contexts may share the
+        default manager (team_id::DEFAULT_CONTEXT_ID). Multiple contexts may share the
         same manager instance. Invalidating a shared default affects all contexts
         referencing it.
         """

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -138,17 +138,18 @@ class TenantPluginManagerFactory:
             entry = self._managers.get(context_id)
             if entry is not None:
                 # Shared managers should not expire
-                if entry.is_expired(self._cache_ttl) and not self._is_shared_manager(context_id):
+                if entry.is_expired(self._cache_ttl) and not self._is_default_context(context_id):
                     expired = self._managers.pop(context_id, None)
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
                     return entry.manager
 
             if expired is not None:
-                try:
-                    await expired.manager.shutdown()
-                except Exception:
-                    logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
+                if not self._is_manager_referenced(expired.manager):
+                    try:
+                        await expired.manager.shutdown()
+                    except Exception:
+                        logger.warning("Failed to shutdown expired manager for context_id=%s", context_id, exc_info=True)
 
             inflight = self._inflight.get(context_id)
             if inflight is None:
@@ -167,8 +168,8 @@ class TenantPluginManagerFactory:
                 if self._inflight.get(context_id) is inflight:
                     self._inflight.pop(context_id, None)
 
-    def _is_shared_manager(self, context_id: str) -> bool:
-        """Check if the manager is a shared manager by checking DEFAULT_CONTEXT_ID"""
+    def _is_default_context(self, context_id: str) -> bool:
+        """Check if the context_id is a team or global DEFAULT_CONTEXT_ID"""
         shared_manager = False
         if context_id == DEFAULT_CONTEXT_ID:
             shared_manager = True
@@ -176,6 +177,15 @@ class TenantPluginManagerFactory:
             _, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
             shared_manager = tool_name == DEFAULT_CONTEXT_ID
         return shared_manager
+
+    def _is_manager_referenced(self, manager: TenantPluginManager) -> bool:
+        """Check if a manager instance is referenced by any entry in the cache.
+        Args:
+            manager: The manager instance to check
+        Returns:
+            True if the manager is referenced by at least one cache entry
+        """
+        return any(entry.manager is manager for entry in self._managers.values())
 
     async def _build_manager(self, context_id: str) -> TenantPluginManager:
         """Create, initialise, and cache a new manager for *context_id*.
@@ -192,7 +202,8 @@ class TenantPluginManagerFactory:
         # Parse context_id to check if it's a default context
         if CONTEXT_ID_SEPARATOR in context_id:
             team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
-            if tool_name != DEFAULT_CONTEXT_ID:
+
+            if not self._is_default_context(context_id):
                 async with self._lock:
                     new_config = await self.get_config_from_db(context_id)
 
@@ -356,7 +367,7 @@ class TenantPluginManagerFactory:
             # Check if this manager is shared by other contexts before shutting down
             is_shared = False
             async with self._lock:
-                is_shared = any(entry.manager is old for entry in self._managers.values())
+                is_shared = self._is_manager_referenced(old)
 
             if is_shared:
                 logger.debug("reload_tenant: manager for context_id=%s is shared, skipping shutdown", context_id)

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -173,7 +173,7 @@ class TenantPluginManagerFactory:
         if context_id == DEFAULT_CONTEXT_ID:
             shared_manager = True
         elif CONTEXT_ID_SEPARATOR in context_id:
-            team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+            _ , tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
             shared_manager = tool_name == DEFAULT_CONTEXT_ID
         return shared_manager
 

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -130,13 +130,15 @@ class TenantPluginManagerFactory:
 
     async def get_manager(self, context_id: Optional[str] = None) -> TenantPluginManager:
         """Get or create a TenantPluginManager for the given context."""
+
         context_id = context_id or DEFAULT_CONTEXT_ID
         expired = None
 
         async with self._lock:
             entry = self._managers.get(context_id)
             if entry is not None:
-                if entry.is_expired(self._cache_ttl) and context_id != DEFAULT_CONTEXT_ID:
+                # Shared managers should not expire
+                if entry.is_expired(self._cache_ttl) and not self._is_shared_manager(context_id):
                     expired = self._managers.pop(context_id, None)
                     logger.debug("Cache TTL expired for context_id=%s, rebuilding", context_id)
                 else:
@@ -164,6 +166,16 @@ class TenantPluginManagerFactory:
             async with self._lock:
                 if self._inflight.get(context_id) is inflight:
                     self._inflight.pop(context_id, None)
+
+    def _is_shared_manager(self, context_id: str) -> bool:
+        """Check if the manager is a shared manager by checking DEFAULT_CONTEXT_ID"""
+        shared_manager = False
+        if context_id == DEFAULT_CONTEXT_ID:
+            shared_manager = True
+        elif CONTEXT_ID_SEPARATOR in context_id:
+            team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+            shared_manager = tool_name == DEFAULT_CONTEXT_ID
+        return shared_manager
 
     async def _build_manager(self, context_id: str) -> TenantPluginManager:
         """Create, initialise, and cache a new manager for *context_id*.

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -480,11 +480,3 @@ GatewayTenantPluginManagerFactory = TenantPluginManagerFactory
 def make_context_id(team_id: str, tool_name: str) -> str:
     """Build the context_id string expected by TenantPluginManagerFactory."""
     return f"{team_id}{CONTEXT_ID_SEPARATOR}{tool_name}"
-
-
-def get_team_id_from_context(context_id: str) -> Optional[str]:
-    """Get team_id from context_id"""
-    if CONTEXT_ID_SEPARATOR in context_id:
-        team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR, 1)
-        return team_id
-    return None

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -173,7 +173,7 @@ class TenantPluginManagerFactory:
         if context_id == DEFAULT_CONTEXT_ID:
             shared_manager = True
         elif CONTEXT_ID_SEPARATOR in context_id:
-            _ , tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+            _, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
             shared_manager = tool_name == DEFAULT_CONTEXT_ID
         return shared_manager
 

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -177,10 +177,12 @@ class TenantPluginManagerFactory:
         new_config = None
         team_id = None
 
-        if CONTEXT_ID_SEPARATOR in context_id and DEFAULT_CONTEXT_ID not in context_id:
-            team_id = get_team_id_from_context(context_id)
-            async with self._lock:
-                new_config = await self.get_config_from_db(context_id)
+        # Parse context_id to check if it's a default context
+        if CONTEXT_ID_SEPARATOR in context_id:
+            team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+            if tool_name != DEFAULT_CONTEXT_ID:
+                async with self._lock:
+                    new_config = await self.get_config_from_db(context_id)
 
         if new_config is None:
             async with self._lock:

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -189,8 +189,7 @@ class TenantPluginManagerFactory:
                 if default is not None:
                     self._managers[context_id] = default
                     return default.manager
-                else:
-                    context_id = default_team_context
+                context_id = default_team_context
 
         try:
             config = self._merge_tenant_config(new_config)
@@ -434,7 +433,7 @@ class TenantPluginManagerFactory:
     async def invalidate_all(self) -> None:
         """Reload every cached manager concurrently, logging failures."""
         async with self._lock:
-            context_ids = [ctx_id for ctx_id in self._managers]
+            context_ids = list(self._managers)
         results = await asyncio.gather(
             *(self.reload_tenant(ctx_id) for ctx_id in context_ids),
             return_exceptions=True,
@@ -478,5 +477,4 @@ def get_team_id_from_context(context_id: str) -> Optional[str]:
     if CONTEXT_ID_SEPARATOR in context_id:
         team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR)
         return team_id
-    else:
-        return None
+    return None

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -204,12 +204,12 @@ class TenantPluginManagerFactory:
             team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR, 1)
 
             if not self._is_default_context(context_id):
-                async with self._lock:
-                    new_config = await self.get_config_from_db(context_id)
+                new_config = await self.get_config_from_db(context_id)
 
         if new_config is None:
+            default_team_context = make_context_id(team_id, DEFAULT_CONTEXT_ID) if team_id else DEFAULT_CONTEXT_ID
+
             async with self._lock:
-                default_team_context = make_context_id(team_id, DEFAULT_CONTEXT_ID) if team_id else DEFAULT_CONTEXT_ID
                 default = self._managers.get(default_team_context)
                 if default is not None:
                     self._managers[context_id] = default
@@ -464,32 +464,65 @@ class TenantPluginManagerFactory:
         return overrides if overrides else None
 
     async def invalidate_all(self) -> None:
-        """Reload every cached manager concurrently, logging failures."""
+        """Reload every cached manager with two-phase approach to prevent alias race conditions.
+
+        Phase 1: Rebuild all default contexts (team-id::##global##) concurrently.
+        Phase 2: Rebuild all aliases concurrently after defaults complete.
+
+        This ensures aliases always reference the newly rebuilt default managers.
+        """
         async with self._lock:
             context_ids = list(self._managers)
-        results = await asyncio.gather(
-            *(self.reload_tenant(ctx_id) for ctx_id in context_ids),
+
+        # Phase 1: Rebuild default contexts first
+        defaults = [cid for cid in context_ids if self._is_default_context(cid)]
+        default_results = await asyncio.gather(
+            *(self.reload_tenant(ctx_id) for ctx_id in defaults),
             return_exceptions=True,
         )
-        for ctx_id, result in zip(context_ids, results):
+
+        # Phase 2: Rebuild aliases after defaults complete
+        aliases = [cid for cid in context_ids if not self._is_default_context(cid)]
+        alias_results = await asyncio.gather(
+            *(self.reload_tenant(ctx_id) for ctx_id in aliases),
+            return_exceptions=True,
+        )
+
+        # Log failures from both phases
+        for ctx_id, result in zip(defaults + aliases, default_results + alias_results):
             if isinstance(result, BaseException):
                 logger.warning("invalidate_all: reload failed for context_id=%s (%s)", ctx_id, result)
-        logger.debug("invalidate_all: rebuilt %d managers (%d failures)", len(context_ids), sum(1 for r in results if isinstance(r, BaseException)))
 
     async def invalidate_team(self, team_id: str, separator: Optional[str] = None) -> None:
-        """Reload every cached manager whose context_id starts with team_id plus separator."""
+        """Reload every cached manager whose context_id starts with team_id plus separator.
+
+        Uses two-phase approach: rebuilds team default context first, then aliases.
+        This prevents aliases from referencing stale default managers during invalidation.
+        """
         sep = separator if separator is not None else CONTEXT_ID_SEPARATOR
         prefix = f"{team_id}{sep}"
         async with self._lock:
             context_ids = [cid for cid in self._managers if cid.startswith(prefix)]
-        results = await asyncio.gather(
-            *(self.reload_tenant(ctx_id) for ctx_id in context_ids),
+
+        # Phase 1: Rebuild team default context first
+        defaults = [cid for cid in context_ids if self._is_default_context(cid)]
+        default_results = await asyncio.gather(
+            *(self.reload_tenant(ctx_id) for ctx_id in defaults),
             return_exceptions=True,
         )
-        for ctx_id, result in zip(context_ids, results):
+
+        # Phase 2: Rebuild team aliases after default completes
+        aliases = [cid for cid in context_ids if not self._is_default_context(cid)]
+        alias_results = await asyncio.gather(
+            *(self.reload_tenant(ctx_id) for ctx_id in aliases),
+            return_exceptions=True,
+        )
+
+        # Log failures from both phases
+        for ctx_id, result in zip(defaults + aliases, default_results + alias_results):
             if isinstance(result, BaseException):
                 logger.warning("invalidate_team: reload failed for context_id=%s (%s)", ctx_id, result)
-        logger.debug("invalidate_team: team=%s rebuilt %d managers (%d failures)", team_id, len(context_ids), sum(1 for r in results if isinstance(r, BaseException)))
+        logger.debug("invalidate_team: team=%s rebuilt %d managers (%d failures)", team_id, len(context_ids), sum(1 for r in (default_results + alias_results) if isinstance(r, BaseException)))
 
     def iter_context_ids(self) -> list[str]:
         """Return a snapshot of the cached context IDs."""

--- a/mcpgateway/plugins/gateway_plugin_manager.py
+++ b/mcpgateway/plugins/gateway_plugin_manager.py
@@ -201,7 +201,7 @@ class TenantPluginManagerFactory:
 
         # Parse context_id to check if it's a default context
         if CONTEXT_ID_SEPARATOR in context_id:
-            team_id, tool_name = context_id.split(CONTEXT_ID_SEPARATOR, 1)
+            team_id, _ = context_id.split(CONTEXT_ID_SEPARATOR, 1)
 
             if not self._is_default_context(context_id):
                 async with self._lock:

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -18,18 +18,22 @@ Tests cover:
 
 # Standard
 import asyncio
+import os
 import time
+import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 # First-Party
-from mcpgateway.db import Base
+from mcpgateway.db import Base, ToolPluginBinding, utc_now
 from mcpgateway.plugins import reload_plugin_context, set_global_observability
 from mcpgateway.plugins.gateway_plugin_manager import (
     CONTEXT_ID_SEPARATOR,
@@ -288,9 +292,6 @@ class TestGetConfigFromDb:
     @pytest.mark.asyncio
     async def test_invalid_on_error_rejected_by_db_constraint(self, db_session):
         """An invalid on_error value is rejected by the DB CHECK constraint."""
-        from mcpgateway.db import ToolPluginBinding, utc_now
-        from sqlalchemy.exc import IntegrityError
-        import uuid
 
         row = ToolPluginBinding(
             id=uuid.uuid4().hex,
@@ -390,7 +391,6 @@ class TestMergeTenantConfigOnError:
     """Verify that _merge_tenant_config propagates on_error from overrides."""
 
     def _make_factory_with_base_config(self):
-        from mcpgateway.plugins.gateway_plugin_manager import TenantPluginManagerFactory
 
         factory = TenantPluginManagerFactory.__new__(TenantPluginManagerFactory)
         factory._base_config = MagicMock()
@@ -408,8 +408,6 @@ class TestMergeTenantConfigOnError:
         return factory, plugin, captured_updates
 
     def test_on_error_applied_when_present(self):
-        from cpex.framework import OnError
-        from mcpgateway.plugins.gateway_plugin_manager import PluginConfigOverride
 
         factory, _plugin, captured = self._make_factory_with_base_config()
         overrides = [PluginConfigOverride(name="TestPlugin", on_error=OnError.IGNORE)]
@@ -419,7 +417,6 @@ class TestMergeTenantConfigOnError:
         assert captured[0].get("on_error") == OnError.IGNORE
 
     def test_on_error_not_applied_when_none(self):
-        from mcpgateway.plugins.gateway_plugin_manager import PluginConfigOverride
 
         factory, _plugin, captured = self._make_factory_with_base_config()
         overrides = [PluginConfigOverride(name="TestPlugin")]
@@ -475,7 +472,6 @@ class TestBuildManager:
 
     @pytest.mark.asyncio
     async def test_build_manager_happy_path(self, factory):
-        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
         mock_manager = AsyncMock()
         mock_manager.initialize = AsyncMock()
         mock_manager.shutdown = AsyncMock()
@@ -638,7 +634,6 @@ class TestGetManager:
     @pytest.mark.asyncio
     async def test_get_manager_returns_cached(self, factory):
         mock_manager = AsyncMock()
-        import time
 
         factory._managers["ctx"] = _CachedManager(manager=mock_manager, created_at=time.monotonic())
         result = await factory.get_manager("ctx")
@@ -669,7 +664,6 @@ class TestGetManager:
         cached_manager = AsyncMock()
 
         async def build_and_inject(context_id):
-            import time
             factory._managers[context_id] = _CachedManager(manager=cached_manager, created_at=time.monotonic())
             return mock_manager
 
@@ -680,8 +674,6 @@ class TestGetManager:
 
     @pytest.mark.asyncio
     async def test_distinct_default_manager_for_each_team(self, db_session):
-        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID, TenantPluginManagerFactory
-        import os
 
         yaml_path = os.path.join(os.path.dirname(__file__), "fixtures/configs/valid_no_plugin.yaml")
         factory = TenantPluginManagerFactory(
@@ -699,8 +691,6 @@ class TestGetManager:
     @pytest.mark.asyncio
     async def test_default_manager_is_not_applied_when_context_id_has_config(self, db_session):
 
-        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID, TenantPluginManagerFactory
-        import os
 
         yaml_path = os.path.join(os.path.dirname(__file__), "fixtures/configs/valid_single_filter_plugin.yaml")
         factory = TenantPluginManagerFactory(
@@ -729,10 +719,8 @@ class TestGetManager:
     @pytest.mark.asyncio
     async def test_default_context_never_expires_from_cache(self, factory):
         """Default context entry is never evicted due to TTL expiry."""
-        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
 
         default_manager = AsyncMock()
-        import time
 
         # Create an expired entry for default context
         factory._managers[DEFAULT_CONTEXT_ID] = _CachedManager(
@@ -748,8 +736,6 @@ class TestGetManager:
     @pytest.mark.asyncio
     async def test_fallback_to_default_manager_when_no_tenant_config(self, factory):
         """When tenant has no config and default manager exists, reuse default manager."""
-        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
-        import time
 
         team_x_default = f"team-x::{DEFAULT_CONTEXT_ID}"
 
@@ -1060,7 +1046,6 @@ class TestApplyRedisModeOverrides:
 
     @pytest.mark.asyncio
     async def test_validation_error_skipped(self, factory):
-        from pydantic import ValidationError
 
         config, plugin = self._make_config_with_plugin()
         plugin.model_copy = MagicMock(side_effect=ValidationError.from_exception_data("test", []))
@@ -1159,9 +1144,8 @@ class TestCachedManagerExpiry:
             assert entry.is_expired(30) is True
 
     def test_ttl_positive_not_expired_before_deadline(self):
-        import time as _time
 
-        now = _time.monotonic()
+        now = time.monotonic()
         entry = _CachedManager(manager=MagicMock(), created_at=now)
         assert entry.is_expired(9999) is False
 
@@ -1175,8 +1159,6 @@ class TestEnforceIgnoreErrorDbBinding:
     @pytest.mark.asyncio
     async def test_enforce_ignore_error_from_db_binding(self, db_session):
         """DB bindings with mode='enforce_ignore_error' map to SEQUENTIAL + OnError.IGNORE."""
-        from mcpgateway.db import ToolPluginBinding, utc_now
-        import uuid
 
         binding = ToolPluginBinding(
             id=str(uuid.uuid4()),

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -605,9 +605,9 @@ class TestBuildManager:
         """Tool names containing DEFAULT_CONTEXT_ID substring should still get DB lookup."""
         mock_manager = AsyncMock()
         mock_manager.initialize = AsyncMock()
-        
+
         mock_config = [MagicMock()]  # Non-empty config from DB
-        
+
         with (
             patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=mock_config) as mock_db,
             patch.object(factory, "_apply_redis_mode_overrides", new_callable=AsyncMock, side_effect=lambda c: c),
@@ -615,7 +615,7 @@ class TestBuildManager:
         ):
             # Tool name contains "##global##" but is not exactly "##global##"
             result = await factory._build_manager("team-a::my##global##tool")
-        
+
         # Should have called get_config_from_db because tool_name != DEFAULT_CONTEXT_ID
         mock_db.assert_awaited_once_with("team-a::my##global##tool")
         assert result is mock_manager

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -473,9 +473,13 @@ class TestBuildManager:
 
     @pytest.mark.asyncio
     async def test_build_manager_happy_path(self, factory):
+        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
         mock_manager = AsyncMock()
         mock_manager.initialize = AsyncMock()
         mock_manager.shutdown = AsyncMock()
+
+
+        default_team_context_id = f"team::{DEFAULT_CONTEXT_ID}"
 
         with (
             patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=None),
@@ -486,7 +490,7 @@ class TestBuildManager:
 
         assert result is mock_manager
         mock_manager.initialize.assert_awaited_once()
-        assert "team::tool" in factory._managers
+        assert default_team_context_id in factory._managers
 
     @pytest.mark.asyncio
     async def test_build_manager_shuts_down_old_manager(self, factory):
@@ -497,8 +501,10 @@ class TestBuildManager:
         new_manager = AsyncMock()
         new_manager.initialize = AsyncMock()
 
+        config_override = [PluginConfigOverride(name="test_plugin", config={}, mode=PluginMode.SEQUENTIAL)]
+
         with (
-            patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=None),
+            patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=config_override),
             patch.object(factory, "_apply_redis_mode_overrides", new_callable=AsyncMock, side_effect=lambda c: c),
             patch("mcpgateway.plugins.gateway_plugin_manager.TenantPluginManager", return_value=new_manager),
         ):
@@ -650,8 +656,98 @@ class TestGetManager:
 
         assert result is cached_manager
 
+    @pytest.mark.asyncio
+    async def test_distinct_default_manager_for_each_team(self, db_session):
+        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID, TenantPluginManagerFactory
+        import os
 
-# ---------------------------------------------------------------------------
+        yaml_path = os.path.join(os.path.dirname(__file__), "fixtures/configs/valid_no_plugin.yaml")
+        factory = TenantPluginManagerFactory(
+            yaml_path=yaml_path,
+            db_factory=lambda: db_session,
+        )
+        manager_a_1 = await factory.get_manager("team_a::tool_1")
+        manager_a_2 = await factory.get_manager("team_a::tool_2")
+        manager_b_1 = await factory.get_manager("team_b::tool_1")
+
+        assert manager_a_1 is manager_a_2
+        assert manager_a_1 is not manager_b_1
+
+
+    @pytest.mark.asyncio
+    async def test_default_manager_is_not_applied_when_context_id_has_config(self, db_session):
+
+        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID, TenantPluginManagerFactory
+        import os
+
+        yaml_path = os.path.join(os.path.dirname(__file__), "fixtures/configs/valid_single_filter_plugin.yaml")
+        factory = TenantPluginManagerFactory(
+            yaml_path=yaml_path,
+            db_factory=lambda: db_session,
+        )
+
+        manager_a_1 = await factory.get_manager("team_a::tool_1")
+        manager_a_2 = await factory.get_manager("team_a::tool_1")
+        manager_a_3 = await factory.get_manager("team_a::tool_2")
+
+        new_config = [PluginConfigOverride(
+            name="DenyListPlugin",
+            config={},
+            mode=PluginMode.SEQUENTIAL
+        )]
+
+        with patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=new_config):
+            await factory.reload_tenant("team_a::tool_1") # Called when API is called with new bindings
+            manager_a_1 = await factory.get_manager("team_a::tool_1")
+
+        assert manager_a_1 is not manager_a_2
+        assert manager_a_2 is manager_a_3
+
+
+    @pytest.mark.asyncio
+    async def test_default_context_never_expires_from_cache(self, factory):
+        """Default context entry is never evicted due to TTL expiry."""
+        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
+
+        default_manager = AsyncMock()
+        import time
+
+        # Create an expired entry for default context
+        factory._managers[DEFAULT_CONTEXT_ID] = _CachedManager(
+            manager=default_manager,
+            created_at=time.monotonic() - 1000  # Very old
+        )
+
+        # Should return cached manager even though TTL expired
+        result = await factory.get_manager(DEFAULT_CONTEXT_ID)
+        assert result is default_manager
+
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_default_manager_when_no_tenant_config(self, factory):
+        """When tenant has no config and default manager exists, reuse default manager."""
+        from mcpgateway.plugins.gateway_plugin_manager import DEFAULT_CONTEXT_ID
+        import time
+
+        team_x_default = f"team-x::{DEFAULT_CONTEXT_ID}"
+
+        default_manager = AsyncMock()
+        factory._managers[team_x_default] = _CachedManager(
+            manager=default_manager,
+            created_at=time.monotonic()
+        )
+
+        # Mock get_config_from_db to return None (no tenant config)
+        with patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=None):
+            result = await factory.get_manager("team-x::tool-y")
+
+        # Should return the default manager
+        assert result is default_manager
+        # Verify it was cached for the tenant context
+        assert "team-x::tool-y" in factory._managers
+        assert factory._managers["team-x::tool-y"].manager is default_manager
+
+
 # reload_tenant
 # ---------------------------------------------------------------------------
 
@@ -766,7 +862,24 @@ class TestShutdown:
         assert len(factory._managers) == 0
 
 
-# ---------------------------------------------------------------------------
+    @pytest.mark.asyncio
+    async def test_shutdown_deduplicates_shared_managers(self, factory):
+        """When multiple contexts share a manager, shutdown is called only once."""
+        shared_manager = AsyncMock()
+        shared_manager.shutdown = AsyncMock()
+
+        # Multiple contexts sharing the same manager instance
+        factory._managers["ctx1"] = _CachedManager(manager=shared_manager, created_at=0)
+        factory._managers["ctx2"] = _CachedManager(manager=shared_manager, created_at=0)
+        factory._managers["ctx3"] = _CachedManager(manager=shared_manager, created_at=0)
+
+        await factory.shutdown()
+
+        # Shutdown should be called exactly once despite 3 contexts
+        shared_manager.shutdown.assert_awaited_once()
+        assert len(factory._managers) == 0
+
+
 # _apply_redis_mode_overrides
 # ---------------------------------------------------------------------------
 
@@ -1009,7 +1122,6 @@ class TestEnforceIgnoreErrorDbBinding:
 # ---------------------------------------------------------------------------
 # invalidate_team prefix collision safety
 # ---------------------------------------------------------------------------
-
 
 class TestInvalidateTeamPrefixSafety:
     @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -18,6 +18,7 @@ Tests cover:
 
 # Standard
 import asyncio
+import time
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -32,6 +33,7 @@ from mcpgateway.db import Base
 from mcpgateway.plugins import reload_plugin_context, set_global_observability
 from mcpgateway.plugins.gateway_plugin_manager import (
     CONTEXT_ID_SEPARATOR,
+    DEFAULT_CONTEXT_ID,
     GatewayTenantPluginManagerFactory,
     PluginConfigOverride,
     TenantPluginManagerFactory,
@@ -766,6 +768,43 @@ class TestGetManager:
         # Verify it was cached for the tenant context
         assert "team-x::tool-y" in factory._managers
         assert factory._managers["team-x::tool-y"].manager is default_manager
+
+
+
+    @pytest.mark.asyncio
+    async def test_team_default_contexts_never_expire_from_cache(self, factory):
+        """Team-specific default context entries (team::DEFAULT_CONTEXT_ID) are never evicted due to TTL expiry."""
+
+        # Create expired entries for various default contexts
+        team_a_default = f"team_a::{DEFAULT_CONTEXT_ID}"
+        team_b_default = f"team_b::{DEFAULT_CONTEXT_ID}"
+
+        manager_team_a = AsyncMock()
+        manager_default = AsyncMock()
+        manager_team_b = AsyncMock()
+
+        # Create expired entries (very old timestamps)
+        factory._managers[team_a_default] = _CachedManager(
+            manager=manager_team_a,
+            created_at=time.monotonic() - 1000
+        )
+        factory._managers[DEFAULT_CONTEXT_ID] = _CachedManager(
+            manager=manager_default,
+            created_at=time.monotonic() - 1000
+        )
+        factory._managers[team_b_default] = _CachedManager(
+            manager=manager_team_b,
+            created_at=time.monotonic() - 1000
+        )
+
+        # Should return cached managers even though TTL expired
+        result_team_a = await factory.get_manager(team_a_default)
+        result_default = await factory.get_manager(DEFAULT_CONTEXT_ID)
+        result_team_b = await factory.get_manager(team_b_default)
+
+        assert result_team_a is manager_team_a
+        assert result_default is manager_default
+        assert result_team_b is manager_team_b
 
 
 # reload_tenant

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -812,6 +812,33 @@ class TestReloadTenant:
         ):
             result = await factory.reload_tenant("ctx")
 
+
+    @pytest.mark.asyncio
+    async def test_reload_does_not_shutdown_shared_manager(self, factory):
+        """When reloading a context that shares a manager, don't shutdown the shared manager."""
+        shared_manager = AsyncMock()
+        shared_manager.shutdown = AsyncMock()
+
+        # Two contexts sharing the same manager (simulating default manager fallback)
+        factory._managers["ctx1"] = _CachedManager(manager=shared_manager, created_at=0)
+        factory._managers["ctx2"] = _CachedManager(manager=shared_manager, created_at=0)
+
+        new_manager = AsyncMock()
+        new_manager.initialize = AsyncMock()
+
+        with (
+            patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=None),
+            patch.object(factory, "_apply_redis_mode_overrides", new_callable=AsyncMock, side_effect=lambda c: c),
+            patch("mcpgateway.plugins.gateway_plugin_manager.TenantPluginManager", return_value=new_manager),
+        ):
+            result = await factory.reload_tenant("ctx1")
+
+        assert result is new_manager
+        # Shared manager should NOT be shut down because ctx2 still references it
+        shared_manager.shutdown.assert_not_called()
+        assert factory._managers["ctx2"].manager is shared_manager
+
+
         assert result is new_manager
 
 

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -600,6 +600,26 @@ class TestBuildManager:
             with pytest.raises(asyncio.CancelledError):
                 await factory._build_manager("team::tool")
 
+    @pytest.mark.asyncio
+    async def test_build_manager_tool_name_containing_global_gets_db_lookup(self, factory):
+        """Tool names containing DEFAULT_CONTEXT_ID substring should still get DB lookup."""
+        mock_manager = AsyncMock()
+        mock_manager.initialize = AsyncMock()
+        
+        mock_config = [MagicMock()]  # Non-empty config from DB
+        
+        with (
+            patch.object(factory, "get_config_from_db", new_callable=AsyncMock, return_value=mock_config) as mock_db,
+            patch.object(factory, "_apply_redis_mode_overrides", new_callable=AsyncMock, side_effect=lambda c: c),
+            patch("mcpgateway.plugins.gateway_plugin_manager.TenantPluginManager", return_value=mock_manager),
+        ):
+            # Tool name contains "##global##" but is not exactly "##global##"
+            result = await factory._build_manager("team-a::my##global##tool")
+        
+        # Should have called get_config_from_db because tool_name != DEFAULT_CONTEXT_ID
+        mock_db.assert_awaited_once_with("team-a::my##global##tool")
+        assert result is mock_manager
+
 
 # ---------------------------------------------------------------------------
 # get_manager

--- a/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
+++ b/tests/unit/mcpgateway/plugins/test_gateway_plugin_manager.py
@@ -1088,6 +1088,228 @@ class TestGetConfigFromDbErrors:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Two-phase invalidation: race condition prevention
+# ---------------------------------------------------------------------------
+
+
+class TestTwoPhaseInvalidationRaceCondition:
+    """Tests to verify two-phase invalidation prevents alias race conditions."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_all_rebuilds_defaults_before_aliases(self):
+        """Verify invalidate_all rebuilds default contexts before aliases."""
+        with patch("cpex.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+            factory = TenantPluginManagerFactory(yaml_path="/fake.yaml")
+
+        # Track rebuild order
+        rebuild_order = []
+
+        async def track_rebuild(context_id):
+            rebuild_order.append(context_id)
+            mock_mgr = AsyncMock()
+            mock_mgr.initialize = AsyncMock()
+            return mock_mgr
+
+        # Setup: 2 teams with defaults and aliases
+        default_mgr = AsyncMock()
+        factory._managers = {
+            "team-a::##global##": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-a::tool1": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-a::tool2": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-b::##global##": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-b::tool1": _CachedManager(manager=default_mgr, created_at=0.0),
+        }
+
+        with patch.object(factory, "_build_manager", side_effect=track_rebuild):
+            await factory.invalidate_all()
+
+        # Verify defaults rebuilt before aliases
+        defaults = [cid for cid in rebuild_order if factory._is_default_context(cid)]
+        aliases = [cid for cid in rebuild_order if not factory._is_default_context(cid)]
+
+        # All defaults should appear before any alias
+        last_default_idx = max(rebuild_order.index(d) for d in defaults)
+        first_alias_idx = min(rebuild_order.index(a) for a in aliases)
+
+        assert last_default_idx < first_alias_idx, "Defaults must complete before aliases start"
+
+    @pytest.mark.asyncio
+    async def test_invalidate_team_rebuilds_team_default_before_aliases(self):
+        """Verify invalidate_team rebuilds team default before team aliases."""
+        with patch("cpex.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+            factory = TenantPluginManagerFactory(yaml_path="/fake.yaml")
+
+        rebuild_order = []
+
+        async def track_rebuild(context_id):
+            rebuild_order.append(context_id)
+            mock_mgr = AsyncMock()
+            mock_mgr.initialize = AsyncMock()
+            return mock_mgr
+
+        # Setup: team-a with default and aliases, team-b should not be touched
+        default_mgr = AsyncMock()
+        factory._managers = {
+            "team-a::##global##": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-a::tool1": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-a::tool2": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-b::##global##": _CachedManager(manager=default_mgr, created_at=0.0),
+            "team-b::tool1": _CachedManager(manager=default_mgr, created_at=0.0),
+        }
+
+        with patch.object(factory, "_build_manager", side_effect=track_rebuild):
+            await factory.invalidate_team("team-a")
+
+        # Verify only team-a contexts rebuilt
+        assert "team-a::##global##" in rebuild_order
+        assert "team-a::tool1" in rebuild_order
+        assert "team-a::tool2" in rebuild_order
+        assert "team-b::##global##" not in rebuild_order
+        assert "team-b::tool1" not in rebuild_order
+
+        # Verify team-a default rebuilt before team-a aliases
+        team_a_contexts = [cid for cid in rebuild_order if cid.startswith("team-a::")]
+        default_idx = team_a_contexts.index("team-a::##global##")
+        alias_indices = [i for i, cid in enumerate(team_a_contexts) if not factory._is_default_context(cid)]
+
+        assert all(default_idx < idx for idx in alias_indices), "Team default must complete before team aliases"
+
+    @pytest.mark.asyncio
+    async def test_aliases_reference_new_default_after_invalidation(self):
+        """Verify aliases reference newly rebuilt default managers after invalidation."""
+        with patch("cpex.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+            factory = TenantPluginManagerFactory(yaml_path="/fake.yaml")
+
+        # Setup: old managers
+        old_default_mgr = AsyncMock()
+        old_default_mgr.shutdown = AsyncMock()
+        factory._managers = {
+            "team-x::##global##": _CachedManager(manager=old_default_mgr, created_at=0.0),
+            "team-x::tool1": _CachedManager(manager=old_default_mgr, created_at=0.0),
+        }
+
+        # Mock _build_manager to return new managers
+        new_default_mgr = AsyncMock()
+        new_default_mgr.initialize = AsyncMock()
+
+        build_count = 0
+
+        async def build_new_manager(context_id):
+            nonlocal build_count
+            build_count += 1
+
+            if factory._is_default_context(context_id):
+                # Default context gets new manager
+                factory._managers[context_id] = _CachedManager(manager=new_default_mgr, created_at=time.monotonic())
+                return new_default_mgr
+            else:
+                # Alias looks up default (simulating lines 213-217)
+                default_ctx = "team-x::##global##"
+                default_entry = factory._managers.get(default_ctx)
+                if default_entry is not None:
+                    # Create alias pointing to default's manager
+                    factory._managers[context_id] = default_entry
+                    return default_entry.manager
+                return new_default_mgr
+
+        with patch.object(factory, "_build_manager", side_effect=build_new_manager):
+            await factory.invalidate_all()
+
+        # Verify both contexts now reference the NEW default manager
+        assert factory._managers["team-x::##global##"].manager is new_default_mgr
+        assert factory._managers["team-x::tool1"].manager is new_default_mgr
+        assert factory._managers["team-x::##global##"].manager is factory._managers["team-x::tool1"].manager
+
+    @pytest.mark.asyncio
+    async def test_no_race_with_redis_override_changes(self):
+        """Verify no race when Redis overrides change during invalidation."""
+        with patch("cpex.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+            factory = TenantPluginManagerFactory(yaml_path="/fake.yaml")
+
+        # Simulate Redis override changing during invalidation
+        redis_mode = "disabled"
+
+        async def build_with_redis_override(context_id):
+            # Simulate reading Redis override
+            mock_mgr = AsyncMock()
+            mock_mgr.initialize = AsyncMock()
+            mock_mgr.redis_mode = redis_mode  # Track what Redis value was read
+            factory._managers[context_id] = _CachedManager(manager=mock_mgr, created_at=time.monotonic())
+            return mock_mgr
+
+        old_mgr = AsyncMock()
+        factory._managers = {
+            "team-y::##global##": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-y::tool1": _CachedManager(manager=old_mgr, created_at=0.0),
+        }
+
+        with patch.object(factory, "_build_manager", side_effect=build_with_redis_override):
+            await factory.invalidate_all()
+
+        # Both should have read the same Redis value (no stale reads)
+        default_mgr = factory._managers["team-y::##global##"].manager
+        alias_mgr = factory._managers["team-y::tool1"].manager
+
+        # In two-phase, alias should reference the same manager as default
+        # (or if separate managers, both should have same Redis config)
+        assert default_mgr.redis_mode == alias_mgr.redis_mode == redis_mode
+
+    @pytest.mark.asyncio
+    async def test_multiple_teams_invalidate_all_maintains_consistency(self):
+        """Verify invalidate_all maintains consistency across multiple teams."""
+        with patch("cpex.framework.manager.ConfigLoader.load_config", return_value=MagicMock(plugins=[])):
+            factory = TenantPluginManagerFactory(yaml_path="/fake.yaml")
+
+        # Setup: 3 teams with defaults and aliases
+        old_mgr = AsyncMock()
+        factory._managers = {
+            "team-a::##global##": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-a::tool1": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-b::##global##": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-b::tool1": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-c::##global##": _CachedManager(manager=old_mgr, created_at=0.0),
+            "team-c::tool1": _CachedManager(manager=old_mgr, created_at=0.0),
+        }
+
+        # Track which manager each context gets
+        manager_map = {}
+
+        async def build_and_track(context_id):
+            new_mgr = AsyncMock()
+            new_mgr.initialize = AsyncMock()
+            new_mgr.context_id = context_id  # Track origin
+
+            if factory._is_default_context(context_id):
+                # Default gets new manager
+                factory._managers[context_id] = _CachedManager(manager=new_mgr, created_at=time.monotonic())
+                manager_map[context_id] = new_mgr
+                return new_mgr
+            else:
+                # Alias looks up its team default
+                team_id = context_id.split("::")[0]
+                default_ctx = f"{team_id}::##global##"
+                default_entry = factory._managers.get(default_ctx)
+                if default_entry is not None:
+                    factory._managers[context_id] = default_entry
+                    manager_map[context_id] = default_entry.manager
+                    return default_entry.manager
+                return new_mgr
+
+        with patch.object(factory, "_build_manager", side_effect=build_and_track):
+            await factory.invalidate_all()
+
+        # Verify each team's aliases reference their team's default manager
+        assert manager_map["team-a::tool1"] is manager_map["team-a::##global##"]
+        assert manager_map["team-b::tool1"] is manager_map["team-b::##global##"]
+        assert manager_map["team-c::tool1"] is manager_map["team-c::##global##"]
+
+        # Verify different teams have different managers
+        assert manager_map["team-a::##global##"] is not manager_map["team-b::##global##"]
+        assert manager_map["team-b::##global##"] is not manager_map["team-c::##global##"]
+
+
+
 class TestSetGlobalObservability:
     def test_propagates_to_active_factory(self):
         mock_factory = MagicMock()

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Third-Party
 import pytest
 from pydantic import ValidationError as _PydValidationError
-from cpex.framework import 
+from cpex.framework import
 
 # First-Party
 from mcpgateway.plugins._redis import set_shared_redis_provider

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -19,17 +19,23 @@ All Redis interactions are mocked — no real Redis needed.
 
 # Standard
 import asyncio
-import json as _json_mod
+import json
+import logging
 import time
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Third-Party
 import pytest
+from pydantic import ValidationError as _PydValidationError
+from cpex.framework import 
 
 # First-Party
 from mcpgateway.plugins._redis import set_shared_redis_provider
-
+import mcpgateway.plugins as framework
+from mcpgateway.plugins.gateway_plugin_manager import (
+    _CachedManager, DEFAULT_CONTEXT_ID, GatewayTenantPluginManagerFactory
+)
 
 @contextmanager
 def _mock_redis(*, client=None, side_effect=None):
@@ -39,9 +45,7 @@ def _mock_redis(*, client=None, side_effect=None):
     now that the plugin layer uses ``mcpgateway.plugins._redis`` for dependency inversion.
     Also invalidates the short-lived ``are_plugins_enabled_shared`` cache.
     """
-    import mcpgateway.plugins as _framework
-
-    _framework._shared_enabled_cache = None
+    framework._shared_enabled_cache = None
 
     if side_effect is not None:
         set_shared_redis_provider(AsyncMock(side_effect=side_effect))
@@ -54,14 +58,14 @@ def _mock_redis(*, client=None, side_effect=None):
         yield
     finally:
         set_shared_redis_provider(None)
-        _framework._shared_enabled_cache = None
+        framework._shared_enabled_cache = None
 
 
 def _unwrap_published_message(raw: str) -> dict:
     """Extract the inner invalidation message from a possibly HMAC-signed envelope."""
-    parsed = _json_mod.loads(raw)
+    parsed = json.loads(raw)
     if isinstance(parsed, dict) and "sig" in parsed and "payload" in parsed:
-        return _json_mod.loads(parsed["payload"])
+        return json.loads(parsed["payload"])
     return parsed
 
 
@@ -73,7 +77,6 @@ def _make_bare_factory(**attrs):
     pre-set attributes (``_managers``, ``_cache_ttl``, etc.); sensible defaults
     are applied for the ones tests usually don't care about.
     """
-    from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
     factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
     factory._managers = attrs.get("_managers", {})
@@ -99,73 +102,61 @@ class TestArePluginsEnabledShared:
     @pytest.mark.asyncio
     async def test_reads_true_from_redis(self):
         """When Redis has 'true', returns True."""
-        from mcpgateway.plugins import are_plugins_enabled_shared
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value="true")
 
         with _mock_redis(client=mock_client):
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_reads_false_from_redis(self):
         """When Redis has 'false', returns False."""
-        from mcpgateway.plugins import are_plugins_enabled_shared
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value="false")
 
         with _mock_redis(client=mock_client):
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is False
 
     @pytest.mark.asyncio
     async def test_reads_bytes_from_redis(self):
         """When Redis returns bytes (decode_responses=False), handles correctly."""
-        from mcpgateway.plugins import are_plugins_enabled_shared
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=b"true")
 
         with _mock_redis(client=mock_client):
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_falls_back_to_in_memory_when_redis_unavailable(self):
         """When Redis client is None, falls back to in-memory _PLUGINS_ENABLED."""
-        from mcpgateway.plugins import are_plugins_enabled_shared, enable_plugins
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
 
         with _mock_redis():
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_falls_back_to_in_memory_when_redis_key_missing(self):
         """When Redis key doesn't exist, falls back to in-memory flag."""
-        from mcpgateway.plugins import are_plugins_enabled_shared, enable_plugins
-
-        enable_plugins(False)
+        framework.enable_plugins(False)
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=None)
 
         with _mock_redis(client=mock_client):
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is False
 
     @pytest.mark.asyncio
     async def test_falls_back_on_redis_exception(self):
         """When Redis raises an exception, falls back to in-memory flag."""
-        from mcpgateway.plugins import are_plugins_enabled_shared, enable_plugins
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
 
         with _mock_redis(side_effect=Exception("connection refused")):
-            result = await are_plugins_enabled_shared()
+            result = await framework.are_plugins_enabled_shared()
             assert result is True
 
 
@@ -175,50 +166,42 @@ class TestEnablePluginsShared:
     @pytest.mark.asyncio
     async def test_writes_true_to_redis(self):
         """enable_plugins_shared(True) writes 'true' to Redis."""
-        from mcpgateway.plugins import enable_plugins_shared
-
         mock_client = AsyncMock()
         mock_client.set = AsyncMock()
 
         with _mock_redis(client=mock_client):
-            await enable_plugins_shared(True)
+            await framework.enable_plugins_shared(True)
             mock_client.set.assert_called_once_with("plugin:global:enabled", "true")
 
     @pytest.mark.asyncio
     async def test_writes_false_to_redis(self):
         """enable_plugins_shared(False) writes 'false' to Redis."""
-        from mcpgateway.plugins import enable_plugins_shared
-
         mock_client = AsyncMock()
         mock_client.set = AsyncMock()
 
         with _mock_redis(client=mock_client):
-            await enable_plugins_shared(False)
+            await framework.enable_plugins_shared(False)
             mock_client.set.assert_called_once_with("plugin:global:enabled", "false")
 
     @pytest.mark.asyncio
     async def test_updates_in_memory_flag(self):
         """enable_plugins_shared also updates the in-memory _PLUGINS_ENABLED flag."""
-        from mcpgateway.plugins import are_plugins_enabled, enable_plugins, enable_plugins_shared
-
-        enable_plugins(True)
-        assert are_plugins_enabled() is True
+        framework.enable_plugins(True)
+        assert framework.are_plugins_enabled() is True
 
         with _mock_redis():
-            await enable_plugins_shared(False)
-            assert are_plugins_enabled() is False
+            await framework.enable_plugins_shared(False)
+            assert framework.are_plugins_enabled() is False
 
     @pytest.mark.asyncio
     async def test_survives_redis_failure(self):
         """When Redis write fails, in-memory flag is still updated."""
-        from mcpgateway.plugins import are_plugins_enabled, enable_plugins, enable_plugins_shared
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
 
         with _mock_redis(side_effect=Exception("connection refused")):
-            await enable_plugins_shared(False)
+            await framework.enable_plugins_shared(False)
             # In-memory flag should still be updated
-            assert are_plugins_enabled() is False
+            assert framework.are_plugins_enabled() is False
 
 
 # ---------------------------------------------------------------------------
@@ -232,45 +215,37 @@ class TestGetPluginModeOverride:
     @pytest.mark.asyncio
     async def test_reads_mode_from_redis(self):
         """Returns the mode string stored in Redis."""
-        from mcpgateway.plugins import get_plugin_mode_override
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value="enforce")
 
         with _mock_redis(client=mock_client):
-            result = await get_plugin_mode_override("RateLimiterPlugin")
+            result = await framework.get_plugin_mode_override("RateLimiterPlugin")
             assert result == "enforce"
             mock_client.get.assert_called_once_with("plugin:RateLimiterPlugin:mode")
 
     @pytest.mark.asyncio
     async def test_returns_none_when_no_override(self):
         """Returns None when no Redis key exists (use YAML default)."""
-        from mcpgateway.plugins import get_plugin_mode_override
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=None)
 
         with _mock_redis(client=mock_client):
-            result = await get_plugin_mode_override("RateLimiterPlugin")
+            result = await framework.get_plugin_mode_override("RateLimiterPlugin")
             assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_redis_unavailable(self):
         """Returns None when Redis client is None."""
-        from mcpgateway.plugins import get_plugin_mode_override
-
         with _mock_redis():
-            result = await get_plugin_mode_override("RateLimiterPlugin")
+            result = await framework.get_plugin_mode_override("RateLimiterPlugin")
             assert result is None
 
     @pytest.mark.asyncio
     async def test_raises_runtime_error_on_redis_exception(self):
         """Redis transport errors surface as RuntimeError so callers can distinguish them from 'no override'."""
-        from mcpgateway.plugins import get_plugin_mode_override
-
         with _mock_redis(side_effect=Exception("timeout")):
             with pytest.raises(RuntimeError, match="Redis client unavailable"):
-                await get_plugin_mode_override("RateLimiterPlugin")
+                await framework.get_plugin_mode_override("RateLimiterPlugin")
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +259,6 @@ class TestTTLCacheExpiry:
     @pytest.mark.asyncio
     async def test_cache_returns_manager_within_ttl(self):
         """Cached manager is returned when within TTL."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         cached = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
         factory = _make_bare_factory(_managers={"test::tool": cached})
@@ -295,7 +269,6 @@ class TestTTLCacheExpiry:
     @pytest.mark.asyncio
     async def test_cache_evicts_after_ttl(self):
         """Cached manager is reported as expired once the TTL window has passed."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         expired = _CachedManager(manager=MagicMock(), created_at=time.monotonic() - 60)
         factory = _make_bare_factory(_managers={"test::tool": expired}, _cache_ttl=5)
@@ -307,13 +280,11 @@ class TestTTLCacheExpiry:
 
     def test_cache_ttl_default(self):
         """Default TTL is 30 seconds."""
-        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
         assert GatewayTenantPluginManagerFactory.DEFAULT_CACHE_TTL == 30
 
     def test_cache_ttl_zero_disables(self):
         """TTL of 0 short-circuits the expiry check so entries never auto-evict."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         entry = _CachedManager(manager=MagicMock(), created_at=time.monotonic() - 10_000)
         assert entry.is_expired(0) is False
@@ -383,8 +354,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_corrupt_redis_falls_through_to_local_override(self):
         """A corrupt Redis value must not shadow a valid local override — both candidates are tried in priority order."""
-        import mcpgateway.plugins as framework
-
         factory = self._make_factory()
         config = self._build_config(["A"])
 
@@ -405,15 +374,13 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_invalid_mode_value_skipped_not_batch_aborted(self, caplog):
         """One bad Redis value must not drop valid overrides for the rest of the batch."""
-        import logging as _logging
-
         factory = self._make_factory()
         config = self._build_config(["A", "B"])
 
         mock_client = AsyncMock()
         mock_client.mget = AsyncMock(return_value=[b"not_a_mode", b"enforce"])
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
             with _mock_redis(client=mock_client):
                 result = await factory._apply_redis_mode_overrides(config)
 
@@ -426,7 +393,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_local_override_applied_when_redis_has_nothing(self):
         """Redis-less deployments: the in-process override map drives the rebuild."""
-        import mcpgateway.plugins as framework
 
         factory = self._make_factory()
         config = self._build_config(["A", "B"])
@@ -448,7 +414,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_redis_value_beats_local_override(self):
         """When both Redis and the local map hold a value, Redis wins — cluster coordination beats local drift."""
-        import mcpgateway.plugins as framework
 
         factory = self._make_factory()
         config = self._build_config(["A"])
@@ -468,7 +433,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_local_override_applied_when_redis_client_none(self):
         """No Redis provider at all: the in-process map is the sole source."""
-        import mcpgateway.plugins as framework
 
         factory = self._make_factory()
         config = self._build_config(["A"])
@@ -485,7 +449,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_expired_redis_synced_local_override_is_pruned(self):
         """Regression pin for the "stuck past 24 h" bug: a Redis-synced entry whose TTL has elapsed must not apply."""
-        import mcpgateway.plugins as framework
 
         factory = self._make_factory()
         config = self._build_config(["A", "B"])
@@ -512,7 +475,6 @@ class TestApplyRedisModeOverrides:
     @pytest.mark.asyncio
     async def test_mget_failure_warns_and_returns_input(self, caplog):
         """Redis transport failures surface as WARNING — not silent DEBUG — so operators see them."""
-        import logging as _logging
 
         factory = self._make_factory()
         config = self._build_config(["A"])
@@ -520,20 +482,18 @@ class TestApplyRedisModeOverrides:
         mock_client = AsyncMock()
         mock_client.mget = AsyncMock(side_effect=Exception("EPIPE"))
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
             with _mock_redis(client=mock_client):
                 result = await factory._apply_redis_mode_overrides(config)
 
         assert result is config
-        assert any(rec.levelno == _logging.WARNING for rec in caplog.records)
+        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
 
 
 class SimpleNamespacePlugin:
     """Tiny stand-in plugin with a mode-carrying enum attribute."""
 
     def __init__(self, name, mode):
-        from cpex.framework import PluginMode
-
         self.name = name
         self.mode = mode if isinstance(mode, PluginMode) else PluginMode(mode)
 
@@ -549,7 +509,6 @@ class TestDBErrorFallback:
     @pytest.mark.asyncio
     async def test_raises_on_db_error(self):
         """DB failures must raise so the rebuild fails loudly — silently falling back to YAML drops security-relevant overrides."""
-        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
         factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
         factory._db_factory = MagicMock(side_effect=Exception("connection refused"))
@@ -560,7 +519,6 @@ class TestDBErrorFallback:
     @pytest.mark.asyncio
     async def test_returns_none_for_invalid_context_id(self):
         """When context_id has no separator, returns None."""
-        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
         factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
         factory._db_factory = MagicMock()
@@ -571,7 +529,6 @@ class TestDBErrorFallback:
     @pytest.mark.asyncio
     async def test_returns_none_for_empty_bindings(self):
         """When no bindings found, returns None."""
-        from mcpgateway.plugins.gateway_plugin_manager import GatewayTenantPluginManagerFactory
 
         mock_session = MagicMock()
         factory = GatewayTenantPluginManagerFactory.__new__(GatewayTenantPluginManagerFactory)
@@ -593,16 +550,13 @@ class TestInvalidateAllPluginManagers:
     @pytest.mark.asyncio
     async def test_delegates_to_factory_invalidate_all(self):
         """Module helper routes through ``factory.invalidate_all()`` rather than reaching into private state."""
-        from mcpgateway.plugins import invalidate_all_plugin_managers
-        import mcpgateway.plugins as framework
-
         mock_factory = AsyncMock()
         mock_factory.invalidate_all = AsyncMock()
 
         original_factory = framework._plugin_manager_factory
         framework._plugin_manager_factory = mock_factory
         try:
-            await invalidate_all_plugin_managers()
+            await framework.invalidate_all_plugin_managers()
             mock_factory.invalidate_all.assert_awaited_once()
         finally:
             framework._plugin_manager_factory = original_factory
@@ -610,8 +564,6 @@ class TestInvalidateAllPluginManagers:
     @pytest.mark.asyncio
     async def test_noop_when_factory_is_none(self):
         """No error when factory is not initialized."""
-        import mcpgateway.plugins as framework
-
         original_factory = framework._plugin_manager_factory
         framework._plugin_manager_factory = None
         try:
@@ -632,14 +584,12 @@ class TestPubSubPublisher:
     @pytest.mark.asyncio
     async def test_global_toggle_publishes_message(self):
         """enable_plugins_shared publishes an invalidation message."""
-        from mcpgateway.plugins import enable_plugins_shared
-
         mock_client = AsyncMock()
         mock_client.set = AsyncMock()
         mock_client.publish = AsyncMock()
 
         with _mock_redis(client=mock_client):
-            await enable_plugins_shared(False)
+            await framework.enable_plugins_shared(False)
             mock_client.publish.assert_called_once()
             # Verify channel name
             call_args = mock_client.publish.call_args
@@ -652,16 +602,14 @@ class TestPubSubPublisher:
     @pytest.mark.asyncio
     async def test_global_toggle_publish_failure_doesnt_crash(self):
         """If publish fails, the toggle still succeeds."""
-        from mcpgateway.plugins import enable_plugins_shared, are_plugins_enabled
-
         mock_client = AsyncMock()
         mock_client.set = AsyncMock()
         mock_client.publish = AsyncMock(side_effect=Exception("publish failed"))
 
         with _mock_redis(client=mock_client):
-            await enable_plugins_shared(True)
+            await framework.enable_plugins_shared(True)
             # Should not crash — in-memory flag updated
-            assert are_plugins_enabled() is True
+            assert framework.are_plugins_enabled() is True
 
 
 class TestPubSubSubscriber:
@@ -670,23 +618,15 @@ class TestPubSubSubscriber:
     @pytest.mark.asyncio
     async def test_subscriber_updates_flag_on_global_toggle(self):
         """Subscriber updates in-memory flag when receiving global_toggle message."""
-        from mcpgateway.plugins import _handle_invalidation_message, enable_plugins
-        import json
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
         message = {"type": "message", "data": json.dumps({"type": "global_toggle", "enabled": False})}
-        await _handle_invalidation_message(message)
+        await framework._handle_invalidation_message(message)
 
-        from mcpgateway.plugins import are_plugins_enabled
-
-        assert are_plugins_enabled() is False
+        assert framework.are_plugins_enabled() is False
 
     @pytest.mark.asyncio
     async def test_subscriber_evicts_managers_on_mode_change(self):
         """Subscriber triggers factory-wide invalidation when a mode_change frame arrives."""
-        import mcpgateway.plugins as framework
-        import json
-
         mock_factory = AsyncMock()
         mock_factory.invalidate_all = AsyncMock()
 
@@ -702,23 +642,19 @@ class TestPubSubSubscriber:
     @pytest.mark.asyncio
     async def test_subscriber_ignores_non_message_types(self):
         """Subscriber ignores subscribe/unsubscribe messages."""
-        from mcpgateway.plugins import _handle_invalidation_message, enable_plugins, are_plugins_enabled
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
         # "subscribe" type messages should be ignored
         message = {"type": "subscribe", "data": None}
-        await _handle_invalidation_message(message)
-        assert are_plugins_enabled() is True  # Unchanged
+        await framework._handle_invalidation_message(message)
+        assert framework.are_plugins_enabled() is True  # Unchanged
 
     @pytest.mark.asyncio
     async def test_subscriber_handles_malformed_message(self):
         """Subscriber doesn't crash on malformed JSON."""
-        from mcpgateway.plugins import _handle_invalidation_message, enable_plugins, are_plugins_enabled
-
-        enable_plugins(True)
+        framework.enable_plugins(True)
         message = {"type": "message", "data": "not valid json {{{"}
-        await _handle_invalidation_message(message)
-        assert are_plugins_enabled() is True  # Unchanged, no crash
+        await framework._handle_invalidation_message(message)
+        assert framework.are_plugins_enabled() is True  # Unchanged, no crash
 
 
 class TestPublishHelpers:
@@ -727,14 +663,13 @@ class TestPublishHelpers:
     @pytest.mark.asyncio
     async def test_publish_plugin_mode_change_sends_mode_change_message(self):
         """publish_plugin_mode_change must SET the key AND publish a mode_change frame."""
-        from mcpgateway.plugins import publish_plugin_mode_change
 
         client = AsyncMock()
         client.set = AsyncMock()
         client.publish = AsyncMock()
 
         with _mock_redis(client=client):
-            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+            ok = await framework.publish_plugin_mode_change("RateLimiterPlugin", "enforce")
 
         assert ok is True
         # SET carries the 24h TTL
@@ -751,14 +686,13 @@ class TestPublishHelpers:
     @pytest.mark.asyncio
     async def test_publish_plugin_mode_change_returns_false_on_set_failure(self):
         """A SET transport failure must surface as False so the caller signals the outage."""
-        from mcpgateway.plugins import publish_plugin_mode_change
 
         client = AsyncMock()
         client.set = AsyncMock(side_effect=Exception("ECONNREFUSED"))
         client.publish = AsyncMock()
 
         with _mock_redis(client=client):
-            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+            ok = await framework.publish_plugin_mode_change("RateLimiterPlugin", "enforce")
 
         assert ok is False
         client.publish.assert_not_awaited()  # No half-state broadcast
@@ -766,8 +700,6 @@ class TestPublishHelpers:
     @pytest.mark.asyncio
     async def test_local_entry_expiry_aligns_with_redis_ttl_on_success(self):
         """Redis-synced local entries must carry a ~24 h monotonic expiry — otherwise they'd outlive the Redis key."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import publish_plugin_mode_change
 
         client = AsyncMock()
         client.set = AsyncMock()
@@ -775,7 +707,7 @@ class TestPublishHelpers:
 
         before = time.monotonic()
         with _mock_redis(client=client):
-            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+            ok = await framework.publish_plugin_mode_change("RateLimiterPlugin", "enforce")
         after = time.monotonic()
 
         assert ok is True
@@ -789,15 +721,13 @@ class TestPublishHelpers:
     @pytest.mark.asyncio
     async def test_local_entry_has_no_expiry_when_redis_set_fails(self):
         """Local-only entries (Redis SET failed) must be durable — the operator never got confirmation the timer started."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import publish_plugin_mode_change
 
         client = AsyncMock()
         client.set = AsyncMock(side_effect=Exception("ECONNREFUSED"))
         client.publish = AsyncMock()
 
         with _mock_redis(client=client):
-            ok = await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+            ok = await framework.publish_plugin_mode_change("RateLimiterPlugin", "enforce")
 
         assert ok is False
         entry = framework._state.get_local_mode_overrides_live()["RateLimiterPlugin"]
@@ -808,13 +738,12 @@ class TestPublishHelpers:
     @pytest.mark.asyncio
     async def test_publish_binding_change_sends_binding_change_message(self):
         """publish_binding_change must emit a binding_change frame with the context id."""
-        from mcpgateway.plugins import publish_binding_change
 
         client = AsyncMock()
         client.publish = AsyncMock()
 
         with _mock_redis(client=client):
-            ok = await publish_binding_change("team_a::my_tool")
+            ok = await framework.publish_binding_change("team_a::my_tool")
 
         assert ok is True
         pub_call = client.publish.call_args
@@ -829,15 +758,13 @@ class TestPublishToListenerRoundTrip:
     @pytest.mark.asyncio
     async def test_mode_change_publish_triggers_factory_invalidate(self):
         """Publishing a mode_change must cause the listener handler to trigger cluster-wide invalidation."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message, publish_plugin_mode_change
 
         # Simulate the local factory on the *listener* side. Module helper routes
         # through ``factory.invalidate_all()``, so we just assert that was awaited.
         mock_factory = AsyncMock()
         mock_factory.invalidate_all = AsyncMock()
 
-        # Capture the published frame; feed it back into _handle_invalidation_message
+        # Capture the published frame; feed it back into framework._handle_invalidation_message
         # to mimic the Redis pub/sub round-trip on a peer worker.
         published = {}
 
@@ -853,11 +780,11 @@ class TestPublishToListenerRoundTrip:
         framework._plugin_manager_factory = mock_factory
         try:
             with _mock_redis(client=client):
-                await publish_plugin_mode_change("RateLimiterPlugin", "enforce")
+                await framework.publish_plugin_mode_change("RateLimiterPlugin", "enforce")
 
             assert published["channel"] == "plugin:invalidation"
             frame = {"type": "message", "data": published["payload"]}
-            await _handle_invalidation_message(frame)
+            await framework._handle_invalidation_message(frame)
 
             # Listener-side handler delegates to the factory's public invalidate_all.
             mock_factory.invalidate_all.assert_awaited_once()
@@ -867,20 +794,18 @@ class TestPublishToListenerRoundTrip:
     @pytest.mark.asyncio
     async def test_global_toggle_pubsub_invalidates_local_cache(self):
         """A global_toggle broadcast must drop the short-lived local cache, not just update the flag."""
-        import json
-        from mcpgateway.plugins import _handle_invalidation_message, are_plugins_enabled_shared, enable_plugins
 
-        enable_plugins(True)
+        framework.enable_plugins(True)
         # Prime the local cache with True.
         with _mock_redis():
-            assert await are_plugins_enabled_shared() is True
+            assert await framework.are_plugins_enabled_shared() is True
 
         # Broadcast flips the toggle OFF.
-        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "global_toggle", "enabled": False})})
+        await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "global_toggle", "enabled": False})})
 
         # Next read must NOT serve the cached True — it must reflect the new state.
         with _mock_redis():
-            assert await are_plugins_enabled_shared() is False
+            assert await framework.are_plugins_enabled_shared() is False
 
 
 class TestFactoryInvalidateTeam:
@@ -888,14 +813,13 @@ class TestFactoryInvalidateTeam:
 
     @pytest.mark.asyncio
     async def test_invalidates_only_matching_team(self):
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory(
             _managers={
                 "team_a::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
                 "team_a::tool_2": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
                 "team_b::tool_1": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
-                "__global__": _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
+                DEFAULT_CONTEXT_ID: _CachedManager(manager=MagicMock(), created_at=time.monotonic()),
             }
         )
         factory.reload_tenant = AsyncMock()
@@ -909,7 +833,6 @@ class TestFactoryInvalidateTeam:
     @pytest.mark.asyncio
     async def test_uses_class_separator_when_not_specified(self):
         """Default separator is ``CONTEXT_ID_SEPARATOR`` — saves the listener from knowing it on the wire."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory(
             _managers={
@@ -931,13 +854,12 @@ class TestTeamBindingChangeRoundTrip:
 
     @pytest.mark.asyncio
     async def test_publish_team_binding_change_emits_correct_frame(self):
-        from mcpgateway.plugins import publish_team_binding_change
 
         client = AsyncMock()
         client.publish = AsyncMock()
 
         with _mock_redis(client=client):
-            ok = await publish_team_binding_change("team_a")
+            ok = await framework.publish_team_binding_change("team_a")
 
         assert ok is True
         pub_call = client.publish.call_args
@@ -948,11 +870,7 @@ class TestTeamBindingChangeRoundTrip:
     @pytest.mark.asyncio
     async def test_handler_evicts_every_per_tool_context_for_team(self):
         """A team_binding_change frame on a remote worker must reload every ``team_a::*`` cache entry."""
-        import json
 
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory(
             _managers={
@@ -967,7 +885,7 @@ class TestTeamBindingChangeRoundTrip:
         framework._plugin_manager_factory = factory
         try:
             frame = {"type": "message", "data": json.dumps({"type": "team_binding_change", "team_id": "team_a"})}
-            await _handle_invalidation_message(frame)
+            await framework._handle_invalidation_message(frame)
         finally:
             framework._plugin_manager_factory = original_factory
 
@@ -981,8 +899,6 @@ class TestSubscriberHandlesBindingChange:
     @pytest.mark.asyncio
     async def test_subscriber_handles_binding_change(self):
         """Subscriber evicts specific context on binding_change message."""
-        import mcpgateway.plugins as framework
-        import json
 
         mock_factory = AsyncMock()
         mock_factory.reload_tenant = AsyncMock()
@@ -1003,15 +919,11 @@ class TestListenerLocalMirror:
     @pytest.mark.asyncio
     async def test_mode_change_populates_local_map_with_broadcast_ttl(self):
         """The handler stamps ``(mode, monotonic + ttl_seconds)`` using the publisher's TTL, not a local constant."""
-        import json
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message
 
         # No factory needed for this assertion; invalidate_all is a no-op.
         framework._state.clear_local_mode_overrides()
         before = time.monotonic()
-        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce", "ttl_seconds": 600})})
+        await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce", "ttl_seconds": 600})})
         after = time.monotonic()
 
         entry = framework._state.get_local_mode_overrides_live()["Foo"]
@@ -1024,14 +936,10 @@ class TestListenerLocalMirror:
     @pytest.mark.asyncio
     async def test_mode_change_falls_back_to_default_ttl_without_field(self):
         """Older publishers that omit ``ttl_seconds`` fall back to the 24 h default."""
-        import json
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message
 
         framework._state.clear_local_mode_overrides()
         before = time.monotonic()
-        await _handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce"})})
+        await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "mode_change", "plugin": "Foo", "mode": "enforce"})})
         after = time.monotonic()
 
         _, expires_at = framework._state.get_local_mode_overrides_live()["Foo"]
@@ -1040,11 +948,10 @@ class TestListenerLocalMirror:
 
     def test_backing_dict_identity_is_stable(self):
         """Regression pin: writers and readers must share one dict object — introducing a copy would split the listener from the manager."""
-        from mcpgateway.plugins import _state
 
-        first = _state.get_local_mode_overrides_live()
-        _state.set_local_mode_override("Identity", "enforce", None)
-        assert _state.get_local_mode_overrides_live() is first
+        first = framework._state.get_local_mode_overrides_live()
+        framework._state.set_local_mode_override("Identity", "enforce", None)
+        assert framework._state.get_local_mode_overrides_live() is first
 
 
 class TestListenerStartup:
@@ -1053,28 +960,20 @@ class TestListenerStartup:
     @pytest.mark.asyncio
     async def test_skips_start_when_no_redis_provider(self, caplog):
         """Single-node deployments without a Redis provider must not create the listener task."""
-        import logging as _logging
-
-        from mcpgateway.plugins import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
-        from mcpgateway.plugins._redis import set_shared_redis_provider
 
         set_shared_redis_provider(None)
-        import mcpgateway.plugins as framework
-
         framework._pubsub_task = None
 
-        with caplog.at_level(_logging.INFO, logger="mcpgateway.plugins"):
-            await start_plugin_invalidation_listener()
+        with caplog.at_level(logging.INFO, logger="mcpgateway.plugins"):
+            await framework.start_plugin_invalidation_listener()
 
         assert framework._pubsub_task is None
         assert any("no Redis provider" in rec.message for rec in caplog.records)
-        await stop_plugin_invalidation_listener()
+        await framework.stop_plugin_invalidation_listener()
 
     @pytest.mark.asyncio
     async def test_concurrent_starts_only_create_one_task(self, monkeypatch):
         """Two racing callers must not both reach ``asyncio.create_task`` (TOCTOU guard)."""
-        from mcpgateway.plugins import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
-        import mcpgateway.plugins as framework
 
         framework._pubsub_task = None
 
@@ -1086,32 +985,28 @@ class TestListenerStartup:
         monkeypatch.setattr(framework, "_redis", AsyncMock(return_value=dummy_client))
 
         await asyncio.gather(
-            start_plugin_invalidation_listener(),
-            start_plugin_invalidation_listener(),
-            start_plugin_invalidation_listener(),
+            framework.start_plugin_invalidation_listener(),
+            framework.start_plugin_invalidation_listener(),
+            framework.start_plugin_invalidation_listener(),
         )
 
         assert framework._pubsub_task is not None
-        await stop_plugin_invalidation_listener()
+        await framework.stop_plugin_invalidation_listener()
         assert framework._pubsub_task is None
 
     @pytest.mark.asyncio
     async def test_probe_failure_does_not_start_and_logs(self, monkeypatch, caplog):
         """If the Redis probe raises, the listener must not start and the failure must log at WARNING."""
-        import logging as _logging
-
-        from mcpgateway.plugins import start_plugin_invalidation_listener, stop_plugin_invalidation_listener
-        import mcpgateway.plugins as framework
 
         framework._pubsub_task = None
         monkeypatch.setattr(framework, "_redis", AsyncMock(side_effect=RuntimeError("probe blew up")))
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins"):
-            await start_plugin_invalidation_listener()
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
+            await framework.start_plugin_invalidation_listener()
 
         assert framework._pubsub_task is None
         assert any("probe failed" in rec.message for rec in caplog.records)
-        await stop_plugin_invalidation_listener()
+        await framework.stop_plugin_invalidation_listener()
 
 
 class TestPublishPartialWriteSignaling:
@@ -1119,35 +1014,29 @@ class TestPublishPartialWriteSignaling:
 
     @pytest.mark.asyncio
     async def test_enable_plugins_shared_errors_on_publish_failure(self, caplog):
-        import logging as _logging
-
-        from mcpgateway.plugins import enable_plugins_shared
 
         client = AsyncMock()
         client.set = AsyncMock()
         client.publish = AsyncMock(side_effect=Exception("broker down"))
 
-        with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins"):
+        with caplog.at_level(logging.ERROR, logger="mcpgateway.plugins"):
             with _mock_redis(client=client):
-                await enable_plugins_shared(True)
+                await framework.enable_plugins_shared(True)
 
-        assert any("broadcast failed" in rec.message and rec.levelno == _logging.ERROR for rec in caplog.records)
+        assert any("broadcast failed" in rec.message and rec.levelno == logging.ERROR for rec in caplog.records)
 
     @pytest.mark.asyncio
     async def test_publish_plugin_mode_change_errors_on_publish_failure(self, caplog):
-        import logging as _logging
-
-        from mcpgateway.plugins import publish_plugin_mode_change
 
         client = AsyncMock()
         client.set = AsyncMock()
         client.publish = AsyncMock(side_effect=Exception("broker down"))
 
-        with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins"):
+        with caplog.at_level(logging.ERROR, logger="mcpgateway.plugins"):
             with _mock_redis(client=client):
-                await publish_plugin_mode_change("Foo", "enforce")
+                await framework.publish_plugin_mode_change("Foo", "enforce")
 
-        assert any("broadcast failed" in rec.message and rec.levelno == _logging.ERROR for rec in caplog.records)
+        assert any("broadcast failed" in rec.message and rec.levelno == logging.ERROR for rec in caplog.records)
 
 
 class TestFactoryInitFailureSurface:
@@ -1164,13 +1053,12 @@ class TestFactoryInitFailureSurface:
     """
 
     def test_malformed_yaml_raises(self, tmp_path):
-        from mcpgateway.plugins import init_plugin_manager_factory
 
         bad = tmp_path / "bad.yaml"
         bad.write_text("plugins: [this is not a valid plugin list:::")
 
         with pytest.raises(Exception):
-            init_plugin_manager_factory(
+            framework.init_plugin_manager_factory(
                 yaml_path=str(bad),
                 timeout=30,
                 hook_policies={},
@@ -1179,14 +1067,13 @@ class TestFactoryInitFailureSurface:
             )
 
     def test_invalid_config_shape_raises(self, tmp_path):
-        from mcpgateway.plugins import init_plugin_manager_factory
 
         bad = tmp_path / "bad.yaml"
         # A plugin entry without 'name' (required field) must fail validation.
         bad.write_text("plugins:\n  - kind: some.Plugin\n    hooks: [tool_pre_invoke]\n")
 
         with pytest.raises(Exception):
-            init_plugin_manager_factory(
+            framework.init_plugin_manager_factory(
                 yaml_path=str(bad),
                 timeout=30,
                 hook_policies={},
@@ -1200,46 +1087,33 @@ class TestFactoryInitDegradedSignal:
 
     @pytest.mark.asyncio
     async def test_get_plugin_manager_emits_error_once_on_degraded_node(self, caplog):
-        import logging as _logging
 
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import (
-            _reset_factory_init_degraded_for_tests,
-            enable_plugins,
-            get_plugin_manager,
-            mark_factory_init_degraded,
-        )
-
-        _reset_factory_init_degraded_for_tests()
+        framework._reset_factory_init_degraded_for_tests()
         framework._plugin_manager_factory = None
-        enable_plugins(True)  # Seed in-memory flag so are_plugins_enabled_shared() returns True.
-        mark_factory_init_degraded()
+        framework.enable_plugins(True)  # Seed in-memory flag so are_plugins_enabled_shared() returns True.
+        framework.mark_factory_init_degraded()
 
         with _mock_redis():
-            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins"):
-                assert await get_plugin_manager() is None
-                assert await get_plugin_manager() is None
+            with caplog.at_level(logging.ERROR, logger="mcpgateway.plugins"):
+                assert await framework.get_plugin_manager() is None
+                assert await framework.get_plugin_manager() is None
 
-        degraded_errors = [rec for rec in caplog.records if rec.levelno == _logging.ERROR and "factory init failed" in rec.message]
+        degraded_errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR and "factory init failed" in rec.message]
         # One ERROR, not one per request.
         assert len(degraded_errors) == 1, f"expected 1 ERROR, got {len(degraded_errors)}: {[r.message for r in degraded_errors]}"
 
     @pytest.mark.asyncio
     async def test_no_error_when_factory_is_initialized(self, caplog):
         """A healthy node never emits the degraded-boot ERROR."""
-        import logging as _logging
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import enable_plugins, get_plugin_manager
 
         mock_factory = AsyncMock()
         mock_factory.get_manager = AsyncMock(return_value=MagicMock())
         framework._plugin_manager_factory = mock_factory
-        enable_plugins(True)
+        framework.enable_plugins(True)
 
         with _mock_redis():
-            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins"):
-                await get_plugin_manager()
+            with caplog.at_level(logging.ERROR, logger="mcpgateway.plugins"):
+                await framework.get_plugin_manager()
 
         assert not any("factory init failed" in rec.message for rec in caplog.records)
         framework._plugin_manager_factory = None
@@ -1247,22 +1121,14 @@ class TestFactoryInitDegradedSignal:
     @pytest.mark.asyncio
     async def test_no_error_when_toggle_is_off(self, caplog):
         """Degraded node with the shared toggle off must stay quiet — the opt-out is doing its job."""
-        import logging as _logging
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import (
-            enable_plugins,
-            get_plugin_manager,
-            mark_factory_init_degraded,
-        )
 
         framework._plugin_manager_factory = None
-        enable_plugins(False)  # toggle off
-        mark_factory_init_degraded()
+        framework.enable_plugins(False)  # toggle off
+        framework.mark_factory_init_degraded()
 
         with _mock_redis():
-            with caplog.at_level(_logging.ERROR, logger="mcpgateway.plugins"):
-                await get_plugin_manager()
+            with caplog.at_level(logging.ERROR, logger="mcpgateway.plugins"):
+                await framework.get_plugin_manager()
 
         assert not any("factory init failed" in rec.message for rec in caplog.records)
 
@@ -1273,9 +1139,6 @@ class TestListenerBackoff:
     @pytest.mark.asyncio
     async def test_escalates_to_error_after_five_consecutive_failures(self, monkeypatch, caplog):
         """Exponential backoff plus ERROR log after 5 failures keeps ops visibility when Redis is flaky."""
-        import logging as _logging
-
-        import mcpgateway.plugins as framework
 
         # Force every subscribe attempt to raise, so the backoff loop cycles.
         async def _always_raises():
@@ -1293,15 +1156,15 @@ class TestListenerBackoff:
 
         monkeypatch.setattr(framework.asyncio, "sleep", _fake_sleep)
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins"):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
             try:
                 await framework._plugin_invalidation_listener()
             except asyncio.CancelledError:
                 pass
 
         # First 4 failures at WARNING; failure #5 onward at ERROR.
-        warnings = [r for r in caplog.records if r.levelno == _logging.WARNING and "reconnecting" in r.message]
-        errors = [r for r in caplog.records if r.levelno == _logging.ERROR and "reconnecting" in r.message]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "reconnecting" in r.message]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR and "reconnecting" in r.message]
         assert len(warnings) == 4, f"expected 4 WARNING-level failures before escalation, got {len(warnings)}"
         assert len(errors) >= 1, "expected ERROR-level logs after the 5th consecutive failure"
 
@@ -1316,7 +1179,6 @@ class TestFactoryGetManagerBranches:
     @pytest.mark.asyncio
     async def test_cache_ttl_expiry_evicts_and_rebuilds(self):
         """An expired cache entry must be popped and re-built, not served stale."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory(_cache_ttl=0.001)
         stale = MagicMock(name="stale_manager")
@@ -1338,7 +1200,6 @@ class TestFactoryGetManagerBranches:
     @pytest.mark.asyncio
     async def test_apply_redis_mode_overrides_handles_client_exception(self, caplog):
         """A client-factory exception logs a WARNING and falls through to YAML defaults (no override applied)."""
-        import logging as _logging
 
         factory = _make_bare_factory()
         # Build a minimal Config-like object with a single plugin.
@@ -1350,7 +1211,7 @@ class TestFactoryGetManagerBranches:
         config.plugins = [plugin]
 
         with _mock_redis(side_effect=RuntimeError("no client")):
-            with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
                 result = await factory._apply_redis_mode_overrides(config)
 
         # Config is returned unchanged (no model_copy invoked).
@@ -1360,10 +1221,6 @@ class TestFactoryGetManagerBranches:
     @pytest.mark.asyncio
     async def test_apply_redis_mode_overrides_skips_override_on_validation_error(self, caplog):
         """``plugin.model_copy`` raising ``ValidationError`` logs a WARNING and leaves the plugin untouched."""
-        import logging as _logging
-
-        from pydantic import ValidationError as _PydValidationError
-        from cpex.framework import PluginMode
 
         factory = _make_bare_factory()
         plugin = MagicMock()
@@ -1381,7 +1238,7 @@ class TestFactoryGetManagerBranches:
         mock_client.mget = AsyncMock(return_value=[b"permissive"])
 
         with _mock_redis(client=mock_client):
-            with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+            with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
                 result = await factory._apply_redis_mode_overrides(config)
 
         # Config is returned unchanged because the one override failed validation.
@@ -1395,15 +1252,12 @@ class TestInvalidateHelpers:
     @pytest.mark.asyncio
     async def test_invalidate_all_logs_when_reload_raises(self, caplog):
         """One reload failure must not abort the sweep — it logs and moves on."""
-        import logging as _logging
-
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory()
         factory._managers["ctx-a"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
         factory.reload_tenant = AsyncMock(side_effect=RuntimeError("reload blew up"))
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
             await factory.invalidate_all()
 
         assert any("invalidate_all: reload failed" in rec.message for rec in caplog.records)
@@ -1411,23 +1265,19 @@ class TestInvalidateHelpers:
     @pytest.mark.asyncio
     async def test_invalidate_team_logs_when_reload_raises(self, caplog):
         """Same guarantee on the team-scoped sweep."""
-        import logging as _logging
-
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory()
         factory.CONTEXT_ID_SEPARATOR = "::"
         factory._managers["team-a::tool-1"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
         factory.reload_tenant = AsyncMock(side_effect=RuntimeError("reload blew up"))
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins.gateway_plugin_manager"):
             await factory.invalidate_team("team-a")
 
         assert any("invalidate_team: reload failed" in rec.message for rec in caplog.records)
 
     def test_iter_context_ids_returns_snapshot_list(self):
         """``iter_context_ids`` copies the cache keys so callers iterating without the lock are safe."""
-        from mcpgateway.plugins.gateway_plugin_manager import _CachedManager
 
         factory = _make_bare_factory()
         factory._managers["ctx-a"] = _CachedManager(manager=MagicMock(), created_at=time.monotonic())
@@ -1445,36 +1295,33 @@ class TestRedisExceptionBranches:
     @pytest.mark.asyncio
     async def test_read_shared_enabled_falls_back_on_client_get_exception(self):
         """When ``client.get`` raises, ``_read_shared_enabled`` falls back to the in-memory flag."""
-        from mcpgateway.plugins import _read_shared_enabled, enable_plugins
 
-        enable_plugins(True)
+        framework.enable_plugins(True)
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=RuntimeError("broken pipe"))
 
         with _mock_redis(client=mock_client):
-            result = await _read_shared_enabled()
+            result = await framework._read_shared_enabled()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_enable_plugins_shared_returns_false_on_set_exception(self):
         """A Redis SET that raises is downgraded to a local-only toggle change."""
-        from mcpgateway.plugins import enable_plugins_shared, are_plugins_enabled
 
         mock_client = AsyncMock()
         mock_client.set = AsyncMock(side_effect=RuntimeError("ECONNRESET"))
         mock_client.publish = AsyncMock()
 
         with _mock_redis(client=mock_client):
-            ok = await enable_plugins_shared(True)
+            ok = await framework.enable_plugins_shared(True)
 
         assert ok is False
         # In-memory flag is still updated even when the Redis write blew up.
-        assert are_plugins_enabled() is True
+        assert framework.are_plugins_enabled() is True
 
     @pytest.mark.asyncio
     async def test_publish_invalidation_returns_false_on_client_error(self, monkeypatch):
         """When the Redis client factory itself raises, publish bails at False."""
-        import mcpgateway.plugins as framework
 
         async def _always_raises():
             raise RuntimeError("no redis")
@@ -1487,7 +1334,6 @@ class TestRedisExceptionBranches:
     @pytest.mark.asyncio
     async def test_publish_plugin_mode_change_redis_client_exception(self, monkeypatch):
         """``_redis()`` failure still stamps the local override so the worker honours the change."""
-        import mcpgateway.plugins as framework
 
         async def _always_raises():
             raise RuntimeError("no redis")
@@ -1507,14 +1353,12 @@ class TestRedisExceptionBranches:
     @pytest.mark.asyncio
     async def test_get_plugin_mode_override_raises_on_client_get_exception(self):
         """``client.get`` blowing up surfaces as ``RuntimeError`` so callers see "Redis unreachable"."""
-        from mcpgateway.plugins import get_plugin_mode_override
-
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
 
         with _mock_redis(client=mock_client):
             with pytest.raises(RuntimeError, match="Redis GET failed"):
-                await get_plugin_mode_override("Foo")
+                await framework.get_plugin_mode_override("Foo")
 
 
 class TestFactoryAccessors:
@@ -1522,50 +1366,43 @@ class TestFactoryAccessors:
 
     def test_get_plugin_manager_factory_returns_live_factory(self):
         """When a factory is set, the accessor returns it rather than ``None``."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import get_plugin_manager_factory, reset_plugin_manager_factory
 
         sentinel = MagicMock(name="sentinel-factory")
         framework._plugin_manager_factory = sentinel
         try:
-            assert get_plugin_manager_factory() is sentinel
+            assert framework.get_plugin_manager_factory() is sentinel
         finally:
-            reset_plugin_manager_factory()
+            framework.reset_plugin_manager_factory()
 
     def test_list_configured_plugin_names_returns_config_names(self):
         """With a live factory whose ``plugin_names`` property has entries, the helper returns them."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import list_configured_plugin_names, reset_plugin_manager_factory
 
         fake_factory = MagicMock()
         fake_factory.plugin_names = ["PluginOne", "PluginTwo"]
 
         framework._plugin_manager_factory = fake_factory
         try:
-            assert list_configured_plugin_names() == ["PluginOne", "PluginTwo"]
+            assert framework.list_configured_plugin_names() == ["PluginOne", "PluginTwo"]
         finally:
-            reset_plugin_manager_factory()
+            framework.reset_plugin_manager_factory()
 
     def test_list_configured_plugin_names_empty_without_factory(self):
         """No factory yet → empty list (covers the early-return branch)."""
-        from mcpgateway.plugins import list_configured_plugin_names, reset_plugin_manager_factory
 
-        reset_plugin_manager_factory()
-        assert list_configured_plugin_names() == []
+        framework.reset_plugin_manager_factory()
+        assert framework.list_configured_plugin_names() == []
 
     def test_list_configured_plugin_names_empty_when_config_has_no_plugins(self):
         """Factory present but empty ``plugin_names`` → empty list."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import list_configured_plugin_names, reset_plugin_manager_factory
 
         fake_factory = MagicMock()
         fake_factory.plugin_names = []
 
         framework._plugin_manager_factory = fake_factory
         try:
-            assert list_configured_plugin_names() == []
+            assert framework.list_configured_plugin_names() == []
         finally:
-            reset_plugin_manager_factory()
+            framework.reset_plugin_manager_factory()
 
 
 class TestInitPluginManagerFactory:
@@ -1573,8 +1410,6 @@ class TestInitPluginManagerFactory:
 
     def test_db_factory_forwarded_to_factory(self, monkeypatch):
         """Passing a ``db_factory`` must forward it to ``TenantPluginManagerFactory``."""
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import init_plugin_manager_factory, reset_plugin_manager_factory
 
         captured_kwargs: dict = {}
 
@@ -1590,9 +1425,9 @@ class TestInitPluginManagerFactory:
         def _fake_session_local():
             return MagicMock(name="Session")
 
-        reset_plugin_manager_factory()
+        framework.reset_plugin_manager_factory()
         try:
-            init_plugin_manager_factory(
+            framework.init_plugin_manager_factory(
                 yaml_path="does/not/matter.yaml",
                 timeout=30.0,
                 hook_policies={},
@@ -1603,7 +1438,7 @@ class TestInitPluginManagerFactory:
             assert captured_kwargs["yaml_path"] == "does/not/matter.yaml"
             assert captured_kwargs["db_factory"] is _fake_session_local
         finally:
-            reset_plugin_manager_factory()
+            framework.reset_plugin_manager_factory()
 
 
 class TestListenerMessageValidation:
@@ -1612,49 +1447,35 @@ class TestListenerMessageValidation:
     @pytest.mark.asyncio
     async def test_handle_invalidation_message_drops_unknown_frame(self, caplog):
         """A frame whose ``type`` doesn't match any discriminator is logged and ignored."""
-        import logging as _logging
-        import json as _json
 
-        from mcpgateway.plugins import _handle_invalidation_message
-
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins"):
-            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "bogus_event", "payload": 1})})
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
+            await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "bogus_event", "payload": 1})})
 
         assert any("unrecognised plugin invalidation frame" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
     async def test_handle_invalidation_team_binding_logs_when_invalidate_team_raises(self, monkeypatch, caplog):
         """Invalidate-team failure during pub/sub must be logged (not raised) so the listener loop survives."""
-        import logging as _logging
-        import json as _json
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message
 
         fake_factory = MagicMock()
         fake_factory.invalidate_team = AsyncMock(side_effect=RuntimeError("cache busted"))
         monkeypatch.setattr(framework, "_plugin_manager_factory", fake_factory)
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins"):
-            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "team_binding_change", "team_id": "team-a"})})
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
+            await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "team_binding_change", "team_id": "team-a"})})
 
         assert any("team_binding_change failed" in rec.message for rec in caplog.records)
 
     @pytest.mark.asyncio
     async def test_handle_invalidation_binding_change_logs_when_reload_raises(self, monkeypatch, caplog):
         """Reload-tenant failure during pub/sub must be logged (not raised)."""
-        import logging as _logging
-        import json as _json
-
-        import mcpgateway.plugins as framework
-        from mcpgateway.plugins import _handle_invalidation_message
 
         fake_factory = MagicMock()
         fake_factory.reload_tenant = AsyncMock(side_effect=RuntimeError("cache busted"))
         monkeypatch.setattr(framework, "_plugin_manager_factory", fake_factory)
 
-        with caplog.at_level(_logging.WARNING, logger="mcpgateway.plugins"):
-            await _handle_invalidation_message({"type": "message", "data": _json.dumps({"type": "binding_change", "context_id": "ctx-a"})})
+        with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
+            await framework._handle_invalidation_message({"type": "message", "data": json.dumps({"type": "binding_change", "context_id": "ctx-a"})})
 
         assert any("binding_change reload failed" in rec.message for rec in caplog.records)
 
@@ -1670,7 +1491,6 @@ class TestListenerLoopBranches:
         the loop cleanly, so the coroutine returns rather than propagating —
         we verify the polling sleep was hit at least once.
         """
-        import mcpgateway.plugins as framework
 
         monkeypatch.setattr(framework, "_redis", AsyncMock(return_value=None))
 
@@ -1693,7 +1513,6 @@ class TestListenerLoopBranches:
     @pytest.mark.asyncio
     async def test_listener_subscribes_and_dispatches_one_message_then_cancels(self, monkeypatch):
         """The happy subscribe → listen → dispatch → cancel path runs to completion."""
-        import mcpgateway.plugins as framework
 
         seen: list[dict] = []
 
@@ -1737,7 +1556,6 @@ class TestHMACSigningVerification:
     @pytest.fixture(autouse=True)
     def _patch_hmac_key(self, monkeypatch):
         """Patch _get_invalidation_hmac_key to return a known key by default."""
-        import mcpgateway.plugins as framework
 
         self._framework = framework
         self._key = b"test-hmac-secret"
@@ -1754,9 +1572,9 @@ class TestHMACSigningVerification:
         """A message with a modified signature is rejected."""
         payload = '{"action":"toggle","enabled":true}'
         signed = self._framework._sign_message(payload)
-        envelope = _json_mod.loads(signed)
+        envelope = json.loads(signed)
         envelope["sig"] = "deadbeef" * 8
-        tampered = _json_mod.dumps(envelope)
+        tampered = json.dumps(envelope)
         result = self._framework._verify_and_extract(tampered)
         assert result is None
 
@@ -1764,15 +1582,15 @@ class TestHMACSigningVerification:
         """A message with a modified payload but original sig is rejected."""
         payload = '{"action":"toggle","enabled":true}'
         signed = self._framework._sign_message(payload)
-        envelope = _json_mod.loads(signed)
+        envelope = json.loads(signed)
         envelope["payload"] = '{"action":"toggle","enabled":false}'
-        tampered = _json_mod.dumps(envelope)
+        tampered = json.dumps(envelope)
         result = self._framework._verify_and_extract(tampered)
         assert result is None
 
     def test_missing_payload_key_in_envelope(self):
         """An envelope with sig but no payload key is treated as unsigned."""
-        msg = _json_mod.dumps({"sig": "abc123", "other": "data"})
+        msg = json.dumps({"sig": "abc123", "other": "data"})
         result = self._framework._verify_and_extract(msg)
         assert result == msg
 
@@ -1785,7 +1603,6 @@ class TestHMACSigningVerification:
 
     def test_unsigned_message_accepted_with_warning_when_key_set(self, caplog):
         """When HMAC key is set and an unsigned message arrives, a warning is logged."""
-        import logging
 
         payload = '{"action":"toggle","enabled":true}'
         with caplog.at_level(logging.WARNING, logger="mcpgateway.plugins"):
@@ -1793,7 +1610,7 @@ class TestHMACSigningVerification:
         assert result == payload
         assert "unsigned message" in caplog.text
 
-    def test_invalid_json_returns_none(self):
+    def test_invalidjson_returns_none(self):
         """Non-JSON input is rejected."""
         result = self._framework._verify_and_extract("not valid json{{{")
         assert result is None

--- a/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
+++ b/tests/unit/mcpgateway/plugins/test_plugin_runtime_management.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Third-Party
 import pytest
 from pydantic import ValidationError as _PydValidationError
-from cpex.framework import
+from cpex.framework import PluginMode
 
 # First-Party
 from mcpgateway.plugins._redis import set_shared_redis_provider


### PR DESCRIPTION
<!--
For specialized templates, append to your PR URL:
  ?template=bug_fix.md   - Bug fixes
  ?template=feature.md   - New features
  ?template=docs.md      - Documentation
  ?template=plugin.md    - New plugins

Example: https://github.com/IBM/mcp-context-forge/compare/main...your-branch?expand=1&template=bug_fix.md
-->

# Pull Request

## 🔗 Related Issue

Closes #5431

---

## 📝 Summary

The plugin manager factory uses the config.yaml to create a default manager that is used for all tool calls that are not customized via dynamic plugins. The currently behaviour is to recreate the default manager for each new id, which was ok for pure python class plugins. The current fix is to reuse the single default manager for all ids so we dont recreate plugins with the same config. 

Improvements:
Performance: Eliminates redundant plugin manager
Memory: Sharing of identical configurations


---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [ ] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

_List exact commands, screenshots, videos, logs, reproduction steps, or manual validation. If evidence is not feasible, explain why._

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `make lint`     |        |
| Unit tests                | `make test`     |        |
| Coverage ≥ 80%            | `make coverage` |        |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No secrets or credentials committed

---

## 📓 Notes (optional)

_Screenshots, design decisions, or additional context._
