### PR TITLE
ci: exclude s390x/ppc64le from merge queue gate

### DIFF
--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -139,7 +139,14 @@ jobs:
   # s390x/ppc64le runners in the merge queue critical path.
   # ---------------------------------------------------------------
   wheels:
+    # `matrix.suffix != ''` is always true (both arches are non-empty). Its only
+    # purpose is to reference matrix context in the job-level `if`, forcing GitHub
+    # to expand the matrix even when the job is skipped. Without a matrix reference
+    # here, a skipped matrix job collapses to a single check that renders the raw
+    # name template ("Build wheels (${{ matrix.suffix }})"). Forcing expansion lets
+    # each per-arch skipped check render its interpolated name instead.
     if: >-
+      matrix.suffix != '' &&
       github.event_name != 'pull_request' &&
       github.event_name != 'merge_group' &&
       needs.docker-inputs.outputs.changed == 'true'

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -139,14 +139,7 @@ jobs:
   # s390x/ppc64le runners in the merge queue critical path.
   # ---------------------------------------------------------------
   wheels:
-    # `matrix.suffix != ''` is always true (both arches are non-empty). Its only
-    # purpose is to reference matrix context in the job-level `if`, forcing GitHub
-    # to expand the matrix even when the job is skipped. Without a matrix reference
-    # here, a skipped matrix job collapses to a single check that renders the raw
-    # name template ("Build wheels (${{ matrix.suffix }})"). Forcing expansion lets
-    # each per-arch skipped check render its interpolated name instead.
     if: >-
-      matrix.suffix != '' &&
       github.event_name != 'pull_request' &&
       github.event_name != 'merge_group' &&
       needs.docker-inputs.outputs.changed == 'true'

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -3,13 +3,18 @@
 # ===============================================================
 #
 # This workflow builds container images for multiple architectures:
-#   - linux/amd64 (native on ubuntu-24.04) - PR (build only), merge queue (build only), push
-#   - linux/arm64 (native on ubuntu-24.04-arm) - merge queue (build only), push
-#   - linux/s390x (native on ubuntu-24.04-s390x) - merge queue (build only), push
-#   - linux/ppc64le (native on ubuntu-24.04-ppc64le) - merge queue (build only), push
+#   - linux/amd64  (native on ubuntu-24.04)        - PR (build only), merge queue (build only), push
+#   - linux/arm64  (native on ubuntu-24.04-arm)     - merge queue (build only), push
+#   - linux/s390x  (native on ubuntu-24.04-s390x)   - push and workflow_dispatch only (NOT merge queue)
+#   - linux/ppc64le (native on ubuntu-24.04-ppc64le) - push and workflow_dispatch only (NOT merge queue)
+#
+# s390x and ppc64le are excluded from the merge queue to avoid stalling it while
+# waiting for scarce native runner pools. A per-entry gate step skips their build
+# steps when the event is merge_group. They still build and push on every push to
+# main and on workflow_dispatch, so the multiplatform manifest is always complete.
 #
 # Pipeline:
-#   1. Build platform images in parallel (amd64 on PR; all arches on merge queue + push)
+#   1. Build platform images in parallel (amd64+arm64 on merge queue; all arches on push)
 #   2. Create multiplatform manifest (push and tags only)
 #   3. Sign and attest with Cosign (keyless OIDC, push and tags only)
 #
@@ -129,12 +134,14 @@ jobs:
   # closure — Containerfile.lite always resolves via PyPI for those arches.
   # s390x/ppc64le wheels are content-addressed by sha256(uv.lock) and the
   # build is idempotent (skipped when the lock-hash tag already exists).
-  # Rides the same non-PR events as the platform builds below
-  # (push/merge_group/workflow_dispatch).
+  # Rides the same non-PR, non-merge-group events as the platform builds below
+  # (push/workflow_dispatch). Excluded from merge_group to avoid acquiring
+  # s390x/ppc64le runners in the merge queue critical path.
   # ---------------------------------------------------------------
   wheels:
     if: >-
       github.event_name != 'pull_request' &&
