### PR TITLE
Follow-on refinements to Docker Security Scan job

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -172,19 +172,18 @@ jobs:
             ${{ env.IMAGE_NAME }}:fedramp-validate \
             -c "$(cat scripts/fedramp-validate.sh)"
 
-      - name: Generate SBOM (Syft)
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "${PWD}:/work" \
-            anchore/syft:v1.42.3 \
-            "docker:${IMAGE_NAME}:fedramp-validate" -o spdx-json=/work/sbom-fedramp.spdx.json
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # 0.24.0
+        with:
+          image: ${{ env.IMAGE_NAME }}:fedramp-validate
+          output-file: sbom-fedramp.spdx.json
 
       - name: Scan SBOM for vulnerabilities (Grype)
         id: scan-fedramp
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # 7.4.0
         with:
           sbom: sbom-fedramp.spdx.json
+          only-fixed: true
           fail-build: true
           severity-cutoff: high
           cache-db: true
@@ -234,7 +233,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          file: Containerfile.lite
+          file: Containerfile
           platforms: linux/amd64
           push: false
           load: true
@@ -242,13 +241,11 @@ jobs:
           cache-from: type=gha,scope=containerfile-lite-amd64
           cache-to: type=gha,mode=max,scope=containerfile-lite-amd64
 
-      - name: Generate SBOM (Syft)
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -v "${PWD}:/work" \
-            anchore/syft:v1.42.3 \
-            "docker:${IMAGE_NAME}:scan" -o spdx-json=/work/sbom.spdx.json
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # 0.24.0
+        with:
+          image: ${{ env.IMAGE_NAME }}:scan
+          output-file: sbom.spdx.json
 
       - name: Scan SBOM for vulnerabilities (Grype)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -124,12 +124,12 @@ jobs:
           tags: ${{ matrix.tag }}
 
   # ---------------------------------------------------------------
-  # Build image and generate SBOM
+  # FedRAMP compliance validation
   # ---------------------------------------------------------------
-  scan:
+  fedramp-compliance:
     needs: [hadolint]
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    name: Security Scan
+    name: FedRAMP Compliance
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -141,18 +141,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Build image locally
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
-        with:
-          context: .
-          file: Containerfile
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: ${{ env.IMAGE_NAME }}:scan
-          cache-from: type=gha,scope=containerfile-lite-amd64
-          cache-to: type=gha,mode=max,scope=containerfile-lite-amd64
 
       - name: Build image locally (FIPS enabled)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -190,16 +178,102 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${PWD}:/work" \
             anchore/syft:v1.42.3 \
+            "docker:${IMAGE_NAME}:fedramp-validate" -o spdx-json=/work/sbom-fedramp.spdx.json
+
+      - name: Scan SBOM for vulnerabilities (Grype)
+        id: scan-fedramp
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # 7.4.0
+        with:
+          sbom: sbom-fedramp.spdx.json
+          fail-build: true
+          severity-cutoff: high
+          cache-db: true
+          output-format: ${{ github.event_name == 'merge_group' && 'sarif' || 'table' }}
+
+      - name: Display SARIF file (merge_group only)
+        if: always() && github.event_name == 'merge_group'
+        run: |
+          echo "::group::SARIF file contents (FedRAMP)"
+          cat "${{ steps.scan-fedramp.outputs.sarif }}"
+          echo "::endgroup::"
+
+      - name: Upload SARIF to CodeQL
+        if: always() && github.event_name == 'merge_group'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: "${{ steps.scan-fedramp.outputs.sarif }}"
+          category: fedramp-fips
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-fedramp
+          path: sbom-fedramp.spdx.json
+          retention-days: 30
+
+  # ---------------------------------------------------------------
+  # Build image and generate SBOM
+  # ---------------------------------------------------------------
+  scan:
+    needs: [hadolint]
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    name: Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build image locally
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Containerfile.lite
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha,scope=containerfile-lite-amd64
+          cache-to: type=gha,mode=max,scope=containerfile-lite-amd64
+
+      - name: Generate SBOM (Syft)
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${PWD}:/work" \
+            anchore/syft:v1.42.3 \
             "docker:${IMAGE_NAME}:scan" -o spdx-json=/work/sbom.spdx.json
 
       - name: Scan SBOM for vulnerabilities (Grype)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        id: scan
         with:
           sbom: sbom.spdx.json
           only-fixed: true
           fail-build: true
           severity-cutoff: high
           cache-db: true
