### PR TITLE
fix: resolve double /v1/v1 prefix on tool plugin bindings routes and restore legacy unversioned aliases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-03T14:53:01Z",
+  "generated_at": "2026-07-06T10:05:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/mcpgateway/routers/tool_plugin_bindings.py
+++ b/mcpgateway/routers/tool_plugin_bindings.py
@@ -7,7 +7,8 @@ Authors: Madhumohan Jaishankar
 Tool Plugin Bindings Router.
 Provides endpoints for configuring per-tool per-tenant plugin policies.
 
-Endpoints:
+Endpoints (canonical paths under the /v1 mount; also served unversioned via the
+deprecated legacy mount when LEGACY_API_ENABLED is true):
     POST   /v1/tools/plugin_bindings                              — Create or update bindings (upsert)
     GET    /v1/tools/plugin_bindings                              — List all bindings
     GET    /v1/tools/plugin_bindings/{team_id}                    — List bindings for a specific team
@@ -34,7 +35,7 @@ from mcpgateway.services.tool_plugin_binding_service import ToolPluginBindingFor
 logging_service = LoggingService()
 logger = logging_service.get_logger(__name__)
 
-router = APIRouter(prefix="/v1/tools/plugin_bindings", tags=["Tool Plugin Bindings"])
+router = APIRouter(prefix="/tools/plugin_bindings", tags=["Tool Plugin Bindings"])
 
 _service = ToolPluginBindingService()
 

--- a/tests/unit/mcpgateway/middleware/test_deprecation_middleware.py
+++ b/tests/unit/mcpgateway/middleware/test_deprecation_middleware.py
@@ -34,6 +34,9 @@ class TestIsLegacyPath:
             "/tools",
             "/tools/123",
             "/tools/123/execute",
+            "/tools/plugin_bindings",
+            "/tools/plugin_bindings/team-1",
+            "/tools/plugin_bindings/8b6ff37b-0000-0000-0000-000000000000",
             "/servers",
             "/servers/abc/sse",
             "/resources",
@@ -72,6 +75,8 @@ class TestIsLegacyPath:
         [
             "/v1/tools",
             "/v1/tools/123",
+            "/v1/tools/plugin_bindings",
+            "/v1/tools/plugin_bindings/team-1",
             "/v1/servers",
             "/v1/admin",
             "/v1/a2a",
@@ -234,6 +239,26 @@ class TestDeprecationHeadersMiddlewareHeaders:
         mw = DeprecationHeadersMiddleware(_build_app("/servers/123"), sunset_date=SUNSET)
         _, headers = await _call(mw, "/servers/123")
         assert headers.get("link") == '</v1/servers/123>; rel="successor-version"'
+
+    @pytest.mark.asyncio
+    async def test_headers_on_legacy_plugin_bindings_path(self):
+        """Unversioned /tools/plugin_bindings/** gets full deprecation stamping."""
+        path = "/tools/plugin_bindings/team-1"
+        mw = DeprecationHeadersMiddleware(_build_app(path), sunset_date=SUNSET)
+        status, headers = await _call(mw, path)
+        assert status == 200
+        assert headers.get("sunset") == SUNSET
+        assert headers.get("deprecation") == "true"
+        assert headers.get("link") == '</v1/tools/plugin_bindings/team-1>; rel="successor-version"'
+
+    @pytest.mark.asyncio
+    async def test_no_headers_on_v1_plugin_bindings_path(self):
+        """Canonical /v1/tools/plugin_bindings must never be stamped."""
+        path = "/v1/tools/plugin_bindings"
+        mw = DeprecationHeadersMiddleware(_build_app(path), sunset_date=SUNSET)
+        _, headers = await _call(mw, path)
+        assert "sunset" not in headers
+        assert "deprecation" not in headers
 
     @pytest.mark.asyncio
     async def test_websocket_scope_passed_through_unchanged(self):

--- a/tests/unit/mcpgateway/test_api_versioning_parity.py
+++ b/tests/unit/mcpgateway/test_api_versioning_parity.py
@@ -11,7 +11,7 @@ to be missing on that router's legacy routes.
 import pytest
 from fastapi import APIRouter
 
-from mcpgateway.api.v1 import _assemble_routers
+from mcpgateway.api.v1 import _assemble_routers, build_legacy_router, build_v1_router
 from mcpgateway.config import settings
 from mcpgateway.middleware.deprecation import _LEGACY_PREFIXES
 from tests.helpers.router_helpers import collect_routes
@@ -99,10 +99,11 @@ def test_legacy_prefixes_match_assembled_routers():
 
     # Exclude permanently unversioned prefixes that should NOT have deprecation headers
     # These are intentionally not in _LEGACY_PREFIXES
+    # NOTE: "/v1" is deliberately NOT excluded — no assembled router may hardcode
+    # a /v1 prefix (it would double up as /v1/v1/** under build_v1_router).
     permanently_unversioned = {
         "/.well-known",  # RFC 9116 - permanently unversioned
         "/api",          # Internal API prefix (if present)
-        "/v1",           # Already-versioned routes (e.g. tool_plugin_bindings hardcodes /v1 prefix)
         "/version",      # Diagnostics endpoint — no deprecation headers (like /health)
     }
 
@@ -171,6 +172,59 @@ def test_core_prefixes_present(prefix: str):
         f"Core prefix {prefix} missing from _LEGACY_PREFIXES. "
         f"This would cause deprecation headers to be missing on legacy routes."
     )
