### PR TITLE
feat(ui-rewrite): add manage team members dialog with full member CRUD

### DIFF
--- a/client/src/api/teams.test.ts
+++ b/client/src/api/teams.test.ts
@@ -1,10 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createTeam, addTeamMember, deleteTeam } from "./teams";
+import {
+  createTeam,
+  addTeamMember,
+  updateTeamMember,
+  removeTeamMember,
+  listTeamMembers,
+  deleteTeam,
+} from "./teams";
 import { api } from "./client";
 
 vi.mock("@/api/client", () => ({
   api: {
+    get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -71,6 +80,102 @@ describe("addTeamMember", () => {
     await expect(
       addTeamMember("team-1", { email: "user@example.com", role: "member" }),
     ).rejects.toThrow("already a member");
+  });
+});
+
+describe("listTeamMembers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GETs the team's members endpoint and returns the array", async () => {
+    const members = [
+      { user_email: "a@example.com", role: "owner", joined_at: "2024-01-01T00:00:00Z" },
+    ];
+    vi.mocked(api.get).mockResolvedValue(members);
+
+    const result = await listTeamMembers("team-1");
+
+    expect(api.get).toHaveBeenCalledWith("/teams/team-1/members");
+    expect(result).toEqual(members);
+  });
+
+  it("URL-encodes the team id", async () => {
+    vi.mocked(api.get).mockResolvedValue([]);
+
+    await listTeamMembers("team/1");
+
+    expect(api.get).toHaveBeenCalledWith("/teams/team%2F1/members");
+  });
+
+  it("propagates errors from the API", async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error("forbidden"));
+
+    await expect(listTeamMembers("team-1")).rejects.toThrow("forbidden");
+  });
+});
+
+describe("updateTeamMember", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PUTs the role to the member endpoint", async () => {
+    vi.mocked(api.put).mockResolvedValue(undefined);
+
+    await updateTeamMember("team-1", "user@example.com", { role: "owner" });
+
+    expect(api.put).toHaveBeenCalledWith("/teams/team-1/members/user%40example.com", {
+      role: "owner",
+    });
+  });
+
+  it("URL-encodes both the team id and the user email", async () => {
+    vi.mocked(api.put).mockResolvedValue(undefined);
+
+    await updateTeamMember("team/1", "a b@example.com", { role: "member" });
+
+    expect(api.put).toHaveBeenCalledWith("/teams/team%2F1/members/a%20b%40example.com", {
+      role: "member",
+    });
+  });
+
+  it("propagates errors from the API", async () => {
+    vi.mocked(api.put).mockRejectedValue(new Error("not found"));
+
+    await expect(updateTeamMember("team-1", "user@example.com", { role: "owner" })).rejects.toThrow(
+      "not found",
+    );
+  });
+});
+
+describe("removeTeamMember", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("DELETEs the member endpoint", async () => {
+    vi.mocked(api.delete).mockResolvedValue(undefined);
+
+    await removeTeamMember("team-1", "user@example.com");
+
+    expect(api.delete).toHaveBeenCalledWith("/teams/team-1/members/user%40example.com");
+  });
+
+  it("URL-encodes both the team id and the user email", async () => {
+    vi.mocked(api.delete).mockResolvedValue(undefined);
+
+    await removeTeamMember("team/1", "a b@example.com");
+
+    expect(api.delete).toHaveBeenCalledWith("/teams/team%2F1/members/a%20b%40example.com");
+  });
+
+  it("propagates errors from the API", async () => {
+    vi.mocked(api.delete).mockRejectedValue(new Error("cannot remove last owner"));
+
+    await expect(removeTeamMember("team-1", "user@example.com")).rejects.toThrow(
+      "cannot remove last owner",
+    );
   });
 });
 

--- a/client/src/api/teams.ts
+++ b/client/src/api/teams.ts
@@ -1,5 +1,5 @@
 import { api } from "@/api/client";
