### PR TITLE
test: assert RBAC allow-path tools lists are non-empty

### DIFF
--- a/tests/live_gateway/mcp/test_mcp_rbac_transport.py
+++ b/tests/live_gateway/mcp/test_mcp_rbac_transport.py
@@ -786,6 +786,7 @@ class TestMcpPerServerEndpoint:
         tools = _mcp_tools_list(outsider_user["access_token"], server_url=server_url)
         # May see only that server's tools
         print(f"    -> Outsider via /servers/{server_id}/mcp: {len(tools)} tools")
+        assert tools, "public server should advertise its associated tools, not an empty list"
 
     def test_team_member_accesses_team_server(self, test_users: dict, visibility_servers: dict) -> None:
         """Developer can access the team server's per-server endpoint."""
@@ -793,6 +794,7 @@ class TestMcpPerServerEndpoint:
         server_url = f"{BASE_URL}/servers/{server_id}"
         tools = _mcp_tools_list(test_users["developer"]["access_token"], server_url=server_url)
         print(f"    -> Developer via /servers/{server_id}/mcp: {len(tools)} tools")
+        assert tools, "team server should advertise its associated tools, not an empty list"
 
     def test_outsider_denied_team_server(self, outsider_user: dict, visibility_servers: dict) -> None:
         """Outsider cannot access team server's per-server endpoint."""


### PR DESCRIPTION
# Bug-fix PR

## Summary

The per-server allow-path checks (`test_public_token_accesses_public_server`, `test_team_member_accesses_team_server`) only asserted that `tools/list` succeeded. A deployment that cannot serve the server's backend can answer with an empty tool list, and the tests passed while proving nothing. They now assert the visibility servers actually advertise their associated tools.

On split deployments this pairs with #5519: unsupported-transport servers are no longer half-served by the dataplane, so the per-server route delivers real tools (directly or via control-plane fallback routing) and these assertions hold.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff lint + format | `uv run ruff check / format --check` on the test file | Pass |

## Checklist

- [x] Code formatted
- [x] No secrets/credentials committed