+
+
+def _empty_router_kwargs() -> dict[str, APIRouter]:
+    """Return the full set of inline-router kwargs as empty APIRouters."""
+    names = [
+        "protocol_router",
+        "tool_router",
+        "resource_router",
+        "prompt_router",
+        "gateway_router",
+        "root_router",
+        "server_router",
+        "metrics_router",
+        "tag_router",
+        "export_import_router",
+        "a2a_router",
+    ]
+    return {name: APIRouter() for name in names}
+
+
+class TestPluginBindingsRoutePrefixes:
+    """Regression tests for the /v1/v1 double-prefix bug (tool_plugin_bindings).
+
+    The tool_plugin_bindings router must NOT hardcode a /v1 prefix: it is
+    dual-mounted via build_v1_router (prefix /v1) and build_legacy_router
+    (no prefix), so a hardcoded /v1 produced /v1/v1/tools/plugin_bindings/**
+    on the canonical mount and left the unversioned legacy alias missing.
+    """
+
+    def test_v1_router_serves_plugin_bindings_under_single_v1(self):
+        """Canonical routes live at /v1/tools/plugin_bindings/**."""
+        v1_router = build_v1_router(settings, **_empty_router_kwargs())
+        paths = [p for p, *_ in collect_routes(v1_router)]
+
+        assert "/v1/tools/plugin_bindings/" in paths
+        assert "/v1/tools/plugin_bindings/{team_id}" in paths
+        assert "/v1/tools/plugin_bindings/{binding_id}" in paths
+
+    def test_v1_router_has_no_double_v1_paths(self):
+        """No route on the v1 mount may start with /v1/v1."""
+        v1_router = build_v1_router(settings, **_empty_router_kwargs())
+        doubled = [p for p, *_ in collect_routes(v1_router) if p.startswith("/v1/v1")]
+        assert not doubled, f"Double /v1 prefix on routes: {doubled}"
+
+    def test_legacy_router_serves_unversioned_plugin_bindings(self):
+        """Legacy aliases live at /tools/plugin_bindings/** (no /v1 anywhere)."""
+        legacy_router = build_legacy_router(settings, **_empty_router_kwargs())
+        paths = [p for p, *_ in collect_routes(legacy_router)]
+
+        assert "/tools/plugin_bindings/" in paths
+        assert "/tools/plugin_bindings/{team_id}" in paths
+        assert "/tools/plugin_bindings/{binding_id}" in paths
+        assert not any(p.startswith("/v1") for p in paths), "Legacy mount must not contain /v1 paths"
 
 
 def test_llm_admin_router_csrf_dependency():


### PR DESCRIPTION
## 📌 Summary

The Tool Plugin Bindings API was served at `/v1/v1/tools/plugin_bindings/**` (double version prefix) on the canonical mount, and the unversioned legacy alias `/tools/plugin_bindings/**` did not exist at all. This PR fixes the router prefix so the endpoints follow the same dual-mount pattern as every other router:

- **Canonical**: `/v1/tools/plugin_bindings/**` — in the OpenAPI schema, no deprecation headers
- **Legacy**: `/tools/plugin_bindings/**` — served when `LEGACY_API_ENABLED=true`, stamped with `Deprecation` / `Sunset` / `Link` headers

## 🐞 Root Cause

`mcpgateway/routers/tool_plugin_bindings.py` hardcoded `prefix="/v1/tools/plugin_bindings"` on the router. Since `_assemble_routers()` (`mcpgateway/api/v1/__init__.py`) includes this router into both `build_v1_router` (prefix `/v1`) and `build_legacy_router` (no prefix), the result was:

- v1 mount → `/v1/v1/tools/plugin_bindings/**` (double prefix)
- legacy mount → `/v1/tools/plugin_bindings/**` — worked only by accident, and skipped deprecation headers because `_is_legacy_path()` short-circuits on paths starting with `/v1`

## 💡 Fix Description

- Changed the router prefix to `/tools/plugin_bindings` so each mount applies its own version prefix exactly once. No middleware changes needed: `/tools` is already in `_LEGACY_PREFIXES`, so the legacy alias gets `Deprecation` / `Sunset` / `Link` headers automatically. Token scoping is unaffected (`_strip_v1_prefix()` normalizes both forms identically).
- Removed the `/v1` exclusion from the versioning parity test — any future router that hardcodes a `/v1` prefix in `_assemble_routers` now fails the test.
- Regression tests:
  - v1 mount serves `/v1/tools/plugin_bindings/`, `/{team_id}`, `/{binding_id}`; no route starts with `/v1/v1`
  - legacy mount serves the same paths unversioned, with no `/v1` routes
  - `_is_legacy_path()` classifies binding paths correctly on both mounts
  - legacy binding responses carry `Sunset` / `Deprecation` / correct successor `Link`; canonical `/v1` paths are never stamped

Existing callers (`tests/live_gateway/plugins/_helpers.py`, `docs/docs/api/plugin-bindings-api.md`) already use `/v1/tools/plugin_bindings/` and are correct after this change.

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check | Command | Status |
|-------|---------|--------|
| Targeted unit tests (parity, deprecation middleware, bindings router, api v1) | `pytest tests/unit/mcpgateway/test_api_versioning_parity.py tests/unit/mcpgateway/middleware/test_deprecation_middleware.py tests/unit/mcpgateway/routers/test_tool_plugin_bindings.py tests/unit/mcpgateway/test_api_v1.py` | ✅ 187 passed |
| Lint on changed files | `ruff check`, `pylint` (10.00/10) | ✅ |

## 📐 MCP Compliance (if relevant)

- [x] No breaking change to MCP clients

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] No secrets/credentials committed
