### PR TITLE
fix(dataplane_publisher): publish streamable-HTTP backends only

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-13T12:58:49Z",
+  "generated_at": "2026-07-13T14:32:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-13T12:58:13Z",
+  "generated_at": "2026-07-13T12:58:49Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/docs/docs/deprecations.md
+++ b/docs/docs/deprecations.md
@@ -39,3 +39,20 @@ Runtime signals:
 - Gateway startup logs include a deprecation warning when the middleware is
   enabled.
 - Instantiating the middleware emits a Python `DeprecationWarning`.
+
+## Legacy MCP HTTP+SSE transport
+
+The MCP specification deprecated the legacy two-endpoint HTTP+SSE transport in
+protocol version 2025-03-26 in favor of Streamable HTTP. This is distinct from
+SSE response streams within Streamable HTTP and from the 2026-07-07 ContextForge
+component sunset above. ContextForge has not assigned a removal date to its SSE
+gateway compatibility path, which remains available through the control plane.
+
+Use Streamable HTTP for new gateway registrations. The experimental dataplane
+publisher (`DATAPLANE_PUBLISHER`) publishes only `STREAMABLEHTTP` gateway
+backends. If filtering leaves a virtual server with no publishable backends, the
+publisher omits that virtual host so a split deployment can use the dataplane's
+404 response to fall back to the control plane.
+
+See the MCP [deprecated-feature registry](https://modelcontextprotocol.io/specification/draft/deprecated)
+and [transport guidance](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http).

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -218,9 +218,8 @@ class DataplanePublisherService:
 
             prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
 
-            # The dataplane proxies streamable-HTTP upstreams only; other
-            # transports (e.g. SSE, deprecated and removed in the 2026-07-28
-            # MCP protocol update) are excluded so the published config never
+            # The dataplane proxies streamable-HTTP upstreams only. Legacy
+            # HTTP+SSE gateways are excluded so the published config never
             # advertises a backend the dataplane cannot serve.
             gateway_base = {
                 gateway["id"]: {

--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -218,6 +218,10 @@ class DataplanePublisherService:
 
             prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
 
+            # The dataplane proxies streamable-HTTP upstreams only; other
+            # transports (e.g. SSE, deprecated and removed in the 2026-07-28
+            # MCP protocol update) are excluded so the published config never
+            # advertises a backend the dataplane cannot serve.
             gateway_base = {
                 gateway["id"]: {
                     "name": gateway["name"],
@@ -226,6 +230,7 @@ class DataplanePublisherService:
                     "passthrough_headers": gateway["passthrough_headers"] or [],
                 }
                 for gateway in gateways
+                if (gateway["transport"] or "").upper() == "STREAMABLEHTTP"
             }
 
             virtual_hosts: dict[str, VirtualHostConfig] = {}
@@ -249,6 +254,13 @@ class DataplanePublisherService:
                         "allowed_resource_names": allowed_resource_names,
                         "allowed_prompt_names": allowed_prompt_names,
                     }
+
+                if not backends:
+                    # No publishable backends: leave the virtual host out so
+                    # the dataplane returns 404 for it and deployments can
+                    # route the request back to the control plane, instead of
+                    # serving an empty tool list that looks like success.
+                    continue
 
                 virtual_hosts[server["id"]] = {"backends": backends}
 

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -179,7 +179,7 @@ async def test_full_payload_generation_with_mock_db():
     gateway1.id = "g1"
     gateway1.name = "Gateway 1"
     gateway1.url = "http://localhost:9000"
-    gateway1.transport = "sse"
+    gateway1.transport = "STREAMABLEHTTP"
     gateway1.passthrough_headers = ["Authorization"]
     gateway1.owner_email = "user1@example.com"
     gateway1.team_id = "team1"
@@ -277,7 +277,7 @@ async def test_full_payload_generation_with_mock_db():
         backend = server1["backends"]["g1"]
         assert backend["name"] == "Gateway 1"
         assert backend["url"] == "http://localhost:9000"
-        assert backend["transport"] == "sse"
+        assert backend["transport"] == "STREAMABLEHTTP"
         assert backend["passthrough_headers"] == ["Authorization"]
         assert backend["allowed_tool_names"] == ["public_tool", "private_tool"]
         assert backend["allowed_resource_names"] == ["Resource 1"]
@@ -286,7 +286,9 @@ async def test_full_payload_generation_with_mock_db():
         # Verify user2 sees public server but not private server from user1
         user2_config = payload["user2@example.com"]
         assert "s1" in user2_config["virtual_hosts"]  # public
-        assert "s2" in user2_config["virtual_hosts"]  # own private
+        # Own private server exists but has no backend associations, so it
+        # is omitted from the payload (no publishable backends).
+        assert "s2" not in user2_config["virtual_hosts"]
         user2_backend = user2_config["virtual_hosts"]["s1"]["backends"]["g1"]
         assert user2_backend["allowed_tool_names"] == ["public_tool", "team2_tool"]
 
@@ -377,7 +379,7 @@ def test_create_payload_filters_empty_backends():
                     },
                 }
             ],
