### PR TITLE
fix: normalize dataplane passthrough headers

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -57,7 +57,7 @@ class BackendConfig(TypedDict):
     name: str
     url: str
     transport: str
-    passthrough_headers: list[str] | None
+    passthrough_headers: list[str]
     allowed_tool_names: list[str]
     allowed_resource_names: list[str]
     allowed_prompt_names: list[str]
@@ -216,7 +216,7 @@ class DataplanePublisherService:
                     "name": gateway["name"],
                     "url": gateway["url"],
                     "transport": gateway["transport"],
-                    "passthrough_headers": gateway["passthrough_headers"],
+                    "passthrough_headers": gateway["passthrough_headers"] or [],
                 }
                 for gateway in gateways
             }

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -374,6 +374,33 @@ def test_create_payload_filters_empty_backends():
     assert result["user@example.com"]["virtual_hosts"]["server1"]["backends"] == {}
 
 
+def test_create_payload_normalizes_null_passthrough_headers():
+    """create_payload() emits an empty list for gateways without passthrough headers."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    data = {
+        "user@example.com": {
+            "servers": [
+                {
+                    "id": "server1",
+                    "backend_items": {
+                        "gateway1": {"tools": ["tool1"], "resources": [], "prompts": []},
+                    },
+                }
+            ],
+            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "sse", "passthrough_headers": None}],
+            "prompts": [],
+            "resources": [],
+        }
+    }
+
+    result = service.create_payload(data)
+
+    backend = result["user@example.com"]["virtual_hosts"]["server1"]["backends"]["gateway1"]
+    assert backend["passthrough_headers"] == []
+
+
 def test_create_payload_handles_missing_references():
     """create_payload() handles missing gateway/resource/prompt references."""
     from mcpgateway.services.dataplane_publisher import DataplanePublisherService


### PR DESCRIPTION
# Bug-fix PR

Before opening this PR please:

1. `make lint`            - passes `ruff`, `mypy`, `pylint`
2. `make test`            - all unit + integration tests green
3. `make coverage`        - >= 80 %
4. `make docker docker-run-ssl` or `make podman podman-run-ssl`
5. Update relevant documentation.
6. Tested with sqlite and postgres + redis.
7. Manual regression no longer fails. Ensure the UI and /version work correctly.

---

## Summary

Normalize absent gateway passthrough headers to an empty list in dataplane publisher payloads.

When a gateway has no configured passthrough headers, the stored value can be `null`. The dataplane Redis payload should publish `passthrough_headers: []` so downstream dataplane consumers receive a stable list field.

## Reproduction Steps

No issue linked.

Minimal reproduction:

1. Create or use a gateway without configured passthrough headers.
2. Enable the dataplane publisher.
3. Inspect the published Redis `UserConfig` payload or consume it from the dataplane.
4. The backend config contains `passthrough_headers: null` instead of an empty list.

## Root Cause

`DataplanePublisherService.create_payload()` copied `gateway["passthrough_headers"]` directly into each backend config. For unset gateway passthrough headers, that value is `None`, which serializes to MessagePack null.

## Fix Description

Normalize `None` to `[]` while building the dataplane backend config and update the `BackendConfig` TypedDict to reflect the emitted non-null list contract.

Added regression coverage for a gateway with `passthrough_headers: None`.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Targeted publisher unit tests         | `uv run pytest tests/unit/mcpgateway/services/test_dataplane_publisher.py -q` | Passed |
| Ruff format                           | `uv run ruff format --check mcpgateway/services/dataplane_publisher.py tests/unit/mcpgateway/services/test_dataplane_publisher.py` | Passed |
| Ruff check                            | `uv run ruff check mcpgateway/services/dataplane_publisher.py tests/unit/mcpgateway/services/test_dataplane_publisher.py` | Passed |
| Diff whitespace                       | `git diff --check` | Passed |
| Lint suite                            | `make lint`          | Not run |
| Unit tests                            | `make test`          | Not run |
| Coverage >= 80 %                      | `make coverage`      | Not run |
| Manual regression no longer fails     | steps / screenshots  | Not run |

## MCP Compliance (if relevant)

- [x] Matches current MCP spec
- [x] No breaking change to MCP clients

## Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed