### PR TITLE
fix: resolve _IncludedRouter AttributeError in router path extraction tests

### DIFF
--- a/tests/helpers/router_helpers.py
+++ b/tests/helpers/router_helpers.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""tests/helpers/router_helpers.py
+Copyright 2025
+SPDX-License-Identifier: Apache-2.0
+
+Shared helper functions for testing FastAPI router assembly and path extraction.
+"""
+
+from fastapi import APIRouter
+
+
+def _route_paths(router: APIRouter) -> list[str]:
+    """Collect all route paths registered on a router, including nested routers.
+
+    This helper handles both direct APIRoute objects and nested _IncludedRouter
+    objects, recursively extracting paths with their full prefixes.
+
+    Args:
+        router: APIRouter to extract paths from.
+
+    Returns:
+        List of all route paths including nested router paths with prefixes.
+
+    Example:
+        >>> from fastapi import APIRouter
+        >>> router = APIRouter()
+        >>> router.add_api_route("/test", lambda: "ok")
+        >>> paths = _route_paths(router)
+        >>> "/test" in paths
+        True
+    """
+    paths = []
+    for route in router.routes:
+        if hasattr(route, 'path'):
+            # Direct APIRoute
+            paths.append(route.path)
+        elif hasattr(route, 'original_router'):
+            # _IncludedRouter - recurse into it with its prefix
+            prefix = route.include_context.prefix
+            for nested_route in route.original_router.routes:
+                if hasattr(nested_route, 'path'):
+                    paths.append(prefix + nested_route.path)
+                elif hasattr(nested_route, 'original_router'):
+                    # Nested _IncludedRouter - recurse further
+                    nested_prefix = prefix + nested_route.include_context.prefix
+                    paths.extend(_collect_paths_recursive(nested_route.original_router, nested_prefix))
+    return paths
+
+
+def _collect_paths_recursive(router: APIRouter, prefix: str) -> list[str]:
+    """Helper to recursively collect paths from deeply nested routers.
+
+    Args:
+        router: APIRouter to extract paths from.
+        prefix: Current accumulated prefix from parent routers.
+
+    Returns:
+        List of route paths with the accumulated prefix applied.
+    """
+    paths = []
+    for route in router.routes:
+        if hasattr(route, 'path'):
+            paths.append(prefix + route.path)
+        elif hasattr(route, 'original_router'):
+            nested_prefix = prefix + route.include_context.prefix
+            paths.extend(_collect_paths_recursive(route.original_router, nested_prefix))
+    return paths

--- a/tests/unit/mcpgateway/routers/test_well_known.py
+++ b/tests/unit/mcpgateway/routers/test_well_known.py
@@ -15,6 +15,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+# Test Helpers
+from tests.helpers.router_helpers import _route_paths
+
 # First-Party
 from mcpgateway.routers.well_known import (
     get_base_url_with_protocol,
@@ -252,7 +255,7 @@ def test_v1_prefix_does_not_produce_rfc_violation():
     v1_router = APIRouter(prefix="/v1")
     v1_router.include_router(admin_router)
 
-    final_paths = [route.path for route in v1_router.routes]
+    final_paths = _route_paths(v1_router)
     rfc_violations = [p for p in final_paths if "/.well-known" in p]
     assert rfc_violations == [], f"Including admin_router in /v1 creates RFC 8615 violating paths: {rfc_violations}"
 

--- a/tests/unit/mcpgateway/test_api_v1.py
+++ b/tests/unit/mcpgateway/test_api_v1.py
@@ -23,6 +23,9 @@ from unittest.mock import MagicMock, patch
 from fastapi import APIRouter
 import pytest
 
+# Test Helpers
+from tests.helpers.router_helpers import _collect_paths_recursive, _route_paths
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -71,11 +74,6 @@ def _required_kwargs(**extras) -> dict:
     )
     base.update(extras)
     return base
-
-
-def _route_paths(router: APIRouter) -> list[str]:
-    """Collect all route paths registered on a router."""
-    return [r.path for r in router.routes]
 
 
 def _make_mock_router_module(sentinel_path: str) -> ModuleType:

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -11,6 +11,7 @@ to be missing on that router's legacy routes.
 import pytest
 from fastapi import APIRouter
 
+from tests.helpers.router_helpers import _route_paths
 from mcpgateway.api.v1 import _assemble_routers
 from mcpgateway.config import settings
 from mcpgateway.middleware.deprecation import _LEGACY_PREFIXES
@@ -26,8 +27,7 @@ def extract_router_prefixes(router: APIRouter) -> set[str]:
         Set of unique prefixes (e.g., {"/tools", "/servers"}).
     """
     prefixes = set()
