### PR TITLE
fix: Fix package verify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,6 +373,7 @@ ignore = [
     ".github/**",
     "Makefile",
     "mcpgateway/admin_ui/**",
+    "mcpgateway/static/bundle-*.js",
 ]
 
 [tool.black]


### PR DESCRIPTION
# 🐛 Bug-fix PR

## 📌 Summary

Closes https://github.com/IBM/mcp-context-forge/issues/5349

## 🔁 Reproduction Steps

Run `make verify`, see the failure cause

## 🐞 Root Cause

The JS bundle file is generated and added to the bundle, and the existing bundle on the local directory should not be included into the bundle.

## 💡 Fix Description

Add the JS bundle to the pypackage.toml ignore list.

## 📏 Reviewability

- [X] This PR has one clear purpose
- [X] The linked issue is not labeled `triage`
- [X] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

