### PR TITLE
chore: split test-live-gateway into playwright and non-playwright passes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-06T12:57:22Z",
+  "generated_at": "2026-07-06T14:54:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -358,7 +358,7 @@
         "hashed_secret": "319037749ce37e577db0b3628c7f90e333544391",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 973,
+        "line_number": 983,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -366,7 +366,7 @@
         "hashed_secret": "6ae2832e494d1098e8901fe156083e39399a24f1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 975,
+        "line_number": 985,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -374,7 +374,7 @@
         "hashed_secret": "43fc45734b96bcb1b6cef373e949eb3524ae199b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1627,
+        "line_number": 1637,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -382,7 +382,7 @@
         "hashed_secret": "9d989e8d27dc9e0ec3389fc855f142c3d40f0c50",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1846,
+        "line_number": 1856,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +390,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6062,
+        "line_number": 6072,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +398,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6559,
+        "line_number": 6569,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +406,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6571,
+        "line_number": 6581,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +414,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6643,
+        "line_number": 6653,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -422,7 +422,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7725,
+        "line_number": 7735,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -900,8 +900,18 @@ test-live-gateway: uv  ## Run ALL live-gateway tests (mcp + sso + protocol_compl
 	@echo "   Requires: live ContextForge gateway (typically 'make testing-up') and any"
 	@echo "             extra services per subsuite — see tests/live_gateway/README.md."
 	@echo "   Tests probe BASE_URL ($${MCP_CLI_BASE_URL:-http://localhost:8080}) and self-skip when unreachable."
-	@$(UV_BIN) run --extra plugins pytest -p playwright tests/live_gateway/ -v --tb=short \
-		|| { echo "❌ Live-gateway test suite failed!"; exit 1; }
+	@echo "   Pass 1/2: suites without pytest-playwright (its runtest hook breaks pytest-asyncio tests)."
+	@$(UV_BIN) run --extra plugins pytest -p no:playwright tests/live_gateway/ \
+		--ignore=tests/live_gateway/sso \
+		--ignore=tests/live_gateway/mcp/test_mcp_rbac_transport.py \
+		-v --tb=short \
+		|| { echo "❌ Live-gateway test suite (non-playwright pass) failed!"; exit 1; }
+	@echo "   Pass 2/2: playwright-dependent suites (sso + RBAC transport)."
+	@$(UV_BIN) run --extra plugins pytest -p playwright \
+		tests/live_gateway/sso \
+		tests/live_gateway/mcp/test_mcp_rbac_transport.py \
+		-v --tb=short \
+		|| { echo "❌ Live-gateway test suite (playwright pass) failed!"; exit 1; }
 	@echo "✅ Live-gateway test suite finished."
 
 MCP_ISOLATION_LOCUSTFILE ?= tests/loadtest/locustfile_mcp_isolation.py


### PR DESCRIPTION
# Chore PR

## Summary

`make test-live-gateway` ran the entire `tests/live_gateway/` tree under `-p playwright`. pytest-playwright's runtest hook collides with pytest-asyncio (`RuntimeError: Runner.run() cannot be called from a running event loop`), so every async test in the tree — including the protocol-compliance reference rows that pass standalone — failed regardless of gateway behavior, drowning real regressions in noise (observed: 64 failed + 78 errors in ~17s, ~103 of them this collision).

## Fix Description

Split the target into two passes:

1. `-p no:playwright` over the tree, excluding the two playwright-dependent suites — all asyncio suites now run the same way their individual make targets run them.
2. `-p playwright` over `tests/live_gateway/sso` and `tests/live_gateway/mcp/test_mcp_rbac_transport.py`, the only files importing playwright.

No test content changes; same overall pass/fail contract (first failing pass fails the target).

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Recipe expansion | `make -n test-live-gateway` | two pytest invocations as described |
| Playwright dependency map | `grep -rl playwright tests/live_gateway/` | only the two excluded files |

## Checklist

- [x] No secrets/credentials committed