### PR TITLE
ci(plugins): replace fast-time-server source build with pre-built Docker image

### DIFF
--- a/.github/workflows/plugin-integration.yml
+++ b/.github/workflows/plugin-integration.yml
@@ -38,7 +38,6 @@ on:
             # lives in the repo and must retrigger the suite when it changes.
             - "plugins/sql_sanitizer/**"
             - "tests/live_gateway/plugins/**"
-            - "mcp-servers/rust/fast-time-server/**"
             - ".github/workflows/plugin-integration.yml"
     workflow_dispatch:
 
@@ -48,10 +47,6 @@ permissions:
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
-
-env:
-    CARGO_TERM_COLOR: always
-    RUST_BACKTRACE: 1
 
 jobs:
     plugin-e2e:
@@ -177,26 +172,6 @@ jobs:
                       venv-${{ runner.os }}-python-3.12-
                       venv-${{ runner.os }}-
 
-            - name: Install Rust stable
-              run: |
-                  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-                  echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-                  source $HOME/.cargo/env
-                  rustup toolchain install stable
-                  rustup default stable
-                  rustc --version
-
-            - name: Cache Cargo
-              uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-              with:
-                  path: |
-                      ~/.cargo/registry
-                      ~/.cargo/git
-                      target
-                  key: ${{ runner.os }}-cargo-fast-time-${{ hashFiles('Cargo.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-cargo-fast-time-
-
             - name: Install gateway with plugins and test deps
               # install-dev installs the dev group plus the [plugins] extra, which
               # pulls the cpex wheels the gateway must import at boot.
@@ -209,21 +184,17 @@ jobs:
                   SECRET=$(openssl rand -base64 32)
                   echo "DYNAMIC_JWT_SECRET=$SECRET" >> "${GITHUB_ENV}"
 
-            - name: Build fast-time-server
-              working-directory: mcp-servers/rust/fast-time-server
-              run: cargo build
-
             - name: Start fast-time-server
               run: |
-                  pkill -9 -f "fast-time-server" 2>/dev/null || true
-                  sleep 1
-                  nohup target/debug/fast-time-server \
-                    > fast-time-server.log 2>&1 &
-                  echo $! > fast-time-server.pid
+                  docker rm -f fast-time-server 2>/dev/null || true
+                  docker run --detach \
+                    --name fast-time-server \
+                    --publish 127.0.0.1:9080:9080 \
+                    ghcr.io/ibm/cfex-mcp-fast-time-server:5eac210da1c96a5fb2386c82a0c6f543b68fd76a
 
                   echo "Waiting for fast-time-server..."
                   for i in {1..30}; do
-                    if curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                    if curl -s http://localhost:9080/health >/dev/null 2>&1; then
                       echo "fast-time-server is up!"
                       break
                     fi
@@ -231,9 +202,9 @@ jobs:
                     sleep 2
                   done
 
-                  if ! curl -s http://localhost:8080/health >/dev/null 2>&1; then
+                  if ! curl -s http://localhost:9080/health >/dev/null 2>&1; then
                     echo "ERROR: fast-time-server failed to start"
-                    cat fast-time-server.log
+                    docker logs fast-time-server
                     exit 1
                   fi
 
@@ -320,6 +291,10 @@ jobs:
               run: |
                   . .venv/bin/activate
                   python -m pytest "${{ matrix.plugin.tests }}" -v
+
+            - name: Capture fast-time-server logs on failure
+              if: failure()
+              run: docker logs fast-time-server > fast-time-server.log 2>&1 || true
 
             - name: Upload logs on failure
               if: failure()

--- a/tests/live_gateway/plugins/_helpers.py
+++ b/tests/live_gateway/plugins/_helpers.py
@@ -59,7 +59,9 @@ STATIC_CONFIG_PATH = Path(__file__).resolve().parents[3] / "plugins" / "config.y
 JWT_SECRET = os.getenv("JWT_SECRET_KEY", "my-test-key-but-now-longer-than-32-bytes")  # pragma: allowlist secret
 
 # Where fast-time-server is reachable for federation registration.
-FAST_TIME_URL = os.getenv("FAST_TIME_SERVER_URL", "http://localhost:8080/mcp")
+# The cfex-mcp-fast-time-server image listens on port 9080; override via
+# FAST_TIME_SERVER_URL or run run_plugin_tests.sh which exports it automatically.
+FAST_TIME_URL = os.getenv("FAST_TIME_SERVER_URL", "http://localhost:9080/mcp")
 
 # Bounded polling budget for asynchronous tool federation sync.
 _TOOL_SYNC_ATTEMPTS = 30
@@ -255,7 +257,11 @@ def find_flaky_tool(tools: list[dict[str, Any]]) -> dict[str, Any]:
         AssertionError: If no flaky tool is present.
     """
     flaky = next((t for t in tools if t["name"].endswith("flaky") or t.get("originalName") == "flaky"), None)
-    assert flaky is not None, f"no flaky tool synced; available: {[t['name'] for t in tools]}"
+    assert flaky is not None, (
+        f"no 'flaky' tool synced from fast-time-server; available tools: {[t['name'] for t in tools]}. "
+        "Ensure the image referenced by FAST_TIME_IMAGE exposes the 'flaky' tool "
+        "(ghcr.io/ibm/cfex-mcp-fast-time-server:latest should include it)."
+    )
     return flaky
 
 

--- a/tests/live_gateway/plugins/run_plugin_tests.sh
+++ b/tests/live_gateway/plugins/run_plugin_tests.sh
@@ -16,8 +16,10 @@
 #    REDIS_HOST          Redis host for redis-requiring plugins  (default: 127.0.0.1)
 #    REDIS_PORT          Redis port                     (default: 6379)
 #    VENV_DIR            Path to project virtualenv     (default: .venv)
-#    FAST_TIME_BIN       Path to fast-time-server bin   (default: auto-detected)
+#    FAST_TIME_BIN       Path to fast-time-server bin   (default: workspace target)
 #    FAST_TIME_PORT      fast-time-server port          (default: 8080)
+#    FAST_TIME_SERVER_URL  MCP URL registered with the gateway
+#                                                       (default: derived from FAST_TIME_PORT)
 # ===========================================================================
 set -euo pipefail
 
@@ -38,7 +40,14 @@ REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 VENV_DIR="${VENV_DIR:-${PROJECT_ROOT}/.venv}"
 FAST_TIME_PORT="${FAST_TIME_PORT:-8080}"
-FAST_TIME_BIN="${FAST_TIME_BIN:-${PROJECT_ROOT}/mcp-servers/rust/fast-time-server/target/debug/fast-time-server}"
+# fast-time-server is a Cargo workspace member, so its binary is built into the
+# workspace-root target/ directory (not the crate's own target/).
+FAST_TIME_BIN="${FAST_TIME_BIN:-${PROJECT_ROOT}/target/debug/fast-time-server}"
+# URL the gateway federates to. Derived from FAST_TIME_PORT so a single override
+# moves both the bound port and the registered URL together (they must match, or
+# gateway registration fails with a 502).
+FAST_TIME_SERVER_URL="${FAST_TIME_SERVER_URL:-http://localhost:${FAST_TIME_PORT}/mcp}"
+export FAST_TIME_SERVER_URL
 
 # Args
 FILTER_PLUGIN="${1:-}"    # empty = all
@@ -90,7 +99,14 @@ trap cleanup EXIT
 wait_for_health() {
     local url="$1" label="$2" retries="${3:-40}"
     for i in $(seq 1 "${retries}"); do
-        curl -s "${url}" >/dev/null 2>&1 && { info "${label} is up"; return 0; }
+        # Require a 2xx status: a plain "got a response" check is fooled by an
+        # unrelated proxy (e.g. nginx/docker on the same port) returning 502.
+        local code
+        code="$(curl -s -o /dev/null -w '%{http_code}' "${url}" 2>/dev/null || true)"
+        if [[ "${code}" =~ ^2[0-9][0-9]$ ]]; then
+            info "${label} is up"
+            return 0
+        fi
         sleep 1
     done
     error "${label} did not become healthy at ${url}"
@@ -105,10 +121,8 @@ build_fast_time_server() {
         info "fast-time-server binary already exists — skipping build"
         return 0
     fi
-    info "Building fast-time-server (cargo build)…"
-    local src_dir
-    src_dir="$(dirname "$(dirname "$(dirname "${FAST_TIME_BIN}")")")"
-    (cd "${src_dir}" && cargo build) || {
+    info "Building fast-time-server (cargo build -p fast-time-server)…"
+    (cd "${PROJECT_ROOT}" && cargo build -p fast-time-server) || {
         error "cargo build failed for fast-time-server"
         return 1
     }
@@ -122,7 +136,10 @@ start_fast_time_server() {
     # Kill any stale instance first
     pkill -9 -f "target/debug/fast-time-server" 2>/dev/null || true
     sleep 1
-    nohup "${FAST_TIME_BIN}" > /tmp/fast-time-plugin-tests.log 2>&1 &
+    # Pass --port explicitly so the bound port matches FAST_TIME_SERVER_URL
+    # (the URL the gateway federates to); otherwise the binary's own default
+    # wins and the two silently diverge.
+    nohup "${FAST_TIME_BIN}" --port "${FAST_TIME_PORT}" > /tmp/fast-time-plugin-tests.log 2>&1 &
     FAST_TIME_PID=$!
     wait_for_health "http://localhost:${FAST_TIME_PORT}/health" "fast-time-server" 20
 }

--- a/tests/live_gateway/plugins/run_plugin_tests.sh
+++ b/tests/live_gateway/plugins/run_plugin_tests.sh
@@ -15,11 +15,11 @@
 #    JWT_SECRET_KEY      Must be >32 bytes              (default: see below)
 #    REDIS_HOST          Redis host for redis-requiring plugins  (default: 127.0.0.1)
 #    REDIS_PORT          Redis port                     (default: 6379)
-#    VENV_DIR            Path to project virtualenv     (default: .venv)
-#    FAST_TIME_BIN       Path to fast-time-server bin   (default: workspace target)
-#    FAST_TIME_PORT      fast-time-server port          (default: 8080)
-#    FAST_TIME_SERVER_URL  MCP URL registered with the gateway
-#                                                       (default: derived from FAST_TIME_PORT)
+#    VENV_DIR              Path to project virtualenv     (default: .venv)
+#    FAST_TIME_IMAGE       fast-time-server container image (default: ghcr.io/ibm/cfex-mcp-fast-time-server:5eac210da1c96a5fb2386c82a0c6f543b68fd76a)
+#    FAST_TIME_CONTAINER   docker container name            (default: mcpgw-plugin-test-fast-time)
+#    FAST_TIME_PORT        fast-time-server host port       (default: 9080)
+#    FAST_TIME_SERVER_URL  MCP URL registered with gateway  (default: derived from FAST_TIME_PORT)
 # ===========================================================================
 set -euo pipefail
 
@@ -39,13 +39,11 @@ JWT_SECRET="${JWT_SECRET_KEY:-my-test-key-but-now-longer-than-32-bytes}"
 REDIS_HOST="${REDIS_HOST:-127.0.0.1}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 VENV_DIR="${VENV_DIR:-${PROJECT_ROOT}/.venv}"
-FAST_TIME_PORT="${FAST_TIME_PORT:-8080}"
-# fast-time-server is a Cargo workspace member, so its binary is built into the
-# workspace-root target/ directory (not the crate's own target/).
-FAST_TIME_BIN="${FAST_TIME_BIN:-${PROJECT_ROOT}/target/debug/fast-time-server}"
+FAST_TIME_PORT="${FAST_TIME_PORT:-9080}"
+FAST_TIME_IMAGE="${FAST_TIME_IMAGE:-ghcr.io/ibm/cfex-mcp-fast-time-server:5eac210da1c96a5fb2386c82a0c6f543b68fd76a}"
+FAST_TIME_CONTAINER="${FAST_TIME_CONTAINER:-mcpgw-plugin-test-fast-time}"
 # URL the gateway federates to. Derived from FAST_TIME_PORT so a single override
-# moves both the bound port and the registered URL together (they must match, or
-# gateway registration fails with a 502).
+# moves both the bound port and the registered URL together.
 FAST_TIME_SERVER_URL="${FAST_TIME_SERVER_URL:-http://localhost:${FAST_TIME_PORT}/mcp}"
 export FAST_TIME_SERVER_URL
 
@@ -81,14 +79,13 @@ error()   { echo -e "${RED}[fail]${RESET} $*"; }
 # ---------------------------------------------------------------------------
 # Cleanup state
 # ---------------------------------------------------------------------------
-FAST_TIME_PID=""
 GATEWAY_PID=""
 REDIS_CONTAINER=""
 
 cleanup() {
     info "Cleaning up…"
     [[ -n "${GATEWAY_PID}"     ]] && kill -9 "${GATEWAY_PID}"     2>/dev/null || true
-    [[ -n "${FAST_TIME_PID}"   ]] && kill -9 "${FAST_TIME_PID}"   2>/dev/null || true
+    docker rm -f "${FAST_TIME_CONTAINER}" 2>/dev/null || true
     [[ -n "${REDIS_CONTAINER}" ]] && docker rm -f "${REDIS_CONTAINER}" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -114,34 +111,20 @@ wait_for_health() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 1: Build fast-time-server if binary is missing
-# ---------------------------------------------------------------------------
-build_fast_time_server() {
-    if [[ -x "${FAST_TIME_BIN}" ]]; then
-        info "fast-time-server binary already exists — skipping build"
-        return 0
-    fi
-    info "Building fast-time-server (cargo build -p fast-time-server)…"
-    (cd "${PROJECT_ROOT}" && cargo build -p fast-time-server) || {
-        error "cargo build failed for fast-time-server"
-        return 1
-    }
-    info "fast-time-server built successfully"
-}
-
-# ---------------------------------------------------------------------------
-# Step 2: Start fast-time-server (once for the whole run)
+# Step 1: Start fast-time-server container (once for the whole run)
 # ---------------------------------------------------------------------------
 start_fast_time_server() {
-    # Kill any stale instance first
-    pkill -9 -f "target/debug/fast-time-server" 2>/dev/null || true
-    sleep 1
-    # Pass --port explicitly so the bound port matches FAST_TIME_SERVER_URL
-    # (the URL the gateway federates to); otherwise the binary's own default
-    # wins and the two silently diverge.
-    nohup "${FAST_TIME_BIN}" --port "${FAST_TIME_PORT}" > /tmp/fast-time-plugin-tests.log 2>&1 &
-    FAST_TIME_PID=$!
-    wait_for_health "http://localhost:${FAST_TIME_PORT}/health" "fast-time-server" 20
+    docker rm -f "${FAST_TIME_CONTAINER}" 2>/dev/null || true
+    info "Pulling fast-time-server image: ${FAST_TIME_IMAGE}"
+    docker pull "${FAST_TIME_IMAGE}" || {
+        error "docker pull failed for ${FAST_TIME_IMAGE}"
+        return 1
+    }
+    docker run --detach \
+        --name "${FAST_TIME_CONTAINER}" \
+        --publish "127.0.0.1:${FAST_TIME_PORT}:9080" \
+        "${FAST_TIME_IMAGE}"
+    wait_for_health "http://localhost:${FAST_TIME_PORT}/health" "fast-time-server" 30
 }
 
 # ---------------------------------------------------------------------------
@@ -256,8 +239,7 @@ main() {
     info "  Gateway        : ${GATEWAY_URL}"
     echo
 
-    # Build + start fast-time-server (stays up for the whole run)
-    build_fast_time_server
+    # Pull + start fast-time-server container (stays up for the whole run)
     start_fast_time_server
 
     RESULTS=()


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

---

## 📝 Summary

Removes the Rust source build from the plugin E2E integration workflow and replaces it with a pre-built Docker image (`ghcr.io/ibm/cfex-mcp-fast-time-server`), which is now the canonical home for the fast-time-server after it was migrated out of this repo.

Changes:

- **CI: drop Rust build steps** — removes `Install Rust stable`, `Cache Cargo`, and `Build fast-time-server` steps from `plugin-integration.yml`. The image is pulled and started with `docker run` instead, saving ~2 min per matrix leg.
- **Local runner: switch to Docker** — `run_plugin_tests.sh` now pulls and runs the container instead of building and launching a binary. `FAST_TIME_IMAGE` and `FAST_TIME_CONTAINER` are new overridable variables; `FAST_TIME_BIN` / `FAST_TIME_PID` and the `build_fast_time_server()` function are removed.
- **Port cleaned up** — the image listens on `9080`; previous mapping (`host:8080 → container:9080`) was asymmetric and inherited a stale default. Port is now `9080:9080` end-to-end. `FAST_TIME_PORT` defaults to `9080`; `_helpers.py` default URL updated to match. A single `FAST_TIME_PORT` override still moves both the bound port and the registered URL together.
- **`FAST_TIME_SERVER_URL` exported** — the script exports the derived URL so pytest picks it up without any extra wiring.
- **CI: log capture on failure** — new `Capture fast-time-server logs on failure` step collects `docker logs` output and uploads it as an artifact when the job fails.
- **Clearer error for missing `flaky` tool** — `find_flaky_tool()` assertion message now names the image and the env var to check, making the failure actionable.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

Ran the full plugin integration suite locally with `ghcr.io/ibm/cfex-mcp-fast-time-server:5eac210da1c96a5fb2386c82a0c6f543b68fd76a` — **13/13 passed**.

| Check | Command | Status |
|---|---|---|
| Full plugin suite | `make test-plugin-integration` | ✅ 13/13 pass |
| Image smoke-test (tools/list) | `curl` + MCP initialize handshake | ✅ `flaky` present |
| Script syntax | `bash -n tests/live_gateway/plugins/run_plugin_tests.sh` | ✅ pass |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

To run locally when port 9080 is already occupied:
```bash
FAST_TIME_PORT=9090 make test-plugin-integration
```
To pin a different image tag:
```bash
FAST_TIME_IMAGE=ghcr.io/ibm/cfex-mcp-fast-time-server:<tag> make test-plugin-integration