-    for route in router.routes:
-        path = route.path
+    for path in _route_paths(router):
         # Extract first path segment as prefix
         if path.startswith("/"):
             parts = path.split("/")
@@ -210,16 +210,37 @@ def test_llm_admin_router_csrf_dependency():
     )
 
     # Collect all dependency callables across routes under /admin/llm
-    llm_admin_route_deps: list = []
-    for route in test_router.routes:
-        if hasattr(route, "path") and route.path.startswith("/admin/llm"):
-            for dep in getattr(route, "dependencies", []):
-                llm_admin_route_deps.append(dep.dependency)
+    # Use _route_paths to get all paths including nested routers
+    all_paths = _route_paths(test_router)
+    llm_admin_paths = [p for p in all_paths if p.startswith("/admin/llm")]
 
-    assert llm_admin_route_deps, (
+    assert llm_admin_paths, (
         "No routes found under /admin/llm after assembly — "
         "LLM admin router may not be importable in this environment."
     )
+
+    # Now collect dependencies from routes that match these paths
+    llm_admin_route_deps: list = []
+
+    def collect_deps_recursive(router, prefix=""):
+        """Recursively collect dependencies from routes matching /admin/llm paths."""
+        for route in router.routes:
+            if hasattr(route, "path"):
+                full_path = prefix + route.path
+                if full_path.startswith("/admin/llm"):
+                    for dep in getattr(route, "dependencies", []):
+                        llm_admin_route_deps.append(dep.dependency)
+            elif hasattr(route, "original_router"):
+                nested_prefix = prefix + route.include_context.prefix
+                # Check if this _IncludedRouter's prefix matches /admin/llm
+                if nested_prefix.startswith("/admin/llm"):
+                    # Collect dependencies from the _IncludedRouter's include_context
+                    for dep in route.include_context.dependencies:
+                        llm_admin_route_deps.append(dep.dependency)
+                # Recurse into nested router
+                collect_deps_recursive(route.original_router, nested_prefix)
+
+    collect_deps_recursive(test_router)
     assert enforce_admin_csrf in llm_admin_route_deps, (
         "enforce_admin_csrf not found in /admin/llm route dependencies. "
         "Add dependencies=[Depends(enforce_admin_csrf)] to the llm_admin_router include_router call "

--- a/tests/unit/mcpgateway/test_legacy_router.py
+++ b/tests/unit/mcpgateway/test_legacy_router.py
@@ -29,8 +29,11 @@ from unittest.mock import patch
 from fastapi import APIRouter
 import pytest
 
+# Test Helpers
+from tests.helpers.router_helpers import _collect_paths_recursive, _route_paths
+
 # ---------------------------------------------------------------------------
-# Helpers (duplicated from test_api_v1.py intentionally — no shared module)
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -75,10 +78,6 @@ def _required_kwargs(**extras) -> dict:
     )
     base.update(extras)
     return base
-
-
-def _route_paths(router: APIRouter) -> list[str]:
-    return [r.path for r in router.routes]
 
 
 def _make_mock_router_module(sentinel_path: str) -> ModuleType:


### PR DESCRIPTION
Factor out router path extraction logic into shared helper module to eliminate code duplication and fix AttributeError when accessing _IncludedRouter.path. Fixes test failures in test_v1_prefix_does_not_produce_rfc_violation, test_legacy_prefixes_match_assembled_routers, and test_llm_admin_router_csrf_dependency.