### PR TITLE
feat(api): add POST /v1/mcp-servers/test endpoint for React UI connection testing

### DIFF
--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -53,7 +53,7 @@ import orjson
 from pydantic import BaseModel, SecretStr, ValidationError
 from pydantic_core import ValidationError as CoreValidationError
 from sqlalchemy import and_, bindparam, case, cast, desc, false, func, or_, select, String, text
-from sqlalchemy.exc import DataError, IntegrityError, InvalidRequestError, OperationalError, SQLAlchemyError
+from sqlalchemy.exc import DataError, IntegrityError, InvalidRequestError, OperationalError
 from sqlalchemy.orm import joinedload, selectinload, Session, with_loader_criteria
 from sqlalchemy.sql.functions import coalesce
 from starlette.background import BackgroundTask
@@ -156,12 +156,19 @@ from mcpgateway.services.content_security import ContentSizeError, ContentTypeEr
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.services.export_service import ExportError, ExportService
-from mcpgateway.services.gateway_service import GatewayConnectionError, GatewayDuplicateConflictError, GatewayLookupConflictError, GatewayNameConflictError, GatewayNotFoundError, GatewayService
+from mcpgateway.services.gateway_service import (
+    GatewayConnectionError,
+    GatewayDuplicateConflictError,
+    GatewayLookupConflictError,
+    GatewayNameConflictError,
+    GatewayNotFoundError,
+    GatewayService,
+    test_gateway_connectivity,
+)
 from mcpgateway.services.import_service import ConflictStrategy
 from mcpgateway.services.import_service import ImportError as ImportServiceError
 from mcpgateway.services.import_service import ImportService, ImportValidationError
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.oauth_manager import OAuthManager
 from mcpgateway.services.openapi_service import fetch_and_extract_schemas
 from mcpgateway.services.password_policy_service import PasswordPolicyError, PasswordPolicyService
 from mcpgateway.services.performance_service import get_performance_service
@@ -183,11 +190,9 @@ from mcpgateway.utils.orjson_response import ORJSONResponse
 from mcpgateway.utils.pagination import paginate_query
 from mcpgateway.utils.passthrough_headers import PassthroughHeadersError
 from mcpgateway.utils.paths import resolve_root_path as _resolve_root_path
-from mcpgateway.utils.retry_manager import ResilientHttpClient
 from mcpgateway.utils.security_cookies import clear_auth_cookie, CookieTooLargeError, set_auth_cookie
-from mcpgateway.utils.services_auth import decode_auth, encode_auth
+from mcpgateway.utils.services_auth import encode_auth
 from mcpgateway.utils.sqlalchemy_modifier import json_contains_tag_expr
-from mcpgateway.utils.url_auth import sanitize_url_for_logging
 from mcpgateway.utils.validate_signature import sign_data
 from mcpgateway.utils.verify_credentials import verify_jwt_token_cached
 
