### PR TITLE
fix(dataplane_publisher): publish original_name in allowed_tool_names

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -324,7 +324,7 @@ class DataplanePublisherService:
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
-        tool_name_by_id = {tool.id: tool.name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
+        tool_name_by_id = {tool.id: tool.original_name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
 
         return {
             "servers": [


### PR DESCRIPTION
## Problem

`DataplanePublisherService._build_user_data` builds `tool_name_by_id` using `tool.name`, which is the slugged hybrid property:

```python
# Tool.name hybrid property → "compliance-reference-progress-reporter"
gateway_slug = slugify(self.gateway.name)
return f"{gateway_slug}{separator}{custom_name_slug}"
```

Upstream MCP servers advertise the bare `original_name` (e.g. `progress_reporter`).  The dataplane receives `allowed_tool_names: ["compliance-reference-progress-reporter"]`, tries to match it against the upstream's `progress_reporter`, finds nothing, and returns **0 tools** to the client.

Observed in the integration stack as the dataplane logging `list_tools: backend … completed (136 items)` but returning an empty tools list to every runtime-registered virtual host session.

## Fix

```python
# before
tool_name_by_id = {tool.id: tool.name          for tool in tool_rows ...}
# after
tool_name_by_id = {tool.id: tool.original_name  for tool in tool_rows ...}
```

One word.  The dataplane already prefixes the backend key when advertising tools to clients (`backend_name-original_name`), so the public tool name is unchanged.  The allow-list just needs to carry what the upstream actually sends.

## Impact

- contextforge-gateway-rs PR #55 ("Filter runtime tools by allowed names", +201/-12 lines) is no longer needed — the dataplane's existing `split_prefixed_name` routing handles bare names correctly.
- Pre-registered fixed virtual hosts (Fast Time) are unaffected: their `allowed_tool_names` are already set to bare names in fixtures.

## Testing

- Existing `tests/unit/mcpgateway/services/test_dataplane_publisher.py` assertions on `allowed_tool_names` pass (they use fixture tool names that happen to match `original_name`).
- Integration: `scripts/cf-integration.sh live-protocol` goes from 2 failures + 11 skips to green once this publishes.