### PR TITLE
Fix/fastapi 0.137 included router path

### DIFF
--- a/tests/helpers/router_helpers.py
+++ b/tests/helpers/router_helpers.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""Location: ./tests/helpers/router_helpers.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+
+FastAPI router introspection helpers shared across the test suite.
+
+These utilities abstract over the ``_IncludedRouter`` lazy-wrapper introduced
+in FastAPI 0.137.0 so that tests work correctly against both FastAPI ≤ 0.136
+(eager route expansion) and ≥ 0.137 (lazy ``_IncludedRouter`` wrappers).
+"""
+
+from __future__ import annotations
+
+
+def collect_routes(router) -> list[tuple[str, object, list]]:
+    """Return ``(full_path, route, include_deps)`` triples for every leaf route on *router*.
+
+    ``include_deps`` is the list of :class:`fastapi.params.Depends` objects
+    accumulated from enclosing ``_IncludedRouter`` wrappers (FastAPI ≥ 0.137).
+    On FastAPI ≤ 0.136 this list is always empty because ``include_router``
+    copies dependencies directly onto each leaf route's ``.dependencies``.
+
+    This covers both FastAPI versions for tests that inspect route dependencies:
+
+    * FastAPI ≤ 0.136: check ``getattr(route, "dependencies", [])``
+    * FastAPI ≥ 0.137: check ``include_deps``
+
+    To get paths only: ``[p for p, *_ in collect_routes(router)]``.
+
+    Args:
+        router: Any ``fastapi.APIRouter`` instance.
+
+    Returns:
+        A list of ``(path_str, route_object, include_deps)`` triples.
+    """
+    try:
+        from fastapi.routing import _IncludedRouter  # type: ignore[attr-defined]
+    except ImportError:
+        _IncludedRouter = None  # type: ignore[assignment,misc]
+
+    if _IncludedRouter is None:
+        # FastAPI ≤ 0.136: include_router eagerly expands routes; paths already
+        # contain the fully-qualified prefix and deps are on the route itself.
+        return [(r.path, r, []) for r in router.routes]
+
+    # FastAPI 0.137+: include_router stores lazy _IncludedRouter wrappers.
+    # Accumulate include_context.dependencies as we descend so callers see the
+    # full effective dependency set without knowing about _IncludedRouter.
+    def _collect(routes: list, prefix: str, acc_deps: list) -> list[tuple[str, object, list]]:
+        result: list[tuple[str, object, list]] = []
+        for r in routes:
+            if isinstance(r, _IncludedRouter):
+                combined_deps = acc_deps + list(r.include_context.dependencies or [])
+                result.extend(_collect(
+                    r.original_router.routes,
+                    prefix + r.include_context.prefix,
+                    combined_deps,
+                ))
+            else:
+                result.append((prefix + r.path, r, acc_deps))
+        return result
+
+    items: list[tuple[str, object, list]] = []
+    for r in router.routes:
+        if isinstance(r, _IncludedRouter):
+            # include_context.prefix already contains the parent router prefix.
+            # include_context.dependencies already includes the parent router deps.
+            top_deps = list(r.include_context.dependencies or [])
+            items.extend(_collect(r.original_router.routes, r.include_context.prefix, top_deps))
+        else:
+            # Direct routes already have the router's own prefix embedded.
+            items.append((r.path, r, []))
+    return items

--- a/tests/unit/mcpgateway/routers/test_well_known.py
+++ b/tests/unit/mcpgateway/routers/test_well_known.py
@@ -21,6 +21,7 @@ from mcpgateway.routers.well_known import (
     get_well_known_file_content,
     validate_security_txt,
 )
+from tests.helpers.router_helpers import collect_routes
 
 # ---------- get_base_url_with_protocol ----------
 
@@ -252,7 +253,7 @@ def test_v1_prefix_does_not_produce_rfc_violation():
     v1_router = APIRouter(prefix="/v1")
     v1_router.include_router(admin_router)
 
-    final_paths = [route.path for route in v1_router.routes]
+    final_paths = [p for p, *_ in collect_routes(v1_router)]
     rfc_violations = [p for p in final_paths if "/.well-known" in p]
     assert rfc_violations == [], f"Including admin_router in /v1 creates RFC 8615 violating paths: {rfc_violations}"
 

--- a/tests/unit/mcpgateway/test_api_v1.py
+++ b/tests/unit/mcpgateway/test_api_v1.py
@@ -23,6 +23,11 @@ from unittest.mock import MagicMock, patch
 from fastapi import APIRouter
 import pytest
 
+# First-Party
+from tests.helpers.router_helpers import collect_routes
+
+_route_paths = lambda r: [p for p, *_ in collect_routes(r)]  # noqa: E731
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -71,11 +76,6 @@ def _required_kwargs(**extras) -> dict:
     )
     base.update(extras)
     return base
-
-
-def _route_paths(router: APIRouter) -> list[str]:
-    """Collect all route paths registered on a router."""
-    return [r.path for r in router.routes]
 
 
 def _make_mock_router_module(sentinel_path: str) -> ModuleType:

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter
 from mcpgateway.api.v1 import _assemble_routers
 from mcpgateway.config import settings
 from mcpgateway.middleware.deprecation import _LEGACY_PREFIXES
+from tests.helpers.router_helpers import collect_routes
 
 
 def extract_router_prefixes(router: APIRouter) -> set[str]:
@@ -26,8 +27,7 @@ def extract_router_prefixes(router: APIRouter) -> set[str]:
         Set of unique prefixes (e.g., {"/tools", "/servers"}).
     """
     prefixes = set()
-    for route in router.routes:
-        path = route.path
+    for path, *_ in collect_routes(router):
         # Extract first path segment as prefix
         if path.startswith("/"):
             parts = path.split("/")
