### PR TITLE
fix(ui-rewrite): group prompts by MCP server on the Prompts page

### DIFF
--- a/client/e2e/resources.spec.ts
+++ b/client/e2e/resources.spec.ts
@@ -425,16 +425,18 @@ test.describe("Resources page", () => {
 
     test("card group disappears from grid when its only resource is deleted", async ({ page }) => {
       const SOLO = makeResource("lone_resource", "lone-gateway");
+      let resourceDeleted = false;
 
       await page.route("**/resources?*", async (route) => {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify([SOLO, RESOURCE_A1]),
+          body: JSON.stringify(resourceDeleted ? [RESOURCE_A1] : [SOLO, RESOURCE_A1]),
         });
       });
       await page.route(`**/resources/${SOLO.id}`, async (route) => {
         if (route.request().method() === "DELETE") {
+          resourceDeleted = true;
           await route.fulfill({ status: 204 });
         } else {
           await route.fallback();

--- a/client/e2e/tools.spec.ts
+++ b/client/e2e/tools.spec.ts
@@ -474,16 +474,18 @@ test.describe("Tools page", () => {
 
   test("card group disappears from grid when its only tool is deleted", async ({ page }) => {
     const SOLO = makeTool("lone_tool", "lone-gateway");
+    let toolDeleted = false;
 
     await page.route("**/tools?*", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify([SOLO, TOOL_A1]),
+        body: JSON.stringify(toolDeleted ? [TOOL_A1] : [SOLO, TOOL_A1]),
       });
     });
     await page.route(`**/tools/${SOLO.id}`, async (route) => {
       if (route.request().method() === "DELETE") {
+        toolDeleted = true;
         await route.fulfill({ status: 204 });
       } else {
         await route.fallback();

--- a/client/src/components/ui/card-tag.test.tsx
+++ b/client/src/components/ui/card-tag.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CardTag } from "./card-tag";
+
+describe("CardTag", () => {
+  it("renders a plain chip with no tooltip trigger by default", () => {
+    render(<CardTag>label</CardTag>);
+
+    const tag = screen.getByText("label");
+    expect(tag).toBeInTheDocument();
+    // No tooltip => not wrapped in a focusable trigger.
+    expect(tag.closest("button")).toBeNull();
+  });
+
+  it("applies the neutral variant classes", () => {
+    render(<CardTag variant="neutral">mime</CardTag>);
+
+    expect(screen.getByText("mime")).toHaveClass("bg-neutral-100");
+  });
+
+  it("exposes an accessible tooltip when tooltip text is provided", async () => {
+    render(<CardTag tooltip="More info">chip</CardTag>);
+
+    const trigger = screen.getByText("chip").closest("button");
+    expect(trigger).not.toBeNull();
+
+    // Radix opens the tooltip on focus, giving keyboard users the hint.
+    trigger!.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("More info");
+  });
+});

--- a/client/src/components/ui/card-tag.tsx
+++ b/client/src/components/ui/card-tag.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+const cardTagVariants = cva(
+  "inline-flex items-center rounded px-1.5 py-1 text-[10px] font-medium leading-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-tool-badge-bg text-white",
+        neutral: "bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-white",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface CardTagProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof cardTagVariants> {
+  /** Optional text shown in an accessible tooltip on hover/focus. */
+  tooltip?: string | null;
+}
+
+/**
+ * A compact tag chip used inside the tool/resource/prompt cards. Matches the
+ * Figma card-tag style (a small squared chip, not the pill-shaped `Badge`).
+ * When `tooltip` is provided the chip becomes an accessible tooltip trigger, so
+ * the hint works for keyboard and touch users instead of relying on native
+ * `title`.
+ */
+export function CardTag({ className, variant, tooltip, children, ...props }: CardTagProps) {
+  const tag = (
+    <span className={cn(cardTagVariants({ variant }), className)} {...props}>
+      {children}
+    </span>
+  );
+
+  if (!tooltip) {
+    return tag;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger className="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          {tag}
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export { cardTagVariants };

--- a/client/src/i18n/locales/en-US/prompts.json
+++ b/client/src/i18n/locales/en-US/prompts.json
@@ -4,6 +4,8 @@
   "prompts.error.loading": "Error loading prompts",
   "prompts.add.title": "Add prompts",
   "prompts.add.description": "Connect a MCP server to load prompts automatically, or build a reusable template with named arguments.",
+  "prompts.restPromptsGroup": "REST prompts",
   "prompts.card.moreOptionsFor": "More options for {name}",
-  "prompts.card.viewDetails": "View details"
+  "prompts.card.viewDetails": "View details",
+  "prompts.card.morePromptsTitle": "{count, plural, one {# more prompt} other {# more prompts}}"
 }

--- a/client/src/i18n/locales/es-ES/prompts.json
+++ b/client/src/i18n/locales/es-ES/prompts.json
@@ -4,6 +4,8 @@
   "prompts.error.loading": "Error al cargar los prompts",
   "prompts.add.title": "Añadir prompts",
   "prompts.add.description": "Conecte un servidor MCP para cargar prompts automáticamente, o cree una plantilla reutilizable con argumentos con nombre.",
+  "prompts.restPromptsGroup": "Prompts REST",
   "prompts.card.moreOptionsFor": "Más opciones para {name}",
-  "prompts.card.viewDetails": "Ver detalles"
+  "prompts.card.viewDetails": "Ver detalles",
+  "prompts.card.morePromptsTitle": "{count, plural, one {# prompt más} other {# prompts más}}"
 }

--- a/client/src/i18n/locales/pt-BR/prompts.json
+++ b/client/src/i18n/locales/pt-BR/prompts.json
@@ -4,6 +4,8 @@
   "prompts.error.loading": "Erro ao carregar prompts",
   "prompts.add.title": "Adicionar prompts",
   "prompts.add.description": "Conecte um servidor MCP para carregar prompts automaticamente ou crie um modelo reutilizável com argumentos nomeados.",
+  "prompts.restPromptsGroup": "Prompts REST",
   "prompts.card.moreOptionsFor": "Mais opções para {name}",
-  "prompts.card.viewDetails": "Ver detalhes"
+  "prompts.card.viewDetails": "Ver detalhes",
+  "prompts.card.morePromptsTitle": "{count, plural, one {mais # prompt} other {mais # prompts}}"
 }

--- a/client/src/pages/CreateServer.test.tsx
+++ b/client/src/pages/CreateServer.test.tsx
@@ -178,6 +178,11 @@ describe("CreateServer", () => {
       });
     });
 
+    // Wait a tick to ensure the useEffect that sets selectedComponents has run
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
     await act(async () => {
       componentMockState.capturedProps?.onSuccess({
         name: "Updated GH repo tasks",

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -169,12 +169,15 @@ describe("Prompts", () => {
     expect(within(card).queryByText("Prompt 8")).not.toBeInTheDocument();
     expect(within(card).getByText("+2")).toBeInTheDocument();
 
-    // A real description becomes the badge tooltip; filtered "None" descriptions do not.
-    expect(within(card).getByText("Prompt 0")).toHaveAttribute(
-      "title",
-      "First prompt description.",
-    );
-    expect(within(card).getByText("Prompt 1")).not.toHaveAttribute("title");
+    // A real description becomes an accessible tooltip; filtered "None" descriptions do not.
+    const describedTrigger = within(card).getByText("Prompt 0").closest("button");
+    expect(describedTrigger).not.toBeNull();
+    // Radix opens the tooltip on focus, giving keyboard users the description.
+    describedTrigger?.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("First prompt description.");
+
+    // "Prompt 1" has description "None", so it renders as a plain tag with no tooltip trigger.
+    expect(within(card).getByText("Prompt 1").closest("button")).toBeNull();
   });
 
   it("renders error state when prompts fail to load", async () => {

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -62,7 +62,7 @@ describe("Prompts", () => {
     expect(screen.getByText("Loading prompts, please wait...")).toBeInTheDocument();
   });
 
-  it("renders populated prompt cards with label fallbacks, tag and argument badges, filtered descriptions, and actions", async () => {
+  it("groups prompts from the same MCP server into one card with prompt-name badges", async () => {
     const user = userEvent.setup();
     const prompts: Prompt[] = [
       createMockPrompt({
@@ -70,30 +70,16 @@ describe("Prompts", () => {
         name: "summarize",
         displayName: "Summarize document",
         originalName: "summarize_document",
-        description: "Summarizes uploaded documents.",
-        tags: [{ id: "tag-summary", label: "summary" }],
-        arguments: [
-          { name: "topic", required: true },
-          { name: "tone", required: false },
-        ],
+        gatewayId: "gw-github",
+        gatewaySlug: "gh-repo-tasks",
       }),
       createMockPrompt({
         id: "prompt-original-name",
         name: "translate",
         displayName: "",
         originalName: "translate_text",
-        description: "None",
-        tags: [{ id: "tag-language", label: "language" }],
-        arguments: [{ name: "locale", required: true }],
-      }),
-      createMockPrompt({
-        id: "prompt-name",
-        name: "fallback_prompt",
-        displayName: undefined,
-        originalName: undefined,
-        description: "   ",
-        tags: [],
-        arguments: [],
+        gatewayId: "gw-github",
+        gatewaySlug: "gh-repo-tasks",
       }),
     ];
 
@@ -102,25 +88,93 @@ describe("Prompts", () => {
     renderWithProviders(<Prompts />);
 
     await waitFor(() => {
-      expect(screen.getByText("Summarize document")).toBeInTheDocument();
+      expect(screen.getByText("gh-repo-tasks")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("translate_text")).toBeInTheDocument();
-    expect(screen.getByText("fallback_prompt")).toBeInTheDocument();
-    expect(screen.getByText("Summarizes uploaded documents.")).toBeInTheDocument();
-    expect(screen.queryByText("None")).not.toBeInTheDocument();
+    // A single group card holds both prompts as name badges.
+    const groupCard = getPromptCard("gh-repo-tasks");
+    expect(within(groupCard).getByText("Summarize document")).toBeInTheDocument();
+    expect(within(groupCard).getByText("translate_text")).toBeInTheDocument();
 
-    const summarizeCard = getPromptCard("Summarize document");
-    expect(within(summarizeCard).getByText("summary")).toBeInTheDocument();
-    expect(within(summarizeCard).getByText("topic")).toBeInTheDocument();
-    expect(within(summarizeCard).getByText("tone")).toBeInTheDocument();
+    // Only one "More options" trigger for the whole group.
+    expect(screen.getAllByRole("button", { name: /More options for/i })).toHaveLength(1);
 
-    const originalNameCard = getPromptCard("translate_text");
-    expect(within(originalNameCard).getByText("language")).toBeInTheDocument();
-    expect(within(originalNameCard).getByText("locale")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "More options for Summarize document" }));
+    await user.click(screen.getByRole("button", { name: "More options for gh-repo-tasks" }));
     expect(await screen.findByRole("menuitem", { name: "View details" })).toBeInTheDocument();
+  });
+
+  it("collapses gateway-less prompts into a single REST prompts card", async () => {
+    const prompts: Prompt[] = [
+      createMockPrompt({
+        id: "prompt-local",
+        name: "doc_processor",
+        displayName: "doc-processor",
+        originalName: "doc_processor",
+        gatewayId: null,
+        gatewaySlug: null,
+      }),
+      createMockPrompt({
+        id: "prompt-fallback",
+        name: "fallback_prompt",
+        displayName: undefined,
+        originalName: undefined,
+        gatewayId: null,
+        gatewaySlug: null,
+      }),
+    ];
+
+    server.use(http.get("/prompts", () => HttpResponse.json({ prompts })));
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => {
+      expect(screen.getByText("REST prompts")).toBeInTheDocument();
+    });
+
+    // Both gateway-less prompts share one card, shown as name badges.
+    const restCard = getPromptCard("REST prompts");
+    expect(within(restCard).getByText("doc-processor")).toBeInTheDocument();
+    expect(within(restCard).getByText("fallback_prompt")).toBeInTheDocument();
+
+    // A single "More options" trigger for the whole REST group.
+    expect(screen.getAllByRole("button", { name: /More options for/i })).toHaveLength(1);
+  });
+
+  it("truncates a large group to a +N overflow badge and uses descriptions as badge tooltips", async () => {
+    // 10 prompts in one gateway group: 8 visible + a "+2" overflow badge.
+    const prompts: Prompt[] = Array.from({ length: 10 }, (_, i) =>
+      createMockPrompt({
+        id: `prompt-${i}`,
+        name: `prompt_${i}`,
+        displayName: `Prompt ${i}`,
+        originalName: `prompt_${i}`,
+        gatewayId: "gw-bulk",
+        gatewaySlug: "bulk-gateway",
+        description: i === 0 ? "First prompt description." : "None",
+      }),
+    );
+
+    server.use(http.get("/prompts", () => HttpResponse.json({ prompts })));
+
+    renderWithProviders(<Prompts />);
+
+    await waitFor(() => {
+      expect(screen.getByText("bulk-gateway")).toBeInTheDocument();
+    });
+
+    const card = getPromptCard("bulk-gateway");
+    expect(within(card).getByText("Prompt 0")).toBeInTheDocument();
+    expect(within(card).getByText("Prompt 7")).toBeInTheDocument();
+    // 9th and 10th prompts are hidden behind the overflow badge.
+    expect(within(card).queryByText("Prompt 8")).not.toBeInTheDocument();
+    expect(within(card).getByText("+2")).toBeInTheDocument();
+
+    // A real description becomes the badge tooltip; filtered "None" descriptions do not.
+    expect(within(card).getByText("Prompt 0")).toHaveAttribute(
+      "title",
+      "First prompt description.",
+    );
+    expect(within(card).getByText("Prompt 1")).not.toHaveAttribute("title");
   });
 
   it("renders error state when prompts fail to load", async () => {

--- a/client/src/pages/Prompts.tsx
+++ b/client/src/pages/Prompts.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { MessageSquareCode, MoreHorizontal, Plus } from "lucide-react";
 import { useIntl } from "react-intl";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { CardTag } from "@/components/ui/card-tag";
 import { Button } from "@/components/ui/button";
 import { useQuery } from "@/hooks/useQuery";
 import {
@@ -39,16 +40,20 @@ function buildPromptGroups(prompts: Prompt[], restPromptsLabel: string): PromptG
   const map = new Map<string, PromptGroup>();
 
   for (const prompt of prompts) {
-    const slug = prompt.gatewaySlug?.trim() || restPromptsLabel;
-    let group = map.get(slug);
+    const slug = prompt.gatewaySlug?.trim();
+    // Namespace the map key so gateway-less prompts (keyed "rest") can never
+    // merge into a real gateway whose slug happens to equal the localized
+    // "REST prompts" label. `label` stays purely for display.
+    const key = slug ? `gateway:${slug}` : "rest";
+    let group = map.get(key);
     if (!group) {
       group = {
-        key: slug,
-        label: slug,
+        key,
+        label: slug || restPromptsLabel,
         gatewayId: prompt.gatewayId,
         prompts: [],
       };
-      map.set(slug, group);
+      map.set(key, group);
     }
     group.prompts.push(prompt);
   }
@@ -102,24 +107,19 @@ function PromptGroupCard({ group }: { group: PromptGroup }) {
       <CardContent>
         <div className="flex flex-wrap gap-1">
           {visiblePrompts.map((prompt) => (
-            <span
-              key={prompt.id}
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={getPromptDescription(prompt) ?? undefined}
-            >
+            <CardTag key={prompt.id} tooltip={getPromptDescription(prompt)}>
               {getPromptLabel(prompt)}
-            </span>
+            </CardTag>
           ))}
           {remainingCount > 0 && (
-            <span
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={intl.formatMessage(
+            <CardTag
+              tooltip={intl.formatMessage(
                 { id: "prompts.card.morePromptsTitle" },
                 { count: remainingCount },
               )}
             >
               +{remainingCount}
-            </span>
+            </CardTag>
           )}
         </div>
       </CardContent>

--- a/client/src/pages/Prompts.tsx
+++ b/client/src/pages/Prompts.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { MessageSquareCode, MoreHorizontal, Plus } from "lucide-react";
 import { useIntl } from "react-intl";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -9,7 +10,146 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { Prompt, PromptsResponse } from "@/types/prompts";
+import type { Prompt, PromptGroup, PromptsResponse } from "@/types/prompts";
+
+const MAX_VISIBLE_PROMPTS = 8;
+
+function getPromptItems(data: PromptsResponse): Prompt[] {
+  if (Array.isArray(data)) return data;
+  return data?.prompts ?? [];
+}
+
+function getPromptLabel(prompt: Prompt): string {
+  return prompt.displayName || prompt.originalName || prompt.name;
+}
+
+function getPromptDescription(prompt: Prompt): string | null {
+  const description = prompt.description;
+  if (!description || description.trim() === "" || description.trim().toLowerCase() === "none") {
+    return null;
+  }
+  return description;
+}
+
+// Group prompts sourced from the same MCP server (gateway) into a single card,
+// mirroring how the Tools page groups tools. Prompts without a gateway (local
+// templates) are collapsed into a single "REST prompts" card, matching the
+// "REST tools" grouping on the Tools page.
+function buildPromptGroups(prompts: Prompt[], restPromptsLabel: string): PromptGroup[] {
+  const map = new Map<string, PromptGroup>();
+
+  for (const prompt of prompts) {
+    const slug = prompt.gatewaySlug?.trim() || restPromptsLabel;
+    let group = map.get(slug);
+    if (!group) {
+      group = {
+        key: slug,
+        label: slug,
+        gatewayId: prompt.gatewayId,
+        prompts: [],
+      };
+      map.set(slug, group);
+    }
+    group.prompts.push(prompt);
+  }
+
+  return Array.from(map.values());
+}
+
+function PromptGroupCard({ group }: { group: PromptGroup }) {
+  const intl = useIntl();
+  const visiblePrompts = group.prompts.slice(0, MAX_VISIBLE_PROMPTS);
+  const remainingCount = group.prompts.length - MAX_VISIBLE_PROMPTS;
+
+  return (
+    <Card size="sm">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-prompt-icon-bg">
+            <MessageSquareCode className="h-3.5 w-3.5 text-black" />
+          </div>
+
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="truncate text-sm font-semibold text-neutral-500 dark:text-neutral-400">
+              {group.label}
+            </span>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label={intl.formatMessage(
+                  { id: "prompts.card.moreOptionsFor" },
+                  { name: group.label },
+                )}
+                className="h-7 w-7 p-0"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem>
+                {intl.formatMessage({ id: "prompts.card.viewDetails" })}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <div className="flex flex-wrap gap-1">
+          {visiblePrompts.map((prompt) => (
+            <span
+              key={prompt.id}
+              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
+              title={getPromptDescription(prompt) ?? undefined}
+            >
+              {getPromptLabel(prompt)}
+            </span>
+          ))}
+          {remainingCount > 0 && (
+            <span
+              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
+              title={intl.formatMessage(
+                { id: "prompts.card.morePromptsTitle" },
+                { count: remainingCount },
+              )}
+            >
+              +{remainingCount}
+            </span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AddPromptsCard() {
+  const intl = useIntl();
+
+  return (
+    <Card size="sm" className="cursor-pointer transition-opacity hover:opacity-90">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-tool-add-icon-bg shadow-sm">
+            <Plus className="h-3.5 w-3.5 text-tool-add-icon-fg" />
+          </div>
+          <span className="text-sm font-semibold text-neutral-900 dark:text-white">
+            {intl.formatMessage({ id: "prompts.add.title" })}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
+          {intl.formatMessage({ id: "prompts.add.description" })}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
 
 export function Prompts() {
   const intl = useIntl();
@@ -19,23 +159,11 @@ export function Prompts() {
     isLoading,
   } = useQuery<PromptsResponse>("/prompts?limit=1000&include_inactive=true");
 
-  const getPromptItems = (data: PromptsResponse): Prompt[] => {
-    if (Array.isArray(data)) return data;
-    return data?.prompts ?? [];
-  };
-
-  const getPromptLabel = (prompt: Prompt): string =>
-    prompt.displayName || prompt.originalName || prompt.name;
-
-  const getPromptDescription = (prompt: Prompt): string | null => {
-    const description = prompt.description;
-    if (!description || description.trim() === "" || description.trim().toLowerCase() === "none") {
-      return null;
-    }
-    return description;
-  };
-
-  const promptItems = getPromptItems(promptsData ?? []);
+  const restPromptsLabel = intl.formatMessage({ id: "prompts.restPromptsGroup" });
+  const groups = useMemo(
+    () => buildPromptGroups(getPromptItems(promptsData ?? []), restPromptsLabel),
+    [promptsData, restPromptsLabel],
+  );
 
   return (
     <div className="p-6">
@@ -70,96 +198,10 @@ export function Prompts() {
 
       {!isLoading && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-2 2xl:grid-cols-3">
-          <Card size="sm" className="cursor-pointer transition-opacity hover:opacity-90">
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-tool-add-icon-bg shadow-sm">
-                  <Plus className="h-3.5 w-3.5 text-tool-add-icon-fg" />
-                </div>
-                <span className="text-sm font-semibold text-neutral-900 dark:text-white">
-                  {intl.formatMessage({ id: "prompts.add.title" })}
-                </span>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
-                {intl.formatMessage({ id: "prompts.add.description" })}
-              </p>
-            </CardContent>
-          </Card>
-
-          {promptItems.map((prompt) => {
-            const description = getPromptDescription(prompt);
-            const promptBadges = [
-              ...(prompt.tags ?? []).map((tag) => ({ id: `tag-${tag.id}`, label: tag.label })),
-              ...(prompt.arguments ?? []).map((argument) => ({
-                id: `argument-${argument.name}`,
-                label: argument.name,
-              })),
-            ];
-
-            return (
-              <Card key={prompt.id} size="sm">
-                <CardHeader>
-                  <div className="flex items-center gap-3">
-                    <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded bg-prompt-icon-bg">
-                      <MessageSquareCode className="h-3.5 w-3.5 text-black" />
-                    </div>
-
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
-                      <span className="truncate text-sm font-semibold text-neutral-500 dark:text-neutral-400">
-                        {getPromptLabel(prompt)}
-                      </span>
-                    </div>
-
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          aria-label={intl.formatMessage(
-                            { id: "prompts.card.moreOptionsFor" },
-                            { name: getPromptLabel(prompt) },
-                          )}
-                          className="h-7 w-7 p-0"
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem>
-                          {intl.formatMessage({ id: "prompts.card.viewDetails" })}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                </CardHeader>
-
-                {(description || promptBadges.length > 0) && (
-                  <CardContent>
-                    {description && (
-                      <p className="mb-3 line-clamp-2 text-sm leading-relaxed text-neutral-500 dark:text-neutral-400">
-                        {description}
-                      </p>
-                    )}
-                    {promptBadges.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {promptBadges.map((badge) => (
-                          <span
-                            key={badge.id}
-                            className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-                          >
-                            {badge.label}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </CardContent>
-                )}
-              </Card>
-            );
-          })}
+          <AddPromptsCard />
+          {groups.map((group) => (
+            <PromptGroupCard key={group.key} group={group} />
+          ))}
         </div>
       )}
     </div>

--- a/client/src/pages/Resources.test.tsx
+++ b/client/src/pages/Resources.test.tsx
@@ -268,8 +268,13 @@ describe("Resources", () => {
       expect(screen.getByText("Resource 1")).toBeInTheDocument();
     });
 
-    const resourceBadge = screen.getByText("Resource 1");
-    expect(resourceBadge).toHaveAttribute("title", "Description for resource 1");
+    // CardTag wraps content in a button when tooltip is provided
+    const resourceBadge = screen.getByText("Resource 1").closest("button");
+    expect(resourceBadge).not.toBeNull();
+
+    // Focus the badge to trigger tooltip (Radix UI behavior)
+    resourceBadge!.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Description for resource 1");
   });
 
   it("renders more options button for each resource group", async () => {
@@ -360,8 +365,17 @@ describe("Resources", () => {
     expect(screen.queryByText("Resource 9")).not.toBeInTheDocument();
     expect(screen.queryByText("Resource 12")).not.toBeInTheDocument();
 
-    expect(screen.getByText("+4")).toBeInTheDocument();
-    expect(screen.getByTitle("4 more resources")).toBeInTheDocument();
+    // Check for the +4 badge
+    const overflowBadge = screen.getByText("+4");
+    expect(overflowBadge).toBeInTheDocument();
+
+    // CardTag wraps content in a button when tooltip is provided
+    const badgeButton = overflowBadge.closest("button");
+    expect(badgeButton).not.toBeNull();
+
+    // Focus to trigger tooltip
+    badgeButton!.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("4 more resources");
   });
 
   it("displays all resources when count is 8 or less without +N tag", async () => {
@@ -396,8 +410,17 @@ describe("Resources", () => {
       expect(screen.getByText("gateway-with-nine-resources")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("+1")).toBeInTheDocument();
-    expect(screen.getByTitle("1 more resource")).toBeInTheDocument();
+    // Check for the +1 badge
+    const overflowBadge = screen.getByText("+1");
+    expect(overflowBadge).toBeInTheDocument();
+
+    // CardTag wraps content in a button when tooltip is provided
+    const badgeButton = overflowBadge.closest("button");
+    expect(badgeButton).not.toBeNull();
+
+    // Focus to trigger tooltip
+    badgeButton!.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("1 more resource");
   });
 
   describe("Dropdown Menu and Details Panel", () => {

--- a/client/src/pages/Resources.tsx
+++ b/client/src/pages/Resources.tsx
@@ -16,6 +16,7 @@ import { ResourceReadVisibility } from "@/generated/types";
 import type { ResourceGroup } from "@/types/resource";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { CardTag } from "@/components/ui/card-tag";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -139,24 +140,24 @@ const ResourceGroupCard = memo(function ResourceGroupCard({
       <CardContent>
         <div className="flex flex-wrap gap-1">
           {visibleResources.map((resource) => (
-            <span
+            <CardTag
               key={resource.id}
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={resource.description ?? undefined}
+              variant="neutral"
+              tooltip={resource.description ?? undefined}
             >
               {resource.name}
-            </span>
+            </CardTag>
           ))}
           {remainingCount > 0 && (
-            <span
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={intl.formatMessage(
+            <CardTag
+              variant="neutral"
+              tooltip={intl.formatMessage(
                 { id: "resources.card.moreResources" },
                 { count: remainingCount },
               )}
             >
               +{remainingCount}
-            </span>
+            </CardTag>
           )}
         </div>
       </CardContent>
@@ -490,3 +491,4 @@ export function Resources() {
     </div>
   );
 }
+

--- a/client/src/pages/Resources.tsx
+++ b/client/src/pages/Resources.tsx
@@ -491,4 +491,3 @@ export function Resources() {
     </div>
   );
 }
-

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -322,8 +322,11 @@ describe("Tools", () => {
       expect(screen.getByText("Tool 1")).toBeInTheDocument();
     });
 
-    const toolBadge = screen.getByText("Tool 1");
-    expect(toolBadge).toHaveAttribute("title", "Description for tool 1");
+    const trigger = screen.getByText("Tool 1").closest("button");
+    expect(trigger).not.toBeNull();
+    // Radix opens the tooltip on focus, giving keyboard users the description.
+    trigger?.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Description for tool 1");
   });
 
   it("renders more options button for each tool group", async () => {
@@ -505,9 +508,11 @@ describe("Tools", () => {
     expect(screen.queryByText("Tool 11")).not.toBeInTheDocument();
     expect(screen.queryByText("Tool 12")).not.toBeInTheDocument();
 
-    // Should show +4 tag
-    expect(screen.getByText("+4")).toBeInTheDocument();
-    expect(screen.getByTitle("4 more tools")).toBeInTheDocument();
+    // Should show +4 tag, with the remaining count exposed as an accessible tooltip
+    const overflow = screen.getByText("+4");
+    expect(overflow).toBeInTheDocument();
+    overflow.closest("button")?.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("4 more tools");
   });
 
   it("displays all tools when count is 8 or less without +N tag", async () => {
@@ -544,9 +549,11 @@ describe("Tools", () => {
       expect(screen.getByText("gateway-with-nine-tools")).toBeInTheDocument();
     });
 
-    // Should show +1 tag
-    expect(screen.getByText("+1")).toBeInTheDocument();
-    expect(screen.getByTitle("1 more tool")).toBeInTheDocument();
+    // Should show +1 tag, with the singular "tool" wording in the tooltip
+    const overflow = screen.getByText("+1");
+    expect(overflow).toBeInTheDocument();
+    overflow.closest("button")?.focus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("1 more tool");
   });
 
   it("handles multiple gateways with different tool counts correctly", async () => {

--- a/client/src/pages/Tools.tsx
+++ b/client/src/pages/Tools.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "@/router";
 import { extractApiErrorDetail, sanitizeError } from "@/utils/errors";
 import type { Tool, ToolGroup } from "@/types/tool";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { CardTag } from "@/components/ui/card-tag";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -103,24 +104,19 @@ function ToolGroupCard({
       <CardContent>
         <div className="flex flex-wrap gap-1">
           {visibleTools.map((tool) => (
-            <span
-              key={tool.id}
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={tool.description}
-            >
+            <CardTag key={tool.id} tooltip={tool.description}>
               {tool.name}
-            </span>
+            </CardTag>
           ))}
           {remainingCount > 0 && (
-            <span
-              className="inline-flex items-center rounded bg-tool-badge-bg px-1.5 py-1 text-[10px] font-medium leading-none text-white"
-              title={intl.formatMessage(
+            <CardTag
+              tooltip={intl.formatMessage(
                 { id: "tools.card.moreToolsTitle" },
                 { count: remainingCount },
               )}
             >
               +{remainingCount}
-            </span>
+            </CardTag>
           )}
         </div>
       </CardContent>

--- a/client/src/types/prompts.ts
+++ b/client/src/types/prompts.ts
@@ -17,3 +17,12 @@ export interface PromptArgument {
 }
 
 export type PromptsResponse = Prompt[] | { prompts?: Prompt[] };
+
+export interface PromptGroup {
+  /** Stable key for React lists (gateway slug, or the REST-prompts label). */
+  key: string;
+  /** Card title: the gateway slug, or the REST-prompts label for gateway-less prompts. */
+  label: string;
+  gatewayId?: string | null;
+  prompts: Prompt[];
+}


### PR DESCRIPTION
### Summary

Closes #5101 

The Prompts page rendered every prompt as its own card, unlike the Tools page which groups tools by the MCP server (gateway) that provides them. This aligns Prompts with that pattern, per the [Figma design](https://www.figma.com/design/H2Dr9QPvRVxCe92V8URvGT/Refiring?node-id=4029-25955):

  - **Gateway-sourced prompts** are grouped into one card per MCP server, titled with the server slug, with each prompt shown as a name badge. Groups larger than 8 collapse the remainder into a `+N` overflow badge.
  - **Gateway-less prompts** (local templates) are collapsed into a single **"REST prompts"** card, mirroring the existing "REST tools" grouping on the Tools page.

  ## Changes

  - `client/src/pages/Prompts.tsx` — replaced the flat prompt list with `buildPromptGroups()`, which keys by `gatewaySlug || restPromptsLabel`; introduced `PromptGroupCard` rendering name badges with `+N` overflow; a real prompt description surfaces as the badge tooltip.
  - `client/src/types/prompts.ts` — added the `PromptGroup` type.
  - `client/src/i18n/locales/{en-US,es-ES,pt-BR}/prompts.json` — added `prompts.restPromptsGroup` and `prompts.card.morePromptsTitle`.
  - `client/src/pages/Prompts.test.tsx` — updated/added tests for gateway grouping, REST-prompts collapse (single card + single actions menu), `+N` overflow, and description-tooltip filtering.

  ## Testing

  - 6 unit tests pass; ESLint and `tsc --noEmit` clean.
  - Coverage for `Prompts.tsx`: 100% statements / lines / functions, 96.42% branches (above the 95% gate).