### PR TITLE
test: skip plugin E2E suites when the gateway has no enabled plugins

### DIFF
--- a/tests/live_gateway/plugins/conftest.py
+++ b/tests/live_gateway/plugins/conftest.py
@@ -54,6 +54,28 @@ def admin_client(admin_token: str) -> Generator[httpx.Client, None, None]:
         yield client
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _require_gateway_plugins(admin_client: httpx.Client) -> None:
+    """Skip the plugin E2E suites when the gateway has no plugins loaded.
+
+    These suites are designed for a gateway booted out-of-band with a
+    plugin enforce config (plugin-integration.yml workflow). Against a
+    general-purpose stack (e.g. docker-compose with PLUGINS_ENABLED=false)
+    every test failed at fixture setup instead of skipping. Probe
+    ``/admin/plugins`` once per session and skip cleanly unless the
+    subsystem is enabled and at least one plugin is loaded.
+    """
+    try:
+        resp = admin_client.get("/admin/plugins")
+    except httpx.HTTPError as exc:
+        pytest.skip(f"cannot probe gateway plugin state ({exc}); plugin E2E suites need a gateway booted with a plugin config")
+    if resp.status_code != 200:
+        pytest.skip(f"/admin/plugins returned HTTP {resp.status_code}; plugin E2E suites need a gateway booted with a plugin config")
+    payload = resp.json()
+    if not payload.get("plugins_globally_enabled", False) or not payload.get("enabled_count"):
+        pytest.skip("gateway has no enabled plugins; plugin E2E suites need a gateway booted with a plugin enforce config")
+
+
 @pytest.fixture(scope="session")
 def fast_time_server(admin_client: httpx.Client, admin_token: str) -> Generator[dict[str, str], None, None]:
     """Provision a virtual server exposing the fast-time ``echo`` tool.


### PR DESCRIPTION
# Bug-fix PR

## Summary

The `tests/live_gateway/plugins` suites are designed for a gateway booted out-of-band with a plugin enforce config (plugin-integration.yml workflow). Run against a general-purpose stack — e.g. the docker-compose stack, where the plugin subsystem reports 43 known / 0 enabled plugins — every test **errors** at fixture setup (the fast-time gateway self-registration fails with 502 before any plugin logic runs) instead of skipping. In a full `tests/live_gateway/` sweep that is 36 errors of pure noise.

## Fix Description

Add a session-scoped autouse fixture that probes `GET /admin/plugins` once and skips the suites cleanly unless `plugins_globally_enabled` is true and `enabled_count` is non-zero. Unreachable gateway or non-200 responses also skip with an actionable reason. The dedicated plugin-integration workflow (enforce config, enabled plugins) is unaffected.

## Reviewability

- [x] This PR has one clear purpose
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

## Verification

| Check | Command | Status |
|-------|---------|--------|
| Ruff lint + format | `uv run ruff check / format --check` on the conftest | Pass |
| Compose stack (0 enabled plugins) | `pytest tests/live_gateway/plugins/ -v` | 36 skipped (was 36 errors) |

## Checklist

- [x] Code formatted
- [x] No secrets/credentials committed