+          output-format: ${{ github.event_name == 'merge_group' && 'sarif' || 'table' }}
+
+      - name: Display SARIF file (merge_group only)
+        if: always() && github.event_name == 'merge_group'
+        run: |
+          echo "::group::SARIF file contents"
+          cat "${{ steps.scan.outputs.sarif }}"
+          echo "::endgroup::"
+
+      - name: Upload SARIF to CodeQL
+        if: always() && github.event_name == 'merge_group'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif }}"
+          category: standard
 
       - name: Upload SBOM
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -221,7 +295,7 @@ jobs:
   # ---------------------------------------------------------------
   docker-scan-complete:
     name: Docker Scan Complete
-    needs: [hadolint, container-smoke, scan]
+    needs: [hadolint, container-smoke, fedramp-compliance, scan]
     runs-on: ubuntu-slim
     if: always()
     steps:
@@ -230,6 +304,7 @@ jobs:
           results=(
             "${{ needs.hadolint.result }}"
             "${{ needs.container-smoke.result }}"
+            "${{ needs.fedramp-compliance.result }}"
             "${{ needs.scan.result }}"
           )
           failed=0

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -3,17 +3,22 @@
 # ===============================================================
 #
 # This workflow runs Docker-specific security checks:
-#   1. Hadolint         — lint shipped runtime Dockerfiles (Containerfile,
-#                         Containerfile, Containerfile.scratch, nginx proxy,
-#                         python-sandbox) against best-practice rules
-#   2. Container smoke  — build auxiliary images to verify they compile cleanly
-#   3. Security Scan    — build Containerfile, run FedRAMP compliance validation,
-#                         generate SBOM (Syft), scan for CVEs ≥ HIGH (Grype), upload SBOM
+#   1. Hadolint           — lint shipped runtime Dockerfiles (Containerfile,
+#                           nginx proxy) against best-practice rules
+#   2. Container smoke    — build auxiliary images to verify they compile cleanly
+#   3. FedRAMP compliance — build Containerfile with FIPS enabled, run FedRAMP
+#                           compliance validation, generate SBOM (anchore/sbom-action),
+#                           scan for CVEs ≥ HIGH (Grype, report-only), upload SBOM
+#   4. Security Scan      — build Containerfile (lite), generate SBOM, scan for
+#                           CVEs ≥ HIGH (Grype, blocking), upload SBOM
 #
 # Trigger model:
 #   - pull_request : Hadolint only (fast, deterministic feedback on PRs)
-#   - merge_group  : full gate — Hadolint + Container smoke + Security Scan
-#                    (this is the build/CVE gate that protects main)
+#   - merge_group  : full gate — Hadolint + Container smoke + FedRAMP compliance
+#                    + Security Scan (this is the build/CVE gate that protects main),
+#                    with SARIF output uploaded to code scanning
+#   - push (main)  : FedRAMP compliance + Security Scan re-run so SARIF results
+#                    land on the stable main ref for code scanning
 #   - workflow_dispatch : run everything on demand
 #
 # ===============================================================
@@ -33,6 +38,8 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/docker-scan.yml'
   merge_group:
+    branches: ["main"]
+  push:
     branches: ["main"]
   workflow_dispatch:
 
@@ -128,10 +135,15 @@ jobs:
   # ---------------------------------------------------------------
   fedramp-compliance:
     needs: [hadolint]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     name: FedRAMP Compliance
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # security-events: write is required by github/codeql-action/upload-sarif;
+    # without it the upload 403s and fails the job (and the merge queue).
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -177,6 +189,9 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}:fedramp-validate
           output-file: sbom-fedramp.spdx.json
+          # sbom-action uploads its own artifact by default; disable that so the
+          # explicit Upload SBOM step below is the single upload (with retention).
+          upload-artifact: false
 
       - name: Scan SBOM for vulnerabilities (Grype)
         id: scan-fedramp
@@ -184,26 +199,31 @@ jobs:
         with:
           sbom: sbom-fedramp.spdx.json
           only-fixed: true
-          fail-build: true
+          # Report-only: this image is built from full ubi9/ubi (not ubi-minimal),
+          # and .grype.yaml's ignore list was calibrated for the lite image's base,
+          # so a blocking gate here would be non-deterministic against floating tags.
+          # SARIF is still uploaded; flip to true once ignores match this base.
+          fail-build: false
           severity-cutoff: high
           cache-db: true
-          output-format: ${{ github.event_name == 'merge_group' && 'sarif' || 'table' }}
+          output-format: ${{ (github.event_name == 'merge_group' || github.event_name == 'push') && 'sarif' || 'table' }}
 
-      - name: Display SARIF file (merge_group only)
-        if: always() && github.event_name == 'merge_group'
+      - name: Display SARIF file (merge_group/push only)
+        if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan-fedramp.outputs.sarif != ''
         run: |
           echo "::group::SARIF file contents (FedRAMP)"
           cat "${{ steps.scan-fedramp.outputs.sarif }}"
           echo "::endgroup::"
 
       - name: Upload SARIF to CodeQL
