### PR TITLE
fix(api): Check for existing team membership before accepting invitation

### DIFF
--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -293,7 +293,8 @@ class TeamInvitationService:
 
         Raises:
             ValueError: If invitation is invalid or expired, or if the user is already a member
-                (including the race where a concurrent accept commits first)
+                (including races where a concurrent accept wins the insert, or wins the reactivation
+                of a stale row via the compare-and-swap UPDATE on is_active)
             Exception: If acceptance fails
 
         Examples:
@@ -359,11 +360,35 @@ class TeamInvitationService:
             # Reuse any prior (inactive) membership row for this (team_id, user_email) pair instead of
             # inserting a duplicate: uq_team_member is unique regardless of is_active, so a stale row left
             # behind by a previous removal from the team would otherwise collide on insert.
-            # Row-lock the reused row so two concurrent accepts can't both UPDATE it and commit silently.
+            # with_for_update() row-locks the reused row on backends that support it (e.g. Postgres), but
+            # is a silent no-op on SQLite -- this project's default DB -- so it alone does not close the
+            # race between two concurrent accepts both reactivating the same stale row. The conditional
+            # UPDATE below (matched against the is_active=False state we just observed) is what actually
+            # closes the race on every backend: only one of two racing callers can flip is_active from
+            # False to True, the other gets rowcount 0 and is turned into the same "already a member"
+            # error used for the commit-time IntegrityError race on the insert path below.
             membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).with_for_update().first()
 
             reactivated = membership is not None
             if membership:
+                if membership.is_active:
+                    # Closed by with_for_update() on Postgres: another transaction reactivated this row
+                    # between our earlier "already a member" check and acquiring the lock here.
+                    self.db.rollback()
+                    raise ValueError("User is already a member of this team")
+
+                updated_rows = (
+                    self.db.query(EmailTeamMember)
+                    .filter(EmailTeamMember.id == membership.id, EmailTeamMember.is_active.is_(False))
+                    .update({"role": invitation.role, "joined_at": utc_now(), "invited_by": invitation.invited_by, "is_active": True}, synchronize_session=False)
+                )
+                if updated_rows == 0:
+                    # Lost the race to another concurrent accept (e.g. on SQLite, where with_for_update()
+                    # above does not actually lock): the row was reactivated between our read and this UPDATE.
+                    self.db.rollback()
+                    raise ValueError("User is already a member of this team")
+
+                # Keep the in-memory object in sync with the row the bulk UPDATE above just changed.
                 membership.role = invitation.role
                 membership.joined_at = utc_now()
                 membership.invited_by = invitation.invited_by
@@ -379,7 +404,7 @@ class TeamInvitationService:
                 self.db.commit()
             except IntegrityError as integrity_error:
                 self.db.rollback()
-                logger.warning("Concurrent accept detected for %s on team %s: %s", invitation.email, invitation.team_id, integrity_error)
+                logger.warning("Concurrent accept detected for %s on team %s: %s", SecurityValidator.sanitize_log_message(invitation.email), invitation.team_id, integrity_error)
                 raise ValueError("User is already a member of this team") from integrity_error
 
             # Write the same audit trail entry that TeamManagementService.add_member_to_team writes,

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -23,6 +23,7 @@ import secrets
 from typing import Any, List, Optional
 
 # Third-Party
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -354,15 +355,29 @@ class TeamInvitationService:
             # Check team member limit (explicit per-team value or global default)
             check_team_member_capacity(self.db, team)
 
-            # Create team membership
-            membership = EmailTeamMember(team_id=invitation.team_id, user_email=invitation.email, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)
+            # Reuse any prior (inactive) membership row for this (team_id, user_email) pair instead of
+            # inserting a duplicate: uq_team_member is unique regardless of is_active, so a stale row left
+            # behind by a previous removal from the team would otherwise collide on insert.
+            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).first()
 
