### PR TITLE
ci: add Slack notifications for merge queue ejection and direct merges

### DIFF
--- a/.github/workflows/notify-slack-direct-merge.yml
+++ b/.github/workflows/notify-slack-direct-merge.yml
@@ -1,0 +1,86 @@
+# ======================================================================
+# Notify Slack on Direct Merge to Main (Merge Queue Bypass)
+# ======================================================================
+#
+# Fires when a PR is merged directly to main by a human without going
+# through the merge queue. Normal queue-based merges are performed by
+# github-merge-queue[bot] (type: Bot) and are intentionally excluded.
+#
+# Notification includes:
+#   - PR number, title, and direct link
+#   - PR author
+#   - Who bypassed the queue and merged it directly
+#
+# Required secret (repo Settings → Secrets and variables → Actions):
+#   SLACK_MERGE_NOTIFICATION_WEBHOOK_URL — Incoming Webhook URL for #contextforge-merge-notifications
+#
+# workflow_dispatch lets you manually trigger this workflow from any branch
+# to verify the Slack integration (secret + action) works end-to-end.
+#
+# ======================================================================
+
+name: Notify Slack on Direct Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+# Each merged PR is unique — never cancel a notification in flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Send Slack direct-merge notification
+    # Fire only when a human merges directly (not github-merge-queue[bot]).
+    # Always run on manual dispatch for testing.
+    if: >
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.merged_by.type != 'Bot') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Build Slack payload
+        id: payload
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || 'N/A' }}
+          PR_TITLE:  ${{ github.event.pull_request.title  || 'Manual test dispatch' }}
+          PR_URL:    ${{ github.event.pull_request.html_url || format('{0}/{1}/pulls', github.server_url, github.repository) }}
+          PR_AUTHOR:  ${{ github.event.pull_request.user.login      || github.actor }}
+          MERGED_BY:  ${{ github.event.pull_request.merged_by.login || github.actor }}
+          BASE_REF:   ${{ github.event.pull_request.base.ref || 'main' }}
+        run: |
+          SLACK_SUMMARY=":rotating_light: *PR #${PR_NUMBER} merged directly to \`${BASE_REF}\` (bypassed merge queue)*"
+          SLACK_BODY=":rotating_light: *PR merged directly to \`${BASE_REF}\` (bypassed merge queue)*
+• *PR:* <${PR_URL}|#${PR_NUMBER}: ${PR_TITLE}>
+• *Author:* \`${PR_AUTHOR}\`
+• *Merged by:* \`${MERGED_BY}\`"
+
+          PAYLOAD=$(jq -n \
+            --arg text "$SLACK_SUMMARY" \
+            --arg body "$SLACK_BODY" \
+            '{text: $text, blocks: [{type: "section", text: {type: "mrkdwn", text: $body}}]}')
+
+          {
+            echo "payload<<PAYLOAD_EOF"
+            echo "$PAYLOAD"
+            echo "PAYLOAD_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_MERGE_NOTIFICATION_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: ${{ steps.payload.outputs.payload }}

--- a/.github/workflows/notify-slack-direct-merge.yml
+++ b/.github/workflows/notify-slack-direct-merge.yml
@@ -61,11 +61,10 @@ jobs:
           MERGED_BY:  ${{ github.event.pull_request.merged_by.login || github.actor }}
           BASE_REF:   ${{ github.event.pull_request.base.ref || 'main' }}
         run: |
-          SLACK_SUMMARY=":rotating_light: *PR #${PR_NUMBER} merged directly to \`${BASE_REF}\` (bypassed merge queue)*"
-          SLACK_BODY=":rotating_light: *PR merged directly to \`${BASE_REF}\` (bypassed merge queue)*
-• *PR:* <${PR_URL}|#${PR_NUMBER}: ${PR_TITLE}>
-• *Author:* \`${PR_AUTHOR}\`
-• *Merged by:* \`${MERGED_BY}\`"
+          SLACK_SUMMARY=$(printf ':rotating_light: *PR #%s merged directly to `%s` (bypassed merge queue)*' \
+            "$PR_NUMBER" "$BASE_REF")
+          SLACK_BODY=$(printf ':rotating_light: *PR merged directly to `%s` (bypassed merge queue)*\n• *PR:* <%s|#%s: %s>\n• *Author:* `%s`\n• *Merged by:* `%s`' \
+            "$BASE_REF" "$PR_URL" "$PR_NUMBER" "$PR_TITLE" "$PR_AUTHOR" "$MERGED_BY")
 
           PAYLOAD=$(jq -n \
             --arg text "$SLACK_SUMMARY" \

--- a/.github/workflows/notify-slack-merge-queue-ejection.yml
+++ b/.github/workflows/notify-slack-merge-queue-ejection.yml
@@ -82,12 +82,9 @@ jobs:
             *)           REASON_TEXT="ejected (reason: ${REASON:-test dispatch})" ;;
           esac
 
-          SLACK_SUMMARY=":warning: *PR #${PR_NUM} ejected from merge queue*"
-          SLACK_BODY=":warning: *PR ejected from merge queue*
-• *PR:* <${PR_URL}|#${PR_NUM}: ${PR_TITLE}>
-• *Author:* \`${PR_AUTHOR}\`
-• *Reason:* ${REASON_TEXT}
-• *Base branch:* \`${BASE_REF}\`"
+          SLACK_SUMMARY=$(printf ':warning: *PR #%s ejected from merge queue*' "$PR_NUM")
+          SLACK_BODY=$(printf ':warning: *PR ejected from merge queue*\n• *PR:* <%s|#%s: %s>\n• *Author:* `%s`\n• *Reason:* %s\n• *Base branch:* `%s`' \
+            "$PR_URL" "$PR_NUM" "$PR_TITLE" "$PR_AUTHOR" "$REASON_TEXT" "$BASE_REF")
 
           PAYLOAD=$(jq -n \
             --arg text "$SLACK_SUMMARY" \

--- a/.github/workflows/notify-slack-merge-queue-ejection.yml
+++ b/.github/workflows/notify-slack-merge-queue-ejection.yml
@@ -1,0 +1,108 @@
+# ======================================================================
+# Notify Slack on Merge Queue Ejection
+# ======================================================================
+#
+# Fires whenever the merge queue destroys a merge group for any reason
+# other than a successful merge, and sends a Slack notification to
+# #contextforge-merge-queue-alerts with:
+#   - PR number, title, and direct link
+#   - PR author
+#   - Ejection reason:
+#       • "manually removed by <user>"  (reason: dequeued)
+#       • "auto-ejected (checks failed or base branch updated)"  (reason: invalidated)
+#
+# Required secret (repo Settings → Secrets and variables → Actions):
+#   SLACK_MERGE_NOTIFICATION_WEBHOOK_URL — Incoming Webhook URL for #contextforge-merge-notifications
+#
+# workflow_dispatch lets you manually trigger this workflow from any branch
+# to verify the Slack integration (secret + action) works end-to-end.
+#
+# ======================================================================
+
+name: Notify Slack on Merge Queue Ejection
+
+on:
+  merge_group:
+    types: [destroyed]
+  workflow_dispatch:
+
+# Each ejection event is unique — never cancel a notification in flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.merge_group.head_sha || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Send Slack merge queue ejection notification
+    # Skip successful merges; always run on manual dispatch for testing.
+    if: github.event.reason != 'merged' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Gather PR info and build Slack payload
+        id: info
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          REASON: ${{ github.event.reason }}
+          SENDER: ${{ github.event.sender.login }}
+          BASE_REF: ${{ github.event.merge_group.base_ref || 'main' }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          # Extract PR number from head_ref (e.g. gh-readonly-queue/main/pr-123-abcdef)
+          PR_NUM=$(echo "$HEAD_REF" | grep -oP 'pr-\K\d+' || true)
+
+          if [[ -n "$PR_NUM" ]]; then
+            PR_DATA=$(gh api "repos/${REPO}/pulls/${PR_NUM}")
+            PR_TITLE=$(echo "$PR_DATA"  | jq -r '.title')
+            PR_URL=$(echo "$PR_DATA"    | jq -r '.html_url')
+            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
+          else
+            # workflow_dispatch fallback — no real merge group context
+            PR_NUM="N/A"
+            PR_TITLE="Manual test dispatch"
+            PR_URL="${SERVER_URL}/${REPO}/pulls"
+            PR_AUTHOR="${ACTOR}"
+          fi
+
+          case "$REASON" in
+            dequeued)    REASON_TEXT="manually removed by \`${SENDER}\`" ;;
+            invalidated) REASON_TEXT="auto-ejected (checks failed or base branch updated)" ;;
+            *)           REASON_TEXT="ejected (reason: ${REASON:-test dispatch})" ;;
+          esac
+
+          SLACK_SUMMARY=":warning: *PR #${PR_NUM} ejected from merge queue*"
+          SLACK_BODY=":warning: *PR ejected from merge queue*
+• *PR:* <${PR_URL}|#${PR_NUM}: ${PR_TITLE}>
+• *Author:* \`${PR_AUTHOR}\`
+• *Reason:* ${REASON_TEXT}
+• *Base branch:* \`${BASE_REF}\`"
+
+          PAYLOAD=$(jq -n \
+            --arg text "$SLACK_SUMMARY" \
+            --arg body "$SLACK_BODY" \
+            '{text: $text, blocks: [{type: "section", text: {type: "mrkdwn", text: $body}}]}')
+
+          {
+            echo "payload<<PAYLOAD_EOF"
+            echo "$PAYLOAD"
+            echo "PAYLOAD_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.SLACK_MERGE_NOTIFICATION_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: ${{ steps.info.outputs.payload }}

--- a/.github/workflows/notify-slack-merge-queue-ejection.yml
+++ b/.github/workflows/notify-slack-merge-queue-ejection.yml
@@ -2,14 +2,16 @@
 # Notify Slack on Merge Queue Ejection
 # ======================================================================
 #
-# Fires whenever the merge queue destroys a merge group for any reason
-# other than a successful merge, and sends a Slack notification to
-# #contextforge-merge-queue-alerts with:
+# Fires when a PR is removed from the merge queue without being merged,
+# and sends a Slack notification to #contextforge-merge-notifications with:
 #   - PR number, title, and direct link
 #   - PR author
-#   - Ejection reason:
-#       • "manually removed by <user>"  (reason: dequeued)
-#       • "auto-ejected (checks failed or base branch updated)"  (reason: invalidated)
+#   - Ejection reason inferred from the event sender:
+#       • "manually removed by <user>"  (sender.type == User)
+#       • "auto-ejected (checks failed or base branch updated)"  (sender.type == Bot)
+#
+# Note: the merge_group event only supports the checks_requested activity
+# type as a workflow trigger; ejection is detected via pull_request: dequeued.
 #
 # Required secret (repo Settings → Secrets and variables → Actions):
 #   SLACK_MERGE_NOTIFICATION_WEBHOOK_URL — Incoming Webhook URL for #contextforge-merge-notifications
@@ -22,69 +24,53 @@
 name: Notify Slack on Merge Queue Ejection
 
 on:
-  merge_group:
-    types: [destroyed]
+  pull_request:
+    types: [dequeued]
   workflow_dispatch:
 
 # Each ejection event is unique — never cancel a notification in flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.merge_group.head_sha || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   notify:
     name: Send Slack merge queue ejection notification
-    # Skip successful merges; always run on manual dispatch for testing.
-    if: github.event.reason != 'merged' || github.event_name == 'workflow_dispatch'
+    # Safety filter: skip if the PR was somehow already merged.
+    # Always run on manual dispatch for testing.
+    if: github.event.pull_request.merged != true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     permissions:
       contents: read
-      pull-requests: read
 
     steps:
-      - name: Gather PR info and build Slack payload
-        id: info
+      - name: Build Slack payload
+        id: payload
         env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.merge_group.head_ref }}
-          REASON: ${{ github.event.reason }}
-          SENDER: ${{ github.event.sender.login }}
-          BASE_REF: ${{ github.event.merge_group.base_ref || 'main' }}
-          REPO: ${{ github.repository }}
-          SERVER_URL: ${{ github.server_url }}
-          ACTOR: ${{ github.actor }}
+          PR_NUMBER:    ${{ github.event.pull_request.number   || 'N/A' }}
+          PR_TITLE:     ${{ github.event.pull_request.title    || 'Manual test dispatch' }}
+          PR_URL:       ${{ github.event.pull_request.html_url || format('{0}/{1}/pulls', github.server_url, github.repository) }}
+          PR_AUTHOR:    ${{ github.event.pull_request.user.login || github.actor }}
+          BASE_REF:     ${{ github.event.pull_request.base.ref  || 'main' }}
+          SENDER_TYPE:  ${{ github.event.sender.type }}
+          SENDER_LOGIN: ${{ github.event.sender.login || github.actor }}
         run: |
-          # Extract PR number from head_ref (e.g. gh-readonly-queue/main/pr-123-abcdef)
-          PR_NUM=$(echo "$HEAD_REF" | grep -oP 'pr-\K\d+' || true)
-
-          if [[ -n "$PR_NUM" ]]; then
-            PR_DATA=$(gh api "repos/${REPO}/pulls/${PR_NUM}")
-            PR_TITLE=$(echo "$PR_DATA"  | jq -r '.title')
-            PR_URL=$(echo "$PR_DATA"    | jq -r '.html_url')
-            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.user.login')
+          if [[ "$SENDER_TYPE" == "Bot" ]]; then
+            REASON_TEXT="auto-ejected (checks failed or base branch updated)"
+          elif [[ -n "$SENDER_TYPE" ]]; then
+            REASON_TEXT=$(printf 'manually removed by `%s`' "$SENDER_LOGIN")
           else
-            # workflow_dispatch fallback — no real merge group context
-            PR_NUM="N/A"
-            PR_TITLE="Manual test dispatch"
-            PR_URL="${SERVER_URL}/${REPO}/pulls"
-            PR_AUTHOR="${ACTOR}"
+            REASON_TEXT="ejected (test dispatch)"
           fi
 
-          case "$REASON" in
-            dequeued)    REASON_TEXT="manually removed by \`${SENDER}\`" ;;
-            invalidated) REASON_TEXT="auto-ejected (checks failed or base branch updated)" ;;
-            *)           REASON_TEXT="ejected (reason: ${REASON:-test dispatch})" ;;
-          esac
-
-          SLACK_SUMMARY=$(printf ':warning: *PR #%s ejected from merge queue*' "$PR_NUM")
+          SLACK_SUMMARY=$(printf ':warning: *PR #%s ejected from merge queue*' "$PR_NUMBER")
           SLACK_BODY=$(printf ':warning: *PR ejected from merge queue*\n• *PR:* <%s|#%s: %s>\n• *Author:* `%s`\n• *Reason:* %s\n• *Base branch:* `%s`' \
-            "$PR_URL" "$PR_NUM" "$PR_TITLE" "$PR_AUTHOR" "$REASON_TEXT" "$BASE_REF")
+            "$PR_URL" "$PR_NUMBER" "$PR_TITLE" "$PR_AUTHOR" "$REASON_TEXT" "$BASE_REF")
 
           PAYLOAD=$(jq -n \
             --arg text "$SLACK_SUMMARY" \
@@ -102,4 +88,4 @@ jobs:
         with:
           webhook: ${{ secrets.SLACK_MERGE_NOTIFICATION_WEBHOOK_URL }}
           webhook-type: incoming-webhook
-          payload: ${{ steps.info.outputs.payload }}
+          payload: ${{ steps.payload.outputs.payload }}


### PR DESCRIPTION
## 🔗 Related Issue

Closes [#390](https://github.ibm.com/contextforge-org/internal_issues/issues/390)

---

## 📝 Summary

Here's the updated summary section:

---

## 📝 Summary

Currently, when a PR is ejected from the merge queue or directly merged to `main` bypassing the queue, there is no visibility until someone manually inspects the PR. This PR adds two lightweight GitHub Actions workflows that send Slack notifications to `#contextforge-merge-notifications` for these events.

