### PR TITLE
test: align admin private-server listing test with owner matching

### DIFF
--- a/tests/live_gateway/mcp/test_mcp_rbac_transport.py
+++ b/tests/live_gateway/mcp/test_mcp_rbac_transport.py
@@ -488,25 +488,25 @@ class TestServerVisibilityViaAPI:
     """Verify server visibility via REST API before MCP protocol tests."""
 
     def test_admin_sees_public_and_team_via_http(self, admin_api: APIRequestContext, visibility_servers: dict) -> None:
-        """Admin via HTTP sees public + team servers but NOT private — even own-private (PR #4341).
+        """Admin via HTTP sees public + team servers and their own private servers.
 
-        ``admin_api`` carries a JWT with ``is_admin=true`` and ``teams=null``. After
-        PR #4341 cycle-2 S3-b, ``get_scoped_resource_access_context`` deliberately
-        collapses this shape to ``(None, None)`` so HTTP cannot be a stealthy
-        escalation surface; the service layer then applies the anonymous-bypass
-        rule (public + team only, never private). Admins who need to read their
-        own private rows directly should use a ``team``-scoped token or operate
-        via owner-match workflows. The pre-#4341 ``test_admin_sees_all_servers``
-        assertion encoded the old "admin sees everything" semantics and is
-        superseded by this test plus the explicit not-in assertion below.
+        ``admin_api`` carries a JWT with ``is_admin=true`` and ``teams=null``.
+        ``get_scoped_resource_access_context`` keeps the requester email on the
+        admin-bypass path so the service layer can owner-match (issue #4694,
+        commit 8c186c5e0): the listing returns public rows, team rows, and the
+        caller's own private rows — never another user's private rows. The
+        fixture's private server is created by this same admin, so it appears
+        via owner matching. The earlier revision of this test asserted the
+        pre-#4694 collapse-to-anonymous semantics and failed once owner
+        matching landed.
         """
         resp = admin_api.get("/servers")
         assert resp.status == 200
         server_ids = {s["id"] for s in resp.json()}
         assert visibility_servers["public"]["id"] in server_ids, "Admin should see public server"
         assert visibility_servers["team"]["id"] in server_ids, "Admin should see team server"
-        assert visibility_servers["private"]["id"] not in server_ids, "PR #4341: admin via HTTP must NOT see private server (own-private collapsed by get_scoped_resource_access_context)"
-        print("    -> Admin sees public + team servers; private denied via HTTP collapse")
+        assert visibility_servers["private"]["id"] in server_ids, "Admin should see their own private server via owner matching (issue #4694)"
+        print("    -> Admin sees public + team servers and own private via owner matching")
 
     def test_team_member_sees_public_and_team(self, test_users: dict, playwright: Playwright, visibility_servers: dict) -> None:
         token = test_users["developer"]["access_token"]


### PR DESCRIPTION
# Bug-fix PR

## Summary

`test_admin_sees_public_and_team_via_http` still asserts the pre-#4694 scoping semantics, where the admin-bypass path collapsed to anonymous visibility and hid even the caller's own private servers. Commit 8c186c5e0 (issue #4694) deliberately changed `get_scoped_resource_access_context` to keep the requester email on that path so the service layer can owner-match — the listing now returns public rows, team rows, and the caller's **own** private rows. The fixture's private server is created by the same admin, so it correctly appears and the stale assertion fails on every live run.

## Fix Description

Flip the private-server assertion to expect presence via owner matching and update the docstring to cite the current contract. Another user's private rows remain excluded — the existing outsider/team-member tests in the same class cover those deny paths and keep passing.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff lint + format | `uv run ruff check / format --check` on the test file | Pass |
| Live stack | `pytest -p playwright …::TestServerVisibilityViaAPI -v` | 5 passed |

## Checklist

- [x] Code formatted
- [x] No secrets/credentials committed