### PR TITLE
Sync MCP meta traceparent with outbound header

### DIFF
--- a/docs/docs/architecture/observability-otel.md
+++ b/docs/docs/architecture/observability-otel.md
@@ -147,6 +147,10 @@ and parent span ID consistent for upstream MCP servers that inspect either the
 HTTP headers or the MCP protocol payload. Existing `_meta` fields, such as
 identity or tenant context, are preserved when the trace context is added.
 
+Pooled or registry-backed MCP sessions deliberately skip per-request
+`_meta.traceparent` synchronization because those transports reuse pinned
+headers and do not propagate per-request trace context upstream.
+
 ## W3C Baggage Support
 
 ### Purpose

--- a/docs/docs/architecture/observability-otel.md
+++ b/docs/docs/architecture/observability-otel.md
@@ -128,6 +128,25 @@ This ensures:
 - Distributed traces span multiple services
 - End-to-end visibility across the call chain
 
+### MCP `_meta.traceparent`
+
+For non-pooled remote MCP tool calls, ContextForge also propagates the active
+trace context in the MCP tool-call `_meta` payload:
+
+```json
+{
+  "_meta": {
+    "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+  }
+}
+```
+
+The `_meta.traceparent` value is synchronized with the final outbound
+`traceparent` HTTP header after trace-context injection. This keeps the trace ID
+and parent span ID consistent for upstream MCP servers that inspect either the
+HTTP headers or the MCP protocol payload. Existing `_meta` fields, such as
+identity or tenant context, are preserved when the trace context is added.
+
 ## W3C Baggage Support
 
 ### Purpose

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -189,6 +189,24 @@ def _apply_tool_payload_to_global_context(
         global_context.tenant_id = payload_tenant_id
 
 
+def _sync_meta_traceparent(
+    meta_data: Optional[Dict[str, Any]],
+    request_headers: Mapping[str, str],
+) -> Optional[Dict[str, Any]]:
+    """Return metadata whose traceparent matches the final outbound header."""
+    traceparent = request_headers.get("traceparent")
+    if not traceparent:
+        for key, value in request_headers.items():
+            if key.lower() == "traceparent" and value:
+                traceparent = value
+    if not traceparent:
+        return meta_data
+
+    updated_meta = dict(meta_data or {})
+    updated_meta["traceparent"] = traceparent
+    return updated_meta
+
+
 # Initialize performance tracker, structured logger, audit trail, and metrics buffer for tool operations
 perf_tracker = get_performance_tracker()
 structured_logger = get_structured_logger("tool_service")
@@ -3695,6 +3713,7 @@ class ToolService(BaseService):
                 },
             ):
                 traced_headers = inject_trace_context_headers(headers)
+                meta_data = _sync_meta_traceparent(meta_data, traced_headers)
                 async with streamablehttp_client(url=gateway_url, headers=traced_headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
                     async with ClientSession(read_stream, write_stream) as session:
                         with create_span("mcp.client.initialize", {"contextforge.transport": "streamablehttp", "contextforge.runtime": "python"}):
@@ -5467,6 +5486,7 @@ class ToolService(BaseService):
                                     # Inject within the active client span so an upstream service
                                     # can attach beneath this span when it extracts traceparent.
                                     request_headers = inject_trace_context_headers(headers)
+                                    request_meta_data = _sync_meta_traceparent(meta_data, request_headers)
                                     if correlation_id and request_headers:
                                         request_headers["X-Correlation-ID"] = correlation_id
                                     async with sse_client(url=server_url, headers=request_headers, httpx_client_factory=get_httpx_client_factory) as streams:
@@ -5483,7 +5503,7 @@ class ToolService(BaseService):
                                                 },
                                             ):
                                                 with anyio.fail_after(effective_timeout):
