### PR TITLE
fix(transport): include app_root_path in enforced OAuth audience

### DIFF
--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -909,7 +909,15 @@ def _build_server_resource_url(scope: Scope, server_id: str) -> str:
         return ""
     if not raw:
         return ""
-    return f"{raw}/servers/{server_id}/mcp"
+    # Include app_root_path so the enforced audience matches the advertised
+    # Protected Resource Metadata URL on path-prefixed deployments (e.g. when
+    # the gateway is mounted under /gw behind a reverse proxy). Without this,
+    # the enforced aud is {app_domain}/servers/{id}/mcp while the advertised
+    # resource is {scheme}://{host}{root_path}/servers/{id}/mcp — see #5172.
+    root_path = str(getattr(settings, "app_root_path", "") or "").strip().rstrip("/")
+    if root_path and not root_path.startswith("/"):
+        root_path = "/" + root_path
+    return f"{raw}{root_path}/servers/{server_id}/mcp"
 
 
 def _build_resource_metadata_url(scope: Scope, server_id: str) -> str:

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -17321,3 +17321,35 @@ async def test_list_tools_sso_admin_gets_admin_bypass_at_service_layer(monkeypat
     await list_tools()
 
     assert called["args"] == (None, None)
+
+
+def test_build_server_resource_url_includes_app_root_path(monkeypatch):
+    """#5172: enforced audience includes app_root_path on path-prefixed deployments."""
+    from mcpgateway.transports.streamablehttp_transport import _build_server_resource_url
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.settings.app_domain",
+        "https://gateway.example.com",
+    )
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.settings.app_root_path",
+        "/gw",
+    )
+    url = _build_server_resource_url(scope={}, server_id="srv-1")
+    assert url == "https://gateway.example.com/gw/servers/srv-1/mcp"
+
+
+def test_build_server_resource_url_no_root_path_unchanged(monkeypatch):
+    """Without app_root_path the resource URL is unchanged (backward compatible)."""
+    from mcpgateway.transports.streamablehttp_transport import _build_server_resource_url
+
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.settings.app_domain",
+        "https://gateway.example.com",
+    )
+    monkeypatch.setattr(
+        "mcpgateway.transports.streamablehttp_transport.settings.app_root_path",
+        "",
+    )
+    url = _build_server_resource_url(scope={}, server_id="srv-1")
+    assert url == "https://gateway.example.com/servers/srv-1/mcp"


### PR DESCRIPTION
## 🔗 Related Issue

Closes #5172

## 📝 Summary

`_build_server_resource_url` in `mcpgateway/transports/streamablehttp_transport.py` derives the enforced access-token `aud` from `settings.app_domain` only (`f"{app_domain}/servers/{id}/mcp"`), dropping `app_root_path`. On path-prefixed deployments (`APP_ROOT_PATH` set — e.g. gateway mounted under `/gw` behind an ingress), this diverges from the advertised Protected Resource Metadata URL, which is built via `_build_public_base_url` and includes `scope["root_path"]`:

- advertised resource: `{scheme}://{host}{root_path}/servers/{id}/mcp`
- enforced aud:        `{APP_DOMAIN}/servers/{id}/mcp`  ← missing `root_path`

So tokens minted for the advertised resource fail audience validation on path-prefixed deployments.

**Fix:** include `settings.app_root_path` between `app_domain` and `/servers/` in the enforced audience. Backward compatible — an empty `app_root_path` leaves the URL unchanged.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage` — ⚠️ #5172 is currently labeled `triage`. Submitting the fix for review; happy to wait for triage removal / maintainer acceptance first if preferred.
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [ ] If AI-assisted, I understand and can explain the generated changes

## 🏷️ Type of Change

- [x] Bug fix

## Changes

- `mcpgateway/transports/streamablehttp_transport.py`: `_build_server_resource_url` now appends `settings.app_root_path` (normalized: stripped, leading `/` ensured) between `app_domain` and `/servers/{id}/mcp`.
- `tests/unit/mcpgateway/transports/test_streamablehttp_transport.py`: two tests — `app_root_path="/gw"` → URL includes `/gw`; empty `app_root_path` → URL unchanged.

## Testing

- New tests pass: `uv run pytest tests/unit/mcpgateway/transports/test_streamablehttp_transport.py -k build_server_resource_url` → 2 passed.
- No regression in the OAuth audience/auth suite: `uv run pytest tests/unit/mcpgateway/test_auth.py -k "resource or audience or canonical or oauth"` → 111 passed.
- `ruff check` clean on the changed file.

## Notes for Reviewer

- The fix mirrors how `_build_public_base_url` already includes `scope["root_path"]`, using the operator-set `settings.app_root_path` (same trust anchor as `app_domain`, consistent with the function's existing security note).
- The fix is intentionally minimal and scoped to `_build_server_resource_url` (the enforced-aud path). The advertised-resource path (`_build_resource_metadata_url` → `_build_public_base_url`) already includes `root_path` and is unchanged.
- IBM CLA: I will sign via cla-assistant once it checks this PR.
