### PR TITLE
fix: harden configuration import handling

### DIFF
--- a/mcpgateway/admin_ui/fileTransfer.js
+++ b/mcpgateway/admin_ui/fileTransfer.js
@@ -331,7 +331,8 @@ export const resetImportFile = function () {
 export const previewImport = async function () {
   console.log("🔍 Generating import preview...");
 
-  if (!window.currentImportData) {
+  const importData = window.Admin?.currentImportData;
+  if (!importData) {
     showNotification("❌ Please select an import file first", "error");
     return;
   }
@@ -347,7 +348,7 @@ export const previewImport = async function () {
           "Content-Type": "application/json",
           Authorization: `Bearer ${await getAuthToken()}`,
         },
-        body: JSON.stringify({ data: window.currentImportData }),
+        body: JSON.stringify({ data: importData }),
       },
     );
 
@@ -376,7 +377,8 @@ export const previewImport = async function () {
 export const handleImport = async function (dryRun = false) {
   console.log(`🔄 Starting import (dry_run=${dryRun})`);
 
-  if (!window.currentImportData) {
+  const importData = window.Admin?.currentImportData;
+  if (!importData) {
     showNotification("❌ Please select an import file first", "error");
     return;
   }
@@ -389,7 +391,7 @@ export const handleImport = async function (dryRun = false) {
     const rekeySecret = safeGetElement("import-rekey-secret")?.value || null;
 
     const requestData = {
-      import_data: window.currentImportData,
+      import_data: importData,
       conflict_strategy: conflictStrategy,
       dry_run: dryRun,
       rekey_secret: rekeySecret,

--- a/mcpgateway/admin_ui/initialization.js
+++ b/mcpgateway/admin_ui/initialization.js
@@ -1256,7 +1256,8 @@ export const setupBulkImportModal = function () {
 
 export const initializeExportImport = function () {
   // Prevent double initialization
-  if (window.exportImportInitialized) {
+  window.Admin = window.Admin || {};
+  if (window.Admin.exportImportInitialized || window.exportImportInitialized) {
     console.log("🔄 Export/import already initialized, skipping");
     return;
   }
@@ -1283,7 +1284,12 @@ export const initializeExportImport = function () {
 
   if (importDropZone && importFileInput) {
     // File input handler
-    importDropZone.addEventListener("click", () => importFileInput.click());
+    importDropZone.addEventListener("click", (event) => {
+      if (event.target === importFileInput) {
+        return;
+      }
+      importFileInput.click();
+    });
     importFileInput.addEventListener("change", handleFileSelect);
 
     // Drag and drop handlers
@@ -1305,6 +1311,7 @@ export const initializeExportImport = function () {
 
   // Mark as initialized
   window.Admin.exportImportInitialized = true;
+  window.exportImportInitialized = true;
 };
 
 // ===================================================================

--- a/mcpgateway/services/gateway_service.py
+++ b/mcpgateway/services/gateway_service.py
@@ -1329,6 +1329,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         owner_email: Optional[str] = None,
         visibility: Optional[str] = None,
         initialize_timeout: Optional[float] = None,
+        defer_initialization: bool = False,
     ) -> GatewayRead:
         """Register a new gateway.
 
@@ -1343,6 +1344,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             owner_email (Optional[str]): Email of the user who owns this gateway.
             visibility (Optional[str]): Gateway visibility level (private, team, public).
             initialize_timeout (Optional[float]): Timeout in seconds for gateway initialization.
+            defer_initialization: Persist as pending without contacting the remote gateway.
 
         Returns:
             Created gateway information
@@ -1376,8 +1378,9 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             >>> asyncio.run(service._http_client.aclose())
         """
         visibility = "public" if visibility not in ("private", "team", "public") else visibility
+        use_async_lifecycle = defer_initialization or getattr(settings, "gateway_async_lifecycle_enabled", False) is True
         try:
-            if getattr(settings, "gateway_async_lifecycle_enabled", False) is True:
+            if use_async_lifecycle:
                 existing_gateway = self._get_existing_gateway_for_slug_conflict(
                     db,
                     slug_name=slugify(gateway.name),
@@ -1402,7 +1405,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                 visibility=visibility,
             )
 
-            if getattr(settings, "gateway_async_lifecycle_enabled", False) is True:
+            if use_async_lifecycle:
                 return await self._register_gateway_pending(
                     db,
                     gateway,
@@ -2282,6 +2285,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
         modified_user_agent: Optional[str] = None,
         include_inactive: bool = True,
         user_email: Optional[str] = None,
+        defer_initialization: bool = False,
     ) -> Optional[GatewayRead]:
         """Update a gateway.
 
@@ -2295,6 +2299,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             modified_user_agent: User agent string from the modification request
             include_inactive: Whether to include inactive gateways
             user_email: Email of user performing update (for ownership check)
+            defer_initialization: Persist the update as pending without contacting the remote gateway.
 
         Returns:
             Updated gateway information
@@ -2308,6 +2313,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
             ValidationError: If validation fails
         """
         try:  # pylint: disable=too-many-nested-blocks
+            use_async_lifecycle = defer_initialization or getattr(settings, "gateway_async_lifecycle_enabled", False) is True
             # Acquire row lock and eager-load relationships while locked so
             # concurrent updates are serialized on Postgres.
             gateway = get_for_update(
@@ -2334,7 +2340,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     raise PermissionError("Only the owner can update this gateway")
 
             if gateway.enabled or include_inactive:
-                if getattr(settings, "gateway_async_lifecycle_enabled", False) is True and getattr(gateway, "status", None) == "pending":
+                if use_async_lifecycle and getattr(gateway, "status", None) == "pending":
                     return self.convert_gateway_to_read(gateway)
 
                 # Check for name conflicts if name is being changed
@@ -2652,7 +2658,7 @@ class GatewayService(BaseService):  # pylint: disable=too-many-instance-attribut
                     auth_query_params_decrypted = connection_material.auth_query_params_decrypted
                     init_url = connection_material.url
 
-                if getattr(settings, "gateway_async_lifecycle_enabled", False) is True:
+                if use_async_lifecycle:
                     gateway.status = "pending"
                     gateway.status_message = "Gateway update accepted and pending initialization"
                     gateway.registration_attempts = 0

--- a/mcpgateway/services/import_service.py
+++ b/mcpgateway/services/import_service.py
@@ -29,6 +29,7 @@ import uuid
 from sqlalchemy.orm import Session
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.db import A2AAgent, EmailUser, Gateway, Prompt, Resource, Server, Tool
 from mcpgateway.schemas import AuthenticationValues, GatewayCreate, GatewayUpdate, PromptCreate, PromptUpdate, ResourceCreate, ResourceUpdate, ServerCreate, ServerUpdate, ToolCreate, ToolUpdate
 from mcpgateway.services.gateway_service import GatewayNameConflictError
@@ -749,11 +750,33 @@ class ImportService:
             return
 
         try:
+            defer_gateway_initialization = getattr(settings, "gateway_async_lifecycle_enabled", False) is True
+
+            if conflict_strategy == ConflictStrategy.UPDATE:
+                try:
+                    gateways, _ = await self.gateway_service.list_gateways(db, include_inactive=True)
+                    existing_gateway = next((g for g in gateways if g.name == gateway_name), None)
+                    if existing_gateway:
+                        update_data = self._convert_to_gateway_update(gateway_data)
+                        await self.gateway_service.update_gateway(
+                            db,
+                            existing_gateway.id,
+                            update_data,
+                            modified_by=imported_by,
+                            modified_via="import",
+                            defer_initialization=defer_gateway_initialization,
+                        )
+                        status.updated_entities += 1
+                        logger.debug("Updated gateway: %s", gateway_name)
+                        return
+                except Exception as update_error:
+                    logger.warning("Failed to pre-check gateway %s for update import: %s", gateway_name, str(update_error))
+
             # Convert to GatewayCreate schema
             create_data = self._convert_to_gateway_create(gateway_data)
 
             try:
-                await self.gateway_service.register_gateway(db, create_data, created_by=imported_by, created_via="import")
+                await self.gateway_service.register_gateway(db, create_data, created_by=imported_by, created_via="import", defer_initialization=defer_gateway_initialization)
                 status.created_entities += 1
                 logger.debug("Created gateway: %s", gateway_name)
 
@@ -768,7 +791,14 @@ class ImportService:
                         existing_gateway = next((g for g in gateways if g.name == gateway_name), None)
                         if existing_gateway:
                             update_data = self._convert_to_gateway_update(gateway_data)
-                            await self.gateway_service.update_gateway(db, existing_gateway.id, update_data)
+                            await self.gateway_service.update_gateway(
+                                db,
+                                existing_gateway.id,
+                                update_data,
+                                modified_by=imported_by,
+                                modified_via="import",
+                                defer_initialization=defer_gateway_initialization,
+                            )
                             status.updated_entities += 1
                             logger.debug("Updated gateway: %s", gateway_name)
                         else:
@@ -781,7 +811,7 @@ class ImportService:
                 elif conflict_strategy == ConflictStrategy.RENAME:
                     new_name = f"{gateway_name}_imported_{int(datetime.now().timestamp())}"
                     create_data.name = new_name
-                    await self.gateway_service.register_gateway(db, create_data, created_by=imported_by, created_via="import")
+                    await self.gateway_service.register_gateway(db, create_data, created_by=imported_by, created_via="import", defer_initialization=defer_gateway_initialization)
                     status.created_entities += 1
                     status.warnings.append(f"Renamed gateway {gateway_name} to {new_name}")
                 elif conflict_strategy == ConflictStrategy.FAIL:
@@ -826,7 +856,7 @@ class ImportService:
                 elif conflict_strategy == ConflictStrategy.UPDATE:
                     try:
                         # Find existing server by name
-                        servers = await self.server_service.list_servers(db, include_inactive=True)
+                        servers = self._extract_list_items(await self.server_service.list_servers(db, include_inactive=True))
                         existing_server = next((s for s in servers if s.name == server_name), None)
                         if existing_server:
                             update_data = await self._convert_to_server_update(db, server_data)
@@ -1207,7 +1237,7 @@ class ImportService:
             annotations=tool_data.get("annotations"),
             jsonpath_filter=tool_data.get("jsonpath_filter"),
             auth=auth_info,
-            tags=tool_data.get("tags", []),
+            tags=self._normalize_import_tags(tool_data.get("tags", [])),
         )
 
     def _convert_to_tool_update(self, tool_data: Dict[str, Any]) -> ToolUpdate:
@@ -1236,8 +1266,110 @@ class ImportService:
             annotations=tool_data.get("annotations"),
             jsonpath_filter=tool_data.get("jsonpath_filter"),
             auth=auth_info,
-            tags=tool_data.get("tags"),
+            tags=self._normalize_import_tags(tool_data.get("tags")) if "tags" in tool_data else None,
         )
+
+    def _normalize_import_tags(self, tags: Any) -> List[str]:
+        """Convert exported/read tag shapes into create/update tag strings."""
+        if not tags:
+            return []
+
+        if isinstance(tags, str):
+            return [tags]
+
+        normalized_tags: List[str] = []
+        if not isinstance(tags, list):
+            tags = [tags]
+
+        for tag in tags:
+            if isinstance(tag, str):
+                normalized_tags.append(tag)
+                continue
+
+            if isinstance(tag, dict):
+                tag_value = tag.get("label") or tag.get("id") or tag.get("name") or tag.get("value")
+                if tag_value:
+                    normalized_tags.append(str(tag_value))
+                continue
+
+            if tag is not None:
+                normalized_tags.append(str(tag))
+
+        return normalized_tags
+
+    def _extract_list_items(self, list_result: Any) -> List[Any]:
+        """Extract entity lists from service list responses."""
+        if isinstance(list_result, tuple):
+            return list_result[0]
+        if isinstance(list_result, dict):
+            return list_result.get("data", [])
+        return list_result or []
+
+    def _build_gateway_auth_kwargs(self, gateway_data: Dict[str, Any], *, update: bool = False) -> Dict[str, Any]:
+        """Build GatewayCreate/GatewayUpdate auth kwargs only when credentials are usable."""
+        auth_type = gateway_data.get("auth_type")
+        if not auth_type:
+            return {}
+
+        auth_kwargs: Dict[str, Any] = {"auth_type": auth_type}
+        log_suffix = " update" if update else ""
+
+        if auth_type == "query_param" and gateway_data.get("auth_query_params"):
+            try:
+                auth_query_params = gateway_data["auth_query_params"]
+                if auth_query_params:
+                    param_key = next(iter(auth_query_params.keys()))
+                    encrypted_value = auth_query_params[param_key]
+                    if not encrypted_value or encrypted_value == settings.masked_auth_value:
+                        logger.warning("Skipping query param auth for gateway%s because import has no usable secret", log_suffix)
+                        return {}
+
+                    decrypted_dict = decode_auth(encrypted_value)
+                    decrypted_value = decrypted_dict.get(param_key, "") if isinstance(decrypted_dict, dict) else str(decrypted_dict)
+                    auth_kwargs["auth_query_param_key"] = param_key
+                    auth_kwargs["auth_query_param_value"] = decrypted_value
+                    logger.debug("Importing gateway%s with query_param auth, key: %s", log_suffix, param_key)
+                    return auth_kwargs
+            except Exception as e:
+                logger.warning("Failed to decode query param auth for gateway%s: %s", log_suffix, str(e))
+                return {}
+
+        auth_value = gateway_data.get("auth_value")
+        if not auth_value or auth_value == settings.masked_auth_value:
+            logger.warning("Skipping %s auth for gateway%s because import has no usable auth_value", auth_type, log_suffix)
+            return {}
+
+        try:
+            decoded_auth = decode_auth(auth_value)
+            if not isinstance(decoded_auth, dict):
+                logger.warning("Skipping %s auth for gateway%s because decoded auth is not a mapping", auth_type, log_suffix)
+                return {}
+
+            if auth_type == "basic":
+                auth_header = decoded_auth.get("Authorization", "")
+                if auth_header.startswith("Basic "):
+                    creds = base64.b64decode(auth_header[6:]).decode("utf-8")
+                    username, password = creds.split(":", 1)
+                    auth_kwargs.update({"auth_username": username, "auth_password": password})
+                    return auth_kwargs
+            elif auth_type == "bearer":
+                auth_header = decoded_auth.get("Authorization", "")
+                if auth_header.startswith("Bearer "):
+                    auth_kwargs["auth_token"] = auth_header[7:]
+                    return auth_kwargs
+            elif auth_type == "authheaders":
+                if len(decoded_auth) == 1:
+                    key, value = next(iter(decoded_auth.items()))
+                    auth_kwargs.update({"auth_header_key": key, "auth_header_value": value})
+                else:
+                    auth_kwargs["auth_headers"] = [{"key": k, "value": v} for k, v in decoded_auth.items()]
+                return auth_kwargs
+        except Exception as e:
+            logger.warning("Failed to decode auth data for gateway%s: %s", log_suffix, str(e))
+            return {}
+
+        logger.warning("Skipping %s auth for gateway%s because required auth fields were not found", auth_type, log_suffix)
+        return {}
 
     def _convert_to_gateway_create(self, gateway_data: Dict[str, Any]) -> GatewayCreate:
         """Convert import data to GatewayCreate schema.
@@ -1248,55 +1380,7 @@ class ImportService:
         Returns:
             GatewayCreate schema object
         """
-        # Handle auth data
-        auth_kwargs = {}
-        if gateway_data.get("auth_type"):
-            auth_kwargs["auth_type"] = gateway_data["auth_type"]
-
-            # Handle query_param auth type (new in this version)
-            if gateway_data["auth_type"] == "query_param" and gateway_data.get("auth_query_params"):
-                try:
-                    auth_query_params = gateway_data["auth_query_params"]
-                    if auth_query_params:
-                        # Get the first key-value pair (schema supports single param)
-                        param_key = next(iter(auth_query_params.keys()))
-                        encrypted_value = auth_query_params[param_key]
-                        # Decode the encrypted value - returns dict like {param_key: value}
-                        decrypted_dict = decode_auth(encrypted_value)
-                        # Extract the actual value from the dict
-                        decrypted_value = decrypted_dict.get(param_key, "") if isinstance(decrypted_dict, dict) else str(decrypted_dict)
-                        auth_kwargs["auth_query_param_key"] = param_key
-                        auth_kwargs["auth_query_param_value"] = decrypted_value
-                        logger.debug("Importing gateway with query_param auth, key: %s", param_key)
-                except Exception as e:
-                    logger.warning("Failed to decode query param auth for gateway: %s", str(e))
-            # Decode auth_value to get original credentials
-            elif gateway_data.get("auth_value"):
-                try:
-                    decoded_auth = decode_auth(gateway_data["auth_value"])
-                    if gateway_data["auth_type"] == "basic":
-                        # Extract username and password from Basic auth
-                        auth_header = decoded_auth.get("Authorization", "")
-                        if auth_header.startswith("Basic "):
-                            creds = base64.b64decode(auth_header[6:]).decode("utf-8")
-                            username, password = creds.split(":", 1)
-                            auth_kwargs.update({"auth_username": username, "auth_password": password})
-                    elif gateway_data["auth_type"] == "bearer":
-                        # Extract token from Bearer auth
-                        auth_header = decoded_auth.get("Authorization", "")
-                        if auth_header.startswith("Bearer "):
-                            auth_kwargs["auth_token"] = auth_header[7:]
-                    elif gateway_data["auth_type"] == "authheaders":
-                        # Handle custom headers
-                        if len(decoded_auth) == 1:
-                            key, value = next(iter(decoded_auth.items()))
-                            auth_kwargs.update({"auth_header_key": key, "auth_header_value": value})
-                        else:
-                            # Multiple headers - use the new format
-                            headers_list = [{"key": k, "value": v} for k, v in decoded_auth.items()]
-                            auth_kwargs["auth_headers"] = headers_list
-                except Exception as e:
-                    logger.warning("Failed to decode auth data for gateway: %s", str(e))
+        auth_kwargs = self._build_gateway_auth_kwargs(gateway_data)
 
         return GatewayCreate(
             name=gateway_data["name"],
@@ -1304,7 +1388,7 @@ class ImportService:
             description=gateway_data.get("description"),
             transport=gateway_data.get("transport", "SSE"),
             passthrough_headers=gateway_data.get("passthrough_headers"),
-            tags=gateway_data.get("tags", []),
+            tags=self._normalize_import_tags(gateway_data.get("tags", [])),
             **auth_kwargs,
         )
 
@@ -1317,50 +1401,7 @@ class ImportService:
         Returns:
             GatewayUpdate schema object
         """
-        # Similar to create but all fields optional
-        auth_kwargs = {}
-        if gateway_data.get("auth_type"):
-            auth_kwargs["auth_type"] = gateway_data["auth_type"]
-
-            # Handle query_param auth type (new in this version)
-            if gateway_data["auth_type"] == "query_param" and gateway_data.get("auth_query_params"):
-                try:
-                    auth_query_params = gateway_data["auth_query_params"]
-                    if auth_query_params:
-                        # Get the first key-value pair (schema supports single param)
-                        param_key = next(iter(auth_query_params.keys()))
-                        encrypted_value = auth_query_params[param_key]
-                        # Decode the encrypted value - returns dict like {param_key: value}
-                        decrypted_dict = decode_auth(encrypted_value)
-                        # Extract the actual value from the dict
-                        decrypted_value = decrypted_dict.get(param_key, "") if isinstance(decrypted_dict, dict) else str(decrypted_dict)
-                        auth_kwargs["auth_query_param_key"] = param_key
-                        auth_kwargs["auth_query_param_value"] = decrypted_value
-                        logger.debug("Importing gateway update with query_param auth, key: %s", param_key)
-                except Exception as e:
-                    logger.warning("Failed to decode query param auth for gateway update: %s", str(e))
-            elif gateway_data.get("auth_value"):
-                try:
-                    decoded_auth = decode_auth(gateway_data["auth_value"])
-                    if gateway_data["auth_type"] == "basic":
-                        auth_header = decoded_auth.get("Authorization", "")
-                        if auth_header.startswith("Basic "):
-                            creds = base64.b64decode(auth_header[6:]).decode("utf-8")
-                            username, password = creds.split(":", 1)
-                            auth_kwargs.update({"auth_username": username, "auth_password": password})
-                    elif gateway_data["auth_type"] == "bearer":
-                        auth_header = decoded_auth.get("Authorization", "")
-                        if auth_header.startswith("Bearer "):
-                            auth_kwargs["auth_token"] = auth_header[7:]
-                    elif gateway_data["auth_type"] == "authheaders":
-                        if len(decoded_auth) == 1:
-                            key, value = next(iter(decoded_auth.items()))
-                            auth_kwargs.update({"auth_header_key": key, "auth_header_value": value})
-                        else:
-                            headers_list = [{"key": k, "value": v} for k, v in decoded_auth.items()]
-                            auth_kwargs["auth_headers"] = headers_list
-                except Exception as e:
-                    logger.warning("Failed to decode auth data for gateway update: %s", str(e))
+        auth_kwargs = self._build_gateway_auth_kwargs(gateway_data, update=True)
 
         return GatewayUpdate(
             name=gateway_data.get("name"),
@@ -1368,7 +1409,7 @@ class ImportService:
             description=gateway_data.get("description"),
             transport=gateway_data.get("transport"),
             passthrough_headers=gateway_data.get("passthrough_headers"),
-            tags=gateway_data.get("tags"),
+            tags=self._normalize_import_tags(gateway_data.get("tags")) if "tags" in gateway_data else None,
             **auth_kwargs,
         )
 
@@ -1411,7 +1452,7 @@ class ImportService:
                     logger.warning("Could not resolve tool reference: %s", tool_ref)
                     # Don't include unresolvable references
 
-        return ServerCreate(name=server_data["name"], description=server_data.get("description"), associated_tools=resolved_tool_ids, tags=server_data.get("tags", []))
+        return ServerCreate(name=server_data["name"], description=server_data.get("description"), associated_tools=resolved_tool_ids, tags=self._normalize_import_tags(server_data.get("tags", [])))
 
     async def _convert_to_server_update(self, db: Session, server_data: Dict[str, Any]) -> ServerUpdate:
         """Convert import data to ServerUpdate schema, resolving tool references.
@@ -1442,7 +1483,12 @@ class ImportService:
                 else:
                     logger.warning("Could not resolve tool reference for update: %s", tool_ref)
 
-        return ServerUpdate(name=server_data.get("name"), description=server_data.get("description"), associated_tools=resolved_tool_ids if resolved_tool_ids else None, tags=server_data.get("tags"))
+        return ServerUpdate(
+            name=server_data.get("name"),
+            description=server_data.get("description"),
+            associated_tools=resolved_tool_ids if resolved_tool_ids else None,
+            tags=self._normalize_import_tags(server_data.get("tags")) if "tags" in server_data else None,
+        )
 
     def _convert_to_prompt_create(self, prompt_data: Dict[str, Any]) -> PromptCreate:
         """Convert import data to PromptCreate schema.
@@ -1471,7 +1517,7 @@ class ImportService:
             template=prompt_data["template"],
             description=prompt_data.get("description"),
             arguments=arguments,
-            tags=prompt_data.get("tags", []),
+            tags=self._normalize_import_tags(prompt_data.get("tags", [])),
         )
 
     def _convert_to_prompt_update(self, prompt_data: Dict[str, Any]) -> PromptUpdate:
@@ -1500,7 +1546,7 @@ class ImportService:
             template=prompt_data.get("template"),
             description=prompt_data.get("description"),
             arguments=arguments if arguments else None,
-            tags=prompt_data.get("tags"),
+            tags=self._normalize_import_tags(prompt_data.get("tags")) if "tags" in prompt_data else None,
         )
 
     def _convert_to_resource_create(self, resource_data: Dict[str, Any]) -> ResourceCreate:
@@ -1518,7 +1564,7 @@ class ImportService:
             description=resource_data.get("description"),
             mime_type=resource_data.get("mime_type"),
             content=resource_data.get("content", ""),  # Default empty content
-            tags=resource_data.get("tags", []),
+            tags=self._normalize_import_tags(resource_data.get("tags", [])),
         )
 
     def _convert_to_resource_update(self, resource_data: Dict[str, Any]) -> ResourceUpdate:
@@ -1531,7 +1577,11 @@ class ImportService:
             ResourceUpdate schema object
         """
         return ResourceUpdate(
-            name=resource_data.get("name"), description=resource_data.get("description"), mime_type=resource_data.get("mime_type"), content=resource_data.get("content"), tags=resource_data.get("tags")
+            name=resource_data.get("name"),
+            description=resource_data.get("description"),
+            mime_type=resource_data.get("mime_type"),
+            content=resource_data.get("content"),
+            tags=self._normalize_import_tags(resource_data.get("tags")) if "tags" in resource_data else None,
         )
 
     def get_import_status(self, import_id: str) -> Optional[ImportStatus]:
@@ -1654,7 +1704,7 @@ class ImportService:
                 existing, _ = await self.gateway_service.list_gateways(db)
                 item_info["conflicts_with"] = any(g.name == item_name for g in existing)
             elif entity_type == "servers":
-                existing = await self.server_service.list_servers(db)
+                existing = self._extract_list_items(await self.server_service.list_servers(db))
                 item_info["conflicts_with"] = any(s.name == item_name for s in existing)
             elif entity_type == "prompts":
                 existing, _ = await self.prompt_service.list_prompts(db)

--- a/tests/unit/js/fileTransfer.test.js
+++ b/tests/unit/js/fileTransfer.test.js
@@ -28,7 +28,6 @@ import {
 } from "../../../mcpgateway/admin_ui/fileTransfer.js";
 
 import { showNotification } from "../../../mcpgateway/admin_ui/utils.js";
-import { getAuthToken } from "../../../mcpgateway/admin_ui/tokens.js";
 import { displayImportPreview } from "../../../mcpgateway/admin_ui/selectiveImport.js";
 import { loadTools } from "../../../mcpgateway/admin_ui/tools.js";
 
@@ -758,13 +757,13 @@ describe("previewImport", () => {
     vi.clearAllMocks();
     document.body.innerHTML = "";
     window.ROOT_PATH = "";
-    window.currentImportData = null;
+    window.Admin = { currentImportData: null };
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.ROOT_PATH;
-    delete window.currentImportData;
+    delete window.Admin;
   });
 
   test("shows error when no import data is loaded", async () => {
@@ -777,7 +776,7 @@ describe("previewImport", () => {
   });
 
   test("fetches and displays preview successfully", async () => {
-    window.currentImportData = { version: "1.0", entities: {} };
+    window.Admin.currentImportData = { version: "1.0", entities: {} };
 
     const previewBtn = document.createElement("button");
     previewBtn.id = "import-preview-btn";
@@ -820,7 +819,7 @@ describe("previewImport", () => {
   });
 
   test("handles preview error", async () => {
-    window.currentImportData = { version: "1.0", entities: {} };
+    window.Admin.currentImportData = { version: "1.0", entities: {} };
 
     const previewBtn = document.createElement("button");
     previewBtn.id = "import-preview-btn";
@@ -856,13 +855,13 @@ describe("handleImport", () => {
     vi.clearAllMocks();
     document.body.innerHTML = "";
     window.ROOT_PATH = "";
-    window.currentImportData = null;
+    window.Admin = { currentImportData: null };
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
     delete window.ROOT_PATH;
-    delete window.currentImportData;
+    delete window.Admin;
   });
 
   test("shows error when no import data is loaded", async () => {
@@ -875,7 +874,7 @@ describe("handleImport", () => {
   });
 
   test("performs dry run validation successfully", async () => {
-    window.currentImportData = { version: "1.0", entities: {} };
+    window.Admin.currentImportData = { version: "1.0", entities: {} };
 
     const conflictStrategy = document.createElement("select");
     conflictStrategy.id = "import-conflict-strategy";
@@ -958,7 +957,7 @@ describe("handleImport", () => {
   });
 
   test("performs actual import and refreshes data", async () => {
-    window.currentImportData = { version: "1.0", entities: {} };
+    window.Admin.currentImportData = { version: "1.0", entities: {} };
 
     const conflictStrategy = document.createElement("select");
     conflictStrategy.id = "import-conflict-strategy";
@@ -1046,7 +1045,7 @@ describe("handleImport", () => {
   });
 
   test("handles import error", async () => {
-    window.currentImportData = { version: "1.0", entities: {} };
+    window.Admin.currentImportData = { version: "1.0", entities: {} };
 
     const previewBtn = document.createElement("button");
     previewBtn.id = "import-preview-btn";

--- a/tests/unit/js/initialization.test.js
+++ b/tests/unit/js/initialization.test.js
@@ -1670,6 +1670,15 @@ describe("initializeExportImport", () => {
     expect(loadRecentImports).not.toHaveBeenCalled();
   });
 
+  test("skips if already initialized on window.Admin", () => {
+    window.Admin.exportImportInitialized = true;
+    buildExportImportDOM();
+
+    initializeExportImport();
+
+    expect(loadRecentImports).not.toHaveBeenCalled();
+  });
+
   test("attaches click on export-all-btn -> handleExportAll", () => {
     buildExportImportDOM();
 
@@ -1701,6 +1710,17 @@ describe("initializeExportImport", () => {
     importDropZone.click();
 
     expect(clickSpy).toHaveBeenCalled();
+  });
+
+  test("importDropZone click does not recurse when input click bubbles", () => {
+    const { importDropZone, importFileInput } = buildExportImportDOM();
+    const clickSpy = vi.spyOn(importFileInput, "click");
+
+    initializeExportImport();
+
+    importDropZone.click();
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
   test("importFileInput change -> handleFileSelect", () => {
@@ -1769,6 +1789,7 @@ describe("initializeExportImport", () => {
     initializeExportImport();
 
     expect(window.Admin.exportImportInitialized).toBe(true);
+    expect(window.exportImportInitialized).toBe(true);
   });
 
   test("calls loadRecentImports", () => {

--- a/tests/unit/mcpgateway/services/test_gateway_service.py
+++ b/tests/unit/mcpgateway/services/test_gateway_service.py
@@ -951,6 +951,52 @@ class TestGatewayService:
         assert result.status == "pending"
 
     @pytest.mark.asyncio
+    async def test_update_gateway_defer_initialization_still_checks_duplicates(self, gateway_service, mock_gateway, test_db, monkeypatch):
+        """Deferred updates should still enforce local duplicate gateway policy."""
+        mock_gateway.id = "gw-1"
+        mock_gateway.status = "active"
+        mock_gateway.url = "http://example.com/original"
+        mock_gateway.transport = "SSE"
+        mock_gateway.auth_type = None
+        mock_gateway.auth_value = None
+        mock_gateway.auth_query_params = None
+        mock_gateway.oauth_config = None
+        mock_gateway.ca_certificate = None
+        mock_gateway.ca_certificate_sig = None
+        mock_gateway.signing_algorithm = None
+        mock_gateway.client_cert = None
+        mock_gateway.client_key = None
+        mock_gateway.version = 1
+        mock_gateway.team_id = None
+        mock_gateway.tools = []
+        mock_gateway.resources = []
+        mock_gateway.prompts = []
+
+        test_db.execute = Mock(return_value=_make_execute_result(scalar=mock_gateway))
+        test_db.commit = Mock()
+        test_db.refresh = Mock()
+
+        duplicate_check = Mock(return_value=None)
+        monkeypatch.setattr(gateway_service, "_check_gateway_uniqueness", duplicate_check)
+        monkeypatch.setattr("mcpgateway.services.gateway_service._get_registry_cache", lambda: SimpleNamespace(invalidate_gateways=AsyncMock()))
+        monkeypatch.setattr("mcpgateway.services.gateway_service._get_tool_lookup_cache", lambda: SimpleNamespace(invalidate_gateway=AsyncMock()))
+        monkeypatch.setattr("mcpgateway.cache.admin_stats_cache.admin_stats_cache", SimpleNamespace(invalidate_tags=AsyncMock()))
+        gateway_service._notify_gateway_updated = AsyncMock()
+        gateway_service._initialize_gateway = AsyncMock()
+
+        mock_gateway_read = MagicMock()
+        mock_gateway_read.masked.return_value = mock_gateway_read
+        mock_gateway_read.status = "pending"
+
+        with patch("mcpgateway.services.gateway_service.GatewayRead.model_validate", return_value=mock_gateway_read):
+            result = await gateway_service.update_gateway(test_db, "gw-1", GatewayUpdate(name=mock_gateway.name, url=mock_gateway.url), modified_via="import", defer_initialization=True)
+
+        duplicate_check.assert_called_once()
+        gateway_service._initialize_gateway.assert_not_called()
+        assert mock_gateway.status == "pending"
+        assert result.status == "pending"
+
+    @pytest.mark.asyncio
     async def test_update_gateway_async_retry_returns_existing_pending_gateway(self, gateway_service, mock_gateway, test_db, monkeypatch):
         """Async update retry should return existing pending gateway without applying new changes."""
         mock_gateway.id = "gw-1"

--- a/tests/unit/mcpgateway/services/test_import_service.py
+++ b/tests/unit/mcpgateway/services/test_import_service.py
@@ -16,6 +16,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 
 # First-Party
+from mcpgateway.config import settings
 from mcpgateway.schemas import ToolCreate
 from mcpgateway.services.gateway_service import GatewayNameConflictError
 from mcpgateway.services.import_service import ConflictStrategy, ImportConflictError, ImportError, ImportService, ImportStatus, ImportValidationError
@@ -120,8 +121,10 @@ async def test_validate_entity_fields_missing_required(import_service):
 
 
 @pytest.mark.asyncio
-async def test_import_configuration_success(import_service, mock_db, valid_import_data):
+async def test_import_configuration_success(import_service, mock_db, valid_import_data, monkeypatch):
     """Test successful configuration import."""
+    monkeypatch.setattr(settings, "gateway_async_lifecycle_enabled", False)
+
     # Setup mocks for successful bulk creation
     import_service.tool_service.register_tools_bulk.return_value = {"created": 1, "updated": 0, "skipped": 0, "failed": 0, "errors": []}
     import_service.gateway_service.register_gateway.return_value = MagicMock()
@@ -141,6 +144,22 @@ async def test_import_configuration_success(import_service, mock_db, valid_impor
     gateway_call = import_service.gateway_service.register_gateway.await_args.kwargs
     assert gateway_call["created_by"] == "test_user"
     assert gateway_call["created_via"] == "import"
+    assert gateway_call["defer_initialization"] is False
+
+
+@pytest.mark.asyncio
+async def test_import_configuration_defers_gateway_when_async_lifecycle_enabled(import_service, mock_db, valid_import_data, monkeypatch):
+    """Gateway import should only defer initialization when the async lifecycle worker is enabled."""
+    monkeypatch.setattr(settings, "gateway_async_lifecycle_enabled", True)
+
+    import_service.tool_service.register_tools_bulk.return_value = {"created": 1, "updated": 0, "skipped": 0, "failed": 0, "errors": []}
+    import_service.gateway_service.register_gateway.return_value = MagicMock()
+
+    status = await import_service.import_configuration(db=mock_db, import_data=valid_import_data, imported_by="test_user")
+
+    assert status.status == "completed"
+    gateway_call = import_service.gateway_service.register_gateway.await_args.kwargs
+    assert gateway_call["defer_initialization"] is True
 
 
 @pytest.mark.asyncio
@@ -570,6 +589,26 @@ async def test_convert_schema_methods(import_service):
 
 
 @pytest.mark.asyncio
+async def test_import_converters_accept_exported_tag_objects(import_service, mock_db):
+    """Import converters should accept read/export tag objects and pass strings to create/update schemas."""
+    tag_objects = [{"id": "omnichat", "label": "omnichat"}, {"id": "schema", "label": "schema"}]
+    tool_data = {"name": "lookup", "url": "https://api.example.com", "integration_type": "REST", "request_type": "GET", "tags": tag_objects}
+
+    tool_create = import_service._convert_to_tool_create(tool_data)
+    assert tool_create.tags == tag_objects
+
+    tool_update = import_service._convert_to_tool_update(tool_data)
+    assert tool_update.tags == tag_objects
+
+    import_service.tool_service.list_tools.return_value = ([], None)
+    server_create = await import_service._convert_to_server_create(mock_db, {"name": "srv", "tags": tag_objects})
+    assert server_create.tags == tag_objects
+
+    server_update = await import_service._convert_to_server_update(mock_db, {"name": "srv", "tags": tag_objects})
+    assert server_update.tags == tag_objects
+
+
+@pytest.mark.asyncio
 async def test_get_entity_identifier(import_service):
     """Test entity identifier extraction."""
     # Test tools (uses name)
@@ -873,6 +912,29 @@ async def test_gateway_conflict_update_not_found(import_service, mock_db):
 
 
 @pytest.mark.asyncio
+async def test_gateway_update_strategy_updates_existing_without_create_probe(import_service, mock_db, monkeypatch):
+    """Gateway UPDATE imports should avoid create-time uniqueness probes when a matching gateway exists."""
+    monkeypatch.setattr(settings, "gateway_async_lifecycle_enabled", False)
+
+    gateway_data = {"name": "existing_gateway", "url": "https://gateway.example.com", "description": "Existing gateway", "transport": "SSE"}
+    import_data = {"version": "2025-03-26", "exported_at": "2025-01-01T00:00:00Z", "entities": {"gateways": [gateway_data]}, "metadata": {"entity_counts": {"gateways": 1}}}
+    mock_gateway = MagicMock()
+    mock_gateway.name = "existing_gateway"
+    mock_gateway.id = "gateway_id"
+    import_service.gateway_service.list_gateways.return_value = ([mock_gateway], None)
+    import_service.gateway_service.update_gateway.return_value = MagicMock()
+
+    status = await import_service.import_configuration(db=mock_db, import_data=import_data, conflict_strategy=ConflictStrategy.UPDATE, imported_by="test_user")
+
+    assert status.updated_entities == 1
+    import_service.gateway_service.register_gateway.assert_not_called()
+    update_call = import_service.gateway_service.update_gateway.await_args
+    assert update_call.args[1] == "gateway_id"
+    assert update_call.kwargs["modified_via"] == "import"
+    assert update_call.kwargs["defer_initialization"] is False
+
+
+@pytest.mark.asyncio
 async def test_gateway_conflict_update_exception(import_service, mock_db):
     """Test gateway UPDATE conflict strategy when update operation fails."""
     gateway_data = {"name": "error_gateway", "url": "https://gateway.example.com", "description": "Error gateway", "transport": "SSE"}
@@ -969,6 +1031,26 @@ async def test_server_conflict_update_success(import_service, mock_db):
     # Should update the server
     assert status.updated_entities == 1
     import_service.server_service.update_server.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_server_conflict_update_accepts_tuple_list_response(import_service, mock_db):
+    """Server UPDATE conflict handling should accept list_servers tuple responses."""
+    server_data = {"name": "update_server", "description": "Updated server", "tool_ids": ["tool1", "tool2"]}
+    import_data = {"version": "2025-03-26", "exported_at": "2025-01-01T00:00:00Z", "entities": {"servers": [server_data]}, "metadata": {"entity_counts": {"servers": 1}}}
+
+    import_service.server_service.register_server.side_effect = ServerNameConflictError("update_server")
+    import_service.tool_service.list_tools.return_value = ([], None)
+    mock_server = MagicMock()
+    mock_server.name = "update_server"
+    mock_server.id = "server_id"
+    import_service.server_service.list_servers.return_value = ([mock_server], None)
+    import_service.server_service.update_server.return_value = MagicMock()
+
+    status = await import_service.import_configuration(db=mock_db, import_data=import_data, conflict_strategy=ConflictStrategy.UPDATE, imported_by="test_user")
+
+    assert status.updated_entities == 1
+    assert not any("'list' object has no attribute 'name'" in warning for warning in status.warnings)
 
 
 @pytest.mark.asyncio
@@ -1405,9 +1487,9 @@ async def test_gateway_auth_conversion_decode_error(import_service):
     """Test gateway conversion with invalid auth data."""
     gateway_data = {"name": "error_gateway", "url": "https://example.com", "auth_type": "basic", "auth_value": "invalid_encrypted_data"}
 
-    # Should raise ValidationError because auth fields are missing after decode failure
-    with pytest.raises(Exception):  # ValidationError or similar
-        import_service._convert_to_gateway_create(gateway_data)
+    gateway_create = import_service._convert_to_gateway_create(gateway_data)
+    assert gateway_create.name == "error_gateway"
+    assert gateway_create.auth_type in (None, "")
 
 
 @pytest.mark.asyncio
@@ -1445,9 +1527,9 @@ async def test_gateway_update_auth_decode_error(import_service):
         "auth_value": "invalid_encrypted_data_update",
     }
 
-    # Should raise ValidationError because auth token is missing after decode failure
-    with pytest.raises(Exception):  # ValidationError or similar
-        import_service._convert_to_gateway_update(gateway_data)
+    gateway_update = import_service._convert_to_gateway_update(gateway_data)
+    assert gateway_update.name == "update_error_gateway"
+    assert gateway_update.auth_type in (None, "")
 
 
 @pytest.mark.asyncio
@@ -2027,7 +2109,7 @@ async def test_preview_import_builds_bundles_and_conflicts(import_service, mock_
 
     import_service.tool_service.list_tools.return_value = ([SimpleNamespace(original_name="tool1")], None)
     import_service.gateway_service.list_gateways.return_value = ([SimpleNamespace(name="gw1")], None)
-    import_service.server_service.list_servers.return_value = [SimpleNamespace(name="srv1")]
+    import_service.server_service.list_servers.return_value = ([SimpleNamespace(name="srv1")], None)
     import_service.prompt_service.list_prompts.return_value = ([SimpleNamespace(name="prompt1")], None)
     import_service.resource_service.list_resources.return_value = ([SimpleNamespace(uri="file:///res1")], None)
 
@@ -2409,9 +2491,8 @@ async def test_gateway_create_with_authheaders_multiple(import_service):
 async def test_gateway_create_auth_decode_failure(import_service):
     """Test gateway conversion with auth decode failure.
 
-    When auth_value decoding fails, the conversion logs a warning but continues.
-    However, if auth_type is 'bearer', GatewayCreate schema requires auth_token,
-    which causes a ValidationError since auth decoding failed to populate auth_token.
+    When auth_value decoding fails, the conversion logs a warning and imports
+    the gateway without auth so the secret can be re-entered later.
     """
     gateway_data = {
         "name": "bad_auth_gw",
@@ -2420,13 +2501,25 @@ async def test_gateway_create_auth_decode_failure(import_service):
         "auth_value": "invalid-encrypted-data",
     }
 
-    # When auth decoding fails for bearer type, GatewayCreate validation fails
-    # because bearer auth requires auth_token which wasn't populated
-    with pytest.raises(Exception) as exc_info:
-        import_service._convert_to_gateway_create(gateway_data)
+    result = import_service._convert_to_gateway_create(gateway_data)
 
-    # Should be a pydantic ValidationError for missing auth_token
-    assert "auth_token" in str(exc_info.value) or "bearer" in str(exc_info.value).lower()
+    assert result.name == "bad_auth_gw"
+    assert result.auth_type in (None, "")
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_missing_auth_value_skips_auth(import_service):
+    """Gateway imports with auth_type but no secret should not fail validation."""
+    gateway_data = {
+        "name": "missing_auth_gw",
+        "url": "https://gw.example.com",
+        "auth_type": "bearer",
+    }
+
+    result = import_service._convert_to_gateway_create(gateway_data)
+
+    assert result.name == "missing_auth_gw"
+    assert result.auth_type in (None, "")
 
 
 # ============================================================================
@@ -2523,11 +2616,12 @@ async def test_gateway_auth_conversion_query_param_decode_error(import_service):
     settings.insecure_queryparam_auth_allowed_hosts = []
     try:
         with patch("mcpgateway.services.import_service.decode_auth", side_effect=Exception("boom")):
-            with pytest.raises(Exception):
-                import_service._convert_to_gateway_create(gateway_data)
+            gw = import_service._convert_to_gateway_create(gateway_data)
     finally:
         settings.insecure_allow_queryparam_auth = original_allow
         settings.insecure_queryparam_auth_allowed_hosts = original_hosts
+
+    assert gw.auth_type in (None, "")
 
 
 @pytest.mark.asyncio
@@ -2550,8 +2644,9 @@ async def test_gateway_update_auth_conversion_query_param_decode_error(import_se
     gateway_data = {"name": "qp_gateway", "url": "https://example.com", "auth_type": "query_param", "auth_query_params": {"api_key": "enc"}}  # pragma: allowlist secret
 
     with patch("mcpgateway.services.import_service.decode_auth", side_effect=Exception("boom")):
-        with pytest.raises(Exception):
-            import_service._convert_to_gateway_update(gateway_data)
+        gw = import_service._convert_to_gateway_update(gateway_data)
+
+    assert gw.auth_type in (None, "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #5500

## Summary

Configuration imports could fail or behave inconsistently when importing exported gateway/server data back into an existing instance. The main failure modes were around gateway UPDATE conflict handling, exported tag object shapes, masked or undecodable auth values, tuple-shaped service list responses, and Admin UI import state stored under `window.Admin`.

This PR keeps the fix scoped to the import path and related UI state handling.

## Root Cause

- Gateway imports using the UPDATE conflict strategy still attempted a create path first, which could trip create-time uniqueness checks before updating an existing gateway.
- Gateway imports immediately initialized remote gateways unless the global async lifecycle flag was enabled, which made bulk imports depend on remote gateway availability.
- Exported/read tag data can arrive as tag objects, while create/update schemas expect normalized tag values.
- Gateway auth conversion assumed encrypted auth values were present and decodable. Masked or invalid exported secrets could make the import fail validation instead of importing the gateway without credentials for later re-entry.
- Server conflict and preview paths assumed `list_servers()` returned a plain list, while service methods can return `(items, pagination)` tuples.
- Import preview/submit looked at the legacy global `window.currentImportData` even though current Admin UI state is namespaced on `window.Admin`.
- The import drop-zone click handler could re-trigger when the file input click bubbled back through the drop zone.

## Fix Description

- Added an explicit `defer_initialization` option to gateway register/update flows so imports can persist gateway changes as pending when async lifecycle is enabled, without contacting the remote gateway inline.
- Changed gateway UPDATE imports to pre-check for an existing gateway by name and update it directly when present, avoiding unnecessary create probes.
- Centralized import tag normalization and applied it consistently across tools, gateways, servers, prompts, and resources.
- Centralized gateway auth import conversion so masked, missing, invalid, or undecodable auth payloads are skipped cleanly instead of producing partial auth schemas that fail validation.
- Added a small list-response extractor for import paths that need to accept tuple or dictionary service responses.
- Updated Admin UI import preview/submit to read `window.Admin.currentImportData` and kept the legacy initialization flag synchronized for compatibility.
- Guarded the import drop-zone click handler against bubbled input clicks.
- Added focused Python and Vitest coverage for the changed import, gateway, and Admin UI behaviors.

## Verification

| Check | Command | Status |
|---|---|---|
| Python service tests | `.venv/bin/pytest tests/unit/mcpgateway/services/test_import_service.py tests/unit/mcpgateway/services/test_gateway_service.py -q` | Passed |
| JS import UI tests | `PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\" npx vitest run tests/unit/js/fileTransfer.test.js tests/unit/js/initialization.test.js` | Passed |
| JS lint on touched files | `PATH=\"/opt/homebrew/bin:/usr/local/bin:$PATH\" npx eslint mcpgateway/admin_ui/fileTransfer.js mcpgateway/admin_ui/initialization.js tests/unit/js/fileTransfer.test.js tests/unit/js/initialization.test.js` | Passed |
| Whitespace check | `git diff --check` | Passed |

Note: I attempted `ruff check` on the touched Python files, but the available Homebrew `ruff` binary could not parse the repository's current `pyproject.toml` because it does not recognize `PLW0717`. No project config changes were made for that local tool-version mismatch.

## Checklist

- [x] One clear bug-fix purpose
- [x] Tests added/updated for changed behavior
- [x] No secrets or credentials committed