-                                                    tool_call_result = await session.call_tool(tool_name_original, arguments, meta=meta_data)
+                                                    tool_call_result = await session.call_tool(tool_name_original, arguments, meta=request_meta_data)
                                             with create_span(
                                                 "mcp.client.response",
                                                 {
@@ -5649,6 +5669,7 @@ class ToolService(BaseService):
                                     # Inject within the active client span so an upstream service
                                     # can attach beneath this span when it extracts traceparent.
                                     request_headers = inject_trace_context_headers(headers)
+                                    request_meta_data = _sync_meta_traceparent(meta_data, request_headers)
                                     if correlation_id and request_headers:
                                         request_headers["X-Correlation-ID"] = correlation_id
                                     async with streamablehttp_client(url=server_url, headers=request_headers, httpx_client_factory=get_httpx_client_factory) as (
@@ -5669,7 +5690,7 @@ class ToolService(BaseService):
                                                 },
                                             ):
                                                 with anyio.fail_after(effective_timeout):
-                                                    tool_call_result = await session.call_tool(tool_name_original, arguments, meta=meta_data)
+                                                    tool_call_result = await session.call_tool(tool_name_original, arguments, meta=request_meta_data)
                                             with create_span(
                                                 "mcp.client.response",
                                                 {

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -199,6 +199,7 @@ def _sync_meta_traceparent(
         for key, value in request_headers.items():
             if key.lower() == "traceparent" and value:
                 traceparent = value
+                break
     if not traceparent:
         return meta_data
 
@@ -3713,7 +3714,7 @@ class ToolService(BaseService):
                 },
             ):
                 traced_headers = inject_trace_context_headers(headers)
-                meta_data = _sync_meta_traceparent(meta_data, traced_headers)
+                request_meta_data = _sync_meta_traceparent(meta_data, traced_headers)
                 async with streamablehttp_client(url=gateway_url, headers=traced_headers, timeout=settings.mcpgateway_direct_proxy_timeout) as (read_stream, write_stream, _get_session_id):
                     async with ClientSession(read_stream, write_stream) as session:
                         with create_span("mcp.client.initialize", {"contextforge.transport": "streamablehttp", "contextforge.runtime": "python"}):
@@ -3728,9 +3729,9 @@ class ToolService(BaseService):
                             },
                         ):
                             # Call tool with meta if provided
