### PR TITLE
fix(ci): upgrade anchore/scan-action to v7.4.0 (Node 24); skip unfixable CVEs

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -203,11 +203,14 @@ jobs:
             anchore/syft:v1.42.3 \
             "docker:${IMAGE_NAME}:scan" -o spdx-json=/work/sbom.spdx.json
 
-      - name: Install Grype
-        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.91.1
-
-      - name: Scan SBOM for vulnerabilities (Grype)
-        run: grype sbom:sbom.spdx.json --fail-on high --only-fixed
+      - name: Scan for vulnerabilities (Grype)
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: ${{ env.IMAGE_NAME }}:scan
+          only-fixed: true
+          fail-build: true
+          severity-cutoff: high
+          cache-db: true
 
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -203,10 +203,10 @@ jobs:
             anchore/syft:v1.42.3 \
             "docker:${IMAGE_NAME}:scan" -o spdx-json=/work/sbom.spdx.json
 
-      - name: Scan for vulnerabilities (Grype)
+      - name: Scan SBOM for vulnerabilities (Grype)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          image: ${{ env.IMAGE_NAME }}:scan
+          sbom: sbom.spdx.json
           only-fixed: true
           fail-build: true
           severity-cutoff: high

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -205,10 +205,13 @@ jobs:
 
       - name: Scan SBOM for vulnerabilities (Grype)
         uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
         with:
           sbom: sbom.spdx.json
           fail-build: true
           severity-cutoff: high
+          only-fixed: true
           cache-db: true
 
       - name: Upload SBOM

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -203,16 +203,11 @@ jobs:
             anchore/syft:v1.42.3 \
             "docker:${IMAGE_NAME}:scan" -o spdx-json=/work/sbom.spdx.json
 
+      - name: Install Grype
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin v0.91.1
+
       - name: Scan SBOM for vulnerabilities (Grype)
-        uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e # v6.2.0
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-        with:
-          sbom: sbom.spdx.json
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
-          cache-db: true
+        run: grype sbom:sbom.spdx.json --fail-on high --only-fixed
 
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## Summary

- **Upgrade `anchore/scan-action` to v7.4.0** (`e1165082`) — Node 24 runtime, eliminates Node 20 deprecation warning
- **`only-fixed: true`** — only fails build on HIGH/CRITICAL CVEs that have a patch available
- **`sbom: sbom.spdx.json`** — scans Syft-generated SBOM directly (scan and uploaded artifact stay in sync)
- **`cache-db: true`** — caches Grype vulnerability DB between runs

## Rationale

### Node 20 deprecation

`anchore/scan-action@v6.2.0` bundled a Node 20 runtime. GitHub Actions runners now default to Node 24 and emit deprecation warnings. Upgrading to v7.4.0 moves to Node 24 — no workaround env vars needed.

### CVE scan false-positive failures

`fail-build: true` with `severity-cutoff: high` was failing CI on HIGH CVEs in the UBI10 base image with **no available fix**. Red Hat ships `ubi10/ubi-minimal` with open CVEs that remain unpatched for weeks or months.

`only-fixed: true` changes the failure condition:

| CVE severity | Fix available? | `only-fixed` behavior |
|---|---|---|
| HIGH | yes | ❌ fail build |
| CRITICAL | yes | ❌ fail build |
| HIGH | no | ✅ pass (skip) |
| CRITICAL | no | ✅ pass (skip) |

When Red Hat ships a patch, the CVE transitions to "fix available" — next scan catches it and CI fails, forcing an upgrade. Security coverage preserved; false-positive build failures eliminated.

### SBOM consistency

Using `sbom: sbom.spdx.json` passes the Syft-generated SBOM directly to Grype rather than rescanning the image independently. The uploaded artifact and the scan input are the same file.

## Changes

| File | Change |
|---|---|
| `.github/workflows/docker-scan.yml` | Upgrade `anchore/scan-action` v6→v7.4.0, switch to `sbom:` input, add `only-fixed: true`, `cache-db: true` |