-            self.db.add(membership)
+            if membership:
+                membership.role = invitation.role
+                membership.joined_at = utc_now()
+                membership.invited_by = invitation.invited_by
+                membership.is_active = True
+            else:
+                membership = EmailTeamMember(team_id=invitation.team_id, user_email=invitation.email, role=invitation.role, joined_at=utc_now(), invited_by=invitation.invited_by, is_active=True)
+                self.db.add(membership)
 
             # Deactivate the invitation
             invitation.is_active = False
 
-            self.db.commit()
+            try:
+                self.db.commit()
+            except IntegrityError as integrity_error:
+                self.db.rollback()
+                logger.warning("Concurrent accept detected for %s on team %s: %s", invitation.email, invitation.team_id, integrity_error)
+                raise ValueError("User is already a member of this team") from integrity_error
 
             # Invalidate auth cache for user's team membership
             try:

--- a/mcpgateway/services/team_invitation_service.py
+++ b/mcpgateway/services/team_invitation_service.py
@@ -32,7 +32,7 @@ from mcpgateway.common.validators import SecurityValidator
 from mcpgateway.config import settings
 from mcpgateway.db import EmailTeam, EmailTeamInvitation, EmailTeamMember, EmailUser, utc_now
 from mcpgateway.services.logging_service import LoggingService
-from mcpgateway.services.team_management_service import check_team_member_capacity, get_user_team_count
+from mcpgateway.services.team_management_service import check_team_member_capacity, get_user_team_count, TeamManagementService
 
 # Initialize logging
 logging_service = LoggingService()
@@ -292,7 +292,8 @@ class TeamInvitationService:
             EmailTeamMember: The created team membership record
 
         Raises:
-            ValueError: If invitation is invalid or expired
+            ValueError: If invitation is invalid or expired, or if the user is already a member
+                (including the race where a concurrent accept commits first)
             Exception: If acceptance fails
 
         Examples:
@@ -358,8 +359,10 @@ class TeamInvitationService:
             # Reuse any prior (inactive) membership row for this (team_id, user_email) pair instead of
             # inserting a duplicate: uq_team_member is unique regardless of is_active, so a stale row left
             # behind by a previous removal from the team would otherwise collide on insert.
-            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).first()
+            # Row-lock the reused row so two concurrent accepts can't both UPDATE it and commit silently.
+            membership = self.db.query(EmailTeamMember).filter(EmailTeamMember.team_id == invitation.team_id, EmailTeamMember.user_email == invitation.email).with_for_update().first()
 
+            reactivated = membership is not None
             if membership:
                 membership.role = invitation.role
                 membership.joined_at = utc_now()
@@ -378,6 +381,12 @@ class TeamInvitationService:
                 self.db.rollback()
                 logger.warning("Concurrent accept detected for %s on team %s: %s", invitation.email, invitation.team_id, integrity_error)
                 raise ValueError("User is already a member of this team") from integrity_error
+
+            # Write the same audit trail entry that TeamManagementService.add_member_to_team writes,
+            # so a membership reactivated via invitation-accept isn't invisible in EmailTeamMemberHistory.
+            TeamManagementService(self.db).log_team_member_action(
+                membership.id, invitation.team_id, invitation.email, invitation.role, "reactivated" if reactivated else "added", invitation.invited_by
+            )
 
             # Invalidate auth cache for user's team membership
             try:

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -340,6 +340,19 @@ class TeamManagementService:
                 close()
             raise
 