+      github.event_name != 'merge_group' &&
       needs.docker-inputs.outputs.changed == 'true'
     needs: docker-inputs
     name: Build wheels (${{ matrix.suffix }})
@@ -235,25 +242,29 @@ jobs:
             suffix: amd64
             cache_mode: max
             qemu: false
-            build_on_pr: true    # amd64 builds on PR, merge queue, and push
+            build_on_pr: true
+            build_on_merge_group: true
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             suffix: arm64
             cache_mode: max
             qemu: false
-            build_on_pr: false   # merge queue and push only
+            build_on_pr: false
+            build_on_merge_group: true
           - platform: linux/s390x
             runner: ubuntu-24.04-s390x
             suffix: s390x
             cache_mode: max
             qemu: false
-            build_on_pr: false   # merge queue and push only
+            build_on_pr: false
+            build_on_merge_group: false   # push and workflow_dispatch only — not merge queue
           - platform: linux/ppc64le
             runner: ubuntu-24.04-ppc64le
             suffix: ppc64le
             cache_mode: max
             qemu: false
-            build_on_pr: false   # merge queue and push only
+            build_on_pr: false
+            build_on_merge_group: false   # push and workflow_dispatch only — not merge queue
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
@@ -261,19 +272,37 @@ jobs:
       contents: read
       packages: write
 
-    # amd64: cache-only validation on PR and merge queue; full build+push on push
-    # arm64/s390x/ppc64le: cache-only validation on merge queue; full build+push on push
-    # Condition for build steps: always except PRs skip non-amd64 (build_on_pr)
-    # Condition for push-only steps (login, digest): push/workflow_dispatch only
+    # amd64: cache-only on PR and merge queue; full build+push on push
+    # arm64: cache-only on merge queue; full build+push on push
+    # s390x/ppc64le: all steps skipped on PR and merge queue; full build+push on push
+    #
+    # The `gate` step evaluates build_on_pr and build_on_merge_group for this
+    # matrix entry and sets outputs.build = 'true'/'false'. All subsequent steps
+    # use `if: steps.gate.outputs.build == 'true'` instead of repeating the logic.
     steps:
+      - name: Evaluate build gate
+        id: gate
+        run: |
+          set -euo pipefail
+          build="true"
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.build_on_pr }}" != "true" ]]; then
+            echo "Skipping ${{ matrix.suffix }}: build_on_pr=false"
+            build="false"
+          fi
+          if [[ "${{ github.event_name }}" == "merge_group" && "${{ matrix.build_on_merge_group }}" != "true" ]]; then
+            echo "Skipping ${{ matrix.suffix }}: build_on_merge_group=false"
+            build="false"
+          fi
+          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+
       - name: Checkout code
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
       - name: Set image name lowercase
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         run: |
           IMAGE_NAME_LC=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           echo "IMAGE_NAME_LC=${IMAGE_NAME_LC}" >> "${GITHUB_ENV}"
@@ -281,13 +310,13 @@ jobs:
       # QEMU is not currently triggered (native runners are used for all platforms)
       # but is retained so it can be re-enabled via matrix.qemu if needed.
       - name: Set up QEMU
-        if: matrix.qemu && (github.event_name != 'pull_request' || matrix.build_on_pr)
+        if: matrix.qemu && steps.gate.outputs.build == 'true'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: ${{ matrix.platform }}
 
       - name: Set up Docker Buildx
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           version: latest
@@ -295,7 +324,7 @@ jobs:
       # Login is needed both for pushing the final image (push/workflow_dispatch)
       # and for probing the wheel-image registry below.
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -310,7 +339,7 @@ jobs:
       #   published yet; fall back to UBI_MINIMAL if neither exists (first-ever
       #   run before any wheel image has been published for this arch).
       - name: Compute wheel image ref
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         run: |
           UBI_MINIMAL_DEFAULT=$(grep -m1 '^ARG UBI_MINIMAL=' Containerfile.lite | cut -d= -f2-)
           if [[ "${{ matrix.suffix }}" == "s390x" || "${{ matrix.suffix }}" == "ppc64le" ]]; then