-                            if meta_data:
-                                logger.debug("Forwarding _meta to remote gateway: %s", meta_data)
-                                tool_result = await session.call_tool(name=remote_name, arguments=arguments, meta=meta_data)
+                            if request_meta_data:
+                                logger.debug("Forwarding _meta to remote gateway: %s", request_meta_data)
+                                tool_result = await session.call_tool(name=remote_name, arguments=arguments, meta=request_meta_data)
                             else:
                                 tool_result = await session.call_tool(name=remote_name, arguments=arguments)
                         with create_span(

--- a/mcpgateway/services/tool_service.py
+++ b/mcpgateway/services/tool_service.py
@@ -154,6 +154,8 @@ def _get_tool_lookup_cache():
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
+_W3C_TRACEPARENT_RE = re.compile(r"^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$")
+
 
 def _extract_tenant_id_from_payload(team_id: Any) -> Optional[str]:
     """Extract a valid tenant id from a raw tool payload team_id value.
@@ -189,6 +191,20 @@ def _apply_tool_payload_to_global_context(
         global_context.tenant_id = payload_tenant_id
 
 
+def _is_valid_w3c_traceparent(traceparent: str) -> bool:
+    """Return whether a traceparent value is safe to propagate into MCP _meta."""
+    match = _W3C_TRACEPARENT_RE.fullmatch(traceparent)
+    if not match:
+        return False
+
+    version, trace_id, span_id, _trace_flags = match.groups()
+    if version != "00":
+        return False
+    if trace_id == "0" * 32 or span_id == "0" * 16:
+        return False
+    return True
+
+
 def _sync_meta_traceparent(
     meta_data: Optional[Dict[str, Any]],
     request_headers: Mapping[str, str],
@@ -201,6 +217,8 @@ def _sync_meta_traceparent(
                 traceparent = value
                 break
     if not traceparent:
+        return meta_data
+    if not _is_valid_w3c_traceparent(traceparent):
         return meta_data
 
     updated_meta = dict(meta_data or {})

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -77,6 +77,36 @@ def test_sync_meta_traceparent_updates_existing_value_from_outbound_header():
     assert meta["traceparent"] == "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"
 
 
+def test_sync_meta_traceparent_none_meta_returns_none_when_no_traceparent():
+    assert _sync_meta_traceparent(None, {"Authorization": "Bearer token"}) is None
+
+
+def test_sync_meta_traceparent_empty_headers_returns_original_meta():
+    meta = {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01", "existing": True}
+
+    result = _sync_meta_traceparent(meta, {})
+
+    assert result is meta
+
+
+def test_sync_meta_traceparent_case_insensitive_fallback():
+    meta = {"existing": True}
+    headers = {"Traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01"}
+
+    result = _sync_meta_traceparent(meta, headers)
+
+    assert result == {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01", "existing": True}
+    assert "traceparent" not in meta
+
+
+def test_sync_meta_traceparent_empty_value_returns_original_meta():
+    meta = {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": ""})
+
+    assert result is meta
+
+
 @pytest.fixture(autouse=True)
 def mock_logging_services():
     """Mock audit_trail and structured_logger to prevent database writes during tests."""
@@ -8430,6 +8460,66 @@ class TestInvokeToolDirect:
 
         assert result == expected_result
         session_mock.call_tool.assert_awaited_once_with(name="remote_tool", arguments={"arg": "val"}, meta=meta_data)
+
+    @pytest.mark.asyncio
+    async def test_invoke_tool_direct_syncs_meta_traceparent(self, tool_service, mock_direct_gateway):
+        """Direct remote calls should send matching traceparent values in headers and _meta."""
+        expected_result = MagicMock()
+        meta_data = {
+            "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01",
+            "request_id": "abc-123",
+        }
+        captured_headers = {}
+
+        session_mock = AsyncMock()
+        session_mock.call_tool = AsyncMock(return_value=expected_result)
+
+        client_session_cm = AsyncMock()
+        client_session_cm.__aenter__.return_value = session_mock
+        client_session_cm.__aexit__.return_value = AsyncMock()
+
+        def inject_headers(headers):
+            traced = dict(headers)
+            traced["traceparent"] = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01"
+            return traced
+
+        @asynccontextmanager
+        async def mock_streamable_client(*_args, **kwargs):
+            captured_headers.update(kwargs["headers"])
+            yield ("read", "write", None)
+
+        with (
+            patch("mcpgateway.services.tool_service.fresh_db_session", self._make_fresh_db_session(mock_direct_gateway)),
+            patch("mcpgateway.services.tool_service.settings") as mock_settings,
+            patch("mcpgateway.services.tool_service.check_gateway_access", new_callable=AsyncMock, return_value=True),
+            patch("mcpgateway.services.tool_service.build_gateway_auth_headers", return_value={}),
+            patch("mcpgateway.services.tool_service.inject_trace_context_headers", side_effect=inject_headers),
+            patch("mcpgateway.services.tool_service.streamablehttp_client", mock_streamable_client),
+            patch("mcpgateway.services.tool_service.ClientSession", return_value=client_session_cm),
+        ):
+            mock_settings.mcpgateway_direct_proxy_enabled = True
+            mock_settings.mcpgateway_direct_proxy_timeout = 30
+
+            result = await tool_service.invoke_tool_direct(
+                gateway_id="gw-direct-1",
+                name="remote_tool",
+                arguments={"arg": "val"},
+                meta_data=meta_data,
+                user_email="user@example.com",
+                token_teams=["team-1"],
+            )
+
+        assert result == expected_result
+        assert captured_headers["traceparent"] == "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01"
+        session_mock.call_tool.assert_awaited_once_with(
+            name="remote_tool",
+            arguments={"arg": "val"},
+            meta={
+                "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01",
+                "request_id": "abc-123",
+            },
+        )
+        assert meta_data["traceparent"] == "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"
 
     @pytest.mark.asyncio
     async def test_invoke_tool_direct_gateway_not_found(self, tool_service):

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -42,6 +42,7 @@ from mcpgateway.services.tool_service import (
     _get_validator_class_and_check,
     _is_sensitive_tool_header_name,
     _protect_tool_headers_for_storage,
+    _sync_meta_traceparent,
     _validate_header_mapping_targets,
     _validate_mapping_contents,
     apply_mapping_into_target,
@@ -61,6 +62,19 @@ from mcpgateway.utils.services_auth import encode_auth
 
 # Local
 from tests.helpers.admin_mocks import install_admin_user
+
+
+def test_sync_meta_traceparent_updates_existing_value_from_outbound_header():
+    meta = {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01", "existing": True}
+    headers = {
+        "Traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2222222222222222-01",
+        "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-3333333333333333-01",
+    }
+
+    result = _sync_meta_traceparent(meta, headers)
+
+    assert result == {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-3333333333333333-01", "existing": True}
+    assert meta["traceparent"] == "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"
 
 
 @pytest.fixture(autouse=True)
@@ -2973,6 +2987,11 @@ class TestToolService:
         async def mock_sse_client(*_args, **_kwargs):
             yield ("read", "write")
 
+        def inject_headers(headers):
+            traced = dict(headers)
+            traced["traceparent"] = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-3333333333333333-01"
+            return traced
+
         headers_token = request_headers_var.set({"mcp-session-id": "downstream-sse"})
         try:
             with (
@@ -2980,14 +2999,25 @@ class TestToolService:
                 patch("mcpgateway.services.tool_service.ClientSession", return_value=client_session_cm),
                 patch("mcpgateway.services.tool_service.decode_auth", return_value={"Authorization": "Bearer xyz"}),
                 patch("mcpgateway.services.tool_service.extract_using_jq", side_effect=lambda data, _filt: data),
+                patch("mcpgateway.services.tool_service.inject_trace_context_headers", side_effect=inject_headers),
                 patch("mcpgateway.services.tool_service.get_upstream_session_registry", side_effect=RegistryNotInitializedError("not init")),
             ):
-                result = await tool_service.invoke_tool(test_db, "dummy_tool", {"p": "v"}, request_headers=None)
+                result = await tool_service.invoke_tool(
+                    test_db,
+                    "dummy_tool",
+                    {"p": "v"},
+                    request_headers=None,
+                    meta_data={"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"},
+                )
         finally:
             request_headers_var.reset(headers_token)
 
         session_mock.initialize.assert_awaited_once()
-        session_mock.call_tool.assert_awaited_once_with("dummy_tool", {"p": "v"}, meta=None)
+        session_mock.call_tool.assert_awaited_once_with(
+            "dummy_tool",
+            {"p": "v"},
+            meta={"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-3333333333333333-01"},
+        )
         assert result.content[0].text == "sse fallback ok"
 
     @pytest.mark.asyncio
@@ -3078,11 +3108,21 @@ class TestToolService:
             mock_settings.default_passthrough_headers = []
             mock_settings.tool_timeout = 60
 
-            result = await tool_service.invoke_tool(test_db, "dummy_tool", {"param": "value"}, request_headers=None)
+            result = await tool_service.invoke_tool(
+                test_db,
+                "dummy_tool",
+                {"param": "value"},
+                request_headers=None,
+                meta_data={"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01", "source": "api-server-runs"},
+            )
 
         assert result.content[0].text == "MCP response"
-        assert captured_headers["traceparent"].startswith("00-")
+        assert captured_headers["traceparent"] == "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
         assert captured_headers["X-Correlation-ID"] == "corr-123"
+        assert session_mock.call_tool.await_args.kwargs["meta"] == {
+            "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+            "source": "api-server-runs",
+        }
         assert span_names[:3] == ["tool.invoke", "mcp.client.call", "mcp.client.initialize"]
         assert "mcp.client.request" in span_names
         assert "mcp.client.response" in span_names

--- a/tests/unit/mcpgateway/services/test_tool_service.py
+++ b/tests/unit/mcpgateway/services/test_tool_service.py
@@ -107,6 +107,51 @@ def test_sync_meta_traceparent_empty_value_returns_original_meta():
     assert result is meta
 
 
+def test_sync_meta_traceparent_malformed_header_returns_original_meta():
+    meta = {"existing": True}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": "not-a-real-traceparent"})
+
+    assert result is meta
+    assert "traceparent" not in meta
+
+
+def test_sync_meta_traceparent_rejects_zero_trace_id():
+    meta = {"existing": True}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": "00-00000000000000000000000000000000-1111111111111111-01"})
+
+    assert result is meta
+    assert "traceparent" not in meta
+
+
+def test_sync_meta_traceparent_rejects_zero_span_id():
+    meta = {"existing": True}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-0000000000000000-01"})
+
+    assert result is meta
+    assert "traceparent" not in meta
+
+
+def test_sync_meta_traceparent_rejects_unsupported_version():
+    meta = {"existing": True}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": "01-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1111111111111111-01"})
+
+    assert result is meta
+    assert "traceparent" not in meta
+
+
+def test_sync_meta_traceparent_rejects_uppercase_header_value():
+    meta = {"existing": True}
+
+    result = _sync_meta_traceparent(meta, {"traceparent": "00-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-1111111111111111-01"})
+
+    assert result is meta
+    assert "traceparent" not in meta
+
+
 @pytest.fixture(autouse=True)
 def mock_logging_services():
     """Mock audit_trail and structured_logger to prevent database writes during tests."""


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

N/A - issue number not provided.

---

## 📝 Summary

Fixes trace context propagation for remote MCP tool calls by syncing `_meta.traceparent` with the final outbound `traceparent` header after MCP Gateway injects the active client span context.

Previously, the outbound header correctly used the MCP Gateway client span id, but `_meta.traceparent` could still contain the older span id received from api-server-runs. Remote MCP tool servers therefore saw the same trace id with different span ids in headers vs `_meta`.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Targeted unit tests       | `pytest tests/unit/mcpgateway/services/test_tool_service.py::test_sync_meta_traceparent_updates_existing_value_from_outbound_header tests/unit/mcpgateway/services/test_tool_service.py::TestToolService::test_invoke_tool_sse_falls_back_when_registry_not_initialized tests/unit/mcpgateway/services/test_tool_service.py::TestToolService::test_invoke_tool_mcp_streamablehttp_creates_client_lifecycle_spans -q` | Passed |
| Whitespace check          | `git diff --check` | Passed |
| Pre-commit               | `make pre-commit` | Passed |
| Full requested suite      | `make doctest test lint-web interrogate pylint verify` | Failed only in `verify`: package manifest check reported generated UI assets not tracked in VCS (`mcpgateway/static/bundle-XuLqEPyt.js`, `mcpgateway/static/css/tailwind.min.css`). Earlier phases reached successful doctest, test, interrogate, and pylint output. |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The implementation intentionally copies `_meta` before updating `traceparent`, so callers do not observe mutation of their original metadata dictionary. Existing `_meta` keys such as tenant/agent context are preserved.