@@ -14391,224 +14396,7 @@ async def admin_test_gateway(
         >>> admin_test_gateway.__name__
         'admin_test_gateway'
     """
-    start_time: float = time.monotonic()
-
-    # Build allowlist for gateway test endpoint
-    allowed_hosts_set: set[str] = set()
-
-    if settings.gateway_test_allow_registered_only:
-        # Mode 1: Only allow testing registered gateway URLs
-        # Query all enabled gateways to build allowlist from their base URLs
-        try:
-            query = select(DbGateway.url).where(DbGateway.enabled)
-            if team_id:
-                query = query.where(DbGateway.team_id == team_id)
-            registered_urls = db.execute(query).scalars().all()
-
-            # Extract hostnames from registered gateway URLs
-            for url in registered_urls:
-                try:
-                    parsed = urllib.parse.urlparse(url)
-                    if parsed.hostname:
-                        # Normalize: lowercase and strip trailing dots
-                        hostname = parsed.hostname.lower().rstrip(".")
-                        allowed_hosts_set.add(hostname)
-                except (ValueError, AttributeError) as e:
-                    # Log parse failures to help debug "URL not in allowlist" mysteries
-                    LOGGER.debug("Failed to parse registered gateway URL '%s': %s", url, e)
-                    continue
-        except SQLAlchemyError as e:
-            LOGGER.warning("Failed to build allowlist from registered gateways: %s", e)
-    else:
-        # Mode 2: Use configured host patterns from settings
-        allowed_hosts_set = set(settings.gateway_test_allowed_hosts)
-
-    allowed_hosts = list(allowed_hosts_set)
-
-    # Validate URL with allowlist enforcement and pin a safe resolved IP to close
-    # the DNS rebinding gap between validation-time and connection-time resolution.
-    try:
-        validated_gateway_target = await SecurityValidator.validate_gateway_test_url(str(request.base_url), allowed_hosts, "Gateway test URL")
-    except ValueError as e:
-        # Log the actual error for security monitoring, but return generic message
-        safe_url = sanitize_url_for_logging(str(request.base_url))
-        LOGGER.warning(
-            "Gateway test URL validation failed for %s by user %s: %s",
-            safe_url,
-            get_user_email(user),
-            str(e),
-        )
-        latency_ms = int((time.monotonic() - start_time) * 1000)
-        # Generic error message - don't expose allowlist or validation details
-        return GatewayTestResponse(status_code=400, latency_ms=latency_ms, body={"error": "Invalid gateway URL"})
-
-    validated_base_url = validated_gateway_target["validated_url"]
-    validated_hostname = validated_gateway_target["hostname"]
-    pinned_resolved_ip = validated_gateway_target["resolved_ip"]
-
-    parsed_validated_base_url = urllib.parse.urlparse(validated_base_url)
-    pinned_ip_is_ipv6 = ":" in pinned_resolved_ip
-    if parsed_validated_base_url.port is not None:
-        pinned_netloc = f"[{pinned_resolved_ip}]:{parsed_validated_base_url.port}" if pinned_ip_is_ipv6 else f"{pinned_resolved_ip}:{parsed_validated_base_url.port}"
-        original_authority = f"{validated_hostname}:{parsed_validated_base_url.port}"
-    else:
-        pinned_netloc = f"[{pinned_resolved_ip}]" if pinned_ip_is_ipv6 else pinned_resolved_ip
-        original_authority = validated_hostname
-
-    pinned_base_url = urllib.parse.urlunparse(parsed_validated_base_url._replace(netloc=pinned_netloc))
-    full_url = pinned_base_url.rstrip("/") + "/" + request.path.lstrip("/")
-    full_url = full_url.rstrip("/")
-    safe_validated_url = sanitize_url_for_logging(validated_base_url)
-    LOGGER.info(
-        "Gateway test pinned outbound address for user %s: url=%s hostname=%s pinned_ip=%s",
-        get_user_email(user),
-        safe_validated_url,
-        validated_hostname,
-        pinned_resolved_ip,
-    )
-
-    headers = dict(request.headers or {})
-    headers["Host"] = original_authority
-
-    # Attempt to find a registered gateway matching this URL and team.
-    # Query the raw DB object directly so we get the unmasked auth_value
-    # (get_first_gateway_by_url returns a masked GatewayRead where
-    # auth_value="*****", which cannot be decoded).
-    try:
-        query = select(DbGateway).where(DbGateway.url == validated_base_url, DbGateway.enabled)
-        if team_id:
-            query = query.where(DbGateway.team_id == team_id)
-        gateway = db.execute(query).scalars().first()
-    except Exception:
-        gateway = None
-
-    try:
-        user_email = get_user_email(user)
-        if gateway and gateway.auth_type == "oauth" and gateway.oauth_config:
-            grant_type = gateway.oauth_config.get("grant_type", "client_credentials")
-
-            if grant_type == "authorization_code":
-                # For Authorization Code flow, try to get stored tokens
-                try:
-                    # First-Party
-                    from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
-
-                    token_storage = TokenStorageService(db)
-
-                    # Get user-specific OAuth token
-                    if not user_email:
-                        latency_ms = int((time.monotonic() - start_time) * 1000)
-                        return GatewayTestResponse(
-                            status_code=401, latency_ms=latency_ms, body={"error": f"User authentication required for OAuth-protected gateway '{gateway.name}'. Please ensure you are authenticated."}
-                        )
-
-                    access_token: str = await token_storage.get_user_token(gateway.id, user_email)
-
-                    if access_token:
-                        headers["Authorization"] = f"Bearer {access_token}"
-                    else:
-                        latency_ms = int((time.monotonic() - start_time) * 1000)
-                        return GatewayTestResponse(
-                            status_code=401, latency_ms=latency_ms, body={"error": f"Please authorize {gateway.name} first. Visit /oauth/authorize/{gateway.id} to complete OAuth flow."}
-                        )
-                except Exception as e:
-                    LOGGER.error(f"Failed to obtain stored OAuth token for gateway {gateway.name}: {e}")
-                    latency_ms = int((time.monotonic() - start_time) * 1000)
-                    return GatewayTestResponse(status_code=500, latency_ms=latency_ms, body={"error": f"OAuth token retrieval failed for gateway: {str(e)}"})
-            else:
-                # For Client Credentials flow, get token directly
-                try:
-                    oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
-                    access_token: str = await oauth_manager.get_access_token(
-                        gateway.oauth_config, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key
-                    )
-                    headers["Authorization"] = f"Bearer {access_token}"
-                except Exception as e:
-                    LOGGER.error(f"Failed to obtain OAuth access token for gateway {gateway.name}: {e}")
-                    response_body = {"error": f"OAuth token retrieval failed for gateway: {str(e)}"}
-        elif gateway and gateway.auth_type in ("basic", "bearer", "authheaders") and gateway.auth_value:
-            if isinstance(gateway.auth_value, dict):
-                headers.update(gateway.auth_value)
-            elif isinstance(gateway.auth_value, str):
-                headers.update(decode_auth(gateway.auth_value))
-
-        # Prepare request based on content type
-        content_type = getattr(request, "content_type", "application/json")
-        request_kwargs = {
-            "method": request.method.upper(),
-            "url": full_url,
-            "headers": headers,
-            "extensions": {"sni_hostname": validated_hostname},
-        }
-
-        if request.body is not None:
-            if content_type == "application/x-www-form-urlencoded":
-                # Set proper content type header and use data parameter for form encoding
-                headers["Content-Type"] = "application/x-www-form-urlencoded"
-                request_kwargs["data"] = request.body
-            else:
-                # Default to JSON
-                headers["Content-Type"] = "application/json"
-                request_kwargs["json"] = request.body
-
-        async with ResilientHttpClient(client_args={"timeout": settings.federation_timeout, "verify": not settings.skip_ssl_verify}) as client:
-            response: httpx.Response = await client.request(**request_kwargs)
-        latency_ms = int((time.monotonic() - start_time) * 1000)
-        try:
-            response_body: Union[Dict[str, Any], str] = response.json()
-        except ValueError:
-            response_body = {"details": response.text}
-
-        # Structured logging: Log successful gateway test
-        structured_logger = get_structured_logger("gateway_service")
-        structured_logger.log(
-            level="INFO",
-            message=f"Gateway test completed: {safe_validated_url}",
-            event_type="gateway_tested",
-            component="gateway_service",
-            user_email=get_user_email(user),
-            team_id=team_id,
-            resource_type="gateway",
-            resource_id=gateway.id if gateway else None,
-            custom_fields={
-                "gateway_name": gateway.name if gateway else None,
-                "gateway_url": safe_validated_url,
-                "test_method": request.method,
-                "test_path": request.path,
-                "status_code": response.status_code,
-                "latency_ms": latency_ms,
-            },
-        )
-
-        return GatewayTestResponse(status_code=response.status_code, latency_ms=latency_ms, body=response_body)
-
-    except httpx.RequestError as e:
-        safe_url = sanitize_url_for_logging(str(request.base_url))
-        LOGGER.warning("Gateway test failed for %s: %s", safe_url, e)
-        latency_ms = int((time.monotonic() - start_time) * 1000)
-
-        # Structured logging: Log failed gateway test
-        structured_logger = get_structured_logger("gateway_service")
-        structured_logger.log(
-            level="ERROR",
-            message=f"Gateway test failed: {safe_url}",
-            event_type="gateway_test_failed",
-            component="gateway_service",
-            user_email=get_user_email(user),
-            team_id=team_id,
-            resource_type="gateway",
-            resource_id=gateway.id if gateway else None,
-            error=e,
-            custom_fields={
-                "gateway_name": gateway.name if gateway else None,
-                "gateway_url": safe_url,
-                "test_method": request.method,
-                "test_path": request.path,
-                "latency_ms": latency_ms,
-            },
-        )
-
-        return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "Request failed", "details": str(e)})
+    return await test_gateway_connectivity(request, team_id, user, db)
 
 
 # Event Streaming via SSE to the Admin UI

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -14396,6 +14396,13 @@ async def admin_test_gateway(
         >>> admin_test_gateway.__name__
         'admin_test_gateway'
     """
+    # Reject cross-team access: token_teams=None means admin bypass; a list means the
+    # caller is scoped to those teams only. A caller-supplied team_id outside that list
+    # would allow enumerating other teams' registered gateway hostnames (SSRF allowlist).
+    if team_id is not None:
+        token_teams = user.get("token_teams") if isinstance(user, dict) else None
+        if token_teams is not None and team_id not in token_teams:
+            raise HTTPException(status_code=403, detail="Access to requested team is not permitted")
     return await test_gateway_connectivity(request, team_id, user, db)
 
 

--- a/mcpgateway/alembic/versions/e28cd485ad3c_remove_global_unique_constraints_for_.py
+++ b/mcpgateway/alembic/versions/e28cd485ad3c_remove_global_unique_constraints_for_.py
@@ -109,10 +109,7 @@ def upgrade() -> None:
                 "Run 'alembic downgrade -1' to roll back this migration manually."
             )
         else:
-            raise RuntimeError(
-                f"Migration failed with {len(failures)} error(s):\n  - {error_summary}\n\n"
-                "PostgreSQL will automatically roll back all changes in this transaction."
-            )
+            raise RuntimeError(f"Migration failed with {len(failures)} error(s):\n  - {error_summary}\n\n" "PostgreSQL will automatically roll back all changes in this transaction.")
 
 
 def downgrade() -> None:
@@ -194,7 +191,4 @@ def downgrade() -> None:
                 "Run 'alembic downgrade -1' again or manually inspect schema state."
             )
         else:
-            raise RuntimeError(
-                f"Migration downgrade failed with {len(failures)} error(s):\n  - {error_summary}\n\n"
-                "PostgreSQL will automatically roll back all changes in this transaction."
-            )
+            raise RuntimeError(f"Migration downgrade failed with {len(failures)} error(s):\n  - {error_summary}\n\n" "PostgreSQL will automatically roll back all changes in this transaction.")