+    def log_team_member_action(self, team_member_id: str, team_id: str, user_email: str, role: str, action: str, action_by: Optional[str]):
+        """Public entry point for cross-service audit logging (e.g. from TeamInvitationService).
+
+        Args:
+            team_member_id: ID of the EmailTeamMember
+            team_id: Team ID
+            user_email: Email of the affected user
+            role: Role at the time of action
+            action: Action type ("added", "removed", "reactivated", "role_changed")
+            action_by: Email of the user who performed the action
+        """
+        self._log_team_member_action(team_member_id, team_id, user_email, role, action, action_by)
+
     def _log_team_member_action(self, team_member_id: str, team_id: str, user_email: str, role: str, action: str, action_by: Optional[str]):
         """
         Log a team member action to EmailTeamMemberHistory.

--- a/mcpgateway/services/team_management_service.py
+++ b/mcpgateway/services/team_management_service.py
@@ -350,6 +350,12 @@ class TeamManagementService:
             role: Role at the time of action
             action: Action type ("added", "removed", "reactivated", "role_changed")
             action_by: Email of the user who performed the action
+
+        Examples:
+            >>> from mcpgateway.services.team_management_service import TeamManagementService
+            >>> from unittest.mock import Mock
+            >>> service = TeamManagementService(Mock())
+            >>> service.log_team_member_action("tm-123", "team-123", "user@example.com", "member", "reactivated", "admin@example.com")
         """
         self._log_team_member_action(team_member_id, team_id, user_email, role, action, action_by)
 

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -747,6 +747,47 @@ class TestTeamInvitationService:
         MockTMS.return_value.log_team_member_action.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_accept_invitation_lock_observes_already_reactivated_row(self, service, mock_invitation, mock_team, mock_db):
+        """Test the Postgres-only guard: with_for_update() blocked us until a concurrent accept committed
+        its own reactivation, so the row we now observe is already active. Must reject immediately
+        without attempting the compare-and-swap UPDATE or the commit (issue #5524 follow-up)."""
+        already_reactivated_member = MagicMock(spec=EmailTeamMember)
+        already_reactivated_member.is_active = True
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "call_count"):
+                    query_side_effect.call_count = 0
+                query_side_effect.call_count += 1
+
+                if query_side_effect.call_count == 1:
+                    mock_query.filter.return_value.first.return_value = None
+                elif query_side_effect.call_count == 2:
+                    mock_query.filter.return_value.count.return_value = 0
+                elif query_side_effect.call_count == 3:
+                    # Lock acquired only after the other transaction committed; row is now active.
+                    mock_query.filter.return_value.with_for_update.return_value.first.return_value = already_reactivated_member
+                else:
+                    pytest.fail("compare-and-swap UPDATE must not run once the row is already observed as active")
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with (
+            patch.object(service, "get_invitation_by_token", return_value=mock_invitation),
+            patch("mcpgateway.services.team_invitation_service.TeamManagementService") as MockTMS,
+        ):
+            with pytest.raises(ValueError, match="already a member of this team"):
+                await service.accept_invitation("token")
+
+        mock_db.rollback.assert_called()
+        mock_db.commit.assert_not_called()
+        MockTMS.return_value.log_team_member_action.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_accept_invitation_inserts_new_member_when_no_prior_row(self, service, mock_invitation, mock_team, mock_db):
         """Test accepting invitation inserts a brand-new membership row when no prior row exists at all (issue #5524)."""
 
@@ -805,6 +846,7 @@ class TestTeamInvitationService:
                 # No active member found, and no stale row found either (both first() calls return None)
                 mock_query.filter.return_value.first.return_value = None
                 mock_query.filter.return_value.count.return_value = 0
+                mock_query.filter.return_value.with_for_update.return_value.first.return_value = None
             return mock_query
 
         mock_db.query.side_effect = query_side_effect

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -640,6 +640,70 @@ class TestTeamInvitationService:
                 with pytest.raises(TeamMemberLimitExceededError, match="maximum member limit"):
                     await service.accept_invitation("token")
 
+    @pytest.mark.asyncio
+    async def test_accept_invitation_reactivates_inactive_member(self, service, mock_invitation, mock_team, mock_db):
+        """Test accepting invitation reactivates a stale inactive membership row instead of inserting a duplicate (issue #5524)."""
+        inactive_member = MagicMock(spec=EmailTeamMember)
+        inactive_member.is_active = False
+        inactive_member.role = "member"
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "call_count"):
+                    query_side_effect.call_count = 0
+                query_side_effect.call_count += 1
+
+                if query_side_effect.call_count == 1:
+                    # "already an active member?" check -> no active row
+                    mock_query.filter.return_value.first.return_value = None
+                elif query_side_effect.call_count == 2:
+                    # capacity count()
+                    mock_query.filter.return_value.count.return_value = 0
+                else:
+                    # reuse lookup (any row, regardless of is_active) -> stale inactive row
+                    mock_query.filter.return_value.first.return_value = inactive_member
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with patch.object(service, "get_invitation_by_token", return_value=mock_invitation):
+            result = await service.accept_invitation("token")
+
+        assert result is inactive_member
+        assert inactive_member.is_active is True
+        assert inactive_member.role == mock_invitation.role
+        assert inactive_member.invited_by == mock_invitation.invited_by
+        mock_db.add.assert_not_called()
+        mock_db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_integrity_error_translated(self, service, mock_invitation, mock_team, mock_db):
+        """Test a commit-time IntegrityError (concurrent accept race) is translated to a handled ValueError, not a 500."""
+        # Third-Party
+        from sqlalchemy.exc import IntegrityError
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                # No active member found, and no stale row found either (both first() calls return None)
+                mock_query.filter.return_value.first.return_value = None
+                mock_query.filter.return_value.count.return_value = 0
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+        mock_db.commit.side_effect = IntegrityError("statement", {}, Exception("UNIQUE constraint failed"))
+
+        with patch.object(service, "get_invitation_by_token", return_value=mock_invitation):
+            with pytest.raises(ValueError, match="already a member of this team"):
+                await service.accept_invitation("token")
+
+        mock_db.rollback.assert_called()
+
     # =========================================================================
     # Invitation Decline Tests
     # =========================================================================

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -647,6 +647,8 @@ class TestTeamInvitationService:
         inactive_member.is_active = False
         inactive_member.role = "member"
 
+        update_calls = []
+
         def query_side_effect(model):
             mock_query = MagicMock()
             if model == EmailTeam:
@@ -662,10 +664,15 @@ class TestTeamInvitationService:
                 elif query_side_effect.call_count == 2:
                     # capacity count()
                     mock_query.filter.return_value.count.return_value = 0
-                else:
+                elif query_side_effect.call_count == 3:
                     # reuse lookup (any row, regardless of is_active) -> stale inactive row,
-                    # locked via with_for_update() to close the concurrent-UPDATE race
+                    # locked via with_for_update() to close the concurrent-UPDATE race on Postgres
                     mock_query.filter.return_value.with_for_update.return_value.first.return_value = inactive_member
+                else:
+                    # Cross-dialect compare-and-swap: UPDATE ... WHERE id=? AND is_active=False.
+                    # Winning caller gets rowcount 1; record the filter args used for this call.
+                    update_calls.append(mock_query)
+                    mock_query.filter.return_value.update.return_value = 1
             return mock_query
 
         mock_db.query.side_effect = query_side_effect
@@ -683,11 +690,61 @@ class TestTeamInvitationService:
         mock_db.add.assert_not_called()
         mock_db.commit.assert_called_once()
 
+        # The compare-and-swap UPDATE ran exactly once, conditioned on is_active being False.
+        assert len(update_calls) == 1
+        update_calls[0].filter.assert_called_once()
+        update_calls[0].filter.return_value.update.assert_called_once()
+
         # Reactivating a stale row must leave the same audit trail as a direct add_member_to_team reactivation.
         MockTMS.assert_called_once_with(mock_db)
         MockTMS.return_value.log_team_member_action.assert_called_once_with(
             inactive_member.id, mock_invitation.team_id, mock_invitation.email, mock_invitation.role, "reactivated", mock_invitation.invited_by
         )
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_reactivation_race_loses_is_rejected(self, service, mock_invitation, mock_team, mock_db):
+        """Test that a second concurrent accept losing the compare-and-swap UPDATE is rejected instead of
+        double-reactivating the row and double-logging the audit trail (issue #5524 follow-up).
+
+        Simulates the SQLite case where with_for_update() is a silent no-op: both callers observe the
+        same stale inactive row, but only one of them can win the UPDATE ... WHERE is_active=False race.
+        """
+        inactive_member = MagicMock(spec=EmailTeamMember)
+        inactive_member.is_active = False
+        inactive_member.role = "member"
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "call_count"):
+                    query_side_effect.call_count = 0
+                query_side_effect.call_count += 1
+
+                if query_side_effect.call_count == 1:
+                    mock_query.filter.return_value.first.return_value = None
+                elif query_side_effect.call_count == 2:
+                    mock_query.filter.return_value.count.return_value = 0
+                elif query_side_effect.call_count == 3:
+                    mock_query.filter.return_value.with_for_update.return_value.first.return_value = inactive_member
+                else:
+                    # Another accept already committed the reactivation between our read and this UPDATE.
+                    mock_query.filter.return_value.update.return_value = 0
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with (
+            patch.object(service, "get_invitation_by_token", return_value=mock_invitation),
+            patch("mcpgateway.services.team_invitation_service.TeamManagementService") as MockTMS,
+        ):
+            with pytest.raises(ValueError, match="already a member of this team"):
+                await service.accept_invitation("token")
+
+        mock_db.rollback.assert_called()
+        mock_db.commit.assert_not_called()
+        MockTMS.return_value.log_team_member_action.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_accept_invitation_inserts_new_member_when_no_prior_row(self, service, mock_invitation, mock_team, mock_db):

--- a/tests/unit/mcpgateway/services/test_team_invitation_service.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service.py
@@ -663,13 +663,17 @@ class TestTeamInvitationService:
                     # capacity count()
                     mock_query.filter.return_value.count.return_value = 0
                 else:
-                    # reuse lookup (any row, regardless of is_active) -> stale inactive row
-                    mock_query.filter.return_value.first.return_value = inactive_member
+                    # reuse lookup (any row, regardless of is_active) -> stale inactive row,
+                    # locked via with_for_update() to close the concurrent-UPDATE race
+                    mock_query.filter.return_value.with_for_update.return_value.first.return_value = inactive_member
             return mock_query
 
         mock_db.query.side_effect = query_side_effect
 
-        with patch.object(service, "get_invitation_by_token", return_value=mock_invitation):
+        with (
+            patch.object(service, "get_invitation_by_token", return_value=mock_invitation),
+            patch("mcpgateway.services.team_invitation_service.TeamManagementService") as MockTMS,
+        ):
             result = await service.accept_invitation("token")
 
         assert result is inactive_member
@@ -678,6 +682,57 @@ class TestTeamInvitationService:
         assert inactive_member.invited_by == mock_invitation.invited_by
         mock_db.add.assert_not_called()
         mock_db.commit.assert_called_once()
+
+        # Reactivating a stale row must leave the same audit trail as a direct add_member_to_team reactivation.
+        MockTMS.assert_called_once_with(mock_db)
+        MockTMS.return_value.log_team_member_action.assert_called_once_with(
+            inactive_member.id, mock_invitation.team_id, mock_invitation.email, mock_invitation.role, "reactivated", mock_invitation.invited_by
+        )
+
+    @pytest.mark.asyncio
+    async def test_accept_invitation_inserts_new_member_when_no_prior_row(self, service, mock_invitation, mock_team, mock_db):
+        """Test accepting invitation inserts a brand-new membership row when no prior row exists at all (issue #5524)."""
+
+        def query_side_effect(model):
+            mock_query = MagicMock()
+            if model == EmailTeam:
+                mock_query.filter.return_value.first.return_value = mock_team
+            elif model == EmailTeamMember:
+                if not hasattr(query_side_effect, "call_count"):
+                    query_side_effect.call_count = 0
+                query_side_effect.call_count += 1
+
+                if query_side_effect.call_count == 1:
+                    # "already an active member?" check -> no active row
+                    mock_query.filter.return_value.first.return_value = None
+                elif query_side_effect.call_count == 2:
+                    # capacity count()
+                    mock_query.filter.return_value.count.return_value = 0
+                else:
+                    # reuse lookup, locked via with_for_update() -> no row at all, ever
+                    mock_query.filter.return_value.with_for_update.return_value.first.return_value = None
+            return mock_query
+
+        mock_db.query.side_effect = query_side_effect
+
+        with (
+            patch.object(service, "get_invitation_by_token", return_value=mock_invitation),
+            patch("mcpgateway.services.team_invitation_service.TeamManagementService") as MockTMS,
+        ):
+            result = await service.accept_invitation("token")
+
+        assert isinstance(result, EmailTeamMember)
+        assert result.team_id == mock_invitation.team_id
+        assert result.user_email == mock_invitation.email
+        assert result.role == mock_invitation.role
+        assert result.invited_by == mock_invitation.invited_by
+        assert result.is_active is True
+        mock_db.add.assert_called_once_with(result)
+        mock_db.commit.assert_called_once()
+
+        MockTMS.return_value.log_team_member_action.assert_called_once_with(
+            result.id, mock_invitation.team_id, mock_invitation.email, mock_invitation.role, "added", mock_invitation.invited_by
+        )
 
     @pytest.mark.asyncio
     async def test_accept_invitation_integrity_error_translated(self, service, mock_invitation, mock_team, mock_db):

--- a/tests/unit/mcpgateway/services/test_team_invitation_service_coverage.py
+++ b/tests/unit/mcpgateway/services/test_team_invitation_service_coverage.py
@@ -161,6 +161,8 @@ class TestAcceptInvitationCoverage:
 
             f.first = _first
             f.count = MagicMock(return_value=1)
+            # No prior membership row to reuse -> insert branch (compare-and-swap UPDATE is not hit)
+            f.with_for_update = MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))
             return q
 
         db.query = _query_side_effect
@@ -171,7 +173,7 @@ class TestAcceptInvitationCoverage:
 
         assert result is not None  # returns the EmailTeamMember instance
         assert invitation.is_active is False
-        db.add.assert_called_once()  # membership created
+        db.add.assert_any_call(result)  # membership created
         db.commit.assert_called()
 
     @pytest.mark.asyncio
@@ -200,6 +202,7 @@ class TestAcceptInvitationCoverage:
 
             f.first = _first
             f.count = MagicMock(return_value=0)
+            f.with_for_update = MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))
             return q
 
         db.query = _query_side_effect
@@ -350,6 +353,7 @@ class TestAcceptInvitationMoreBranches:
 
             f.first = _first
             f.count = MagicMock(return_value=2)  # under limit
+            f.with_for_update = MagicMock(return_value=MagicMock(first=MagicMock(return_value=None)))
             return q
 
         db.query = _query_side_effect


### PR DESCRIPTION
# 🐛 Bug-fix PR

---

## 📌 Summary

Closes #5524 

## 🔁 Reproduction Steps

1. Invite a user to a team (`POST` team invitation endpoint) and have them accept it (becomes an active `email_team_members` row).
2. Invite the same user to the same team again (a fresh invitation is created).
3. Accept the second invitation.
4. Server returns 500 `{"detail":"Failed to accept invitation"}`.

## 🐞 Root Cause

`accept_invitation()` never checks for a pre-existing `inactive` row before inserting, always creating a new membership. This violates the membership uniqueness (`team_id`/`user_email`  pair) whenever one exists (most commonly after a prior removal from the team).

## 💡 Fix Description

Check for an existing membership and, if it exists, update it. Otherwise, create a new one as usual.

## 📏 Reviewability

- [X] This PR has one clear purpose
- [X] The linked issue is not labeled `triage`
- [X] Unrelated bugs or improvements are tracked in separate issues/PRs
- [X] Tests are included with the code they validate
- [X] If AI-assisted, I understand and can explain the generated changes

## 🧪 Verification

| Check                                 | Command              | Status |
|---------------------------------------|----------------------|--------|
| Lint suite                            | `make lint`          |        |
| Unit tests                            | `make test`          |        |
| Coverage ≥ 80 %                       | `make coverage`      |        |
| Manual regression no longer fails     | steps / screenshots  |        |