@@ -334,7 +363,7 @@ jobs:
           fi
 
       - name: Extract metadata
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
@@ -343,7 +372,7 @@ jobs:
             type=raw,value=${{ matrix.suffix }}-${{ github.sha }}
 
       - name: Build and push
-        if: github.event_name != 'pull_request' || matrix.build_on_pr
+        if: steps.gate.outputs.build == 'true'
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:

--- a/.github/workflows/docker-multiplatform.yml
+++ b/.github/workflows/docker-multiplatform.yml
@@ -266,7 +266,10 @@ jobs:
             build_on_pr: false
             build_on_merge_group: false   # push and workflow_dispatch only — not merge queue
 
-    runs-on: ${{ matrix.runner }}
+    # Use a cheap ubuntu-24.04 runner when this matrix entry's gate would skip all
+    # work steps anyway (merge_group or PR with build_on_merge_group/build_on_pr=false).
+    # This avoids acquiring scarce s390x/ppc64le native runner slots for no-op jobs.
+    runs-on: ${{ (github.event_name == 'merge_group' && matrix.build_on_merge_group != true || github.event_name == 'pull_request' && matrix.build_on_pr != true) && 'ubuntu-24.04' || matrix.runner }}
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
## 🔗 Related Issue

Closes [#388](https://github.ibm.com/contextforge-org/internal_issues/issues/388)

---

## 📝 Summary

The `ubuntu-24.04-s390x` and `ubuntu-24.04-ppc64le` native runner pools are scarce. Both the `wheels` job (pre-builds C/Rust extension wheels) and the `build` job were acquiring these runners in the merge queue critical path, stalling PRs for ~60 minutes waiting for queue slots plus build time.

This PR excludes s390x and ppc64le from the merge queue without affecting any other event:

- **`wheels` job**: adds `github.event_name != 'merge_group'` to its `if` condition — s390x/ppc64le runners are not acquired during merge queue checks.
- **`build` matrix**: adds a `build_on_merge_group: false` flag to the s390x and ppc64le entries. A new `gate` step (first step in the `build` job) evaluates this flag and sets `outputs.build = 'true'/'false'`. All subsequent build steps use `if: steps.gate.outputs.build == 'true'`.

**What is unchanged:**
- s390x and ppc64le still build and push on every `push` to `main` and on `workflow_dispatch` — the multiplatform manifest and `latest` tag are unaffected.
- amd64 and arm64 continue to gate the merge queue exactly as before.
- The `build-complete` fan-in job is untouched. When s390x/ppc64le skip their work steps on `merge_group`, the matrix entry still exits as `success` (the gate step itself runs and exits 0), so `needs.build.result == 'success'` holds.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

This is a pure CI workflow change — there is no application code to lint, test, or cover.

| Check | Command | Status |
|---|---|---|
| YAML valid | `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker-multiplatform.yml'))"` | ✅ |
| Lint suite | `make lint` | N/A — no source changes |
| Unit tests | `make test` | N/A — no source changes |
| Coverage ≥ 80% | `make coverage` | N/A — no source changes |

**Behavioral verification** (to be confirmed after this PR triggers CI):

1. On the **merge queue run for this PR**: confirm the `build` job matrix shows s390x and ppc64le completing immediately (gate step logs `Skipping s390x: build_on_merge_group=false`) and `build-complete` passes.
2. On a **push to main** (after merge): confirm all four architectures build and push, and the multiplatform manifest includes all four digests.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`) — N/A, workflow YAML only
- [x] Tests added/updated for changes — N/A, CI-only change
- [x] Documentation updated (if applicable) — header comment in the workflow updated
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Why not nightly-only for s390x/ppc64le?**
Nightly-only would make `latest` stale by up to 24 hours after every push to `main`. The chosen approach — skip on `merge_group` only, keep on `push` — means `latest` is updated on every merge exactly as today.

**Gate step design:**
The gate step always runs (no `if` on the step itself) and always exits 0. This ensures the matrix job is never left in a `failure` or `skipped` state from the gate alone — only a real build failure will fail the job. `build-complete` relies on `needs.build.result == 'success'`, which this design preserves.