--- a/mcpgateway/auth_context.py
+++ b/mcpgateway/auth_context.py
@@ -638,6 +638,7 @@ def get_rpc_filter_context(request: Request, user) -> tuple[Optional[str], Optio
     if not is_admin and token_teams is None and getattr(request.state, "token_use", None) == "session":  # nosec B105 - Not a password; token_use is a JWT claim type
         db_user_is_admin = None
         if user_email:
+            # First-Party
             from mcpgateway.db import EmailUser, SessionLocal  # lazy import — avoids cycle
 
             _db = SessionLocal()

--- a/mcpgateway/main.py
+++ b/mcpgateway/main.py
@@ -12324,6 +12324,16 @@ try:
 except ImportError as e:
     logger.error(f"A2A agent plugin bindings router not available: {e}")
 
+# MCP servers REST API router (provides POST /v1/mcp-servers/test for React UI)
+try:
+    # First-Party
+    from mcpgateway.routers.mcp_servers_router import router as mcp_servers_router  # pylint: disable=import-outside-toplevel
+
+    app.include_router(mcp_servers_router)
+    logger.info("MCP servers router included")
+except ImportError as e:
+    logger.error(f"MCP servers router not available: {e}")
+
 # Include log search router if structured logging is enabled
 if getattr(settings, "structured_logging_enabled", True):
     try:

--- a/mcpgateway/middleware/token_scoping.py
+++ b/mcpgateway/middleware/token_scoping.py
@@ -115,6 +115,8 @@ _PERMISSION_PATTERNS: List[Tuple[str, Pattern[str], str]] = [
     ("POST", re.compile(r"^/gateways/[^/]+/"), Permissions.GATEWAYS_UPDATE),  # POST to sub-resources (state, toggle, refresh)
     ("PUT", re.compile(r"^/gateways/[^/]+(?:$|/)"), Permissions.GATEWAYS_UPDATE),
     ("DELETE", re.compile(r"^/gateways/[^/]+(?:$|/)"), Permissions.GATEWAYS_DELETE),
+    # MCP Servers REST API (v1 prefix stripped by middleware before matching)
+    ("POST", re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ),
     # Metrics permissions
     ("GET", re.compile(r"^/metrics(?:$|/)"), Permissions.ADMIN_METRICS),
     ("POST", re.compile(r"^/metrics/reset(?:$|/)"), Permissions.ADMIN_METRICS),

--- a/mcpgateway/routers/mcp_servers_router.py
+++ b/mcpgateway/routers/mcp_servers_router.py
@@ -46,13 +46,16 @@ def _validated_team_id(team_id: Optional[str] = Query(None, description="Filter 
     Examples:
         >>> _validated_team_id(None) is None
         True
+        >>> _validated_team_id("") is None
+        True
         >>> try:
         ...     _validated_team_id("not-a-uuid")
         ... except Exception as e:
         ...     e.status_code
         400
     """
-    if team_id is None:
+    # Match admin _normalize_team_id: empty string means "no filter"
+    if not team_id:
         return None
     try:
         return uuid.UUID(str(team_id)).hex

--- a/mcpgateway/routers/mcp_servers_router.py
+++ b/mcpgateway/routers/mcp_servers_router.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/mcp_servers_router.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+MCP Servers REST API router.
+
+Endpoints:
+    POST /v1/mcp-servers/test  — Test MCP server / gateway connectivity
+"""
+
+# Standard
+from typing import Optional
+import uuid
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.db import get_db
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.schemas import GatewayTestRequest, GatewayTestResponse
+from mcpgateway.services.gateway_service import test_gateway_connectivity
+from mcpgateway.services.logging_service import LoggingService
+
+logging_service = LoggingService()
+logger = logging_service.get_logger(__name__)
+
+router = APIRouter(prefix="/v1/mcp-servers", tags=["MCP Servers"])
+
+
+def _validated_team_id(team_id: Optional[str] = Query(None, description="Filter by team ID")) -> Optional[str]:
+    """Validate and normalize team_id query parameter.
+
+    Args:
+        team_id: Raw team ID from query params.
+
+    Returns:
+        Normalized team ID hex string or None.
+
+    Raises:
+        HTTPException: If the team ID is not a valid UUID.
+
+    Examples:
+        >>> _validated_team_id(None)
+        >>> _validated_team_id("not-a-uuid")
+        Traceback (most recent call last):
+            ...
+        fastapi.exceptions.HTTPException: 400
+    """
+    if team_id is None:
+        return None
+    try:
+        return uuid.UUID(str(team_id)).hex
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid team ID") from exc
+
+
+@router.post("/test", response_model=GatewayTestResponse)
+@require_permission("gateways.read", allow_admin_bypass=False)
+async def check_mcp_server_connectivity(
+    request: GatewayTestRequest,
+    team_id: Optional[str] = Depends(_validated_team_id),
+    user=Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> GatewayTestResponse:
+    """Test MCP server / gateway connectivity.
+
+    Delegates to the shared ``test_gateway_connectivity`` implementation in
+    ``mcpgateway.services.gateway_service``, which handles SSRF protection,
+    DNS-pinning, OAuth token acquisition, and structured logging.
+
+    Args:
+        request (GatewayTestRequest): The request object containing the gateway URL and request details.
+        team_id (Optional[str]): Optional team ID for team-specific gateways.
+        user: Authenticated user context.
+        db (Session): Database session dependency.
+
+    Returns:
+        GatewayTestResponse: The response from the gateway, including status code, latency, and body.
+
+    Examples:
+        >>> callable(check_mcp_server_connectivity)
+        True
+        >>> check_mcp_server_connectivity.__name__
+        'check_mcp_server_connectivity'
+    """
+    return await test_gateway_connectivity(request, team_id, user, db)

--- a/mcpgateway/routers/mcp_servers_router.py
+++ b/mcpgateway/routers/mcp_servers_router.py
@@ -89,4 +89,12 @@ async def check_mcp_server_connectivity(
         >>> check_mcp_server_connectivity.__name__
         'check_mcp_server_connectivity'
     """
+    # Reject cross-team access: token_teams=None means admin bypass; a list means the
+    # caller is scoped to those teams only. A caller-supplied team_id outside that list
+    # would allow enumerating other teams' registered gateway hostnames (SSRF allowlist).
+    if team_id is not None:
+        token_teams = user.get("token_teams") if isinstance(user, dict) else None
+        if token_teams is not None and team_id not in token_teams:
+            raise HTTPException(status_code=403, detail="Access to requested team is not permitted")
+
     return await test_gateway_connectivity(request, team_id, user, db)

--- a/mcpgateway/routers/mcp_servers_router.py
+++ b/mcpgateway/routers/mcp_servers_router.py
@@ -44,11 +44,13 @@ def _validated_team_id(team_id: Optional[str] = Query(None, description="Filter 
         HTTPException: If the team ID is not a valid UUID.
 
     Examples:
-        >>> _validated_team_id(None)
-        >>> _validated_team_id("not-a-uuid")
-        Traceback (most recent call last):
-            ...
-        fastapi.exceptions.HTTPException: 400
+        >>> _validated_team_id(None) is None
+        True
+        >>> try:
+        ...     _validated_team_id("not-a-uuid")
+        ... except Exception as e:
+        ...     e.status_code
+        400
     """
     if team_id is None:
         return None

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -64,7 +64,7 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 from pydantic import ValidationError
 from sqlalchemy import and_, delete, desc, or_, select, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import joinedload, selectinload, Session
 
 try:
@@ -93,7 +93,7 @@ from mcpgateway.db import ResourceMetric, ResourceSubscription, server_prompt_as
 from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import ToolMetric
 from mcpgateway.observability import create_span, set_span_attribute, set_span_error
-from mcpgateway.schemas import GATEWAY_SUPPORTED_TRANSPORTS, GatewayCreate, GatewayRead, GatewayUpdate, PromptCreate, ResourceCreate, ToolCreate
+from mcpgateway.schemas import GATEWAY_SUPPORTED_TRANSPORTS, GatewayCreate, GatewayRead, GatewayTestRequest, GatewayTestResponse, GatewayUpdate, PromptCreate, ResourceCreate, ToolCreate
 
 # logging.getLogger("httpx").setLevel(logging.WARNING)  # Disables httpx logs for regular health checks
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
@@ -6642,6 +6642,253 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 return capabilities, tools, resources, prompts, validation_errors
         sanitized_url = sanitize_url_for_logging(server_url, auth_query_params)
         raise GatewayConnectionError(f"Failed to initialize gateway at {sanitized_url}: Connection could not be established")
+
+
+async def test_gateway_connectivity(
+    request: GatewayTestRequest,
+    team_id: Optional[str],
+    user: Any,
+    db: Session,
+) -> GatewayTestResponse:
+    """Test a gateway by sending a request to its URL.
+
+    Shared implementation used by both the legacy admin route and the v1 REST
+    endpoint.  All URL validation, SSRF protection, DNS-pinning, OAuth token
+    acquisition, and structured logging are handled here.
+
+    Args:
+        request (GatewayTestRequest): The request object containing the gateway URL and request details.
+        team_id (Optional[str]): Optional team ID for team-specific gateways.
+        user (Any): Authenticated user context dict.
+        db (Session): Database session.
+
+    Returns:
+        GatewayTestResponse: The response from the gateway, including status code, latency, and body.
+
+    Examples:
+        >>> import asyncio
+        >>> callable(test_gateway_connectivity)
+        True
+    """
+    # First-Party
+    from mcpgateway.auth_context import get_user_email  # pylint: disable=import-outside-toplevel
+
+    start_time: float = time.monotonic()
+
+    # Build allowlist for gateway test endpoint
+    allowed_hosts_set: set[str] = set()
+
+    if settings.gateway_test_allow_registered_only:
+        # Mode 1: Only allow testing registered gateway URLs
+        # Query all enabled gateways to build allowlist from their base URLs
+        try:
+            query = select(DbGateway.url).where(DbGateway.enabled)
+            if team_id:
+                query = query.where(DbGateway.team_id == team_id)
+            registered_urls = db.execute(query).scalars().all()
+
+            # Extract hostnames from registered gateway URLs
+            for url in registered_urls:
+                try:
+                    parsed = urlparse(url)
+                    if parsed.hostname:
+                        # Normalize: lowercase and strip trailing dots
+                        hostname = parsed.hostname.lower().rstrip(".")
+                        allowed_hosts_set.add(hostname)
+                except (ValueError, AttributeError) as e:
+                    # Log parse failures to help debug "URL not in allowlist" mysteries
+                    logger.debug("Failed to parse registered gateway URL '%s': %s", url, e)
+                    continue
+        except SQLAlchemyError as e:
+            logger.warning("Failed to build allowlist from registered gateways: %s", e)
+    else:
+        # Mode 2: Use configured host patterns from settings
+        allowed_hosts_set = set(settings.gateway_test_allowed_hosts)
+
+    allowed_hosts = list(allowed_hosts_set)
+
+    # Validate URL with allowlist enforcement and pin a safe resolved IP to close
+    # the DNS rebinding gap between validation-time and connection-time resolution.
+    try:
+        validated_gateway_target = await SecurityValidator.validate_gateway_test_url(str(request.base_url), allowed_hosts, "Gateway test URL")
+    except ValueError as e:
+        # Log the actual error for security monitoring, but return generic message
+        safe_url = sanitize_url_for_logging(str(request.base_url))
+        logger.warning(
+            "Gateway test URL validation failed for %s by user %s: %s",
+            safe_url,
+            get_user_email(user),
+            str(e),
+        )
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        # Generic error message - don't expose allowlist or validation details
+        return GatewayTestResponse(status_code=400, latency_ms=latency_ms, body={"error": "Invalid gateway URL"})
+
+    validated_base_url = validated_gateway_target["validated_url"]
+    validated_hostname = validated_gateway_target["hostname"]
+    pinned_resolved_ip = validated_gateway_target["resolved_ip"]
+
+    parsed_validated_base_url = urlparse(validated_base_url)
+    pinned_ip_is_ipv6 = ":" in pinned_resolved_ip
+    if parsed_validated_base_url.port is not None:
+        pinned_netloc = f"[{pinned_resolved_ip}]:{parsed_validated_base_url.port}" if pinned_ip_is_ipv6 else f"{pinned_resolved_ip}:{parsed_validated_base_url.port}"
+        original_authority = f"{validated_hostname}:{parsed_validated_base_url.port}"
+    else:
+        pinned_netloc = f"[{pinned_resolved_ip}]" if pinned_ip_is_ipv6 else pinned_resolved_ip
+        original_authority = validated_hostname
+
+    pinned_base_url = urlunparse(parsed_validated_base_url._replace(netloc=pinned_netloc))
+    full_url = pinned_base_url.rstrip("/") + "/" + request.path.lstrip("/")
+    full_url = full_url.rstrip("/")
+    safe_validated_url = sanitize_url_for_logging(validated_base_url)
+    logger.info(
+        "Gateway test pinned outbound address for user %s: url=%s hostname=%s pinned_ip=%s",
+        get_user_email(user),
+        safe_validated_url,
+        validated_hostname,
+        pinned_resolved_ip,
+    )
+
+    headers = dict(request.headers or {})
+    headers["Host"] = original_authority
+
+    # Attempt to find a registered gateway matching this URL and team.
+    # Query the raw DB object directly so we get the unmasked auth_value
+    # (get_first_gateway_by_url returns a masked GatewayRead where
+    # auth_value="*****", which cannot be decoded).
+    try:
+        query = select(DbGateway).where(DbGateway.url == validated_base_url, DbGateway.enabled)
+        if team_id:
+            query = query.where(DbGateway.team_id == team_id)
+        gateway = db.execute(query).scalars().first()
+    except Exception:
+        gateway = None
+
+    try:
+        user_email = get_user_email(user)
+        if gateway and gateway.auth_type == "oauth" and gateway.oauth_config:
+            grant_type = gateway.oauth_config.get("grant_type", "client_credentials")
+
+            if grant_type == "authorization_code":
+                # For Authorization Code flow, try to get stored tokens
+                try:
+                    # First-Party
+                    from mcpgateway.services.token_storage_service import TokenStorageService  # pylint: disable=import-outside-toplevel
+
+                    token_storage = TokenStorageService(db)
+
+                    # Get user-specific OAuth token
+                    if not user_email:
+                        latency_ms = int((time.monotonic() - start_time) * 1000)
+                        return GatewayTestResponse(
+                            status_code=401, latency_ms=latency_ms, body={"error": f"User authentication required for OAuth-protected gateway '{gateway.name}'. Please ensure you are authenticated."}
+                        )
+
+                    access_token: str = await token_storage.get_user_token(gateway.id, user_email)
+
+                    if access_token:
+                        headers["Authorization"] = f"Bearer {access_token}"
+                    else:
+                        latency_ms = int((time.monotonic() - start_time) * 1000)
+                        return GatewayTestResponse(
+                            status_code=401, latency_ms=latency_ms, body={"error": f"Please authorize {gateway.name} first. Visit /oauth/authorize/{gateway.id} to complete OAuth flow."}
+                        )
+                except Exception as e:
+                    logger.error(f"Failed to obtain stored OAuth token for gateway {gateway.name}: {e}")
+                    latency_ms = int((time.monotonic() - start_time) * 1000)
+                    return GatewayTestResponse(status_code=500, latency_ms=latency_ms, body={"error": f"OAuth token retrieval failed for gateway: {str(e)}"})
+            else:
+                # For Client Credentials flow, get token directly
+                try:
+                    oauth_manager = OAuthManager(request_timeout=int(os.getenv("OAUTH_REQUEST_TIMEOUT", "30")), max_retries=int(os.getenv("OAUTH_MAX_RETRIES", "3")))
+                    access_token: str = await oauth_manager.get_access_token(
+                        gateway.oauth_config, ca_certificate=gateway.ca_certificate, client_cert=gateway.client_cert, client_key=gateway.client_key
+                    )
+                    headers["Authorization"] = f"Bearer {access_token}"
+                except Exception as e:
+                    logger.error(f"Failed to obtain OAuth access token for gateway {gateway.name}: {e}")
+                    response_body = {"error": f"OAuth token retrieval failed for gateway: {str(e)}"}
+        elif gateway and gateway.auth_type in ("basic", "bearer", "authheaders") and gateway.auth_value:
+            if isinstance(gateway.auth_value, dict):
+                headers.update(gateway.auth_value)
+            elif isinstance(gateway.auth_value, str):
+                headers.update(decode_auth(gateway.auth_value))
+
+        # Prepare request based on content type
+        content_type = getattr(request, "content_type", "application/json")
+        request_kwargs = {
+            "method": request.method.upper(),
+            "url": full_url,
+            "headers": headers,
+            "extensions": {"sni_hostname": validated_hostname},
+        }
+
+        if request.body is not None:
+            if content_type == "application/x-www-form-urlencoded":
+                # Set proper content type header and use data parameter for form encoding
+                headers["Content-Type"] = "application/x-www-form-urlencoded"
+                request_kwargs["data"] = request.body
+            else:
+                # Default to JSON
+                headers["Content-Type"] = "application/json"
+                request_kwargs["json"] = request.body
+
+        async with ResilientHttpClient(client_args={"timeout": settings.federation_timeout, "verify": not settings.skip_ssl_verify}) as client:
+            response: httpx.Response = await client.request(**request_kwargs)
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+        try:
+            response_body: Union[Dict[str, Any], str] = response.json()
+        except ValueError:
+            response_body = {"details": response.text}
+
+        # Structured logging: Log successful gateway test
+        structured_logger.log(
+            level="INFO",
+            message=f"Gateway test completed: {safe_validated_url}",
+            event_type="gateway_tested",
+            component="gateway_service",
+            user_email=get_user_email(user),
+            team_id=team_id,
+            resource_type="gateway",
+            resource_id=gateway.id if gateway else None,
+            custom_fields={
+                "gateway_name": gateway.name if gateway else None,
+                "gateway_url": safe_validated_url,
+                "test_method": request.method,
+                "test_path": request.path,
+                "status_code": response.status_code,
+                "latency_ms": latency_ms,
+            },
+        )
+
+        return GatewayTestResponse(status_code=response.status_code, latency_ms=latency_ms, body=response_body)
+
+    except httpx.RequestError as e:
+        safe_url = sanitize_url_for_logging(str(request.base_url))
+        logger.warning("Gateway test failed for %s: %s", safe_url, e)
+        latency_ms = int((time.monotonic() - start_time) * 1000)
+
+        # Structured logging: Log failed gateway test
+        structured_logger.log(
+            level="ERROR",
+            message=f"Gateway test failed: {safe_url}",
+            event_type="gateway_test_failed",
+            component="gateway_service",
+            user_email=get_user_email(user),
+            team_id=team_id,
+            resource_type="gateway",
+            resource_id=gateway.id if gateway else None,
+            error=e,
+            custom_fields={
+                "gateway_name": gateway.name if gateway else None,
+                "gateway_url": safe_url,
+                "test_method": request.method,
+                "test_path": request.path,
+                "latency_ms": latency_ms,
+            },
+        )
+
+        return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "Request failed", "details": str(e)})
 
 
 # Lazy singleton - created on first access, not at module import time.

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -6807,7 +6807,8 @@ async def test_gateway_connectivity(
                     headers["Authorization"] = f"Bearer {access_token}"
                 except Exception as e:
                     logger.error(f"Failed to obtain OAuth access token for gateway {gateway.name}: {e}")
-                    response_body = {"error": f"OAuth token retrieval failed for gateway: {str(e)}"}
+                    latency_ms = int((time.monotonic() - start_time) * 1000)
+                    return GatewayTestResponse(status_code=502, latency_ms=latency_ms, body={"error": "OAuth token retrieval failed for gateway"})
         elif gateway and gateway.auth_type in ("basic", "bearer", "authheaders") and gateway.auth_value:
             if isinstance(gateway.auth_value, dict):
                 headers.update(gateway.auth_value)

--- a/mcpgateway/services/metrics.py
+++ b/mcpgateway/services/metrics.py
@@ -260,7 +260,7 @@ def _get_gateway_lifecycle_pending_registration_attempts_gauge():
 def _collect_gateway_lifecycle_metrics() -> tuple[dict[str, int], int, int]:
     """Collect aggregate lifecycle metrics from gateway rows."""
     # First-Party
-    from mcpgateway.db import Gateway, fresh_db_session  # pylint: disable=import-outside-toplevel
+    from mcpgateway.db import fresh_db_session, Gateway  # pylint: disable=import-outside-toplevel
 
     lifecycle_counts = {"pending": 0, "active": 0, "deleting": 0}
     pending_due_count = 0

--- a/tests/e2e/test_admin_apis.py
+++ b/tests/e2e/test_admin_apis.py
@@ -804,7 +804,7 @@ class TestAdminGatewayAPIs:
 
         # Configure allowlist
         with patch.object(settings, "gateway_test_allowed_hosts", ["api.approved.com"]):
-            with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+            with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                 request_data = {"base_url": "https://evil.com", "path": "/", "method": "GET", "headers": {}, "body": None}
 
                 response = await client.post("/admin/gateways/test", json=request_data, headers=TEST_AUTH_HEADER)
@@ -824,7 +824,7 @@ class TestAdminGatewayAPIs:
         with patch.object(settings, "gateway_test_allow_registered_only", False):
             with patch.object(settings, "gateway_test_allowed_hosts", ["api.example.com"]):
                 with patch("mcpgateway.common.validators.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]):
-                    with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+                    with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                         mock_client = MagicMock()
                         mock_response = MagicMock()
                         mock_response.status_code = 200
@@ -853,7 +853,7 @@ class TestAdminGatewayAPIs:
         # Empty allowlist with registered-only mode off = reject all
         with patch.object(settings, "gateway_test_allow_registered_only", False):
             with patch.object(settings, "gateway_test_allowed_hosts", []):
-                with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+                with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                     request_data = {"base_url": "http://169.254.169.254/", "path": "/", "method": "GET", "headers": {}, "body": None}
 
                     response = await client.post("/admin/gateways/test", json=request_data, headers=TEST_AUTH_HEADER)
@@ -874,7 +874,7 @@ class TestAdminGatewayAPIs:
             with patch.object(settings, "gateway_test_allowed_hosts", ["127.0.0.1"]):
                 with patch.object(settings, "ssrf_protection_enabled", True):
                     with patch.object(settings, "ssrf_allow_localhost", False):
-                        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+                        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                             request_data = {"base_url": "http://127.0.0.1/", "path": "/", "method": "GET", "headers": {}, "body": None}
 
                             response = await client.post("/admin/gateways/test", json=request_data, headers=TEST_AUTH_HEADER)

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -217,3 +217,242 @@ def test_validated_team_id_invalid_uuid_raises_400():
 
     assert exc_info.value.status_code == 400
     assert "Invalid team ID" in exc_info.value.detail
+
+
+def test_validated_team_id_empty_string_raises_400():
+    """Empty string is not a valid UUID → HTTP 400."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validated_team_id("")
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid team ID" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — non-JSON response body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_non_json_response_returns_string_body(gateway_test_request, user_ctx, db_session):
+    """Gateway returning non-JSON text → body is plain string, not dict."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.side_effect = ValueError("not json")
+    mock_response.text = "plain text response"
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 200
+    assert result.body == {"details": "plain text response"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — non-200 status code pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_non_200_status_passes_through(user_ctx, db_session):
+    """Gateway 404 → response carries status_code 404, not raised as exception."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayTestRequest(
+        base_url="http://example.com",
+        path="/missing",
+        method="GET",
+        headers={},
+        body=None,
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.json.return_value = {"error": "not found"}
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 404
+    assert result.body == {"error": "not found"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — gateway_test_allow_registered_only mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_registered_only_allows_registered_host(user_ctx, db_session, monkeypatch):
+    """registered_only=True: URL whose host is in registered DB gateways is allowed."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", True)
+
+    # DB returns the registered gateway URL matching the request host
+    db_session.execute.return_value.scalars.return_value.all.return_value = ["http://example.com"]
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80))]
+
+    monkeypatch.setattr("mcpgateway.common.validators.socket.getaddrinfo", mock_getaddrinfo)
+
+    request = GatewayTestRequest(
+        base_url="http://example.com",
+        path="/test",
+        method="GET",
+        headers={},
+        body=None,
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_registered_only_blocks_unregistered_host(user_ctx, db_session, monkeypatch):
+    """registered_only=True: URL not in registered gateways returns 400."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", True)
+    # No registered gateways → empty allowlist
+    db_session.execute.return_value.scalars.return_value.all.return_value = []
+
+    request = GatewayTestRequest(
+        base_url="http://internal.private.host",
+        path="/secret",
+        method="GET",
+        headers={},
+        body=None,
+    )
+
+    result = await check_mcp_server_connectivity(
+        request=request,
+        team_id=None,
+        user=user_ctx,
+        db=db_session,
+    )
+
+    assert result.status_code == 400
+    assert "error" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — POST method with body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_post_method_with_body(user_ctx, db_session):
+    """POST request with JSON body is forwarded and 201 response returned."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    request = GatewayTestRequest(
+        base_url="http://example.com",
+        path="/api/create",
+        method="POST",
+        headers={"X-Custom-Header": "value"},
+        body={"key": "value"},
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    mock_response.json.return_value = {"id": "abc123"}
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 201
+    assert result.body == {"id": "abc123"}
+    # verify the upstream HTTP call used POST
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs.kwargs.get("method", "").upper() == "POST" or (call_kwargs.args and call_kwargs.args[0].upper() == "POST")
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — timeout error → 502
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_timeout_returns_502(gateway_test_request, user_ctx, db_session):
+    """httpx.TimeoutException during connection → 502 with error body."""
+    import httpx
+
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("request timed out"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 502
+    assert "error" in result.body

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -456,3 +456,131 @@ async def test_test_endpoint_timeout_returns_502(gateway_test_request, user_ctx,
 
     assert result.status_code == 502
     assert "error" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Tests: Deny-path — 401 unauthenticated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_request_returns_401(gateway_test_request, db_session):
+    """Request without authenticated user context raises 401."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_mcp_server_connectivity(
+            request=gateway_test_request,
+            team_id=None,
+            user=None,
+            db=db_session,
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests: Deny-path — 403 insufficient permission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insufficient_permission_returns_403(gateway_test_request, user_ctx, db_session):
+    """User without gateways.read permission is denied with 403."""
+    from fastapi import HTTPException
+
+    with patch("mcpgateway.middleware.rbac.PermissionService") as mock_ps_class:
+        mock_ps = MagicMock()
+        mock_ps.check_permission = AsyncMock(return_value=False)
+        mock_ps_class.return_value = mock_ps
+
+        with pytest.raises(HTTPException) as exc_info:
+            await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Tests: Deny-path — 403 cross-team team_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_team_team_id_returns_403(gateway_test_request, db_session):
+    """Non-admin user supplying a team_id outside their authorized teams raises 403."""
+    import uuid
+    from fastapi import HTTPException
+
+    authorized_team = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").hex
+    foreign_team = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").hex
+
+    non_admin_user = {
+        "email": "user@example.com",
+        "full_name": "Regular User",
+        "is_admin": False,
+        "token_teams": [authorized_team],
+        "db": db_session,
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await check_mcp_server_connectivity(
+            request=gateway_test_request,
+            team_id=foreign_team,
+            user=non_admin_user,
+            db=db_session,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "team" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_admin_bypass_cross_team_team_id_allowed(gateway_test_request, db_session, monkeypatch):
+    """Admin user (token_teams=None) can supply any team_id without 403."""
+    import uuid
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", False)
+    monkeypatch.setattr(config.settings, "gateway_test_allowed_hosts", ["example.com", "*.example.com"])
+
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80))]
+
+    monkeypatch.setattr("mcpgateway.common.validators.socket.getaddrinfo", mock_getaddrinfo)
+
+    foreign_team = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").hex
+
+    admin_user = {
+        "email": "admin@example.com",
+        "full_name": "Admin User",
+        "is_admin": True,
+        "token_teams": None,  # None = admin bypass
+        "db": db_session,
+    }
+
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=foreign_team,
+                user=admin_user,
+                db=db_session,
+            )
+
+    assert result.status_code == 200

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -219,15 +219,9 @@ def test_validated_team_id_invalid_uuid_raises_400():
     assert "Invalid team ID" in exc_info.value.detail
 
 
-def test_validated_team_id_empty_string_raises_400():
-    """Empty string is not a valid UUID → HTTP 400."""
-    from fastapi import HTTPException
-
-    with pytest.raises(HTTPException) as exc_info:
-        _validated_team_id("")
-
-    assert exc_info.value.status_code == 400
-    assert "Invalid team ID" in exc_info.value.detail
+def test_validated_team_id_empty_string_returns_none():
+    """Empty string means "no filter" — matches admin _normalize_team_id."""
+    assert _validated_team_id("") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+++ b/tests/unit/mcpgateway/routers/test_mcp_servers_router.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_mcp_servers_router.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: Mihai Criveti
+
+Unit tests for the MCP Servers router.
+
+Tests cover:
+    - POST /v1/mcp-servers/test: success, SSRF blocked, no permission, bad UUID
+    - _validated_team_id: valid UUID, None, and invalid UUID
+"""
+
+# Standard
+import socket
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Third-Party
+import pytest
+
+# First-Party
+from mcpgateway.routers.mcp_servers_router import _validated_team_id, check_mcp_server_connectivity
+from mcpgateway.schemas import GatewayTestRequest, GatewayTestResponse
+
+# Local
+from tests.utils.rbac_mocks import patch_rbac_decorators, restore_rbac_decorators
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def rbac_bypass():
+    """Bypass RBAC decorators for unit tests."""
+    originals = patch_rbac_decorators()
+    yield
+    restore_rbac_decorators(originals)
+
+
+@pytest.fixture
+def db_session() -> MagicMock:
+    """Mock database session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def user_ctx(db_session: MagicMock) -> dict[str, Any]:
+    """Authenticated admin user context."""
+    return {
+        "email": "admin@example.com",
+        "full_name": "Admin User",
+        "is_admin": True,
+        "token_teams": None,
+        "db": db_session,
+        "permissions": ["gateways.read"],
+    }
+
+
+@pytest.fixture
+def gateway_test_request() -> GatewayTestRequest:
+    """A valid GatewayTestRequest pointing at a public test host."""
+    return GatewayTestRequest(
+        base_url="http://example.com",
+        path="/api/test",
+        method="GET",
+        headers={},
+        body=None,
+    )
+
+
+@pytest.fixture
+def configure_allowlist(monkeypatch):
+    """Configure gateway test allowlist to allow *.example.com and mock DNS."""
+    from mcpgateway import config
+
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", False)
+    monkeypatch.setattr(config.settings, "gateway_test_allowed_hosts", ["example.com", "*.example.com"])
+
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", port or 80))]
+
+    monkeypatch.setattr("mcpgateway.common.validators.socket.getaddrinfo", mock_getaddrinfo)
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_success(gateway_test_request, user_ctx, db_session):
+    """Valid URL with allowed host returns GatewayTestResponse."""
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"ok": True}
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert isinstance(result, GatewayTestResponse)
+    assert result.status_code == 200
+    assert result.body == {"ok": True}
+    assert result.latency_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — SSRF blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_ssrf_blocked(user_ctx, db_session, monkeypatch):
+    """URL pointing at a private IP or unlisted host returns 400."""
+    from mcpgateway import config
+
+    # No allowed hosts and SSRF protection enabled
+    monkeypatch.setattr(config.settings, "gateway_test_allow_registered_only", False)
+    monkeypatch.setattr(config.settings, "gateway_test_allowed_hosts", [])
+
+    db_session.execute.return_value.scalars.return_value.all.return_value = []
+
+    request = GatewayTestRequest(
+        base_url="http://internal.private.host",
+        path="/secret",
+        method="GET",
+        headers={},
+        body=None,
+    )
+
+    result = await check_mcp_server_connectivity(
+        request=request,
+        team_id=None,
+        user=user_ctx,
+        db=db_session,
+    )
+
+    assert result.status_code == 400
+    assert "error" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /test — HTTP error (502)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_allowlist")
+async def test_test_endpoint_request_error_returns_502(gateway_test_request, user_ctx, db_session):
+    """httpx.RequestError during connection is returned as 502."""
+    import httpx
+
+    db_session.execute.return_value.scalars.return_value.first.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.request = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("mcpgateway.services.gateway_service.ResilientHttpClient", return_value=mock_client):
+        with patch("mcpgateway.services.gateway_service.get_structured_logger", return_value=MagicMock(log=MagicMock())):
+            result = await check_mcp_server_connectivity(
+                request=gateway_test_request,
+                team_id=None,
+                user=user_ctx,
+                db=db_session,
+            )
+
+    assert result.status_code == 502
+    assert "error" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Tests: _validated_team_id helper
+# ---------------------------------------------------------------------------
+
+
+def test_validated_team_id_none_returns_none():
+    """None input returns None."""
+    assert _validated_team_id(None) is None
+
+
+def test_validated_team_id_valid_uuid_returns_hex():
+    """Valid UUID is normalised to hex string."""
+    import uuid
+
+    raw = str(uuid.uuid4())
+    result = _validated_team_id(raw)
+    # hex form has no hyphens
+    assert result is not None
+    assert "-" not in result
+    assert len(result) == 32
+
+
+def test_validated_team_id_invalid_uuid_raises_400():
+    """Non-UUID string raises HTTP 400."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validated_team_id("not-a-valid-uuid-at-all")
+
+    assert exc_info.value.status_code == 400
+    assert "Invalid team ID" in exc_info.value.detail

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -3798,7 +3798,7 @@ class TestAdminGatewayTestRoute:
                 body={"test": "data"} if method in ["POST", "PUT", "PATCH"] else None,
             )
 
-            with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+            with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                 mock_response = MagicMock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {"result": "success"}
@@ -3842,7 +3842,7 @@ class TestAdminGatewayTestRoute:
                 body=None,
             )
 
-            with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+            with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                 mock_response = MagicMock()
                 mock_response.status_code = 200
                 mock_response.json.return_value = {}
@@ -3876,7 +3876,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.request = AsyncMock(side_effect=httpx.TimeoutException("Request timed out"))
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -3909,7 +3909,7 @@ class TestAdminGatewayTestRoute:
                 body=None,
             )
 
-            with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+            with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
                 mock_response = MagicMock()
                 mock_response.status_code = 200
                 mock_response.text = response_text
@@ -3963,7 +3963,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {"result": "success"}
@@ -4011,7 +4011,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {}
@@ -4054,7 +4054,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {}
@@ -4095,7 +4095,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {}
@@ -4137,7 +4137,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {"result": "success"}
@@ -4178,7 +4178,7 @@ class TestAdminGatewayTestRoute:
             body=None,
         )
 
-        with patch("mcpgateway.admin.ResilientHttpClient") as mock_client_class:
+        with patch("mcpgateway.services.gateway_service.ResilientHttpClient") as mock_client_class:
             mock_response = MagicMock()
             mock_response.status_code = 200
             mock_response.json.return_value = {"result": "success"}
@@ -15725,8 +15725,8 @@ async def test_admin_test_gateway_json_and_text(monkeypatch, mock_db):
         async def request(self, **_kwargs):
             return MockResponseText()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
     mock_db.execute.return_value.scalars.return_value.first.return_value = None
 
     request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
@@ -15741,7 +15741,7 @@ async def test_admin_test_gateway_json_and_text(monkeypatch, mock_db):
             captured_text.update(kwargs)
             return MockResponseText()
 
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClientText())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClientText())
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
     assert response.body.get("details") == "plain text"
     assert captured_text["url"] == "https://8.8.8.8/test"