@@ -209,10 +209,14 @@ def test_llm_admin_router_csrf_dependency():
         a2a_router=APIRouter(),
     )
 
-    # Collect all dependency callables across routes under /admin/llm
+    # Collect all dependency callables across routes under /admin/llm.
+    # On FastAPI ≤ 0.136 deps are on the leaf route; on ≥ 0.137 they live on
+    # the _IncludedRouter wrapper and are returned as include_deps.
     llm_admin_route_deps: list = []
-    for route in test_router.routes:
-        if hasattr(route, "path") and route.path.startswith("/admin/llm"):
+    for path, route, include_deps in collect_routes(test_router):
+        if path.startswith("/admin/llm"):
+            for dep in include_deps:
+                llm_admin_route_deps.append(dep.dependency)
             for dep in getattr(route, "dependencies", []):
                 llm_admin_route_deps.append(dep.dependency)
 

--- a/tests/unit/mcpgateway/test_legacy_router.py
+++ b/tests/unit/mcpgateway/test_legacy_router.py
@@ -29,6 +29,11 @@ from unittest.mock import patch
 from fastapi import APIRouter
 import pytest
 
+# First-Party
+from tests.helpers.router_helpers import collect_routes
+
+_route_paths = lambda r: [p for p, *_ in collect_routes(r)]  # noqa: E731
+
 # ---------------------------------------------------------------------------
 # Helpers (duplicated from test_api_v1.py intentionally — no shared module)
 # ---------------------------------------------------------------------------
@@ -75,10 +80,6 @@ def _required_kwargs(**extras) -> dict:
     )
     base.update(extras)
     return base
-
-
-def _route_paths(router: APIRouter) -> list[str]:
-    return [r.path for r in router.routes]
 
 
 def _make_mock_router_module(sentinel_path: str) -> ModuleType:


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5445

---

## 📝 Summary

FastAPI 0.137.0 changed how `include_router()` works internally: instead of
eagerly expanding sub-router routes into `APIRoute` objects (with the full
prefix already embedded in `route.path`), it now lazily stores a
`_IncludedRouter` wrapper object in `router.routes`. These wrapper objects
expose `original_router` and `include_context` but **not** `.path`, so any
code that iterates `router.routes` and accesses `.path` directly raises:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

A second, subtler change: `dependencies` passed to `include_router()` are no
longer copied onto each leaf route — they are stored on
`_IncludedRouter.include_context.dependencies` and applied lazily. Any test
inspecting `route.dependencies` for include-level guards silently misses them
on FastAPI ≥ 0.137.

FastAPI 0.137.2 was pulled in transitively by
`prometheus-fastapi-instrumentator>=8.0.1`.

**Changes:**

- **`tests/unit/mcpgateway/_helpers.py`** (new) — single `collect_routes(router)`
  helper that handles both FastAPI versions. Returns `(path, route, include_deps)`
  triples where:
  - `path` — fully-qualified route path (prefix-accumulation aware)
  - `route` — the leaf `APIRoute` object
  - `include_deps` — `Depends` objects accumulated from enclosing
    `_IncludedRouter` wrappers (empty on FastAPI ≤ 0.136 where they are
    already copied onto the route itself)

- **`test_api_v1.py`** / **`test_legacy_router.py`** — replaced per-file inline
  traversal helpers with `collect_routes`.

- **`test_well_known.py`** — replaced per-file inline traversal helper with
  `collect_routes`.

- **`test_api_versioning_parity.py`** — fixed two tests added to `main` after
  the branch was cut:
  - `test_legacy_prefixes_match_assembled_routers` — path iteration now uses
    `collect_routes`.
  - `test_llm_admin_router_csrf_dependency` — dependency check now reads from
    both `include_deps` (FastAPI ≥ 0.137) and `route.dependencies`
    (FastAPI ≤ 0.136) to cover both versions.

No production code was changed; this is a pure test-compatibility fix.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix

---

## 🧪 Verification

Tests were run against **both** FastAPI 0.136.3 (local venv) and 0.137.2
(CI-resolved version) to confirm forward and backward compatibility.

| Check | Command | Status |
|---|---|---|
| Unit tests (FastAPI 0.136.3) | `python3 -m pytest tests/unit/mcpgateway/test_api_v1.py tests/unit/mcpgateway/test_legacy_router.py tests/unit/mcpgateway/routers/test_well_known.py tests/unit/mcpgateway/test_api_versioning_parity.py -q` | ✅ 119/119 passed |
| Lint suite | `make lint` | pending CI |
| Full unit tests | `make test` | pending CI |
| Coverage ≥ 80% | `make coverage` | pending CI |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Why a shared `_helpers.py` instead of per-file helpers?**
All four affected test files needed the same `_IncludedRouter`-aware traversal.
Duplicating it would mean four places to update if FastAPI's internals change
again. A single helper with a clear public contract is easier to maintain and
audit.

**Why return 3-tuples `(path, route, include_deps)`?**
On FastAPI ≥ 0.137, `dependencies` passed to `include_router()` live on the
`_IncludedRouter.include_context.dependencies`, not on the leaf route. Carrying
them through the traversal as `include_deps` lets callers check the full
effective dependency set without knowing about `_IncludedRouter` at all.
Callers that only need paths use `[p for p, *_ in collect_routes(router)]`.

**Prefix accumulation detail:**
In FastAPI 0.137.x, the top-level `_IncludedRouter.include_context.prefix`
already incorporates the parent router's own prefix (e.g. `/v1`), so
accumulation starts from `include_context.prefix` directly. Nested
`_IncludedRouter` objects inside `original_router` carry only their incremental
prefix, which `_collect()` appends to the running total.