### PR TITLE
fix(dataplane_publisher): publish original_name in allowed_tool_names

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -324,7 +324,7 @@ class DataplanePublisherService:
         backend_items_by_server: BackendItemsByServer,
     ) -> dict[str, Any]:
         """Build already-filtered dataplane data for one user."""
-        tool_name_by_id = {tool.id: tool.name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
+        tool_name_by_id = {tool.id: tool.original_name for tool in tool_rows if self._filter_for_user(tool, user_email, team_ids, is_admin=is_admin)}
 
         return {
             "servers": [

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -289,7 +289,7 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(select(DbTool.id, DbTool.name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
+                tool_rows = db.execute(select(DbTool.id, DbTool.name, DbTool.original_name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -289,7 +289,7 @@ class DataplanePublisherService:
                         DbResource.uri_template.is_(None),
                     )
                 ).all()
-                tool_rows = db.execute(select(DbTool.id, DbTool.name, DbTool.original_name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
+                tool_rows = db.execute(select(DbTool.id, DbTool.original_name, DbTool.owner_email, DbTool.team_id, DbTool.visibility).where(DbTool.enabled.is_(True))).all()
                 backend_items_by_server = self._get_backend_items_by_server(db)
 
                 return {

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -191,7 +191,8 @@ async def test_full_payload_generation_with_mock_db():
 
     tool1 = Mock()
     tool1.id = "t1"
-    tool1.name = "public_tool"
+    tool1.name = "gw1-public_tool"
+    tool1.original_name = "public_tool"
     tool1.owner_email = "user1@example.com"
     tool1.team_id = "team1"
     tool1.visibility = "public"
@@ -199,7 +200,8 @@ async def test_full_payload_generation_with_mock_db():
 
     tool2 = Mock()
     tool2.id = "t2"
-    tool2.name = "private_tool"
+    tool2.name = "gw1-private_tool"
+    tool2.original_name = "private_tool"
     tool2.owner_email = "user1@example.com"
     tool2.team_id = "team1"
     tool2.visibility = "private"
@@ -207,7 +209,8 @@ async def test_full_payload_generation_with_mock_db():
 
     tool3 = Mock()
     tool3.id = "t3"
-    tool3.name = "team2_tool"
+    tool3.name = "gw1-team2_tool"
+    tool3.original_name = "team2_tool"
     tool3.owner_email = "user2@example.com"
     tool3.team_id = "team2"
     tool3.visibility = "team"


### PR DESCRIPTION
## Problem

`DataplanePublisherService._build_user_data` builds `tool_name_by_id` using `tool.name`, which is the slugged hybrid property:

```python
# Tool.name hybrid property → "compliance-reference-progress-reporter"
gateway_slug = slugify(self.gateway.name)
return f"{gateway_slug}{separator}{custom_name_slug}"
```

Upstream MCP servers advertise the bare `original_name` (e.g. `progress_reporter`). The dataplane receives `allowed_tool_names: ["compliance-reference-progress-reporter"]`, tries to match it against the upstream's `progress_reporter`, finds nothing, and returns **0 tools** to the client.

Observed in the integration stack as the dataplane logging `list_tools: backend … completed (136 items)` but returning an empty tools list to every runtime-registered virtual host session.

## Fix

```python
# before
tool_name_by_id = {tool.id: tool.name          for tool in tool_rows ...}
# after
tool_name_by_id = {tool.id: tool.original_name  for tool in tool_rows ...}
```

One word. The dataplane already prefixes the backend key when advertising tools to clients (`backend_name-original_name`), so the public tool name seen by clients is unchanged. The allow-list just needs to carry the name the upstream actually advertises.

## Impact

- contextforge-gateway-rs PR #55 ("Filter runtime tools by allowed names", +201/-12 lines) is no longer needed — the dataplane's existing `split_prefixed_name` routing handles bare names correctly.
- Pre-registered fixed virtual hosts (Fast Time) are unaffected.

## Testing

- Existing `tests/unit/mcpgateway/services/test_dataplane_publisher.py` assertions on `allowed_tool_names` pass.
- Integration: `scripts/cf-integration.sh live-protocol` goes from 2 failures + 11 skips to green once this publishes.