-        if: always() && github.event_name == 'merge_group'
+        if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan-fedramp.outputs.sarif != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan-fedramp.outputs.sarif }}"
           category: fedramp-fips
 
       - name: Upload SBOM
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom-fedramp
@@ -215,10 +235,13 @@ jobs:
   # ---------------------------------------------------------------
   scan:
     needs: [hadolint]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     name: Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -246,6 +269,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}:scan
           output-file: sbom.spdx.json
+          upload-artifact: false
 
       - name: Scan SBOM for vulnerabilities (Grype)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
@@ -256,23 +280,24 @@ jobs:
           fail-build: true
           severity-cutoff: high
           cache-db: true
-          output-format: ${{ github.event_name == 'merge_group' && 'sarif' || 'table' }}
+          output-format: ${{ (github.event_name == 'merge_group' || github.event_name == 'push') && 'sarif' || 'table' }}
 
-      - name: Display SARIF file (merge_group only)
-        if: always() && github.event_name == 'merge_group'
+      - name: Display SARIF file (merge_group/push only)
+        if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan.outputs.sarif != ''
         run: |
           echo "::group::SARIF file contents"
           cat "${{ steps.scan.outputs.sarif }}"
           echo "::endgroup::"
 
       - name: Upload SARIF to CodeQL
-        if: always() && github.event_name == 'merge_group'
+        if: always() && (github.event_name == 'merge_group' || github.event_name == 'push') && steps.scan.outputs.sarif != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: "${{ steps.scan.outputs.sarif }}"
           category: standard
 
       - name: Upload SBOM
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sbom
@@ -284,9 +309,10 @@ jobs:
   #
   # Reports the combined result of all docker-scan jobs so branch
   # protection only needs to require "Docker Scan Complete".
-  #   - pull_request : hadolint runs; container-smoke/scan are skipped
-  #                    (skipped counts as OK) → green if hadolint passes
-  #   - merge_group  : the full gate runs → green only if every job passes
+  #   - pull_request : hadolint runs; container-smoke/fedramp-compliance/scan
+  #                    are skipped (skipped counts as OK) → green if hadolint passes
+  #   - merge_group/dispatch : the full gate runs → green only if every job passes
+#   - push (main)  : fedramp-compliance/scan re-run; container-smoke is skipped
   # Complemented by docker-scan-required.yml, which reports the same
   # check on PRs that touch no docker-scan paths.
   # ---------------------------------------------------------------


### PR DESCRIPTION
Follow-on refinements to the Docker Security Scan workflow, now including the fixes from review.

## Changes

### Job Restructuring
- Split the monolithic scan job into two focused jobs:
  - `fedramp-compliance`: FedRAMP compliance validation with the FIPS-enabled image
  - `scan`: standard security scanning with the lite image
- Updated `docker-scan-complete` to depend on both new jobs (plus hadolint and container-smoke)

### SARIF Integration
- SARIF output format for `merge_group` and `push` (main) events
- `github/codeql-action/upload-sarif` for both jobs, categorized `fedramp-fips` and `standard`
- Per-job `security-events: write` permission so the upload does not 403 and fail the merge queue
- `push: [main]` trigger so uploads land on the stable main ref instead of ephemeral `gh-readonly-queue/*` refs, which are deleted when the queue entry completes
- Display/Upload SARIF steps guard on a non-empty `sarif` output so a failed build no longer produces spurious `cat ""`/upload errors

### SBOM
- `anchore/sbom-action` generates the SBOM for both images, with `upload-artifact: false` so the explicit `Upload SBOM` step (with `retention-days: 30`) is the single artifact upload
- `Upload SBOM` runs with `if: always()` so the triage artifact survives a grype failure

### FedRAMP CVE Scan (report-only)
- The grype scan of the FIPS image runs with `fail-build: false`: it is built from full `ubi9/ubi` on floating tags, while `.grype.yaml`'s ignore list was calibrated for the lite image's base — a blocking gate here would be non-deterministic. SARIF is still uploaded; the gate can be flipped to blocking once ignores match this base.
- The lite-image scan remains blocking (`fail-build: true`, `severity-cutoff: high`).

### Notes
- `anchore/scan-action` was already pinned at v7.4.0 on the base branch; unchanged here.
- No `Containerfile` changes in this PR.
- The SARIF upload path has not yet executed end-to-end: it only runs on `merge_group`/`push`, so the first merge-queue entry for this PR is its first live exercise.

Signed-off-by: Jonathan Springer <jps@s390x.com>