-            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "sse", "passthrough_headers": None}],
+            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "STREAMABLEHTTP", "passthrough_headers": None}],
             "prompts": [],
             "resources": [],
         }
@@ -385,9 +387,36 @@ def test_create_payload_filters_empty_backends():
 
     result = service.create_payload(data)
 
-    # Server exists but has no backends (all empty)
-    assert "server1" in result["user@example.com"]["virtual_hosts"]
-    assert result["user@example.com"]["virtual_hosts"]["server1"]["backends"] == {}
+    # A server with no publishable backends is omitted entirely so the
+    # dataplane 404s it instead of serving an empty tool list.
+    assert "server1" not in result["user@example.com"]["virtual_hosts"]
+
+
+def test_create_payload_excludes_non_streamable_gateways():
+    """create_payload() drops backends whose transport the dataplane cannot serve."""
+    from mcpgateway.services.dataplane_publisher import DataplanePublisherService
+
+    service = DataplanePublisherService()
+    data = {
+        "user@example.com": {
+            "servers": [
+                {
+                    "id": "server1",
+                    "backend_items": {
+                        "gateway_sse": {"tools": ["tool1"], "resources": [], "prompts": []},
+                    },
+                }
+            ],
+            "gateways": [{"id": "gateway_sse", "name": "SSE Gateway", "url": "http://localhost:9000/sse", "transport": "SSE", "passthrough_headers": None}],
+            "prompts": [],
+            "resources": [],
+        }
+    }
+
+    result = service.create_payload(data)
+
+    # The SSE backend is excluded and the now-backendless server is omitted.
+    assert result["user@example.com"]["virtual_hosts"] == {}
 
 
 def test_create_payload_normalizes_null_passthrough_headers():
@@ -405,7 +434,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
                     },
                 }
             ],
-            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "sse", "passthrough_headers": None}],
+            "gateways": [{"id": "gateway1", "name": "Gateway 1", "url": "http://localhost:9000", "transport": "STREAMABLEHTTP", "passthrough_headers": None}],
             "prompts": [],
             "resources": [],
         }
@@ -441,8 +470,9 @@ def test_create_payload_handles_missing_references():
     result = service.create_payload(data)
 
     # Server exists but has no backends (gateway missing)
-    assert "server1" in result["user@example.com"]["virtual_hosts"]
-    assert result["user@example.com"]["virtual_hosts"]["server1"]["backends"] == {}
+    # With its only gateway missing, the server has no publishable backends
+    # and is omitted from the payload.
+    assert "server1" not in result["user@example.com"]["virtual_hosts"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Bug-fix PR

## Summary

The dataplane proxies streamable-HTTP upstreams only, but the publisher exported every gateway transport into UserConfig. A virtual server whose backends are SSE (deprecated; removed in the 2026-07-28 MCP protocol update) was therefore advertised to the dataplane, which could not initialize the backend and answered `tools/list` with a successful empty list — indistinguishable from a healthy server with no tools.

## Fix Description

- `create_payload` includes only `STREAMABLEHTTP` gateways (case-insensitive) in the per-user backend map.
- Virtual hosts left with **no publishable backends** are omitted from the payload entirely, so the dataplane returns 404 for them. Split deployments can then route those requests back to the control plane (e.g. an nginx fallback on 404), keeping unsupported-transport servers fully functional through the control-plane path instead of silently empty through the dataplane.
- Unit tests updated to the new contract plus a new case asserting SSE backends are excluded.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff lint + format | `uv run ruff check / format --check` on both files | Pass |
| Publisher unit tests | `uv run pytest tests/unit/mcpgateway/services/test_dataplane_publisher.py` | 22 passed |

## Checklist

- [x] Code formatted
- [x] No secrets/credentials committed