### PR TITLE
fix(dataplane_publisher): per-worker lock id and safer key TTL

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -43,11 +43,13 @@ logger = logging.getLogger(__name__)
 
 USER_CONFIG_KEY = "UserConfig"
 REDIS_PUBLISHER_TIME = 60  # Publish interval in seconds
-# Keys are not deleted explicitly; stale configs expire via Redis TTL.
-PUBLISHER_TTL = 70
+# Keys are not deleted explicitly; stale configs expire via Redis TTL. The
+# TTL must outlive a full missed publish cycle: under load the loop's timer
+# can fire late, and with only a few seconds of margin every UserConfig key
+# expires at once, taking dataplane config down for all subjects until the
+# next snapshot.
+PUBLISHER_TTL = REDIS_PUBLISHER_TIME * 2 + 10
 
-# Worker ID for multi-worker coordination (same pattern as session_affinity.py)
-WORKER_ID = f"{socket.gethostname()}:{os.getpid()}"
 PUBLISHER_LOCK_KEY = "mcpgw:dataplane_publisher:lock"
 
 
@@ -86,6 +88,11 @@ class DataplanePublisherService:
         """Initialize the publisher state and dependent services."""
         self.task: asyncio.Task[None] | None = None
         self._shutdown_event = asyncio.Event()
+        # Computed per instance so each gunicorn worker gets its own id;
+        # a module-level constant is evaluated in the master before fork,
+        # which gives every worker the same id and defeats the lock's
+        # compare-and-swap ownership check (same pattern as session_affinity.py).
+        self.worker_id = f"{socket.gethostname()}:{os.getpid()}"
 
     async def start(self) -> None:
         """Start the background publisher task."""
@@ -137,7 +144,7 @@ class DataplanePublisherService:
                 lock_ttl = REDIS_PUBLISHER_TIME + 30  # Lock expires 30s after publish interval
                 acquired = await redis.set(
                     PUBLISHER_LOCK_KEY,
-                    WORKER_ID,
+                    self.worker_id,
                     nx=True,  # Only set if not exists
                     ex=lock_ttl,  # Auto-expire if worker crashes
                 )
@@ -149,7 +156,7 @@ class DataplanePublisherService:
                     continue
 
                 # We hold the lock - publish data
-                logger.info("Worker %s publishing dataplane payload...", WORKER_ID)
+                logger.info("Worker %s publishing dataplane payload...", self.worker_id)
                 payload = await self.fetch_payload()
 
                 if payload is None:
@@ -181,7 +188,7 @@ class DataplanePublisherService:
                     return 0
                     """
                     try:
-                        await redis.eval(release_script, 1, PUBLISHER_LOCK_KEY, WORKER_ID)
+                        await redis.eval(release_script, 1, PUBLISHER_LOCK_KEY, self.worker_id)
                     except Exception as e:
                         logger.warning("Failed to release lock: %s", e)
 

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -18,6 +18,19 @@ async def _wait_forever():
     await asyncio.Event().wait()
 
 
+def test_worker_id_is_computed_per_service_instance():
+    """Each publisher instance gets the current worker PID."""
+    from mcpgateway.services import dataplane_publisher
+
+    with patch.object(dataplane_publisher.os, "getpid", side_effect=[11111, 22222]):
+        first_service = dataplane_publisher.DataplanePublisherService()
+        second_service = dataplane_publisher.DataplanePublisherService()
+
+    assert first_service.worker_id != second_service.worker_id
+    assert first_service.worker_id.endswith(":11111")
+    assert second_service.worker_id.endswith(":22222")
+
+
 # ============================================================================
 # Lifecycle Management Tests
 # ============================================================================
@@ -546,7 +559,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
     """publish_to_redis() writes msgpack payloads and releases the worker lock."""
     import msgpack
 
-    from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, PUBLISHER_TTL, USER_CONFIG_KEY, DataplanePublisherService
+    from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, PUBLISHER_TTL, REDIS_PUBLISHER_TIME, USER_CONFIG_KEY, DataplanePublisherService
 
     service = DataplanePublisherService()
     payload = {"user@example.com": {"virtual_hosts": {"server1": {"backends": {}}}}}
@@ -577,6 +590,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
     assert msgpack.unpackb(value_arg, raw=False) == payload["user@example.com"]
     assert pipe.set.call_args.kwargs == {"ex": PUBLISHER_TTL}
     pipe.execute.assert_awaited_once()
+    mock_redis.set.assert_awaited_once_with(PUBLISHER_LOCK_KEY, service.worker_id, nx=True, ex=REDIS_PUBLISHER_TIME + 30)
     mock_redis.eval.assert_awaited_once()
     assert mock_redis.eval.await_args.args[1:] == (1, PUBLISHER_LOCK_KEY, service.worker_id)
     mock_wait_for.assert_awaited_once()

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -546,7 +546,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
     """publish_to_redis() writes msgpack payloads and releases the worker lock."""
     import msgpack
 
-    from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, PUBLISHER_TTL, USER_CONFIG_KEY, WORKER_ID, DataplanePublisherService
+    from mcpgateway.services.dataplane_publisher import PUBLISHER_LOCK_KEY, PUBLISHER_TTL, USER_CONFIG_KEY, DataplanePublisherService
 
     service = DataplanePublisherService()
     payload = {"user@example.com": {"virtual_hosts": {"server1": {"backends": {}}}}}
@@ -578,7 +578,7 @@ async def test_publish_writes_payload_releases_lock_and_exits_when_shutdown_wait
     assert pipe.set.call_args.kwargs == {"ex": PUBLISHER_TTL}
     pipe.execute.assert_awaited_once()
     mock_redis.eval.assert_awaited_once()
-    assert mock_redis.eval.await_args.args[1:] == (1, PUBLISHER_LOCK_KEY, WORKER_ID)
+    assert mock_redis.eval.await_args.args[1:] == (1, PUBLISHER_LOCK_KEY, service.worker_id)
     mock_wait_for.assert_awaited_once()
 
 


### PR DESCRIPTION
# Bug-fix PR

## Summary

Two robustness fixes for the dataplane publisher, observed on a live split stack:

- `WORKER_ID` is evaluated at module import — under gunicorn with preload that happens in the master before fork, so every worker publishes as the same `hostname:1` id and the lock's compare-and-swap release cannot distinguish owners. It is now computed per service instance (each worker constructs its own service post-fork), same pattern as `session_affinity.py`.
- UserConfig keys were written with TTL = interval + 10s. A single publish cycle firing late (observed 120–180s gaps between publishes while the event loop was busy under test load) expires every key at once, dropping dataplane config for all subjects until the next snapshot. The TTL is now 2 × interval + 10 so one missed cycle no longer causes an outage.

Default publish cadence and payloads are unchanged.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff lint + format | `uv run ruff check / format --check` on both files | Pass |
| Publisher unit tests | `uv run pytest tests/unit/mcpgateway/services/test_dataplane_publisher.py` | 21 passed |

## Checklist

- [x] Code formatted
- [x] No secrets/credentials committed