**notify-slack-merge-queue-ejection.yml**
Triggers on `pull_request: [dequeued]`, which fires when a PR exits the merge queue without being merged. Infers the ejection reason from `sender.type`:
- `Bot` → "auto-ejected (checks failed or base branch updated)"
- `User` → "manually removed by `<username>`" (includes who removed it)

All PR context (title, author, URL, base branch) comes directly from the event payload — no additional API call needed.

> Note: `merge_group` only exposes `checks_requested` as a workflow trigger type; `destroyed` exists as a webhook action but cannot trigger a workflow `on:` block. `pull_request: dequeued` is the correct and supported signal for queue exits.

**notify-slack-direct-merge.yml**
Triggers on `pull_request: [closed]` targeting `main`. Fires only when `merged_by.type != Bot`, which distinguishes a human bypassing the merge queue from a normal queue-based merge performed by `github-merge-queue[bot]`. Message includes PR title, author, and who merged it directly.

Both workflows use the `SLACK_MERGE_NOTIFICATION_WEBHOOK_URL` repo secret and include a `workflow_dispatch` trigger for end-to-end testing after merge without waiting for a real event.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

These are CI-only workflow files with no application code changes. Functional verification requires the `SLACK_MERGE_NOTIFICATION_WEBHOOK_URL` secret to be present in the repo (already added).

| Check | Command | Status |
|---|---|---|
| YAML lint | `make lint` (yamllint) | Passes — no YAML errors |
| Slack integration (ejection) | Actions → "Notify Slack on Merge Queue Ejection" → Run workflow | Verify message appears in `#contextforge-merge-notifications` after merge |
| Slack integration (direct merge) | Actions → "Notify Slack on Direct Merge to Main" → Run workflow | Verify message appears in `#contextforge-merge-notifications` after merge |
| Real ejection | Queue a PR with a failing check, let it auto-eject | `:warning: PR ejected` message with reason `auto-ejected` |
| Manual dequeue | Queue a PR and manually remove it | `:warning: PR ejected` message with reason `manually removed by <user>` |
| Direct merge bypass | Merge a PR directly to `main` without queuing | `:rotating_light: PR merged directly` message with merger's username |

> `make test` and `make coverage` are not applicable — no application code was changed.

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)
**Secret required:** `SLACK_MERGE_NOTIFICATION_WEBHOOK_URL` — Incoming Webhook URL for `#contextforge-merge-notifications`. Already added to repo secrets.