@@ -15773,7 +15773,7 @@ async def test_admin_test_gateway_rejects_private_ssrf_target(monkeypatch, mock_
             raise AssertionError("Outbound request should not execute for blocked SSRF target")
 
     monkeypatch.setattr("mcpgateway.common.validators.settings", StrictSSRFSettings())
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: ShouldNotBeCalled())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: ShouldNotBeCalled())
 
     request = GatewayTestRequest(base_url="http://127.0.0.1", path="/test", method="GET", headers={}, body=None)
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
@@ -15804,7 +15804,7 @@ async def test_admin_test_gateway_oauth_authorization_code_missing_user_email(mo
     """Cover the 401 branch when OAuth auth-code flow requires a user email."""
     gateway = SimpleNamespace(id="gw-1", name="GW", auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
-    monkeypatch.setattr("mcpgateway.admin.get_user_email", lambda _user: "", raising=True)
+    monkeypatch.setattr("mcpgateway.auth_context.get_user_email", lambda _user: "", raising=True)
     monkeypatch.setattr("mcpgateway.services.token_storage_service.TokenStorageService", lambda _db: MagicMock(), raising=True)
 
     request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
@@ -15842,8 +15842,8 @@ async def test_admin_test_gateway_oauth_authorization_code_token_success_sets_he
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     gateway = SimpleNamespace(id="gw-1", name="GW", auth_type="oauth", oauth_config={"grant_type": "authorization_code"})
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
@@ -15911,10 +15911,10 @@ async def test_admin_test_gateway_oauth_client_credentials_success(monkeypatch, 
 
     oauth_manager = MagicMock()
     oauth_manager.get_access_token = AsyncMock(return_value="tok")
-    monkeypatch.setattr("mcpgateway.admin.OAuthManager", lambda **_kwargs: oauth_manager)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.OAuthManager", lambda **_kwargs: oauth_manager)
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
@@ -15947,10 +15947,10 @@ async def test_admin_test_gateway_oauth_client_credentials_token_error(monkeypat
 
     oauth_manager = MagicMock()
     oauth_manager.get_access_token = AsyncMock(side_effect=RuntimeError("oauth failed"))
-    monkeypatch.setattr("mcpgateway.admin.OAuthManager", lambda **_kwargs: oauth_manager)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.OAuthManager", lambda **_kwargs: oauth_manager)
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     request = GatewayTestRequest(base_url="https://api.example.com", path="/test", method="GET", headers={}, body=None)
     response = await admin_test_gateway(request, None, user={"email": "user@example.com", "db": mock_db}, db=mock_db)
@@ -15992,8 +15992,8 @@ async def test_admin_test_gateway_form_urlencoded_body_handling(monkeypatch, moc
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
     mock_db.execute.return_value.scalars.return_value.first.return_value = None
 
     request = GatewayTestRequest(
@@ -16041,8 +16041,8 @@ async def test_admin_test_gateway_basic_auth_dict_value(monkeypatch, mock_db):
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     gateway = SimpleNamespace(id="gw-1", name="GW", auth_type="bearer", auth_value={"Authorization": "Bearer my-token"}, oauth_config=None)
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
@@ -16084,9 +16084,9 @@ async def test_admin_test_gateway_bearer_auth_str_value(monkeypatch, mock_db):
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
-    monkeypatch.setattr("mcpgateway.admin.decode_auth", lambda val: {"Authorization": "Basic decoded"})
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.decode_auth", lambda val: {"Authorization": "Basic decoded"})
 
     gateway = SimpleNamespace(id="gw-2", name="GW2", auth_type="basic", auth_value="encrypted-string", oauth_config=None)
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
@@ -16128,8 +16128,8 @@ async def test_admin_test_gateway_no_auth_skips_decode(monkeypatch, mock_db):
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     gateway = SimpleNamespace(id="gw-3", name="GW3", auth_type=None, auth_value=None, oauth_config=None)
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
@@ -16171,8 +16171,8 @@ async def test_admin_test_gateway_preserves_caller_headers(monkeypatch, mock_db)
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     gateway = SimpleNamespace(id="gw-4", name="GW4", auth_type="bearer", auth_value={"Authorization": "Bearer stored-token"}, oauth_config=None)
     mock_db.execute.return_value.scalars.return_value.first.return_value = gateway
@@ -16222,8 +16222,8 @@ async def test_admin_test_gateway_wraps_ipv6_pinned_netloc(monkeypatch, mock_db)
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     async def mock_validate_gateway_test_url(value, _allowed_hosts, _field_name="Gateway test URL"):
         return {
@@ -16232,7 +16232,7 @@ async def test_admin_test_gateway_wraps_ipv6_pinned_netloc(monkeypatch, mock_db)
             "resolved_ip": "2001:4860:4860::8888",
         }
 
-    monkeypatch.setattr("mcpgateway.admin.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
 
     mock_db.execute.return_value.scalars.return_value.first.return_value = None
 
@@ -16272,8 +16272,8 @@ async def test_admin_test_gateway_direct_ip_preserves_literal_target(monkeypatch
             captured.update(kwargs)
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     async def mock_validate_gateway_test_url(value, _allowed_hosts, _field_name="Gateway test URL"):
         return {
@@ -16282,7 +16282,7 @@ async def test_admin_test_gateway_direct_ip_preserves_literal_target(monkeypatch
             "resolved_ip": "8.8.8.8",
         }
 
-    monkeypatch.setattr("mcpgateway.admin.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
 
     mock_db.execute.return_value.scalars.return_value.first.return_value = None
 
@@ -16319,8 +16319,8 @@ async def test_admin_test_gateway_skips_disabled_gateway(monkeypatch, mock_db):
         async def request(self, **kwargs):
             return MockResponse()
 
-    monkeypatch.setattr("mcpgateway.admin.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
-    monkeypatch.setattr("mcpgateway.admin.ResilientHttpClient", lambda **_kwargs: MockClient())
+    monkeypatch.setattr("mcpgateway.services.gateway_service.get_structured_logger", lambda *_args, **_kwargs: MagicMock(log=MagicMock()))
+    monkeypatch.setattr("mcpgateway.services.gateway_service.ResilientHttpClient", lambda **_kwargs: MockClient())
 
     async def mock_validate_gateway_test_url(value, _allowed_hosts, _field_name="Gateway test URL"):
         return {
@@ -16329,7 +16329,7 @@ async def test_admin_test_gateway_skips_disabled_gateway(monkeypatch, mock_db):
             "resolved_ip": "8.8.8.8",
         }
 
-    monkeypatch.setattr("mcpgateway.admin.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
+    monkeypatch.setattr("mcpgateway.services.gateway_service.SecurityValidator.validate_gateway_test_url", mock_validate_gateway_test_url)
     execute_result = MagicMock()
     execute_result.scalars.return_value.all.return_value = ["https://api.example.com"]
     execute_result.scalars.return_value.first.return_value = None


### PR DESCRIPTION
Closes #5326

The React UI cannot reach \`/admin/**\` endpoints, which are reserved for the legacy HTMX admin interface. This PR exposes a dedicated v1 REST endpoint so the React "Test Connection" dialog (#5040) can test MCP server / gateway connectivity without touching admin routes.

Rather than duplicating the gateway-test handler, the core logic is extracted into a standalone \`test_gateway_connectivity()\` function in \`gateway_service.py\`. Both the existing \`/admin/gateways/test\` endpoint and the new \`/v1/mcp-servers/test\` endpoint become thin delegation wrappers around this single source of truth.

## Changes

### New files

- **\`mcpgateway/routers/mcp_servers_router.py\`** — \`APIRouter(prefix="/v1/mcp-servers")\` with \`POST /test\`; enforces \`gateways.read\` permission via \`@require_permission("gateways.read", allow_admin_bypass=False)\`; delegates to \`test_gateway_connectivity()\`
- **\`tests/unit/mcpgateway/routers/test_mcp_servers_router.py\`** — unit tests covering success, SSRF blocked, 502 on request error, non-JSON response, registered-only allowlist mode, POST with body, timeout, and \`_validated_team_id\` edge cases, plus deny-path regression tests (401 unauthenticated, 403 insufficient permission, 403 cross-team \`team_id\`, admin-bypass allow case)

### Modified files

- **\`mcpgateway/services/gateway_service.py\`** — extracted \`async def test_gateway_connectivity(request, team_id, user, db)\` from \`admin_test_gateway\`; all security behaviour preserved: DNS-pinning, SSRF allowlist enforcement, OAuth (authorization code + client credentials), basic/bearer/header auth injection, and structured logging on success and failure
- **\`mcpgateway/admin.py\`** — \`admin_test_gateway\` body replaced with a single call to \`test_gateway_connectivity()\`; signature, decorators, and docstring unchanged
- **\`mcpgateway/middleware/token_scoping.py\`** — added \`(POST, re.compile(r"^/mcp-servers/test(?:$|/)"), Permissions.GATEWAYS_READ)\` to the route permission patterns
- **\`mcpgateway/main.py\`** — registered \`mcp_servers_router\` via \`app.include_router()\`
- **\`tests/unit/mcpgateway/test_admin.py\`** / **\`tests/e2e/test_admin_apis.py\`** — updated mock patch targets from \`mcpgateway.admin.*\` to \`mcpgateway.services.gateway_service.*\` to reflect the extraction

## Security hardening (beyond straight extraction)

- **Cross-team \`team_id\` rejection on both routes** — both the v1 endpoint and \`/admin/gateways/test\` now validate the caller-supplied \`team_id\` against the token's \`token_teams\` scope: non-admin callers requesting a team outside their scope get 403 (fail-closed for public-only tokens). Prevents enumerating other teams' registered gateway hostnames via the SSRF allowlist. Admin bypass (\`token_teams=None\`) is preserved. Previously only the v1 route had this guard; the pre-existing admin route was exposed to the same cross-team probing risk, which this PR now closes.
- **OAuth client-credentials failure now fails closed on both routes** — the original admin handler set an error body on token-fetch failure but fell through and sent the outbound request without the \`Authorization\` header (the error body was then overwritten by the upstream response). The extracted implementation returns 502 with a clear token-retrieval error instead, matching the early-return behaviour of the authorization-code branch. **This is a behaviour change to the existing \`/admin/gateways/test\` endpoint:** callers that previously relied on the (arguably broken) unauthenticated fallback will now receive a 502 on OAuth token-fetch failure.
- **\`team_id\` normalization parity** — \`_validated_team_id\` treats an empty \`?team_id=\` as "no filter" (returns \`None\`), matching the admin route's \`_normalize_team_id\`; malformed UUIDs still return 400.

## Minor cleanups

- \`mcpgateway/services/metrics.py\`, \`mcpgateway/auth_context.py\`, and the \`e28cd485ad3c\` migration — formatting/import-order lint fixes picked up along the way (no behaviour change)