-import type { Team } from "@/types/team";
+import type { Team, TeamMember, AddTeamMemberRequest, UpdateTeamMemberRequest } from "@/types/team";
 
 interface CreateTeamPayload {
   name: string;
@@ -8,19 +8,37 @@ interface CreateTeamPayload {
   max_members?: number;
 }
 
-export interface TeamMemberPayload {
-  email: string;
-  role: "owner" | "member";
-}
-
 export function createTeam(payload: CreateTeamPayload): Promise<Team> {
   return api.post<Team>("/teams", payload);
 }
 
-export function addTeamMember(teamId: string, member: TeamMemberPayload): Promise<void> {
-  return api.post<void>(`/teams/${encodeURIComponent(teamId)}/members`, member);
-}
-
 export function deleteTeam(id: string): Promise<void> {
   return api.delete<void>(`/teams/${encodeURIComponent(id)}`);
+}
+
+export function listTeamMembers(teamId: string): Promise<TeamMember[]> {
+  // Default (no include_pagination) returns every team member as a bare array,
+  // with no cursor metadata.
+  return api.get<TeamMember[]>(`/teams/${encodeURIComponent(teamId)}/members`);
+}
+
+export function addTeamMember(teamId: string, data: AddTeamMemberRequest): Promise<void> {
+  return api.post<void>(`/teams/${encodeURIComponent(teamId)}/members`, data);
+}
+
+export function updateTeamMember(
+  teamId: string,
+  userEmail: string,
+  data: UpdateTeamMemberRequest,
+): Promise<void> {
+  return api.put<void>(
+    `/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userEmail)}`,
+    data,
+  );
+}
+
+export function removeTeamMember(teamId: string, userEmail: string): Promise<void> {
+  return api.delete<void>(
+    `/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userEmail)}`,
+  );
 }

--- a/client/src/components/teams/ManageTeamMembersDialog.test.tsx
+++ b/client/src/components/teams/ManageTeamMembersDialog.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
+import { I18nProvider } from "@/i18n";
+import { ManageTeamMembersDialog } from "./ManageTeamMembersDialog";
+import type { MemberRow } from "@/hooks/useTeamMembersForm";
+
+const hookState = {
+  members: [] as MemberRow[],
+  memberOptions: [] as { value: string; label: string }[],
+  isLoading: false,
+  isSaving: false,
+  addRow: vi.fn(),
+  removeRow: vi.fn(),
+  changeEmail: vi.fn(),
+  changeRole: vi.fn(),
+  save: vi.fn(),
+};
+
+const mockCaptured: { options?: { onClose: () => void; onSuccess?: () => void } } = {};
+
+vi.mock("@/hooks/useTeamMembersForm", () => ({
+  AVAILABLE_ROLES: ["owner", "member"],
+  useTeamMembersForm: (options: { onClose: () => void; onSuccess?: () => void }) => {
+    mockCaptured.options = options;
+    return hookState;
+  },
+}));
+
+function renderDialog(ui: ReactElement) {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+}
+
+function baseProps() {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    teamId: "team-1",
+    teamName: "Engineering",
+  };
+}
+
+function existingRow(overrides: Partial<MemberRow> = {}): MemberRow {
+  return {
+    id: "existing-0",
+    email: "existing@example.com",
+    role: "member",
+    isExisting: true,
+    ...overrides,
+  };
+}
+
+function newRow(overrides: Partial<MemberRow> = {}): MemberRow {
+  return {
+    id: "new-1",
+    email: "",
+    role: "member",
+    isExisting: false,
+    ...overrides,
+  };
+}
+
+describe("ManageTeamMembersDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hookState.members = [];
+    hookState.memberOptions = [];
+    hookState.isLoading = false;
+    hookState.isSaving = false;
+  });
+
+  it("renders the title and description", () => {
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    expect(screen.getByText("Manage team members")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add or remove team members and set their permission levels."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading status while members are loading", () => {
+    hookState.isLoading = true;
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    expect(screen.getByRole("status", { busy: true })).toBeInTheDocument();
+  });
+
+  it("renders column headers and a row per member", () => {
+    hookState.members = [existingRow(), newRow()];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    // One email combobox input per member row.
+    expect(screen.getAllByPlaceholderText("Name or email...")).toHaveLength(2);
+  });
+
+  it("disables the email combobox for existing members", () => {
+    hookState.members = [existingRow()];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    // The email input for an existing member shows its email and is disabled.
+    const emailInput = screen.getByPlaceholderText("Name or email...");
+    expect(emailInput).toBeDisabled();
+    expect(emailInput).toHaveValue("existing@example.com");
+  });
+
+  it("calls addRow when Add member is clicked", async () => {
+    const user = userEvent.setup();
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    await user.click(screen.getByRole("button", { name: /Add member/i }));
+
+    expect(hookState.addRow).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls removeRow when a row's Remove button is clicked", async () => {
+    const user = userEvent.setup();
+    hookState.members = [existingRow()];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    await user.click(screen.getByRole("button", { name: /Remove existing@example.com/i }));
+
+    expect(hookState.removeRow).toHaveBeenCalledWith("existing-0");
+  });
+
+  it("calls save when Save is clicked", async () => {
+    const user = userEvent.setup();
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(hookState.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the dialog when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const props = baseProps();
+    renderDialog(<ManageTeamMembersDialog {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the saving label and disables actions while saving", () => {
+    hookState.isSaving = true;
+    hookState.members = [existingRow()];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    const removeButton = screen.getByRole("button", {
+      name: /Remove existing@example.com/i,
+    });
+    expect(removeButton).toBeDisabled();
+  });
+
+  it("shows the current role on the row's role selector", () => {
+    hookState.members = [newRow({ role: "owner" })];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    // Two combobox-role controls: [0] the email Combobox, [1] the role Select trigger.
+    const roleTrigger = screen.getAllByRole("combobox")[1];
+    expect(roleTrigger).toHaveTextContent("owner");
+  });
+
+  it("closes the dialog via the onClose passed to the hook", () => {
+    const props = baseProps();
+    renderDialog(<ManageTeamMembersDialog {...props} />);
+
+    mockCaptured.options?.onClose();
+
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls changeEmail when an option is chosen in the email combobox", async () => {
+    const user = userEvent.setup();
+    hookState.members = [newRow({ id: "new-1" })];
+    hookState.memberOptions = [
+      { value: "picked@example.com", label: "Picked (picked@example.com)" },
+    ];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    await user.click(screen.getByPlaceholderText("Name or email..."));
+    await user.click(await screen.findByText("Picked (picked@example.com)"));
+
+    expect(hookState.changeEmail).toHaveBeenCalledWith("new-1", "picked@example.com");
+  });
+
+  it("calls changeRole when a new role is selected", async () => {
+    const user = userEvent.setup();
+    hookState.members = [newRow({ id: "new-1", role: "member" })];
+    renderDialog(<ManageTeamMembersDialog {...baseProps()} />);
+
+    await user.click(screen.getAllByRole("combobox")[1]);
+    await user.click(await screen.findByRole("option", { name: "owner" }));
+
+    expect(hookState.changeRole).toHaveBeenCalledWith("new-1", "owner");
+  });
+});

--- a/client/src/components/teams/ManageTeamMembersDialog.tsx
+++ b/client/src/components/teams/ManageTeamMembersDialog.tsx
@@ -1,0 +1,176 @@
+import { useCallback } from "react";
+import { useIntl } from "react-intl";
+import { Plus, Trash2, Users } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Combobox } from "../ui/combobox";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import { AVAILABLE_ROLES, useTeamMembersForm } from "@/hooks/useTeamMembersForm";
+
+interface ManageTeamMembersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  teamId: string;
+  teamName: string;
+  onSuccess?: () => void;
+}
+
+export function ManageTeamMembersDialog({
+  open,
+  onOpenChange,
+  teamId,
+  teamName,
+  onSuccess,
+}: ManageTeamMembersDialogProps) {
+  const intl = useIntl();
+  const {
+    members,
+    memberOptions,
+    isLoading,
+    isSaving,
+    addRow,
+    removeRow,
+    changeEmail,
+    changeRole,
+    save,
+  } = useTeamMembersForm({
+    open,
+    teamId,
+    onSuccess,
+    onClose: () => onOpenChange(false),
+  });
+
+  const handleCancel = useCallback(() => {
+    if (!isSaving) {
+      onOpenChange(false);
+    }
+  }, [isSaving, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded bg-yellow-500">
+              <Users className="h-4 w-4 text-black" />
+            </div>
+            {intl.formatMessage({ id: "teams.members.dialog.title" })}
+          </DialogTitle>
+          <DialogDescription>
+            {intl.formatMessage({ id: "teams.members.dialog.description" }, { teamName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {isLoading ? (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-busy="true"
+              className="flex items-center justify-center py-8"
+            >
+              <span className="sr-only">
+                {intl.formatMessage({ id: "teams.members.loading.sr" })}
+              </span>
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-border border-t-primary" />
+            </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                {members.length > 0 && (
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 text-sm font-medium text-foreground">
+                      {intl.formatMessage({ id: "common.name" })}
+                    </div>
+                    <div className="w-32 text-sm font-medium text-foreground">
+                      {intl.formatMessage({ id: "common.role" })}
+                    </div>
+                    <div className="w-[88px]" aria-hidden="true" />
+                  </div>
+                )}
+                {members.map((member) => (
+                  <div key={member.id} className="flex items-center gap-2">
+                    <div className="flex-1">
+                      <Combobox
+                        options={memberOptions}
+                        value={member.email}
+                        onValueChange={(v) => changeEmail(member.id, v)}
+                        placeholder={intl.formatMessage({
+                          id: "teams.members.email.placeholder",
+                        })}
+                        searchPlaceholder={intl.formatMessage({
+                          id: "teams.members.email.placeholder",
+                        })}
+                        emptyText={intl.formatMessage({
+                          id: "teams.members.email.placeholder",
+                        })}
+                        allowCustomValue={false}
+                        disabled={member.isExisting || isSaving}
+                        className="h-9"
+                      />
+                    </div>
+                    <div className="w-32">
+                      <Select
+                        value={member.role}
+                        onValueChange={(value) => changeRole(member.id, value)}
+                        disabled={isSaving}
+                      >
+                        <SelectTrigger className="h-9 w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {AVAILABLE_ROLES.map((role) => (
+                            <SelectItem key={role} value={role}>
+                              {role}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 w-[88px] gap-1.5 px-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
+                      onClick={() => removeRow(member.id)}
+                      disabled={isSaving}
+                      aria-label={intl.formatMessage(
+                        { id: "teams.members.remove.aria" },
+                        { email: member.email },
+                      )}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      {intl.formatMessage({ id: "common.button.remove" })}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+
+              <Button variant="outline" size="sm" onClick={addRow} disabled={isSaving}>
+                <Plus className="h-4 w-4 mr-2" />
+                {intl.formatMessage({ id: "teams.members.add" })}
+              </Button>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
+            {intl.formatMessage({ id: "common.button.cancel" })}
+          </Button>
+          <Button onClick={save} disabled={isLoading || isSaving}>
+            {intl.formatMessage({
+              id: isSaving ? "common.button.saving" : "common.button.save",
+            })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/teams/TeamsTable.test.tsx
+++ b/client/src/components/teams/TeamsTable.test.tsx
@@ -148,6 +148,39 @@ describe("TeamsTable", () => {
     expect(onDelete).toHaveBeenCalledWith("team-99");
   });
 
+  it("calls onManageMembers with the team id when Manage members is clicked", async () => {
+    const user = userEvent.setup();
+    const onManageMembers = vi.fn();
+    renderTable(
+      <TeamsTable
+        teams={[makeTeam({ id: "team-7", name: "Alpha" })]}
+        isLoading={false}
+        onManageMembers={onManageMembers}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Actions for Alpha/i }));
+    await user.click(await screen.findByRole("menuitem", { name: /Manage members/i }));
+
+    expect(onManageMembers).toHaveBeenCalledWith("team-7");
+  });
+
+  it("orders the actions menu as Edit, Manage members, Delete", async () => {
+    const user = userEvent.setup();
+    renderTable(<TeamsTable teams={[makeTeam({ name: "Alpha" })]} isLoading={false} />);
+
+    await user.click(screen.getByRole("button", { name: /Actions for Alpha/i }));
+
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.map((i) => i.textContent)).toEqual(["Edit", "Manage members", "Delete"]);
+  });
+
+  it("renders the team's uppercased initial as its icon", () => {
+    renderTable(<TeamsTable teams={[makeTeam({ name: "alpha" })]} isLoading={false} />);
+
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
   it("renders an accessible actions trigger per team", () => {
     const teams = [makeTeam({ id: "a", name: "Alpha" }), makeTeam({ id: "b", name: "Beta" })];
     renderTable(<TeamsTable teams={teams} isLoading={false} />);

--- a/client/src/components/teams/TeamsTable.tsx
+++ b/client/src/components/teams/TeamsTable.tsx
@@ -1,5 +1,5 @@
 import { useIntl } from "react-intl";
-import { MoreVertical, SquareMenu, Users } from "lucide-react";
+import { MoreVertical, SquareMenu } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -21,14 +21,25 @@ import type { Team } from "../../types/team";
 import { Loading } from "../ui/loading";
 import { formatLocalDateTime } from "../../utils/formatDate";
 
+function getTeamIcon(name: string): string {
+  return name.charAt(0).toUpperCase();
+}
+
 interface TeamsTableProps {
   teams: Team[];
   isLoading: boolean;
   onEdit?: (id: string) => void;
   onDelete?: (id: string) => void;
+  onManageMembers?: (id: string) => void;
 }
 
-export function TeamsTable({ teams, isLoading, onEdit, onDelete }: TeamsTableProps) {
+export function TeamsTable({
+  teams,
+  isLoading,
+  onEdit,
+  onDelete,
+  onManageMembers,
+}: TeamsTableProps) {
   const intl = useIntl();
   const invalidDateLabel = intl.formatMessage({ id: "teams.table.invalidDate" });
 
@@ -76,6 +87,8 @@ export function TeamsTable({ teams, isLoading, onEdit, onDelete }: TeamsTablePro
         </TableHeader>
         <TableBody>
           {teams.map((team) => {
+            const icon = getTeamIcon(team.name);
+
             return (
               <TableRow
                 key={team.id}
@@ -83,8 +96,8 @@ export function TeamsTable({ teams, isLoading, onEdit, onDelete }: TeamsTablePro
               >
                 <TableCell className="px-4 py-2.5">
                   <div className="flex items-center gap-3">
-                    <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-sm bg-yellow-400 shadow-sm">
-                      <Users className="h-4 w-4 text-neutral-900" />
+                    <div className="flex h-6 w-6 items-center justify-center rounded bg-yellow-500">
+                      <span className="text-xs font-semibold text-black">{icon}</span>
                     </div>
                     <span className="font-medium text-neutral-900 dark:text-neutral-100">
                       {team.name}
@@ -142,11 +155,28 @@ export function TeamsTable({ teams, isLoading, onEdit, onDelete }: TeamsTablePro
                           <MoreVertical className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-40">
-                        <DropdownMenuItem onClick={() => onEdit?.(team.id)}>
+                      <DropdownMenuContent align="end" className="w-48">
+                        <DropdownMenuItem
+                          onClick={() => {
+                            // TODO: wire up edit team action
+                            onEdit?.(team.id);
+                          }}
+                        >
                           {intl.formatMessage({ id: "teams.table.actions.edit" })}
                         </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => onDelete?.(team.id)}>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            onManageMembers?.(team.id);
+                          }}
+                        >
+                          {intl.formatMessage({ id: "teams.table.actions.manageMembers" })}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            // TODO: wire up delete team action
+                            onDelete?.(team.id);
+                          }}
+                        >
                           {intl.formatMessage({ id: "teams.table.actions.delete" })}
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/client/src/hooks/useTeamMembersForm.test.ts
+++ b/client/src/hooks/useTeamMembersForm.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { I18nProvider } from "@/i18n";
+import type { TeamMember } from "@/types/team";
+import { useTeamMembersForm } from "./useTeamMembersForm";
+
+vi.mock("@/api/teams", () => ({
+  listTeamMembers: vi.fn(),
+  addTeamMember: vi.fn(() => Promise.resolve()),
+  updateTeamMember: vi.fn(() => Promise.resolve()),
+  removeTeamMember: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/api/client", () => ({
+  api: { get: vi.fn(() => Promise.resolve({ users: [] })) },
+}));
+
+import { listTeamMembers, addTeamMember, updateTeamMember, removeTeamMember } from "@/api/teams";
+import { api } from "@/api/client";
+import { toast } from "sonner";
+
+const TEAM_ID = "team-1";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(I18nProvider, null, children);
+}
+
+function makeMember(overrides: Partial<TeamMember> = {}): TeamMember {
+  return {
+    user_email: "existing@example.com",
+    role: "member",
+    joined_at: "2024-01-01T00:00:00Z",
+    invited_by: "owner@example.com",
+    ...overrides,
+  };
+}
+
+function renderForm(onSuccess = vi.fn(), onClose = vi.fn()) {
+  return {
+    onSuccess,
+    onClose,
+    ...renderHook(() => useTeamMembersForm({ open: true, teamId: TEAM_ID, onSuccess, onClose }), {
+      wrapper,
+    }),
+  };
+}
+
+describe("useTeamMembersForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads members and hides those without an inviter", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([
+      makeMember({ user_email: "a@example.com", invited_by: "owner@example.com" }),
+      makeMember({ user_email: "b@example.com", invited_by: "" }),
+      makeMember({ user_email: "c@example.com", invited_by: null }),
+    ]);
+
+    const { result } = renderForm();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.members.map((m) => m.email)).toEqual(["a@example.com"]);
+  });
+
+  it("builds member options from the user directory", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      users: [
+        { email: "jane@example.com", full_name: "Jane Doe" },
+        { email: "no-name@example.com", full_name: "" },
+      ],
+    });
+
+    const { result } = renderForm();
+
+    await waitFor(() => expect(result.current.memberOptions).toHaveLength(2));
+    expect(result.current.memberOptions).toEqual([
+      {
+        value: "jane@example.com",
+        label: "Jane Doe (jane@example.com)",
+        searchText: "Jane Doe jane@example.com",
+      },
+      {
+        value: "no-name@example.com",
+        label: "no-name@example.com",
+        searchText: "no-name@example.com",
+      },
+    ]);
+  });
+
+  it("fetches the full user directory with limit=0", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    renderForm();
+
+    await waitFor(() =>
+      expect(api.get).toHaveBeenCalledWith(
+        "/auth/email/admin/users?limit=0&include_pagination=true",
+      ),
+    );
+  });
+
+  it("seeds one empty editable row when there are no members", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    const { result } = renderForm();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.members).toHaveLength(1);
+    expect(result.current.members[0]).toMatchObject({
+      email: "",
+      role: "member",
+      isExisting: false,
+    });
+  });
+
+  it("adds new members with an email on save", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    const { result, onSuccess, onClose } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.addRow());
+    const newId = result.current.members[0].id;
+    act(() => result.current.changeEmail(newId, "new@example.com"));
+    act(() => result.current.changeRole(newId, "owner"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(addTeamMember).toHaveBeenCalledWith(TEAM_ID, {
+      email: "new@example.com",
+      role: "owner",
+    });
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("skips new rows with a blank email", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    const { result } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.addRow());
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(addTeamMember).not.toHaveBeenCalled();
+  });
+
+  it("updates the role of an existing member when it changes", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([
+      makeMember({ user_email: "a@example.com", role: "member" }),
+    ]);
+    const { result } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.changeRole(result.current.members[0].id, "owner"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateTeamMember).toHaveBeenCalledWith(TEAM_ID, "a@example.com", {
+      role: "owner",
+    });
+    expect(addTeamMember).not.toHaveBeenCalled();
+    expect(removeTeamMember).not.toHaveBeenCalled();
+  });
+
+  it("does not update an existing member whose role is unchanged", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([
+      makeMember({ user_email: "a@example.com", role: "member" }),
+    ]);
+    const { result } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateTeamMember).not.toHaveBeenCalled();
+  });
+
+  it("removes existing members that were deleted from the rows", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([makeMember({ user_email: "a@example.com" })]);
+    const { result } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.removeRow(result.current.members[0].id));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(removeTeamMember).toHaveBeenCalledWith(TEAM_ID, "a@example.com");
+  });
+
+  it("uses the original email for existing members (email is immutable)", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([
+      makeMember({ user_email: "a@example.com", role: "member" }),
+    ]);
+    const { result } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Even if the row email were somehow changed, an existing member is only
+    // ever role-updated by original email, never re-added under a new email.
+    act(() => result.current.changeRole(result.current.members[0].id, "owner"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(updateTeamMember).toHaveBeenCalledWith(TEAM_ID, "a@example.com", {
+      role: "owner",
+    });
+    expect(addTeamMember).not.toHaveBeenCalled();
+  });
+
+  it("does not load members while the dialog is closed", () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+
+    renderHook(
+      () =>
+        useTeamMembersForm({
+          open: false,
+          teamId: TEAM_ID,
+          onSuccess: vi.fn(),
+          onClose: vi.fn(),
+        }),
+      { wrapper },
+    );
+
+    expect(listTeamMembers).not.toHaveBeenCalled();
+  });
+
+  it("ignores the user directory response after unmount", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    let resolveUsers: (value: { users: unknown[] }) => void = () => {};
+    vi.mocked(api.get).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveUsers = resolve;
+      }),
+    );
+
+    const { result, unmount } = renderForm();
+    unmount();
+    // Resolve the in-flight fetch only after the effect has been cleaned up.
+    resolveUsers({ users: [{ email: "late@example.com", full_name: "Late" }] });
+    await Promise.resolve();
+
+    expect(result.current.memberOptions).toEqual([]);
+  });
+
+  it("logs an error when the user directory fetch fails", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    vi.mocked(api.get).mockRejectedValueOnce(new Error("no users"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderForm();
+
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalled());
+    expect(result.current.memberOptions).toEqual([]);
+    consoleSpy.mockRestore();
+  });
+
+  it("shows an error toast when loading members fails", async () => {
+    vi.mocked(listTeamMembers).mockRejectedValue(new Error("forbidden"));
+
+    const { result } = renderForm();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to load team members",
+      expect.objectContaining({ description: expect.any(String) }),
+    );
+  });
+
+  it("shows an error toast and stays open when saving fails", async () => {
+    vi.mocked(listTeamMembers).mockResolvedValue([]);
+    vi.mocked(addTeamMember).mockRejectedValueOnce(new Error("boom"));
+    const { result, onClose } = renderForm();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.changeEmail(result.current.members[0].id, "new@example.com"));
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Failed to save team members",
+      expect.objectContaining({ description: expect.any(String) }),
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useTeamMembersForm.ts
+++ b/client/src/hooks/useTeamMembersForm.ts
@@ -1,0 +1,192 @@
+import { useState, useCallback, useEffect } from "react";
+import { useIntl } from "react-intl";
+import { toast } from "sonner";
+import { api } from "@/api/client";
+import { listTeamMembers, addTeamMember, updateTeamMember, removeTeamMember } from "@/api/teams";
+import type { ComboboxOption } from "@/components/ui/combobox";
+import type { TeamMember } from "@/types/team";
+import type { UsersResponse } from "@/types/user";
+import { sanitizeError } from "@/utils/errors";
+
+export const AVAILABLE_ROLES = ["owner", "member"] as const;
+
+export interface MemberRow {
+  id: string;
+  email: string;
+  role: string;
+  isExisting: boolean;
+}
+
+/** Creates a blank, editable member row for a not-yet-added member. */
+function createEmptyRow(): MemberRow {
+  return {
+    id: `new-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    email: "",
+    role: "member",
+    isExisting: false,
+  };
+}
+
+export interface UseTeamMembersFormOptions {
+  /** Whether the dialog is open; members are (re)loaded when this becomes true. */
+  open: boolean;
+  /** Team whose members are being managed. */
+  teamId: string;
+  /** Called after a successful save that resulted in at least one change. */
+  onSuccess?: () => void;
+  /** Called after a successful save to close the dialog. */
+  onClose: () => void;
+}
+
+/**
+ * Owns the state and API orchestration for the Manage Team Members dialog:
+ * loading existing members, the editable rows, and diffing rows against the
+ * originally loaded members to add / update roles / remove on save.
+ */
+export function useTeamMembersForm({
+  open,
+  teamId,
+  onSuccess,
+  onClose,
+}: UseTeamMembersFormOptions) {
+  const intl = useIntl();
+  const [members, setMembers] = useState<MemberRow[]>([]);
+  const [originalMembers, setOriginalMembers] = useState<TeamMember[]>([]);
+  const [memberOptions, setMemberOptions] = useState<ComboboxOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Load the directory of users for the member email autocomplete.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get<UsersResponse>("/auth/email/admin/users?limit=0&include_pagination=true")
+      .then((response) => {
+        if (cancelled) return;
+        setMemberOptions(
+          response.users.map((user) => ({
+            value: user.email,
+            label: user.full_name ? `${user.full_name} (${user.email})` : user.email,
+            searchText: [user.full_name, user.email].filter(Boolean).join(" "),
+          })),
+        );
+      })
+      .catch((err) => {
+        console.error("Failed to fetch users for member suggestions:", sanitizeError(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load existing members when the dialog opens.
+  useEffect(() => {
+    if (open && teamId) {
+      setIsLoading(true);
+      listTeamMembers(teamId)
+        .then((teamMembers) => {
+          // Members without an inviter (invited_by null/empty) are not shown.
+          const visibleMembers = teamMembers.filter((m) => Boolean(m.invited_by));
+          const existingMembers: MemberRow[] = visibleMembers.map((m, idx) => ({
+            id: `existing-${idx}`,
+            email: m.user_email,
+            role: m.role,
+            isExisting: true,
+          }));
+          // Always show at least one editable row so members can be added.
+          setMembers(existingMembers.length > 0 ? existingMembers : [createEmptyRow()]);
+          setOriginalMembers(visibleMembers);
+        })
+        .catch((err) => {
+          toast.error(intl.formatMessage({ id: "teams.members.error.load" }), {
+            description: sanitizeError(err),
+          });
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [open, teamId, intl]);
+
+  const addRow = useCallback(() => {
+    setMembers((prev) => [...prev, createEmptyRow()]);
+  }, []);
+
+  const removeRow = useCallback((id: string) => {
+    setMembers((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const changeEmail = useCallback((id: string, email: string) => {
+    setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, email } : m)));
+  }, []);
+
+  const changeRole = useCallback((id: string, role: string) => {
+    setMembers((prev) => prev.map((m) => (m.id === id ? { ...m, role } : m)));
+  }, []);
+
+  const save = useCallback(async () => {
+    setIsSaving(true);
+
+    try {
+      // New rows with an email → add.
+      const membersToAdd = members.filter((m) => !m.isExisting && m.email.trim() !== "");
+
+      // Existing members no longer present in the rows → remove.
+      const currentEmails = new Set(members.map((m) => m.email.toLowerCase()));
+      const membersToRemove = originalMembers.filter(
+        (m) => !currentEmails.has(m.user_email.toLowerCase()),
+      );
+
+      // Existing members whose role changed → update.
+      const originalRoleByEmail = new Map(
+        originalMembers.map((m) => [m.user_email.toLowerCase(), m.role]),
+      );
+      const membersToUpdate = members.filter(
+        (m) => m.isExisting && originalRoleByEmail.get(m.email.toLowerCase()) !== m.role,
+      );
+
+      for (const member of membersToAdd) {
+        await addTeamMember(teamId, { email: member.email, role: member.role });
+      }
+
+      for (const member of membersToUpdate) {
+        await updateTeamMember(teamId, member.email, { role: member.role });
+      }
+
+      for (const member of membersToRemove) {
+        await removeTeamMember(teamId, member.user_email);
+      }
+
+      const totalChanges = membersToAdd.length + membersToUpdate.length + membersToRemove.length;
+      if (totalChanges > 0) {
+        toast.success(intl.formatMessage({ id: "teams.members.success" }, { count: totalChanges }));
+        onSuccess?.();
+      }
+
+      onClose();
+    } catch (err) {
+      toast.error(intl.formatMessage({ id: "teams.members.error.save" }), {
+        description: sanitizeError(err),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [members, originalMembers, teamId, intl, onSuccess, onClose]);
+
+  return {
+    // State
+    members,
+    memberOptions,
+    isLoading,
+    isSaving,
+
+    // Row handlers
+    addRow,
+    removeRow,
+    changeEmail,
+    changeRole,
+
+    // Save
+    save,
+  };
+}

--- a/client/src/i18n/locales/en-US/common.json
+++ b/client/src/i18n/locales/en-US/common.json
@@ -1,5 +1,6 @@
 {
   "common.button.save": "Save",
+  "common.button.saving": "Saving...",
   "common.button.cancel": "Cancel",
   "common.button.delete": "Delete",
   "common.button.edit": "Edit",
@@ -8,6 +9,8 @@
   "common.button.close": "Close",
   "common.button.confirm": "Confirm",
   "common.button.back": "Back",
+  "common.button.remove": "Remove",
+  "common.button.submitting": "Submitting...",
   "common.loading": "Loading...",
   "common.error": "Error",
   "common.success": "Success",
@@ -21,6 +24,7 @@
   "common.actions": "Actions",
   "common.status": "Status",
   "common.name": "Name",
+  "common.role": "Role",
   "common.description": "Description",
   "common.createdAt": "Created At",
   "common.updatedAt": "Updated At",

--- a/client/src/i18n/locales/en-US/common.json
+++ b/client/src/i18n/locales/en-US/common.json
@@ -9,8 +9,6 @@
   "common.button.close": "Close",
   "common.button.confirm": "Confirm",
   "common.button.back": "Back",
-  "common.button.remove": "Remove",
-  "common.button.submitting": "Submitting...",
   "common.loading": "Loading...",
   "common.error": "Error",
   "common.success": "Success",

--- a/client/src/i18n/locales/en-US/teams.json
+++ b/client/src/i18n/locales/en-US/teams.json
@@ -20,6 +20,7 @@
   "teams.table.actions": "Actions",
   "teams.table.invalidDate": "Invalid date",
   "teams.table.actions.label": "Actions for {name}",
+  "teams.table.actions.manageMembers": "Manage members",
   "teams.table.actions.edit": "Edit",
   "teams.table.actions.delete": "Delete",
   "teams.table.description.view": "View description for {name}",
@@ -51,5 +52,14 @@
   "teams.create.warning.membersFailed": "Team {name} created, but some members could not be added",
   "teams.create.creating": "Creating...",
   "teams.create.submit": "Create team",
-  "teams.create.success": "Team created successfully"
+  "teams.create.success": "Team created successfully",
+  "teams.members.dialog.title": "Manage team members",
+  "teams.members.dialog.description": "Add or remove team members and set their permission levels.",
+  "teams.members.email.placeholder": "Name or email...",
+  "teams.members.add": "Add member",
+  "teams.members.remove.aria": "Remove {email}",
+  "teams.members.success": "{count, plural, one {# team member change} other {# team member changes}} saved successfully",
+  "teams.members.loading.sr": "Loading team members, please wait...",
+  "teams.members.error.load": "Failed to load team members",
+  "teams.members.error.save": "Failed to save team members"
 }

--- a/client/src/i18n/locales/es-ES/common.json
+++ b/client/src/i18n/locales/es-ES/common.json
@@ -9,7 +9,6 @@
   "common.button.close": "Cerrar",
   "common.button.confirm": "Confirmar",
   "common.button.back": "Volver",
-  "common.button.remove": "Quitar",
   "common.loading": "Cargando...",
   "common.error": "Error",
   "common.success": "Éxito",

--- a/client/src/i18n/locales/es-ES/common.json
+++ b/client/src/i18n/locales/es-ES/common.json
@@ -1,5 +1,6 @@
 {
   "common.button.save": "Guardar",
+  "common.button.saving": "Guardando...",
   "common.button.cancel": "Cancelar",
   "common.button.delete": "Eliminar",
   "common.button.edit": "Editar",
@@ -8,6 +9,7 @@
   "common.button.close": "Cerrar",
   "common.button.confirm": "Confirmar",
   "common.button.back": "Volver",
+  "common.button.remove": "Quitar",
   "common.loading": "Cargando...",
   "common.error": "Error",
   "common.success": "Éxito",
@@ -21,6 +23,7 @@
   "common.actions": "Acciones",
   "common.status": "Estado",
   "common.name": "Nombre",
+  "common.role": "Rol",
   "common.description": "Descripción",
   "common.createdAt": "Creado el",
   "common.updatedAt": "Actualizado el",

--- a/client/src/i18n/locales/es-ES/teams.json
+++ b/client/src/i18n/locales/es-ES/teams.json
@@ -20,6 +20,7 @@
   "teams.table.actions": "Acciones",
   "teams.table.invalidDate": "Fecha no válida",
   "teams.table.actions.label": "Acciones para {name}",
+  "teams.table.actions.manageMembers": "Gestionar miembros",
   "teams.table.actions.edit": "Editar",
   "teams.table.actions.delete": "Eliminar",
   "teams.table.description.view": "Ver descripción de {name}",
@@ -51,5 +52,14 @@
   "teams.create.warning.membersFailed": "Equipo {name} creado, pero no se pudieron añadir algunos miembros",
   "teams.create.creating": "Creando...",
   "teams.create.submit": "Crear equipo",
-  "teams.create.success": "Equipo creado correctamente"
+  "teams.create.success": "Equipo creado correctamente",
+  "teams.members.dialog.title": "Gestionar miembros del equipo",
+  "teams.members.dialog.description": "Agrega o quita miembros del equipo y define sus niveles de permiso.",
+  "teams.members.email.placeholder": "Nombre o correo electrónico...",
+  "teams.members.add": "Agregar miembro",
+  "teams.members.remove.aria": "Quitar {email}",
+  "teams.members.success": "{count, plural, one {# cambio en miembros del equipo guardado} other {# cambios en miembros del equipo guardados}} correctamente",
+  "teams.members.loading.sr": "Cargando miembros del equipo, espera...",
+  "teams.members.error.load": "No se pudieron cargar los miembros del equipo",
+  "teams.members.error.save": "No se pudieron guardar los miembros del equipo"
 }

--- a/client/src/i18n/locales/pt-BR/common.json
+++ b/client/src/i18n/locales/pt-BR/common.json
@@ -9,7 +9,6 @@
   "common.button.close": "Fechar",
   "common.button.confirm": "Confirmar",
   "common.button.back": "Voltar",
-  "common.button.remove": "Remover",
   "common.loading": "Carregando...",
   "common.error": "Erro",
   "common.success": "Sucesso",

--- a/client/src/i18n/locales/pt-BR/common.json
+++ b/client/src/i18n/locales/pt-BR/common.json
@@ -1,5 +1,6 @@
 {
   "common.button.save": "Salvar",
+  "common.button.saving": "Salvando...",
   "common.button.cancel": "Cancelar",
   "common.button.delete": "Excluir",
   "common.button.edit": "Editar",
@@ -8,6 +9,7 @@
   "common.button.close": "Fechar",
   "common.button.confirm": "Confirmar",
   "common.button.back": "Voltar",
+  "common.button.remove": "Remover",
   "common.loading": "Carregando...",
   "common.error": "Erro",
   "common.success": "Sucesso",
@@ -21,6 +23,7 @@
   "common.actions": "Ações",
   "common.status": "Status",
   "common.name": "Nome",
+  "common.role": "Função",
   "common.description": "Descrição",
   "common.createdAt": "Criado em",
   "common.updatedAt": "Atualizado em",

--- a/client/src/i18n/locales/pt-BR/teams.json
+++ b/client/src/i18n/locales/pt-BR/teams.json
@@ -51,5 +51,14 @@
   "teams.create.warning.membersFailed": "Equipe {name} criada, mas não foi possível adicionar alguns membros",
   "teams.create.creating": "Criando...",
   "teams.create.submit": "Criar equipe",
-  "teams.create.success": "Equipe criada com sucesso"
+  "teams.create.success": "Equipe criada com sucesso",
+  "teams.members.dialog.title": "Gerenciar membros da equipe",
+  "teams.members.dialog.description": "Adicione ou remova membros da equipe e defina seus níveis de permissão.",
+  "teams.members.email.placeholder": "Nome ou e-mail...",
+  "teams.members.add": "Adicionar membro",
+  "teams.members.remove.aria": "Remover {email}",
+  "teams.members.success": "{count, plural, one {# alteração de membros da equipe salva} other {# alterações de membros da equipe salvas}} com sucesso",
+  "teams.members.loading.sr": "Carregando membros da equipe, aguarde...",
+  "teams.members.error.load": "Falha ao carregar os membros da equipe",
+  "teams.members.error.save": "Falha ao salvar os membros da equipe"
 }

--- a/client/src/i18n/locales/pt-BR/teams.json
+++ b/client/src/i18n/locales/pt-BR/teams.json
@@ -20,6 +20,7 @@
   "teams.table.actions": "Ações",
   "teams.table.invalidDate": "Data inválida",
   "teams.table.actions.label": "Ações para {name}",
+  "teams.table.actions.manageMembers": "Gerenciar membros",
   "teams.table.actions.edit": "Editar",
   "teams.table.actions.delete": "Excluir",
   "teams.table.description.view": "Ver descrição de {name}",

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { TeamsTable } from "@/components/teams/TeamsTable";
 import { TeamForm } from "@/components/teams/TeamForm";
 import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
+import { ManageTeamMembersDialog } from "@/components/teams/ManageTeamMembersDialog";
 import { useQuery } from "@/hooks/useQuery";
 import { api } from "@/api/client";
 import { deleteTeam } from "@/api/teams";
@@ -23,6 +24,8 @@ export function Teams() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [teamToDelete, setTeamToDelete] = useState<Team | null>(null);
   const [createFormOpen, setCreateFormOpen] = useState(false);
+  const [membersDialogOpen, setMembersDialogOpen] = useState(false);
+  const [teamForMembers, setTeamForMembers] = useState<Team | null>(null);
 
   const queryPath = useMemo(() => {
     const params = new URLSearchParams();
@@ -79,6 +82,25 @@ export function Teams() {
     },
     [allTeams],
   );
+
+  const handleManageMembers = useCallback(
+    (teamId: string) => {
+      const team = allTeams.find((t) => t.id === teamId);
+      if (team) {
+        setTeamForMembers(team);
+        setMembersDialogOpen(true);
+      }
+    },
+    [allTeams],
+  );
+
+  const handleMembersSuccess = useCallback(async () => {
+    try {
+      await refetch();
+    } catch (refreshErr) {
+      console.error("Failed to refresh teams after member changes:", sanitizeError(refreshErr));
+    }
+  }, [refetch]);
 
   const handleDeleteConfirm = useCallback(async () => {
     if (!teamToDelete) return;
@@ -170,7 +192,12 @@ export function Teams() {
                 </Button>
               </div>
 
-              <TeamsTable teams={allTeams} isLoading={false} onDelete={handleDelete} />
+              <TeamsTable
+                teams={allTeams}
+                isLoading={false}
+                onDelete={handleDelete}
+                onManageMembers={handleManageMembers}
+              />
 
               <div className="flex items-center justify-between mt-6">
                 <div className="flex items-center gap-4">
@@ -247,6 +274,16 @@ export function Teams() {
           cancelLabel={intl.formatMessage({ id: "common.button.cancel" })}
           variant="destructive"
           onConfirm={handleDeleteConfirm}
+        />
+      )}
+
+      {teamForMembers && (
+        <ManageTeamMembersDialog
+          open={membersDialogOpen}
+          onOpenChange={setMembersDialogOpen}
+          teamId={teamForMembers.id}
+          teamName={teamForMembers.name}
+          onSuccess={handleMembersSuccess}
         />
       )}
     </div>

--- a/client/src/types/team.ts
+++ b/client/src/types/team.ts
@@ -17,3 +17,19 @@ export interface TeamsResponse {
   teams: Team[];
   nextCursor?: string;
 }
+
+export interface TeamMember {
+  user_email: string;
+  role: string;
+  joined_at: string;
+  invited_by?: string | null;
+}
+
+export interface AddTeamMemberRequest {
+  email: string;
+  role: string;
+}
+
+export interface UpdateTeamMemberRequest {
+  role: string;
+}


### PR DESCRIPTION
### Summary

Adds a "Manage members" experience to the Teams page. From a team's row actions menu, users can now view a team's current members and add, change the role of, or remove them — all in a single dialog that commits changes on Save.

Closes #5502 

### Changes

- **Manage Team Members dialog** (`ManageTeamMembersDialog`): lists existing members, supports adding members via a user-directory combobox, changing a member's role (owner/member), and removing members. Existing members' emails are immutable; only their role can change.
- **`useTeamMembersForm` hook**: owns the dialog's data flow (member loading,  the editable rows, the user-directory fetch for autocomplete, and the add/update/remove diffing on save), following the existing `useUserForm`/`useUsersList` convention.
- **Teams API client**: adds `listTeamMembers`, `updateTeamMember` (PUT role), and `removeTeamMember`; `addTeamMember` sends the `email` field expected by the backend schema.
- **Teams table**: adds the "Manage members" row action (ordered Edit → Manage members → Delete), renders the team's initial as its icon, and aligns the container styling with the MCP Servers table.
- **i18n**: consolidates shared labels into `common` (`common.role`, `common.button.remove`, `common.button.saving`) and adds the `teams.members.*` strings across en-US, es-ES, and pt-BR.

## Behavior notes

  - Members returned without an inviter (`invited_by` null/empty) are hidden from the dialog.
  - When a team has no listable members, the dialog seeds one empty editable row.
  - The members list is fetched unpaginated (all members, no cursor).
  - Save shows a "Saving..." button state and reports a team-member-specific success toast.

  ## Testing

  - Unit tests for the API client (URLs, encoding, payloads, error propagation), the `useTeamMembersForm` hook (load/filter, add/update/remove diffing, email immutability, error branches), the dialog (presentation wiring), and the Teams table (action ordering, callbacks, icon).
  
<img width="1720" height="895" alt="Screenshot 2026-07-07 at 09 13 14" src="https://github.com/user-attachments/assets/2245cd6b-48cf-4528-bdf9-af1c1cb9312e" />
