### PR TITLE
Fix admin CSRF issuance for non-email platform-admin sessions by bind…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-06T11:55:26Z",
+  "generated_at": "2026-07-06T12:57:22Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5130,7 +5130,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11650,
+        "line_number": 11698,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5138,7 +5138,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 18067,
+        "line_number": 18115,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-03T16:11:43Z",
+  "generated_at": "2026-07-03T16:56:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5130,7 +5130,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11479,
+        "line_number": 11537,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5138,7 +5138,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17896,
+        "line_number": 17954,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-03T16:56:19Z",
+  "generated_at": "2026-07-06T11:55:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5130,7 +5130,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11537,
+        "line_number": 11650,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5138,7 +5138,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17954,
+        "line_number": 18067,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-06T10:05:31Z",
+  "generated_at": "2026-07-03T16:11:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -5130,7 +5130,7 @@
         "hashed_secret": "995e87a207ec41ef95f938dcf53a4184312b0d93",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 11423,
+        "line_number": 11479,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -5138,7 +5138,7 @@
         "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 17840,
+        "line_number": 17896,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -4171,13 +4171,36 @@ async def admin_ui(
 
         # get_current_user_with_permissions may not include auth_provider in its dict.
         # Fall back to the current jwt_token cookie payload before refreshing it,
-        # and preserve any explicit team narrowing from the verified token.
-        existing_token_teams: list[str] | None = None
+        # but only reuse cookie metadata after confirming it matches this user.
         existing_payload: dict[str, Any] | None = None
         jwt_cookie = request.cookies.get("jwt_token")
         if isinstance(jwt_cookie, str) and jwt_cookie:
             try:
                 existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
+            except Exception as provider_error:  # nosec B110 - best-effort provider preservation
+                LOGGER.warning("Could not verify existing JWT cookie for admin session refresh: %s", provider_error)
+                if settings.sso_keycloak_enabled:
+                    auth_provider = "keycloak"
+
+        # Generate a lightweight session JWT token for browser admin calls in every auth mode.
+        email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
+        sub_claim = str(email_user.id) if email_user else admin_email
+        existing_token_teams: list[str] | None = None
+        if isinstance(existing_payload, dict):
+            existing_user = existing_payload.get("user")
+            provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
+            if not provider_from_token:
+                provider_from_token = existing_payload.get("auth_provider")
+            if auth_provider == "local" and isinstance(provider_from_token, str) and provider_from_token.strip():
+                auth_provider = provider_from_token.strip()
+
+            existing_email = existing_payload.get("email")
+            if not existing_email and isinstance(existing_user, dict):
+                existing_email = existing_user.get("email")
+            existing_sub = existing_payload.get("sub")
+            cookie_matches_user = existing_email == admin_email or (isinstance(existing_sub, str) and existing_sub in {admin_email, sub_claim})
+
+            if cookie_matches_user:
                 raw_existing_teams = existing_payload.get("teams")
                 if isinstance(raw_existing_teams, list) and raw_existing_teams:
                     copied_teams: list[str] = []
@@ -4189,26 +4212,9 @@ async def admin_ui(
                     if copied_teams:
                         existing_token_teams = copied_teams
 
-                if auth_provider == "local":
-                    existing_user = existing_payload.get("user")
-                    provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
-                    if not provider_from_token:
-                        provider_from_token = existing_payload.get("auth_provider")
-                    if isinstance(provider_from_token, str) and provider_from_token.strip():
-                        auth_provider = provider_from_token.strip()
-            except Exception as provider_error:  # nosec B110 - best-effort provider preservation
-                LOGGER.warning("Could not resolve auth_provider or team scope from existing JWT cookie; SSO logout or scoped session refresh may not function correctly: %s", provider_error)
-                if auth_provider == "local" and settings.sso_keycloak_enabled:
-                    auth_provider = "keycloak"
-
-        # Generate a lightweight session JWT token for browser admin calls in every auth mode.
-        sub_claim = existing_payload.get("sub") if isinstance(existing_payload, dict) else None
-        if not sub_claim:
-            user_id = user.get("id") if isinstance(user, dict) else getattr(user, "id", None)
-            sub_claim = str(user_id) if user_id else admin_email
         now = datetime.now(timezone.utc)
         payload = {
-            "sub": str(sub_claim),
+            "sub": sub_claim,
             "iss": settings.jwt_issuer,
             "aud": settings.jwt_audience,
             "iat": int(now.timestamp()),

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -64,7 +64,7 @@ from mcpgateway import __version__
 from mcpgateway import version as version_module
 
 # Authentication and password-related imports
-from mcpgateway.auth import get_current_user, get_user_team_roles, normalize_token_teams
+from mcpgateway.auth import get_current_user, get_user_team_roles
 
 # Re-export canonical get_user_email from auth_context for backward compatibility.
 from mcpgateway.auth_context import get_scoped_resource_access_context, get_token_teams_from_request, get_user_email
@@ -4173,13 +4173,21 @@ async def admin_ui(
         # Fall back to the current jwt_token cookie payload before refreshing it,
         # and preserve any explicit team narrowing from the verified token.
         existing_token_teams: list[str] | None = None
+        existing_payload: dict[str, Any] | None = None
         jwt_cookie = request.cookies.get("jwt_token")
         if isinstance(jwt_cookie, str) and jwt_cookie:
             try:
                 existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
-                normalized_existing_teams = normalize_token_teams(existing_payload)
-                if isinstance(normalized_existing_teams, list) and normalized_existing_teams:
-                    existing_token_teams = normalized_existing_teams
+                raw_existing_teams = existing_payload.get("teams")
+                if isinstance(raw_existing_teams, list) and raw_existing_teams:
+                    copied_teams: list[str] = []
+                    for raw_team in raw_existing_teams:
+                        if isinstance(raw_team, str) and raw_team:
+                            copied_teams.append(raw_team)
+                        elif isinstance(raw_team, dict) and raw_team.get("id"):
+                            copied_teams.append(str(raw_team["id"]))
+                    if copied_teams:
+                        existing_token_teams = copied_teams
 
                 if auth_provider == "local":
                     existing_user = existing_payload.get("user")
@@ -4194,11 +4202,13 @@ async def admin_ui(
                     auth_provider = "keycloak"
 
         # Generate a lightweight session JWT token for browser admin calls in every auth mode.
-        email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
-        sub_claim = str(email_user.id) if email_user else admin_email
+        sub_claim = existing_payload.get("sub") if isinstance(existing_payload, dict) else None
+        if not sub_claim:
+            user_id = user.get("id") if isinstance(user, dict) else getattr(user, "id", None)
+            sub_claim = str(user_id) if user_id else admin_email
         now = datetime.now(timezone.utc)
         payload = {
-            "sub": sub_claim,
+            "sub": str(sub_claim),
             "iss": settings.jwt_issuer,
             "aud": settings.jwt_audience,
             "iat": int(now.timestamp()),
@@ -4220,7 +4230,8 @@ async def admin_ui(
         csrf_session_id = str(payload["jti"])
         LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
     except Exception as e:
-        LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
+        LOGGER.exception("Failed to initialize admin browser session for user %s", get_user_email(user))
+        raise HTTPException(status_code=500, detail="Unable to initialize admin session") from e
 
     cookie_action = ui_visibility_config.get("cookie_action")
     if cookie_action:

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -153,6 +153,7 @@ from mcpgateway.services.argon2_service import Argon2PasswordService
 from mcpgateway.services.audit_trail_service import get_audit_trail_service
 from mcpgateway.services.catalog_service import catalog_service
 from mcpgateway.services.content_security import ContentSizeError, ContentTypeError, TemplateValidationError
+from mcpgateway.services.csrf_service import get_csrf_service
 from mcpgateway.services.email_auth_service import AuthenticationError, EmailAuthService, PasswordValidationError
 from mcpgateway.services.encryption_service import get_encryption_service
 from mcpgateway.services.export_service import ExportError, ExportService
@@ -1657,18 +1658,23 @@ def _request_origin_matches(request: Request) -> bool:
     return False
 
 
-def _set_admin_csrf_cookie(request: Request, response: Response) -> str:
+def _set_admin_csrf_cookie(request: Request, response: Response, *, user_id: str | None = None, session_id: str | None = None) -> str:
     """Set or refresh admin CSRF cookie and return token value.
 
     Args:
         request: Incoming request used for existing token and path scoping.
         response: Outgoing response where the cookie will be written.
+        user_id: Optional authenticated user binding for HMAC CSRF tokens.
+        session_id: Optional JWT session binding for HMAC CSRF tokens.
 
     Returns:
         CSRF token value stored in the response cookie.
     """
-    existing_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
-    csrf_token = existing_token if isinstance(existing_token, str) and len(existing_token) >= 32 else secrets.token_urlsafe(32)
+    if user_id and session_id:
+        csrf_token = get_csrf_service().generate_csrf_token(user_id=user_id, session_id=session_id)
+    else:
+        existing_token = request.cookies.get(ADMIN_CSRF_COOKIE_NAME)
+        csrf_token = existing_token if isinstance(existing_token, str) and len(existing_token) >= 32 else secrets.token_urlsafe(32)
 
     use_secure = (settings.environment == "production") or settings.secure_cookies
     max_age = max(300, int(getattr(settings, "token_expiry", 60)) * 60)
@@ -4139,74 +4145,74 @@ async def admin_ui(
         },
     )
 
-    # Set JWT token cookie for HTMX requests if email auth is enabled
-    if getattr(settings, "email_auth_enabled", False):
-        try:
-            # JWT library is imported at top level as jwt
+    csrf_user_id: str | None = None
+    csrf_session_id: str | None = None
+    try:
+        # Determine the admin user email
+        admin_email = get_user_email(user)
+        is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else True)
+        full_name = getattr(settings, "platform_admin_full_name", "Platform User")
+        if isinstance(user, dict):
+            full_name = user.get("full_name") or full_name
+        else:
+            full_name = getattr(user, "full_name", full_name) or full_name
 
-            # Determine the admin user email
-            admin_email = get_user_email(user)
-            is_admin_flag = bool(user.get("is_admin") if isinstance(user, dict) else True)
-            full_name = getattr(settings, "platform_admin_full_name", "Platform User")
-            if isinstance(user, dict):
-                full_name = user.get("full_name") or full_name
-            else:
-                full_name = getattr(user, "full_name", full_name) or full_name
+        # Preserve auth provider across admin UI token refreshes so logout behavior
+        # can reliably detect SSO sessions (e.g., Keycloak) later.
+        auth_provider = "local"
+        if isinstance(user, dict):
+            provider_from_user = user.get("auth_provider")
+            if isinstance(provider_from_user, str) and provider_from_user.strip():
+                auth_provider = provider_from_user.strip()
+        else:
+            provider_from_user = getattr(user, "auth_provider", None)
+            if isinstance(provider_from_user, str) and provider_from_user.strip():
+                auth_provider = provider_from_user.strip()
 
-            # Preserve auth provider across admin UI token refreshes so logout behavior
-            # can reliably detect SSO sessions (e.g., Keycloak) later.
-            auth_provider = "local"
-            if isinstance(user, dict):
-                provider_from_user = user.get("auth_provider")
-                if isinstance(provider_from_user, str) and provider_from_user.strip():
-                    auth_provider = provider_from_user.strip()
-            else:
-                provider_from_user = getattr(user, "auth_provider", None)
-                if isinstance(provider_from_user, str) and provider_from_user.strip():
-                    auth_provider = provider_from_user.strip()
+        # get_current_user_with_permissions may not include auth_provider in its dict.
+        # Fall back to the current jwt_token cookie payload before refreshing it.
+        if auth_provider == "local":
+            jwt_cookie = request.cookies.get("jwt_token")
+            if isinstance(jwt_cookie, str) and jwt_cookie:
+                try:
+                    existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
+                    existing_user = existing_payload.get("user")
+                    provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
+                    if not provider_from_token:
+                        provider_from_token = existing_payload.get("auth_provider")
+                    if isinstance(provider_from_token, str) and provider_from_token.strip():
+                        auth_provider = provider_from_token.strip()
+                except Exception as provider_error:  # nosec B110 - best-effort provider preservation
+                    LOGGER.warning("Could not resolve auth_provider from existing JWT cookie; SSO logout may not function correctly: %s", provider_error)
+                    if settings.sso_keycloak_enabled:
+                        auth_provider = "keycloak"
 
-            # get_current_user_with_permissions may not include auth_provider in its dict.
-            # Fall back to the current jwt_token cookie payload before refreshing it.
-            if auth_provider == "local":
-                jwt_cookie = request.cookies.get("jwt_token")
-                if isinstance(jwt_cookie, str) and jwt_cookie:
-                    try:
-                        existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
-                        existing_user = existing_payload.get("user")
-                        provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
-                        if not provider_from_token:
-                            provider_from_token = existing_payload.get("auth_provider")
-                        if isinstance(provider_from_token, str) and provider_from_token.strip():
-                            auth_provider = provider_from_token.strip()
-                    except Exception as provider_error:  # nosec B110 - best-effort provider preservation
-                        LOGGER.warning("Could not resolve auth_provider from existing JWT cookie; SSO logout may not function correctly: %s", provider_error)
-                        if settings.sso_keycloak_enabled:
-                            auth_provider = "keycloak"
+        # Generate a lightweight session JWT token for browser admin calls in every auth mode.
+        email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
+        sub_claim = str(email_user.id) if email_user else admin_email
+        now = datetime.now(timezone.utc)
+        payload = {
+            "sub": sub_claim,
+            "iss": settings.jwt_issuer,
+            "aud": settings.jwt_audience,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(minutes=settings.token_expiry)).timestamp()),
+            "jti": str(uuid.uuid4()),
+            "auth_provider": auth_provider,
+            "token_use": "session",  # nosec B105 - token type marker, not a password
+            "scopes": {"server_id": None, "permissions": ["*"] if is_admin_flag else [], "ip_restrictions": [], "time_restrictions": {}},
+        }
 
-            # Generate a lightweight session JWT token
-            email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
-            sub_claim = str(email_user.id) if email_user else admin_email
-            now = datetime.now(timezone.utc)
-            payload = {
-                "sub": sub_claim,
-                "iss": settings.jwt_issuer,
-                "aud": settings.jwt_audience,
-                "iat": int(now.timestamp()),
-                "exp": int((now + timedelta(minutes=settings.token_expiry)).timestamp()),
-                "jti": str(uuid.uuid4()),
-                "auth_provider": auth_provider,
-                "token_use": "session",  # nosec B105 - token type marker, not a password
-                "scopes": {"server_id": None, "permissions": ["*"] if is_admin_flag else [], "ip_restrictions": [], "time_restrictions": {}},
-            }
+        # Generate token using centralized token creation
+        token = await create_jwt_token(payload)
 
-            # Generate token using centralized token creation
-            token = await create_jwt_token(payload)
-
-            # Set HTTP-only cookie using centralized security cookie utility
-            set_auth_cookie(response, token, remember_me=False)
-            LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
-        except Exception as e:
-            LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
+        # Set HTTP-only cookie using centralized security cookie utility
+        set_auth_cookie(response, token, remember_me=False)
+        csrf_user_id = str(payload["sub"])
+        csrf_session_id = str(payload["jti"])
+        LOGGER.debug(f"Set session JWT token cookie for user: {admin_email}")
+    except Exception as e:
+        LOGGER.warning(f"Failed to set JWT token cookie for user {user}: {e}")
 
     cookie_action = ui_visibility_config.get("cookie_action")
     if cookie_action:
@@ -4233,7 +4239,7 @@ async def admin_ui(
                 samesite=samesite,
             )
 
-    _set_admin_csrf_cookie(request, response)
+    _set_admin_csrf_cookie(request, response, user_id=csrf_user_id, session_id=csrf_session_id)
     return response
 
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -64,7 +64,7 @@ from mcpgateway import __version__
 from mcpgateway import version as version_module
 
 # Authentication and password-related imports
-from mcpgateway.auth import get_current_user, get_user_team_roles
+from mcpgateway.auth import get_current_user, get_user_team_roles, normalize_token_teams
 
 # Re-export canonical get_user_email from auth_context for backward compatibility.
 from mcpgateway.auth_context import get_scoped_resource_access_context, get_token_teams_from_request, get_user_email
@@ -4170,22 +4170,28 @@ async def admin_ui(
                 auth_provider = provider_from_user.strip()
 
         # get_current_user_with_permissions may not include auth_provider in its dict.
-        # Fall back to the current jwt_token cookie payload before refreshing it.
-        if auth_provider == "local":
-            jwt_cookie = request.cookies.get("jwt_token")
-            if isinstance(jwt_cookie, str) and jwt_cookie:
-                try:
-                    existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
+        # Fall back to the current jwt_token cookie payload before refreshing it,
+        # and preserve any explicit team narrowing from the verified token.
+        existing_token_teams: list[str] | None = None
+        jwt_cookie = request.cookies.get("jwt_token")
+        if isinstance(jwt_cookie, str) and jwt_cookie:
+            try:
+                existing_payload = await verify_jwt_token_cached(jwt_cookie, request)
+                normalized_existing_teams = normalize_token_teams(existing_payload)
+                if isinstance(normalized_existing_teams, list) and normalized_existing_teams:
+                    existing_token_teams = normalized_existing_teams
+
+                if auth_provider == "local":
                     existing_user = existing_payload.get("user")
                     provider_from_token = existing_user.get("auth_provider") if isinstance(existing_user, dict) else None
                     if not provider_from_token:
                         provider_from_token = existing_payload.get("auth_provider")
                     if isinstance(provider_from_token, str) and provider_from_token.strip():
                         auth_provider = provider_from_token.strip()
-                except Exception as provider_error:  # nosec B110 - best-effort provider preservation
-                    LOGGER.warning("Could not resolve auth_provider from existing JWT cookie; SSO logout may not function correctly: %s", provider_error)
-                    if settings.sso_keycloak_enabled:
-                        auth_provider = "keycloak"
+            except Exception as provider_error:  # nosec B110 - best-effort provider preservation
+                LOGGER.warning("Could not resolve auth_provider or team scope from existing JWT cookie; SSO logout or scoped session refresh may not function correctly: %s", provider_error)
+                if auth_provider == "local" and settings.sso_keycloak_enabled:
+                    auth_provider = "keycloak"
 
         # Generate a lightweight session JWT token for browser admin calls in every auth mode.
         email_user = db.query(EmailUser).filter(EmailUser.email == admin_email).first()
@@ -4202,6 +4208,8 @@ async def admin_ui(
             "token_use": "session",  # nosec B105 - token type marker, not a password
             "scopes": {"server_id": None, "permissions": ["*"] if is_admin_flag else [], "ip_restrictions": [], "time_restrictions": {}},
         }
+        if existing_token_teams:
+            payload["teams"] = existing_token_teams
 
         # Generate token using centralized token creation
         token = await create_jwt_token(payload)

--- a/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_csrf_middleware.py
@@ -19,6 +19,7 @@ from starlette.responses import Response
 
 # First-Party
 from mcpgateway.middleware.csrf_middleware import CSRFMiddleware
+from mcpgateway.services.csrf_service import CSRFService
 
 
 @pytest.mark.asyncio
@@ -657,6 +658,82 @@ async def test_csrf_fallback_jwt_context_from_cookie_succeeds():
 
     assert response.status_code == 200
     mock_csrf_service.validate_csrf_token.assert_called_once_with("valid_token", "admin@example.com", "session-jti-1")
+    call_next.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_admin_random_csrf_token_fails_hmac_validation():
+    """Regression: old random admin CSRF cookies are not accepted by global middleware."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+    csrf_service = CSRFService(secret="test-csrf-secret", expiry=3600)  # pragma: allowlist secret
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/prompts/prompt-1"
+    request.headers = {"X-CSRF-Token": "a" * 64}
+    request.state = MagicMock()
+    request.state.user = None
+    request.state.jti = None
+    request.cookies = {"jwt_token": "admin-session-jwt", "mcpgateway_csrf_token": "a" * 64}
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=csrf_service),
+        patch(
+            "mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "session-jti-1"}),
+        ),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "mcpgateway_csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 403
+    assert response.body == b'{"detail":"CSRF validation failed","code":"CSRF_TOKEN_INVALID"}'
+    call_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_admin_bound_csrf_token_from_page_load_passes_hmac_validation():
+    """Token issued for the JWT sub/jti pair on /admin page load passes middleware."""
+    middleware = CSRFMiddleware(app=AsyncMock())
+    call_next = AsyncMock(return_value=Response("ok", status_code=200))
+    csrf_service = CSRFService(secret="test-csrf-secret", expiry=3600)  # pragma: allowlist secret
+    csrf_token = csrf_service.generate_csrf_token("admin@example.com", "session-jti-1")
+
+    request = MagicMock(spec=Request)
+    request.method = "POST"
+    request.url.path = "/prompts/prompt-1"
+    request.headers = {"X-CSRF-Token": csrf_token}
+    request.state = MagicMock()
+    request.state.user = None
+    request.state.jti = None
+    request.cookies = {"jwt_token": "admin-session-jwt", "mcpgateway_csrf_token": csrf_token}
+
+    with (
+        patch("mcpgateway.middleware.csrf_middleware.settings") as mock_settings,
+        patch("mcpgateway.middleware.csrf_middleware.get_csrf_service", return_value=csrf_service),
+        patch(
+            "mcpgateway.middleware.csrf_middleware.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "session-jti-1"}),
+        ),
+    ):
+        mock_settings.csrf_enabled = True
+        mock_settings.auth_required = True
+        mock_settings.csrf_exempt_paths = []
+        mock_settings.csrf_token_name = "X-CSRF-Token"
+        mock_settings.csrf_cookie_name = "mcpgateway_csrf_token"
+        mock_settings.csrf_check_referer = False
+
+        response = await middleware.dispatch(request, call_next)
+
+    assert response.status_code == 200
     call_next.assert_awaited_once_with(request)
 
 

--- a/tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py
+++ b/tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py
@@ -320,6 +320,7 @@ class TestJSONRPCPassthroughSecurity:
         assert response.status_code == status.HTTP_200_OK
 
         # Unauthenticated request should be rejected
+        app.dependency_overrides.clear()
         unauth_response = client.post(
             "/a2a/test-agent/jsonrpc",
             json={
@@ -330,6 +331,9 @@ class TestJSONRPCPassthroughSecurity:
             },
             # No headers - unauthenticated
         )
+        from mcpgateway.main import get_current_user_with_permissions
+
+        app.dependency_overrides[get_current_user_with_permissions] = mock_auth
         assert unauth_response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4674,8 +4674,64 @@ class TestAdminUIRoute:
         assert isinstance(response, HTMLResponse)
         assert response.status_code == 200
 
-        # Verify template was called (cookies are now set during login, not on admin page access)
+        # Verify template was called and cookie handling did not prevent rendering.
         mock_request.app.state.templates.TemplateResponse.assert_called_once()
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_non_email_auth_sets_bound_csrf_cookie(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Platform-admin page load must bind CSRF to the JWT session it issues."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "session-jwt"
+
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert captured_payload["sub"] == "admin@example.com"
+        assert captured_payload["jti"]
+        mock_csrf_service.generate_csrf_token.assert_called_once_with(user_id="admin@example.com", session_id=captured_payload["jti"])
+        assert "mcpgateway_csrf_token=bound-csrf-token" in (response.headers.get("set-cookie") or "")
 
     @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
     @patch.object(ToolService, "list_tools", new_callable=AsyncMock)

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4739,6 +4739,64 @@ class TestAdminUIRoute:
     @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
     @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
     @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_refresh_preserves_session_team_narrowing(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Refreshing admin browser JWT must preserve verified non-empty teams claim."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "refreshed-session-jwt"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": ["team-1"], "auth_provider": "local"}),
+        )
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert captured_payload["teams"] == ["team-1"]
+        assert captured_payload["token_use"] == "session"
+        assert captured_payload["jti"] != "old-jti"
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
     async def test_admin_ui_skips_hidden_sections_data_loading(
         self,
         mock_roots,

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4703,7 +4703,6 @@ class TestAdminUIRoute:
         mock_gateways.return_value = []
         mock_roots.return_value = []
         mock_request.cookies = {}
-        mock_db.query.return_value.filter.return_value.first.return_value = None
 
         captured_payload = {}
 
@@ -4730,6 +4729,10 @@ class TestAdminUIRoute:
         assert isinstance(response, HTMLResponse)
         assert captured_payload["sub"] == "admin@example.com"
         assert captured_payload["jti"]
+        from mcpgateway.db import EmailUser as DbEmailUser
+
+        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
+        assert DbEmailUser not in queried_models
         mock_csrf_service.generate_csrf_token.assert_called_once_with(user_id="admin@example.com", session_id=captured_payload["jti"])
         assert "mcpgateway_csrf_token=bound-csrf-token" in (response.headers.get("set-cookie") or "")
 
@@ -4759,7 +4762,6 @@ class TestAdminUIRoute:
         mock_gateways.return_value = []
         mock_roots.return_value = []
         mock_request.cookies = {"jwt_token": "existing-session-jwt"}
-        mock_db.query.return_value.filter.return_value.first.return_value = None
 
         captured_payload = {}
 
@@ -4790,6 +4792,117 @@ class TestAdminUIRoute:
         assert captured_payload["teams"] == ["team-1"]
         assert captured_payload["token_use"] == "session"
         assert captured_payload["jti"] != "old-jti"
+        from mcpgateway.db import EmailUser as DbEmailUser
+
+        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
+        assert DbEmailUser not in queried_models
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_refresh_does_not_copy_empty_session_teams(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Empty session teams claim means no explicit narrowing and must not be copied."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "refreshed-session-jwt"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": [], "auth_provider": "local"}),
+        )
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert "teams" not in captured_payload
+        from mcpgateway.db import EmailUser as DbEmailUser
+
+        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
+        assert DbEmailUser not in queried_models
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_session_init_failure_fails_loud_without_random_csrf(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Authenticated /admin must not fall back to random CSRF if JWT refresh fails."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {}
+
+        mock_set_auth_cookie = MagicMock()
+        mock_token_urlsafe = MagicMock(return_value="random-csrf-token")
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", AsyncMock(side_effect=RuntimeError("jwt mint failed")))
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", mock_set_auth_cookie)
+        monkeypatch.setattr("mcpgateway.admin.secrets.token_urlsafe", mock_token_urlsafe)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await admin_ui(
+                request=mock_request,
+                team_id=None,
+                include_inactive=False,
+                db=mock_db,
+                user={"email": "admin@example.com", "is_admin": True},
+            )
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Unable to initialize admin session"
+        mock_set_auth_cookie.assert_not_called()
+        mock_token_urlsafe.assert_not_called()
 
     @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
     @patch.object(ToolService, "list_tools", new_callable=AsyncMock)

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -4703,6 +4703,7 @@ class TestAdminUIRoute:
         mock_gateways.return_value = []
         mock_roots.return_value = []
         mock_request.cookies = {}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
 
         captured_payload = {}
 
@@ -4729,132 +4730,8 @@ class TestAdminUIRoute:
         assert isinstance(response, HTMLResponse)
         assert captured_payload["sub"] == "admin@example.com"
         assert captured_payload["jti"]
-        from mcpgateway.db import EmailUser as DbEmailUser
-
-        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
-        assert DbEmailUser not in queried_models
         mock_csrf_service.generate_csrf_token.assert_called_once_with(user_id="admin@example.com", session_id=captured_payload["jti"])
         assert "mcpgateway_csrf_token=bound-csrf-token" in (response.headers.get("set-cookie") or "")
-
-    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
-    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
-    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
-    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
-    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
-    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
-    async def test_admin_ui_refresh_preserves_session_team_narrowing(
-        self,
-        mock_roots,
-        mock_gateways,
-        mock_prompts,
-        mock_resources,
-        mock_tools,
-        mock_servers,
-        mock_request,
-        mock_db,
-        monkeypatch,
-    ):
-        """Refreshing admin browser JWT must preserve verified non-empty teams claim."""
-        mock_servers.return_value = []
-        mock_tools.return_value = ([], None)
-        mock_resources.return_value = []
-        mock_prompts.return_value = []
-        mock_gateways.return_value = []
-        mock_roots.return_value = []
-        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
-
-        captured_payload = {}
-
-        async def fake_create_jwt_token(payload):
-            captured_payload.update(payload)
-            return "refreshed-session-jwt"
-
-        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
-        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
-        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
-        mock_csrf_service = MagicMock()
-        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
-        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
-        monkeypatch.setattr(
-            "mcpgateway.admin.verify_jwt_token_cached",
-            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": ["team-1"], "auth_provider": "local"}),
-        )
-
-        response = await admin_ui(
-            request=mock_request,
-            team_id=None,
-            include_inactive=False,
-            db=mock_db,
-            user={"email": "admin@example.com", "is_admin": True},
-        )
-
-        assert isinstance(response, HTMLResponse)
-        assert captured_payload["teams"] == ["team-1"]
-        assert captured_payload["token_use"] == "session"
-        assert captured_payload["jti"] != "old-jti"
-        from mcpgateway.db import EmailUser as DbEmailUser
-
-        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
-        assert DbEmailUser not in queried_models
-
-    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
-    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
-    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
-    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
-    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
-    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
-    async def test_admin_ui_refresh_does_not_copy_empty_session_teams(
-        self,
-        mock_roots,
-        mock_gateways,
-        mock_prompts,
-        mock_resources,
-        mock_tools,
-        mock_servers,
-        mock_request,
-        mock_db,
-        monkeypatch,
-    ):
-        """Empty session teams claim means no explicit narrowing and must not be copied."""
-        mock_servers.return_value = []
-        mock_tools.return_value = ([], None)
-        mock_resources.return_value = []
-        mock_prompts.return_value = []
-        mock_gateways.return_value = []
-        mock_roots.return_value = []
-        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
-
-        captured_payload = {}
-
-        async def fake_create_jwt_token(payload):
-            captured_payload.update(payload)
-            return "refreshed-session-jwt"
-
-        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
-        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
-        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
-        mock_csrf_service = MagicMock()
-        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
-        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
-        monkeypatch.setattr(
-            "mcpgateway.admin.verify_jwt_token_cached",
-            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": [], "auth_provider": "local"}),
-        )
-
-        response = await admin_ui(
-            request=mock_request,
-            team_id=None,
-            include_inactive=False,
-            db=mock_db,
-            user={"email": "admin@example.com", "is_admin": True},
-        )
-
-        assert isinstance(response, HTMLResponse)
-        assert "teams" not in captured_payload
-        from mcpgateway.db import EmailUser as DbEmailUser
-
-        queried_models = [call.args[0] for call in mock_db.query.call_args_list if call.args]
-        assert DbEmailUser not in queried_models
 
     @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
     @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
@@ -4903,6 +4780,177 @@ class TestAdminUIRoute:
         assert exc_info.value.detail == "Unable to initialize admin session"
         mock_set_auth_cookie.assert_not_called()
         mock_token_urlsafe.assert_not_called()
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_refresh_preserves_matching_session_team_narrowing(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Refreshing admin browser JWT preserves teams only from matching cookie identity."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "refreshed-session-jwt"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": ["team-1"], "auth_provider": "local"}),
+        )
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert captured_payload["teams"] == ["team-1"]
+        assert captured_payload["token_use"] == "session"
+        assert captured_payload["jti"] != "old-jti"
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_refresh_ignores_stale_cookie_identity(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Bearer-authenticated user must not inherit sub or teams from stale cookie."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {"jwt_token": "stale-session-jwt"}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "refreshed-session-jwt"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "old@example.com", "jti": "old-jti", "token_use": "session", "teams": ["old-team"], "auth_provider": "local"}),
+        )
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "new@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert captured_payload["sub"] == "new@example.com"
+        assert "teams" not in captured_payload
+
+    @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
+    @patch.object(ToolService, "list_tools", new_callable=AsyncMock)
+    @patch.object(ResourceService, "list_resources", new_callable=AsyncMock)
+    @patch.object(PromptService, "list_prompts", new_callable=AsyncMock)
+    @patch.object(GatewayService, "list_gateways", new_callable=AsyncMock)
+    @patch.object(RootService, "list_roots", new_callable=AsyncMock)
+    async def test_admin_ui_refresh_does_not_copy_empty_session_teams(
+        self,
+        mock_roots,
+        mock_gateways,
+        mock_prompts,
+        mock_resources,
+        mock_tools,
+        mock_servers,
+        mock_request,
+        mock_db,
+        monkeypatch,
+    ):
+        """Empty session teams claim means no explicit narrowing and must not be copied."""
+        mock_servers.return_value = []
+        mock_tools.return_value = ([], None)
+        mock_resources.return_value = []
+        mock_prompts.return_value = []
+        mock_gateways.return_value = []
+        mock_roots.return_value = []
+        mock_request.cookies = {"jwt_token": "existing-session-jwt"}
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        captured_payload = {}
+
+        async def fake_create_jwt_token(payload):
+            captured_payload.update(payload)
+            return "refreshed-session-jwt"
+
+        monkeypatch.setattr("mcpgateway.admin.settings.email_auth_enabled", False, raising=False)
+        monkeypatch.setattr("mcpgateway.admin.create_jwt_token", fake_create_jwt_token)
+        monkeypatch.setattr("mcpgateway.admin.set_auth_cookie", MagicMock())
+        mock_csrf_service = MagicMock()
+        mock_csrf_service.generate_csrf_token.return_value = "bound-csrf-token"
+        monkeypatch.setattr("mcpgateway.admin.get_csrf_service", lambda: mock_csrf_service)
+        monkeypatch.setattr(
+            "mcpgateway.admin.verify_jwt_token_cached",
+            AsyncMock(return_value={"sub": "admin@example.com", "jti": "old-jti", "token_use": "session", "teams": [], "auth_provider": "local"}),
+        )
+
+        response = await admin_ui(
+            request=mock_request,
+            team_id=None,
+            include_inactive=False,
+            db=mock_db,
+            user={"email": "admin@example.com", "is_admin": True},
+        )
+
+        assert isinstance(response, HTMLResponse)
+        assert "teams" not in captured_payload
 
     @patch.object(ServerService, "list_servers", new_callable=AsyncMock)
     @patch.object(ToolService, "list_tools", new_callable=AsyncMock)


### PR DESCRIPTION
# Bug-fix PR

## Summary

Fixes #5325. Admin UI CSRF cookies are now HMAC-bound for non-email-auth platform-admin sessions, so actions like Render Prompt no longer fail with `CSRF_TOKEN_INVALID`.

## Reproduction Steps

1. Run default config with `EMAIL_AUTH_ENABLED=false`.
2. Log in to `/admin` as platform admin.
3. Open `/admin/#prompts`.
4. Click Render Prompt.
5. Before fix: `POST /prompts/{id}` returns `403 CSRF_TOKEN_INVALID`.

## Root Cause

`GET /admin` only issued bound CSRF cookies when email auth was enabled. Default platform-admin/basic-auth sessions got random double-submit tokens, but global `CSRFMiddleware` requires tokens bound to authenticated JWT `sub` and `jti`.

## Fix Description

`/admin` now creates or refreshes a lightweight browser JWT session for admin UI calls in all auth modes and binds the CSRF cookie to that JWT payload. `_set_admin_csrf_cookie()` keeps random-token fallback for unauthenticated pages, but uses `get_csrf_service().generate_csrf_token()` when `user_id` and `session_id` are available.

Authenticated `/admin` session initialization now fails loud instead of falling back to an unusable random CSRF token. Refresh also preserves scoped session `teams` only when the verified cookie identity matches the authenticated user, and ignores stale-cookie team scope.

## Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## Verification

| Check | Command | Status |
|---|---|---|
| Focused unit tests | `.venv/bin/python -m pytest tests/unit/mcpgateway/test_admin.py tests/unit/mcpgateway/middleware/test_csrf_middleware.py tests/unit/mcpgateway/test_admin_module.py tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py` | Pass, `1369 passed` |
| Compile touched files | `py_compile mcpgateway/admin.py tests/unit/mcpgateway/test_admin.py tests/unit/mcpgateway/middleware/test_csrf_middleware.py tests/unit/mcpgateway/test_admin_module.py tests/unit/mcpgateway/test_a2a_jsonrpc_passthrough.py` | Pass |
| Whitespace check | `git diff --check` | Pass |
| Ruff | `make ruff` | Blocked: existing `pyproject.toml:445` unknown rule selector `PLW0717` |

## MCP Compliance (if relevant)

- [x] No breaking change to MCP clients

## Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed