### PR TITLE
Add v1 catalog API

### DIFF
--- a/mcpgateway/api/v1/__init__.py
+++ b/mcpgateway/api/v1/__init__.py
@@ -349,6 +349,12 @@ def build_v1_router(
         export_import_router=export_import_router,
         a2a_router=a2a_router,
     )
+
+    # First-Party
+    from mcpgateway.routers.catalog import router as catalog_router  # pylint: disable=import-outside-toplevel
+
+    v1_router.include_router(catalog_router)
+    logger.info("Catalog router included - v1 only")
     return v1_router
 
 

--- a/mcpgateway/routers/catalog.py
+++ b/mcpgateway/routers/catalog.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """Location: ./mcpgateway/routers/catalog.py
-Copyright 2026
+Copyright contributors to the MCP-CONTEXT-FORGE project
 SPDX-License-Identifier: Apache-2.0
-Authors: IBM
 
 MCP Registry catalog API router.
 """
@@ -26,7 +25,6 @@ router = APIRouter(prefix="/catalog", tags=["Catalog"])
 
 
 @router.get("", response_model=CatalogListResponse)
-@router.get("/", response_model=CatalogListResponse)
 @require_permission("servers.read")
 async def list_catalog_servers(
     request: Request,

--- a/mcpgateway/routers/catalog.py
+++ b/mcpgateway/routers/catalog.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Location: ./mcpgateway/routers/catalog.py
+Copyright 2026
+SPDX-License-Identifier: Apache-2.0
+Authors: IBM
+
+MCP Registry catalog API router.
+"""
+
+# Standard
+from typing import List, Optional
+
+# Third-Party
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy.orm import Session
+
+# First-Party
+from mcpgateway.auth_context import get_scoped_resource_access_context
+from mcpgateway.config import settings
+from mcpgateway.db import get_db
+from mcpgateway.middleware.rbac import get_current_user_with_permissions, require_permission
+from mcpgateway.schemas import CatalogListRequest, CatalogListResponse
+from mcpgateway.services.catalog_service import catalog_service
+
+router = APIRouter(prefix="/catalog", tags=["Catalog"])
+
+
+@router.get("", response_model=CatalogListResponse)
+@router.get("/", response_model=CatalogListResponse)
+@require_permission("servers.read")
+async def list_catalog_servers(
+    request: Request,
+    category: Optional[str] = None,
+    auth_type: Optional[str] = None,
+    provider: Optional[str] = None,
+    search: Optional[str] = None,
+    tags: Optional[List[str]] = Query(None),
+    show_registered_only: bool = False,
+    show_available_only: bool = True,
+    limit: int = 100,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+) -> CatalogListResponse:
+    """Get MCP registry catalog servers for the authenticated API caller.
+
+    Args:
+        request: FastAPI request object.
+        category: Filter by category.
+        auth_type: Filter by authentication type.
+        provider: Filter by provider.
+        search: Search in name/description.
+        tags: Filter by one or more tags.
+        show_registered_only: Show only already registered servers visible to the caller.
+        show_available_only: Show only available servers.
+        limit: Maximum results.
+        offset: Pagination offset.
+        db: Database session.
+        user: Authenticated user.
+
+    Returns:
+        Catalog servers matching the provided filters.
+
+    Raises:
+        HTTPException: If the catalog feature is disabled.
+    """
+    if not settings.mcpgateway_catalog_enabled:
+        raise HTTPException(status_code=404, detail="Catalog feature is disabled")
+
+    user_email, token_teams = get_scoped_resource_access_context(request, user)
+    catalog_request = CatalogListRequest(
+        category=category,
+        auth_type=auth_type,
+        provider=provider,
+        search=search,
+        tags=tags or [],
+        show_registered_only=show_registered_only,
+        show_available_only=show_available_only,
+        limit=limit,
+        offset=offset,
+    )
+
+    return await catalog_service.get_catalog_servers(catalog_request, db, user_email=user_email, token_teams=token_teams)

--- a/mcpgateway/services/catalog_service.py
+++ b/mcpgateway/services/catalog_service.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 import logging
 from pathlib import Path
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 # Third-Party
 from sqlalchemy import select
@@ -24,6 +24,7 @@ import yaml
 
 # First-Party
 from mcpgateway.config import settings
+from mcpgateway.utils.admin_check import is_admin_bypass_granted
 from mcpgateway.schemas import (
     CatalogBulkRegisterRequest,
     CatalogBulkRegisterResponse,
@@ -106,19 +107,23 @@ class CatalogService:
         except ImportError:
             return None
 
-    async def get_catalog_servers(self, request: CatalogListRequest, db) -> CatalogListResponse:
+    async def get_catalog_servers(self, request: CatalogListRequest, db, user_email: Optional[str] = None, token_teams: Optional[List[str]] = None) -> CatalogListResponse:
         """Get filtered list of catalog servers.
 
         Args:
             request: Filter criteria
             db: Database session
+            user_email: Optional requester email for scoped registration state
+            token_teams: Optional requester team scope for scoped registration state
 
         Returns:
             Filtered catalog servers response
         """
+        is_scoped_request = user_email is not None or token_teams is not None
+
         # Check cache first
         cache = self._get_registry_cache()
-        if cache:
+        if cache and not is_scoped_request:
             filters_hash = cache.hash_filters(
                 category=request.category,
                 auth_type=request.auth_type,
@@ -148,12 +153,26 @@ class CatalogService:
                 # Query all gateways (enabled and disabled) to properly track registration status
                 # Include auth_type and oauth_config to distinguish OAuth servers needing setup
                 # from OAuth servers that were manually disabled after configuration
-                stmt = select(DbGateway.url, DbGateway.enabled, DbGateway.auth_type, DbGateway.oauth_config)
+                stmt = select(
+                    DbGateway.url,
+                    DbGateway.enabled,
+                    DbGateway.auth_type,
+                    DbGateway.oauth_config,
+                    DbGateway.visibility,
+                    DbGateway.team_id,
+                    DbGateway.owner_email,
+                )
                 result = db.execute(stmt)
                 registered_urls = set()
                 oauth_disabled_urls = set()
                 for row in result:
-                    url, enabled, auth_type, oauth_config = row
+                    if len(row) == 4:
+                        url, enabled, auth_type, oauth_config = row
+                        visibility, team_id, owner_email = "public", None, None
+                    else:
+                        url, enabled, auth_type, oauth_config, visibility, team_id, owner_email = row
+                    if is_scoped_request and not self._can_view_registered_gateway(db, visibility, team_id, owner_email, user_email, token_teams):
+                        continue
                     registered_urls.add(url)
                     # Only mark as requiring OAuth config if:
                     # - disabled AND OAuth auth_type AND oauth_config is empty/None
@@ -218,7 +237,7 @@ class CatalogService:
         response = CatalogListResponse(servers=paginated, total=total, categories=all_categories, auth_types=all_auth_types, providers=all_providers, all_tags=all_tags)
 
         # Store in cache
-        if cache:
+        if cache and not is_scoped_request:
             try:
                 cache_data = response.model_dump(mode="json")
                 await cache.set("catalog", cache_data, filters_hash)
@@ -226,6 +245,38 @@ class CatalogService:
                 logger.debug("Failed to cache catalog response: %s", e)
 
         return response
+
+    @staticmethod
+    def _can_view_registered_gateway(
+        db: Session,
+        visibility: str,
+        team_id: Optional[str],
+        owner_email: Optional[str],
+        user_email: Optional[str],
+        token_teams: Optional[List[str]],
+    ) -> bool:
+        """Return whether a registered gateway is visible to a scoped catalog caller."""
+        if visibility == "public":
+            return True
+
+        if is_admin_bypass_granted(db, user_email, token_teams):
+            if visibility == "private":
+                return bool(owner_email and owner_email == user_email)
+            return True
+
+        if not user_email:
+            return False
+
+        if token_teams is not None and len(token_teams) == 0:
+            return False
+
+        if visibility == "private":
+            return bool(owner_email and owner_email == user_email)
+
+        if visibility == "team" and team_id:
+            return bool(token_teams and team_id in token_teams)
+
+        return False
 
     async def register_catalog_server(self, catalog_id: str, request: Optional[CatalogServerRegisterRequest], db: Session) -> CatalogServerRegisterResponse:
         """Register a catalog server as a gateway.

--- a/tests/unit/mcpgateway/routers/test_catalog.py
+++ b/tests/unit/mcpgateway/routers/test_catalog.py
@@ -1,4 +1,10 @@
-"""Unit tests for the v1 catalog API router."""
+# -*- coding: utf-8 -*-
+"""Location: ./tests/unit/mcpgateway/routers/test_catalog.py
+Copyright contributors to the MCP-CONTEXT-FORGE project
+SPDX-License-Identifier: Apache-2.0
+
+Unit tests for the v1 catalog API router.
+"""
 
 # Standard
 from unittest.mock import AsyncMock, MagicMock
@@ -115,6 +121,6 @@ def test_catalog_router_is_v1_only():
     legacy_paths = [path for path, *_ in collect_routes(build_legacy_router(settings, **_empty_router_kwargs()))]
 
     assert "/v1/catalog" in v1_paths
-    assert "/v1/catalog/" in v1_paths
+    assert "/v1/catalog/" not in v1_paths
     assert "/catalog" not in legacy_paths
     assert "/catalog/" not in legacy_paths

--- a/tests/unit/mcpgateway/routers/test_catalog.py
+++ b/tests/unit/mcpgateway/routers/test_catalog.py
@@ -1,0 +1,120 @@
+"""Unit tests for the v1 catalog API router."""
+
+# Standard
+from unittest.mock import AsyncMock, MagicMock
+
+# Third-Party
+from fastapi import APIRouter, HTTPException, Request
+import pytest
+
+# First-Party
+from mcpgateway.api.v1 import build_legacy_router, build_v1_router
+from mcpgateway.config import settings
+from mcpgateway.routers.catalog import list_catalog_servers
+from mcpgateway.schemas import CatalogListResponse
+from tests.helpers.router_helpers import collect_routes
+
+
+@pytest.fixture
+def allow_permission(monkeypatch):
+    """Allow RBAC permission checks to pass for decorator-wrapped handlers."""
+    mock_perm_service = MagicMock()
+    mock_perm_service.check_permission = AsyncMock(return_value=True)
+    monkeypatch.setattr("mcpgateway.middleware.rbac.PermissionService", lambda db: mock_perm_service)
+    monkeypatch.setattr("mcpgateway.plugins.get_plugin_manager", AsyncMock(return_value=None))
+    return mock_perm_service
+
+
+def _empty_router_kwargs() -> dict[str, APIRouter]:
+    """Return the full set of inline-router kwargs as empty APIRouters."""
+    names = [
+        "protocol_router",
+        "tool_router",
+        "resource_router",
+        "prompt_router",
+        "gateway_router",
+        "root_router",
+        "server_router",
+        "metrics_router",
+        "tag_router",
+        "export_import_router",
+        "a2a_router",
+    ]
+    return {name: APIRouter() for name in names}
+
+
+@pytest.mark.asyncio
+async def test_list_catalog_requires_authenticated_user():
+    """Calling the router without an authenticated user returns 401."""
+    request = MagicMock(spec=Request)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_catalog_servers(request, db=MagicMock())
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_catalog_disabled_returns_404(monkeypatch, allow_permission):
+    """The v1 catalog endpoint returns 404 when the catalog feature is disabled."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", False, raising=False)
+    request = MagicMock(spec=Request)
+    db = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_catalog_servers(request, db=db, user={"email": "user@example.com", "db": db})
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Catalog feature is disabled"
+
+
+@pytest.mark.asyncio
+async def test_list_catalog_success_forwards_filters_and_scope(monkeypatch, allow_permission):
+    """The v1 catalog endpoint forwards filters and scoped visibility context."""
+    monkeypatch.setattr("mcpgateway.routers.catalog.settings.mcpgateway_catalog_enabled", True, raising=False)
+    monkeypatch.setattr("mcpgateway.routers.catalog.get_scoped_resource_access_context", MagicMock(return_value=("user@example.com", ["team-a"])))
+    mock_response = CatalogListResponse(servers=[], total=0, categories=[], auth_types=[], providers=[], all_tags=[])
+    mock_get_catalog = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr("mcpgateway.routers.catalog.catalog_service.get_catalog_servers", mock_get_catalog)
+    request = MagicMock(spec=Request)
+    db = MagicMock()
+
+    result = await list_catalog_servers(
+        request,
+        category="Development",
+        auth_type="OAuth2.1",
+        provider="IBM",
+        search="github",
+        tags=["git", "repo"],
+        show_registered_only=True,
+        show_available_only=False,
+        limit=25,
+        offset=50,
+        db=db,
+        user={"email": "user@example.com", "db": db, "token_teams": ["team-a"]},
+    )
+
+    assert result == mock_response
+    catalog_request = mock_get_catalog.await_args.args[0]
+    assert catalog_request.category == "Development"
+    assert catalog_request.auth_type == "OAuth2.1"
+    assert catalog_request.provider == "IBM"
+    assert catalog_request.search == "github"
+    assert catalog_request.tags == ["git", "repo"]
+    assert catalog_request.show_registered_only is True
+    assert catalog_request.show_available_only is False
+    assert catalog_request.limit == 25
+    assert catalog_request.offset == 50
+    assert mock_get_catalog.await_args.args[1] is db
+    assert mock_get_catalog.await_args.kwargs == {"user_email": "user@example.com", "token_teams": ["team-a"]}
+
+
+def test_catalog_router_is_v1_only():
+    """Catalog is exposed at /v1/catalog without creating a legacy /catalog alias."""
+    v1_paths = [path for path, *_ in collect_routes(build_v1_router(settings, **_empty_router_kwargs()))]
+    legacy_paths = [path for path, *_ in collect_routes(build_legacy_router(settings, **_empty_router_kwargs()))]
+
+    assert "/v1/catalog" in v1_paths
+    assert "/v1/catalog/" in v1_paths
+    assert "/catalog" not in legacy_paths
+    assert "/catalog/" not in legacy_paths

--- a/tests/unit/mcpgateway/services/test_catalog_service.py
+++ b/tests/unit/mcpgateway/services/test_catalog_service.py
@@ -7,7 +7,6 @@ Unit Tests for Catalog Service .
 """
 
 # Standard
-import asyncio
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -565,6 +564,81 @@ async def test_get_catalog_servers_cache_store_exception(service):
         req = CatalogListRequest(offset=0, limit=10)
         result = await service.get_catalog_servers(req, db)
         assert result.total == 1
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_servers_scoped_registration_state(service):
+    """Scoped catalog calls only mark gateways registered when visible to the caller."""
+    fake_catalog = {
+        "catalog_servers": [
+            {"id": "visible", "name": "Visible", "url": "http://visible", "category": "cat", "auth_type": "Open", "provider": "prov", "tags": [], "description": "visible"},
+            {"id": "wrong-team", "name": "Wrong Team", "url": "http://wrong-team", "category": "cat", "auth_type": "Open", "provider": "prov", "tags": [], "description": "wrong"},
+            {"id": "private-other", "name": "Private Other", "url": "http://private-other", "category": "cat", "auth_type": "Open", "provider": "prov", "tags": [], "description": "private"},
+        ]
+    }
+    with patch.object(service, "load_catalog", AsyncMock(return_value=fake_catalog)), patch.object(service, "_get_registry_cache", return_value=None):
+        db = MagicMock()
+        db.execute.return_value = [
+            ("http://visible", True, None, None, "team", "team-a", "teammate@example.com"),
+            ("http://wrong-team", True, None, None, "team", "team-b", "teammate@example.com"),
+            ("http://private-other", True, None, None, "private", None, "other@example.com"),
+        ]
+        req = CatalogListRequest(offset=0, limit=10)
+
+        result = await service.get_catalog_servers(req, db, user_email="user@example.com", token_teams=["team-a"])
+
+        by_id = {server.id: server for server in result.servers}
+        assert by_id["visible"].is_registered is True
+        assert by_id["wrong-team"].is_registered is False
+        assert by_id["private-other"].is_registered is False
+
+
+@pytest.mark.asyncio
+async def test_get_catalog_servers_scoped_request_bypasses_shared_cache(service):
+    """Scoped catalog responses are not read from or written to the shared catalog cache."""
+    fake_catalog = {
+        "catalog_servers": [
+            {"id": "1", "name": "srv1", "url": "http://a", "category": "cat", "auth_type": "Open", "provider": "prov", "tags": [], "description": "desc"},
+        ]
+    }
+    mock_cache = AsyncMock()
+    mock_cache.get = AsyncMock(return_value={"servers": [], "total": 0, "categories": [], "auth_types": [], "providers": [], "all_tags": []})
+    mock_cache.hash_filters = MagicMock(return_value="hash123")
+    mock_cache.set = AsyncMock()
+    with patch.object(service, "load_catalog", AsyncMock(return_value=fake_catalog)), patch.object(service, "_get_registry_cache", return_value=mock_cache):
+        db = MagicMock()
+        db.execute.return_value = [("http://a", True, None, None, "public", None, None)]
+        req = CatalogListRequest(offset=0, limit=10)
+
+        result = await service.get_catalog_servers(req, db, user_email="user@example.com", token_teams=[])
+
+        assert result.total == 1
+        mock_cache.get.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+
+def test_can_view_registered_gateway_admin_bypass(monkeypatch):
+    """Admin bypass can see team gateways and own private gateways."""
+    monkeypatch.setattr("mcpgateway.services.catalog_service.is_admin_bypass_granted", lambda *_args: True)
+    db = MagicMock()
+
+    assert CatalogService._can_view_registered_gateway(db, "private", None, "admin@example.com", "admin@example.com", None) is True
+    assert CatalogService._can_view_registered_gateway(db, "team", "team-a", "owner@example.com", "admin@example.com", None) is True
+
+
+def test_can_view_registered_gateway_denies_missing_user():
+    """Non-public gateway is hidden when caller identity is missing."""
+    assert CatalogService._can_view_registered_gateway(MagicMock(), "team", "team-a", "owner@example.com", None, ["team-a"]) is False
+
+
+def test_can_view_registered_gateway_denies_public_only_token():
+    """Public-only token cannot see team/private gateway registration state."""
+    assert CatalogService._can_view_registered_gateway(MagicMock(), "team", "team-a", "owner@example.com", "user@example.com", []) is False
+
+
+def test_can_view_registered_gateway_denies_unknown_visibility():
+    """Unknown non-public visibility falls through to deny."""
+    assert CatalogService._can_view_registered_gateway(MagicMock(), "unknown", None, "owner@example.com", "user@example.com", ["team-a"]) is False
 
 
 # ---------- Register with different auth types ----------


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #4399

---

## 📝 Summary

Adds a v1-only `GET /v1/catalog` API for programmatic MCP registry catalog discovery. The endpoint reuses the existing catalog response models and query filters from the admin MCP registry route, while applying public API RBAC and scoped registration visibility for callers.

Key changes:
- Adds a new Catalog API router mounted only under `/v1/catalog`.
- Keeps `/catalog` from being introduced as a legacy/root alias.
- Extends catalog service registration-state calculation to respect caller scope for `/v1/catalog`.
- Bypasses shared catalog response caching for scoped calls to avoid leaking `is_registered` state between users.
- Adds focused router and service tests.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [ ] Bug fix
- [x] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

| Check                     | Command         | Status |
|---------------------------|-----------------|--------|
| Lint suite                | `uv run ruff check mcpgateway/services/catalog_service.py mcpgateway/routers/catalog.py mcpgateway/api/v1/__init__.py tests/unit/mcpgateway/services/test_catalog_service.py tests/unit/mcpgateway/routers/test_catalog.py` | Pass |
| Unit tests                | `pytest tests/unit/mcpgateway/services/test_catalog_service.py tests/unit/mcpgateway/routers/test_catalog.py tests/unit/mcpgateway/test_api_versioning_parity.py -q` | Pass |
| Coverage ≥ 80%            | `make coverage` | Not run; focused change validated with targeted unit tests |

---

## ✅ Checklist

- [ ] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

The linked issue currently still has the `triage` label, so the reviewability checkbox for that template item is intentionally left unchecked.
