### PR TITLE
fix(ui-rewrite): edit teams from the Teams page

### DIFF
--- a/client/src/api/teams.test.ts
+++ b/client/src/api/teams.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   createTeam,
   addTeamMember,
@@ -6,6 +5,7 @@ import {
   removeTeamMember,
   listTeamMembers,
   deleteTeam,
+  updateTeam,
 } from "./teams";
 import { api } from "./client";
 
@@ -44,6 +44,34 @@ describe("createTeam", () => {
     vi.mocked(api.post).mockRejectedValue(error);
 
     await expect(createTeam({ name: "X", visibility: "public" })).rejects.toThrow("boom");
+  });
+});
+
+describe("updateTeam", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PUTs to the URL-encoded team id with the payload and returns the team", async () => {
+    const team = { id: "team-1", name: "Engineering" };
+    vi.mocked(api.put).mockResolvedValue(team);
+
+    const payload = {
+      name: "Engineering",
+      description: "Eng team",
+      visibility: "public" as const,
+      max_members: 50,
+    };
+    const result = await updateTeam("team/1", payload);
+
+    expect(api.put).toHaveBeenCalledWith("/teams/team%2F1", payload);
+    expect(result).toEqual(team);
+  });
+
+  it("propagates errors from the API", async () => {
+    vi.mocked(api.put).mockRejectedValue(new Error("boom"));
+
+    await expect(updateTeam("team-1", { name: "X" })).rejects.toThrow("boom");
   });
 });
 

--- a/client/src/api/teams.ts
+++ b/client/src/api/teams.ts
@@ -8,8 +8,19 @@ interface CreateTeamPayload {
   max_members?: number;
 }
 
+interface UpdateTeamPayload {
+  name?: string;
+  description?: string;
+  visibility?: "private" | "public";
+  max_members?: number;
+}
+
 export function createTeam(payload: CreateTeamPayload): Promise<Team> {
   return api.post<Team>("/teams", payload);
+}
+
+export function updateTeam(id: string, payload: UpdateTeamPayload): Promise<Team> {
+  return api.put<Team>(`/teams/${encodeURIComponent(id)}`, payload);
 }
 
 export function deleteTeam(id: string): Promise<void> {

--- a/client/src/components/teams/TeamForm.test.tsx
+++ b/client/src/components/teams/TeamForm.test.tsx
@@ -5,7 +5,24 @@ import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
 import { I18nProvider } from "@/i18n";
 import { AuthProvider } from "@/auth/AuthContext";
+import type { Team } from "@/types/team";
 import { TeamForm } from "./TeamForm";
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: "team-9",
+  name: "Platform",
+  slug: "platform",
+  description: "Platform team",
+  created_by: "admin@example.com",
+  is_personal: false,
+  visibility: "public",
+  max_members: 50,
+  member_count: 4,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  is_active: true,
+  ...overrides,
+});
 
 function renderForm(props: Partial<React.ComponentProps<typeof TeamForm>> = {}) {
   return render(
@@ -167,6 +184,73 @@ describe("TeamForm", () => {
 
       await user.click(screen.getAllByRole("button", { name: /remove/i })[0]);
       expect(screen.getAllByRole("button", { name: /remove/i })).toHaveLength(1);
+    });
+  });
+
+  describe("Edit mode", () => {
+    it("pre-fills the team details and swaps to edit labels", () => {
+      renderForm({ team: makeTeam() });
+
+      expect(screen.getByRole("heading", { name: /edit team/i })).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/add team name/i)).toHaveValue("Platform");
+      expect(screen.getByRole("textbox", { name: /description/i })).toHaveValue("Platform team");
+      expect(screen.getByRole("radio", { name: /public/i })).toBeChecked();
+      expect(screen.getByRole("button", { name: /^save changes$/i })).toBeInTheDocument();
+    });
+
+    it("hides member management when editing", () => {
+      renderForm({ team: makeTeam() });
+
+      expect(screen.queryByRole("button", { name: /add team member/i })).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText(/name or email/i)).not.toBeInTheDocument();
+    });
+
+    it("shows an off-list max_members value in the selector instead of rendering blank", () => {
+      renderForm({ team: makeTeam({ max_members: 75 }) });
+
+      // The trigger reflects the team's custom cap via the injected option.
+      expect(screen.getByRole("combobox", { name: /maximum members/i })).toHaveTextContent("75");
+    });
+
+    it("PUTs the update and calls onSuccess then onToggle", async () => {
+      let capturedBody: unknown;
+      server.use(
+        http.put("*/teams/team-9", async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ id: "team-9", name: "Platform Renamed" });
+        }),
+      );
+      const onSuccess = vi.fn();
+      const onToggle = vi.fn();
+      const user = userEvent.setup();
+      renderForm({ team: makeTeam(), onSuccess, onToggle });
+
+      const nameInput = screen.getByPlaceholderText(/add team name/i);
+      await user.clear(nameInput);
+      await user.type(nameInput, "Platform Renamed");
+      await user.click(screen.getByRole("button", { name: /^save changes$/i }));
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+      expect(onToggle).toHaveBeenCalledOnce();
+      expect(capturedBody).toMatchObject({ name: "Platform Renamed", visibility: "public" });
+    });
+
+    it("shows an error and does not close when the update fails", async () => {
+      server.use(
+        http.put("*/teams/team-9", () =>
+          HttpResponse.json({ detail: "Access denied" }, { status: 403 }),
+        ),
+      );
+      const onSuccess = vi.fn();
+      const user = userEvent.setup();
+      renderForm({ team: makeTeam(), onSuccess });
+
+      await user.click(screen.getByRole("button", { name: /^save changes$/i }));
+
+      // A 403 is sanitized to a friendly, non-leaky message rather than echoing
+      // the raw backend detail.
+      await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/permission/i));
+      expect(onSuccess).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/src/components/teams/TeamForm.tsx
+++ b/client/src/components/teams/TeamForm.tsx
@@ -14,20 +14,25 @@ import {
 } from "@/components/ui/select";
 import { Combobox } from "@/components/ui/combobox";
 import { useTeamForm } from "@/hooks/useTeamForm";
+import type { Team } from "@/types/team";
 
-interface CreateTeamFormProps {
+interface TeamFormProps {
   isOpen: boolean;
   onToggle: () => void;
   onSuccess: () => void;
+  /** When provided, the form runs in edit mode, pre-populated with this team. */
+  team?: Team;
 }
 
-export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
+export function TeamForm({ isOpen, onToggle, onSuccess, team }: TeamFormProps) {
   const intl = useIntl();
   const {
+    isEditMode,
     name,
     description,
     visibility,
     maxMembers,
+    maxMembersOptions,
     members,
     memberOptions,
     error,
@@ -42,7 +47,7 @@ export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
     handleMemberRoleChange,
     resetForm,
     handleSubmit,
-  } = useTeamForm();
+  } = useTeamForm(team);
 
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) =>
     handleSubmit(e, () => {
@@ -82,11 +87,13 @@ export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
                 id="create-team-form-title"
                 className="align-middle text-base font-semibold leading-6 tracking-normal text-neutral-950 dark:text-neutral-50"
               >
-                {intl.formatMessage({ id: "teams.create.title" })}
+                {intl.formatMessage({ id: isEditMode ? "teams.edit.title" : "teams.create.title" })}
               </h2>
             </div>
             <p className="text-sm leading-6 text-neutral-600 dark:text-neutral-400">
-              {intl.formatMessage({ id: "teams.create.description" })}
+              {intl.formatMessage({
+                id: isEditMode ? "teams.edit.description" : "teams.create.description",
+              })}
             </p>
           </div>
 
@@ -167,84 +174,89 @@ export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
               )}
             </div>
 
-            {/* Team Members */}
-            <div className="space-y-3">
-              <p className="text-sm text-neutral-600 dark:text-neutral-400">
-                {intl.formatMessage({ id: "teams.create.membersHint" })}
-              </p>
+            {/* Team Members — only when creating; membership is managed
+                separately once a team exists. */}
+            {!isEditMode && (
+              <div className="space-y-3">
+                <p className="text-sm text-neutral-600 dark:text-neutral-400">
+                  {intl.formatMessage({ id: "teams.create.membersHint" })}
+                </p>
 
-              {/* Single grid — labels + member rows share the same column tracks so
+                {/* Single grid — labels + member rows share the same column tracks so
                   the auto Remove column is sized consistently across all rows */}
-              <div className="grid grid-cols-[2fr_1fr_auto] items-center gap-x-2 gap-y-2">
-                {/* Header labels */}
-                <Label className="text-sm font-medium text-neutral-950 dark:text-white">
-                  {intl.formatMessage({ id: "teams.create.memberName" })}
-                </Label>
-                <Label className="text-sm font-medium text-neutral-950 dark:text-white">
-                  {intl.formatMessage({ id: "teams.create.roleLabel" })}
-                </Label>
-                <div />
+                <div className="grid grid-cols-[2fr_1fr_auto] items-center gap-x-2 gap-y-2">
+                  {/* Header labels */}
+                  <Label className="text-sm font-medium text-neutral-950 dark:text-white">
+                    {intl.formatMessage({ id: "teams.create.memberName" })}
+                  </Label>
+                  <Label className="text-sm font-medium text-neutral-950 dark:text-white">
+                    {intl.formatMessage({ id: "teams.create.roleLabel" })}
+                  </Label>
+                  <div />
 
-                {/* One editable row per member */}
-                {members.map((member, index) => (
-                  <Fragment key={index}>
-                    <Combobox
-                      options={memberOptions}
-                      value={member.email}
-                      onValueChange={(v) => handleMemberEmailChange(index, v)}
-                      placeholder={intl.formatMessage({ id: "teams.create.memberPlaceholder" })}
-                      searchPlaceholder={intl.formatMessage({
-                        id: "teams.create.memberPlaceholder",
-                      })}
-                      emptyText={intl.formatMessage({ id: "teams.create.memberPlaceholder" })}
-                      allowCustomValue={false}
-                      disabled={isSubmitting}
-                      className="h-10 border-neutral-300 dark:border-neutral-700"
-                    />
-                    <Select
-                      value={member.role}
-                      onValueChange={(v) => handleMemberRoleChange(index, v as "member" | "owner")}
-                      disabled={isSubmitting}
-                    >
-                      <SelectTrigger className="h-10 w-full border-neutral-300 dark:border-neutral-700">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="member">
-                          {intl.formatMessage({ id: "teams.create.role.member" })}
-                        </SelectItem>
-                        <SelectItem value="owner">
-                          {intl.formatMessage({ id: "teams.create.role.owner" })}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleRemoveMember(index)}
-                      disabled={isSubmitting}
-                      className="h-10 gap-1.5 px-2 text-red-500 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      {intl.formatMessage({ id: "common.button.remove" })}
-                    </Button>
-                  </Fragment>
-                ))}
+                  {/* One editable row per member */}
+                  {members.map((member, index) => (
+                    <Fragment key={index}>
+                      <Combobox
+                        options={memberOptions}
+                        value={member.email}
+                        onValueChange={(v) => handleMemberEmailChange(index, v)}
+                        placeholder={intl.formatMessage({ id: "teams.create.memberPlaceholder" })}
+                        searchPlaceholder={intl.formatMessage({
+                          id: "teams.create.memberPlaceholder",
+                        })}
+                        emptyText={intl.formatMessage({ id: "teams.create.memberPlaceholder" })}
+                        allowCustomValue={false}
+                        disabled={isSubmitting}
+                        className="h-10 border-neutral-300 dark:border-neutral-700"
+                      />
+                      <Select
+                        value={member.role}
+                        onValueChange={(v) =>
+                          handleMemberRoleChange(index, v as "member" | "owner")
+                        }
+                        disabled={isSubmitting}
+                      >
+                        <SelectTrigger className="h-10 w-full border-neutral-300 dark:border-neutral-700">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="member">
+                            {intl.formatMessage({ id: "teams.create.role.member" })}
+                          </SelectItem>
+                          <SelectItem value="owner">
+                            {intl.formatMessage({ id: "teams.create.role.owner" })}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleRemoveMember(index)}
+                        disabled={isSubmitting}
+                        className="h-10 gap-1.5 px-2 text-red-500 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/30 dark:hover:text-red-300"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        {intl.formatMessage({ id: "common.button.remove" })}
+                      </Button>
+                    </Fragment>
+                  ))}
+                </div>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddMember}
+                  disabled={isSubmitting}
+                  className="gap-1.5 border-neutral-200 dark:border-neutral-600"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  {intl.formatMessage({ id: "teams.create.addMemberButton" })}
+                </Button>
               </div>
-
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={handleAddMember}
-                disabled={isSubmitting}
-                className="gap-1.5 border-neutral-200 dark:border-neutral-600"
-              >
-                <Plus className="h-3.5 w-3.5" />
-                {intl.formatMessage({ id: "teams.create.addMemberButton" })}
-              </Button>
-            </div>
+            )}
 
             {/* Maximum Members */}
             <div className="space-y-2">
@@ -262,12 +274,11 @@ export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="10">10</SelectItem>
-                  <SelectItem value="25">25</SelectItem>
-                  <SelectItem value="50">50</SelectItem>
-                  <SelectItem value="100">100</SelectItem>
-                  <SelectItem value="250">250</SelectItem>
-                  <SelectItem value="500">500</SelectItem>
+                  {maxMembersOptions.map((value) => (
+                    <SelectItem key={value} value={value}>
+                      {value}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -287,8 +298,12 @@ export function TeamForm({ isOpen, onToggle, onSuccess }: CreateTeamFormProps) {
               </Button>
               <Button type="submit" disabled={isSubmitting || !name.trim()}>
                 {isSubmitting
-                  ? intl.formatMessage({ id: "teams.create.creating" })
-                  : intl.formatMessage({ id: "teams.create.submit" })}
+                  ? intl.formatMessage({
+                      id: isEditMode ? "teams.edit.saving" : "teams.create.creating",
+                    })
+                  : intl.formatMessage({
+                      id: isEditMode ? "teams.edit.submit" : "teams.create.submit",
+                    })}
               </Button>
             </div>
           </form>

--- a/client/src/hooks/useTeamForm.test.ts
+++ b/client/src/hooks/useTeamForm.test.ts
@@ -383,6 +383,29 @@ describe("useTeamForm", () => {
       expect(capturedBody).not.toHaveProperty("max_members");
     });
 
+    it("sends an empty description so clearing it is persisted, not ignored", async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.put("*/teams/team-1", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: "team-1", name: "Engineering" });
+        }),
+      );
+
+      const { result } = renderHook(() => useTeamForm(makeTeam({ description: "Eng team" })));
+
+      act(() => result.current.setDescription(""));
+
+      await act(async () => {
+        await result.current.handleSubmit(fakeSubmit());
+      });
+
+      await waitFor(() => expect(capturedBody).toHaveProperty("description"));
+      // An empty string (not undefined) reaches the backend, which only
+      // overwrites the stored description when the field is present.
+      expect(capturedBody.description).toBe("");
+    });
+
     it("sets an error and skips onSuccess when the update fails", async () => {
       server.use(
         http.put("*/teams/team-1", () =>

--- a/client/src/hooks/useTeamForm.test.ts
+++ b/client/src/hooks/useTeamForm.test.ts
@@ -6,7 +6,24 @@ import { http, HttpResponse } from "msw";
 import { toast } from "sonner";
 import { server } from "@/test/mocks/server";
 import enMessages from "@/i18n/locales/en-US";
+import type { Team } from "@/types/team";
 import { useTeamForm } from "./useTeamForm";
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: "team-1",
+  name: "Engineering",
+  slug: "engineering",
+  description: "Eng team",
+  created_by: "admin@example.com",
+  is_personal: false,
+  visibility: "public",
+  max_members: 50,
+  member_count: 3,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  is_active: true,
+  ...overrides,
+});
 
 vi.mock("sonner", () => ({
   toast: {
@@ -243,6 +260,138 @@ describe("useTeamForm", () => {
       const { result } = renderHook(() => useTeamForm());
 
       act(() => result.current.setName("Engineering"));
+
+      await act(async () => {
+        await result.current.handleSubmit(fakeSubmit(), onSuccess);
+      });
+
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("pre-populates state from the team and flags edit mode", () => {
+      const team = makeTeam();
+      const { result } = renderHook(() => useTeamForm(team));
+
+      expect(result.current.isEditMode).toBe(true);
+      expect(result.current.name).toBe("Engineering");
+      expect(result.current.description).toBe("Eng team");
+      expect(result.current.visibility).toBe("public");
+      expect(result.current.maxMembers).toBe("50");
+    });
+
+    it("PUTs to the team endpoint and calls onSuccess without touching members", async () => {
+      let capturedBody: unknown;
+      const memberCalls: unknown[] = [];
+      server.use(
+        http.put("*/teams/team-1", async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({ id: "team-1", name: "Renamed" });
+        }),
+        http.post("*/teams/team-1/members", async ({ request }) => {
+          memberCalls.push(await request.json());
+          return HttpResponse.json({}, { status: 201 });
+        }),
+      );
+
+      const onSuccess = vi.fn();
+      const { result } = renderHook(() => useTeamForm(makeTeam()));
+
+      act(() => {
+        result.current.setName("Renamed");
+        result.current.setVisibility("private");
+      });
+
+      await act(async () => {
+        await result.current.handleSubmit(fakeSubmit(), onSuccess);
+      });
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+      expect(capturedBody).toMatchObject({ name: "Renamed", visibility: "private" });
+      // max_members was not touched, so it is omitted to preserve the team's value.
+      expect(capturedBody).not.toHaveProperty("max_members");
+      expect(memberCalls).toHaveLength(0);
+      // Edit mode leaves the entered values in place (no reset to create defaults).
+      expect(result.current.name).toBe("Renamed");
+    });
+
+    it("exposes an off-list max_members value as a selectable option", () => {
+      const { result } = renderHook(() => useTeamForm(makeTeam({ max_members: 75 })));
+
+      expect(result.current.maxMembers).toBe("75");
+      // The custom value is merged into the presets in ascending order.
+      expect(result.current.maxMembersOptions).toEqual([
+        "10",
+        "25",
+        "50",
+        "75",
+        "100",
+        "250",
+        "500",
+      ]);
+    });
+
+    it("keeps only the presets when max_members matches one", () => {
+      const { result } = renderHook(() => useTeamForm(makeTeam({ max_members: 100 })));
+
+      expect(result.current.maxMembersOptions).toEqual(["10", "25", "50", "100", "250", "500"]);
+    });
+
+    it("sends max_members only when the user changes it", async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.put("*/teams/team-1", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: "team-1", name: "Engineering" });
+        }),
+      );
+
+      const { result } = renderHook(() => useTeamForm(makeTeam({ max_members: 50 })));
+
+      act(() => result.current.setMaxMembers("250"));
+
+      await act(async () => {
+        await result.current.handleSubmit(fakeSubmit());
+      });
+
+      await waitFor(() => expect(capturedBody).toHaveProperty("max_members"));
+      expect(capturedBody.max_members).toBe(250);
+    });
+
+    it("omits max_members for a team with no override so it stays unset", async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.put("*/teams/team-1", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: "team-1", name: "Engineering" });
+        }),
+      );
+
+      // max_members undefined => the form shows the default ("100") but must not
+      // pin the team to it on save.
+      const { result } = renderHook(() => useTeamForm(makeTeam({ max_members: undefined })));
+
+      act(() => result.current.setName("Engineering Renamed"));
+
+      await act(async () => {
+        await result.current.handleSubmit(fakeSubmit());
+      });
+
+      await waitFor(() => expect(capturedBody).toHaveProperty("name"));
+      expect(capturedBody).not.toHaveProperty("max_members");
+    });
+
+    it("sets an error and skips onSuccess when the update fails", async () => {
+      server.use(
+        http.put("*/teams/team-1", () =>
+          HttpResponse.json({ detail: "Update failed" }, { status: 403 }),
+        ),
+      );
+
+      const onSuccess = vi.fn();
+      const { result } = renderHook(() => useTeamForm(makeTeam()));
 
       await act(async () => {
         await result.current.handleSubmit(fakeSubmit(), onSuccess);

--- a/client/src/hooks/useTeamForm.ts
+++ b/client/src/hooks/useTeamForm.ts
@@ -188,7 +188,11 @@ export function useTeamForm(team?: Team): UseTeamFormReturn {
           const maxMembersChanged = maxMembers !== initialMaxMembers(team);
           await updateTeam(team.id, {
             name: name.trim(),
-            description: description.trim() || undefined,
+            // Send the trimmed value (an empty string when cleared) rather than
+            // `undefined`. The backend only overwrites the description when the
+            // field is present and non-null, so omitting it would silently keep
+            // the old value when a user intends to clear it.
+            description: description.trim(),
             visibility,
             ...(maxMembersChanged ? { max_members: parseInt(maxMembers, 10) } : {}),
           });

--- a/client/src/hooks/useTeamForm.ts
+++ b/client/src/hooks/useTeamForm.ts
@@ -3,9 +3,10 @@ import { useIntl } from "react-intl";
 import { toast } from "sonner";
 import { z } from "zod";
 import { api } from "@/api/client";
-import { createTeam, addTeamMember } from "@/api/teams";
+import { createTeam, updateTeam, addTeamMember } from "@/api/teams";
 import { sanitizeError } from "@/utils/errors";
 import type { ComboboxOption } from "@/components/ui/combobox";
+import type { Team } from "@/types/team";
 import type { UsersResponse } from "@/types/user";
 
 export type TeamRole = "member" | "owner";
@@ -37,10 +38,12 @@ const createTeamFormSchema = (intl: ReturnType<typeof useIntl>) =>
 
 export interface UseTeamFormReturn {
   // State
+  isEditMode: boolean;
   name: string;
   description: string;
   visibility: TeamVisibility;
   maxMembers: string;
+  maxMembersOptions: string[];
   members: TeamMember[];
   memberOptions: ComboboxOption[];
   error: string | null;
@@ -66,19 +69,49 @@ export interface UseTeamFormReturn {
 
 const INITIAL_MEMBERS: TeamMember[] = [{ email: "", role: "owner" }];
 const DEFAULT_MAX_MEMBERS = "100";
+const MAX_MEMBERS_PRESETS = ["10", "25", "50", "100", "250", "500"];
 
-export function useTeamForm(): UseTeamFormReturn {
+/**
+ * The stringified max-members value the form shows for a team. Falls back to the
+ * default when the team has no per-team override (`max_members` is null), which
+ * mirrors the global default the backend would apply.
+ */
+const initialMaxMembers = (team?: Team): string =>
+  team?.max_members != null ? String(team.max_members) : DEFAULT_MAX_MEMBERS;
+
+/**
+ * Manages the create/edit team form state.
+ *
+ * Pass an existing `team` to run in edit mode: the form is pre-populated with
+ * the team's details and submitting issues a PUT instead of a POST. Member
+ * management is only offered when creating a team — the update endpoint does
+ * not touch membership, which is managed through its own dedicated flow.
+ */
+export function useTeamForm(team?: Team): UseTeamFormReturn {
   const intl = useIntl();
   const schema = useMemo(() => createTeamFormSchema(intl), [intl]);
 
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [visibility, setVisibility] = useState<TeamVisibility>("private");
-  const [maxMembers, setMaxMembers] = useState(DEFAULT_MAX_MEMBERS);
+  const isEditMode = team != null;
+
+  const [name, setName] = useState(team?.name ?? "");
+  const [description, setDescription] = useState(team?.description ?? "");
+  const [visibility, setVisibility] = useState<TeamVisibility>(team?.visibility ?? "private");
+  const [maxMembers, setMaxMembers] = useState(() => initialMaxMembers(team));
   const [members, setMembers] = useState<TeamMember[]>(INITIAL_MEMBERS);
   const [memberOptions, setMemberOptions] = useState<ComboboxOption[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // A team's max_members may fall outside the preset list (e.g. an admin set a
+  // custom cap via the API). Surface the current value as a selectable option so
+  // the dropdown reflects it instead of rendering blank.
+  const maxMembersOptions = useMemo(
+    () =>
+      MAX_MEMBERS_PRESETS.includes(maxMembers)
+        ? MAX_MEMBERS_PRESETS
+        : [...MAX_MEMBERS_PRESETS, maxMembers].sort((a, b) => Number(a) - Number(b)),
+    [maxMembers],
+  );
 
   // Load the directory of users for member autocomplete suggestions.
   useEffect(() => {
@@ -103,13 +136,13 @@ export function useTeamForm(): UseTeamFormReturn {
   }, []);
 
   const resetForm = useCallback(() => {
-    setName("");
-    setDescription("");
-    setVisibility("private");
-    setMaxMembers(DEFAULT_MAX_MEMBERS);
+    setName(team?.name ?? "");
+    setDescription(team?.description ?? "");
+    setVisibility(team?.visibility ?? "private");
+    setMaxMembers(initialMaxMembers(team));
     setMembers([{ email: "", role: "owner" }]);
     setError(null);
-  }, []);
+  }, [team]);
 
   const handleAddMember = useCallback(() => {
     setMembers((prev) => [...prev, { email: "", role: "owner" }]);
@@ -147,7 +180,23 @@ export function useTeamForm(): UseTeamFormReturn {
 
       setIsSubmitting(true);
       try {
-        const team = await createTeam({
+        if (isEditMode) {
+          // Only send max_members when the user actually changed it. Omitting it
+          // preserves the team's existing value — including a null "no override"
+          // that the backend would otherwise leave untouched, rather than
+          // silently pinning it to the displayed default.
+          const maxMembersChanged = maxMembers !== initialMaxMembers(team);
+          await updateTeam(team.id, {
+            name: name.trim(),
+            description: description.trim() || undefined,
+            visibility,
+            ...(maxMembersChanged ? { max_members: parseInt(maxMembers, 10) } : {}),
+          });
+          onSuccess?.();
+          return;
+        }
+
+        const createdTeam = await createTeam({
           name: name.trim(),
           description: description.trim() || undefined,
           visibility,
@@ -158,7 +207,7 @@ export function useTeamForm(): UseTeamFormReturn {
         if (filledMembers.length > 0) {
           const results = await Promise.allSettled(
             filledMembers.map((m) =>
-              addTeamMember(team.id, { email: m.email.trim(), role: m.role }),
+              addTeamMember(createdTeam.id, { email: m.email.trim(), role: m.role }),
             ),
           );
           const failed = results
@@ -173,7 +222,10 @@ export function useTeamForm(): UseTeamFormReturn {
           // (which would tempt the user to resubmit and create a duplicate team).
           if (failed.length > 0) {
             toast.warning(
-              intl.formatMessage({ id: "teams.create.warning.membersFailed" }, { name: team.name }),
+              intl.formatMessage(
+                { id: "teams.create.warning.membersFailed" },
+                { name: createdTeam.name },
+              ),
               { description: failed.join("\n") },
             );
           }
@@ -187,14 +239,27 @@ export function useTeamForm(): UseTeamFormReturn {
         setIsSubmitting(false);
       }
     },
-    [name, description, visibility, maxMembers, members, intl, validateForm, resetForm],
+    [
+      isEditMode,
+      team,
+      name,
+      description,
+      visibility,
+      maxMembers,
+      members,
+      intl,
+      validateForm,
+      resetForm,
+    ],
   );
 
   return {
+    isEditMode,
     name,
     description,
     visibility,
     maxMembers,
+    maxMembersOptions,
     members,
     memberOptions,
     error,

--- a/client/src/i18n/locales/en-US/teams.json
+++ b/client/src/i18n/locales/en-US/teams.json
@@ -61,5 +61,10 @@
   "teams.members.success": "{count, plural, one {# team member change} other {# team member changes}} saved successfully",
   "teams.members.loading.sr": "Loading team members, please wait...",
   "teams.members.error.load": "Failed to load team members",
-  "teams.members.error.save": "Failed to save team members"
+  "teams.members.error.save": "Failed to save team members",
+  "teams.edit.title": "Edit team",
+  "teams.edit.description": "Update your team's details and visibility settings.",
+  "teams.edit.saving": "Saving...",
+  "teams.edit.submit": "Save changes",
+  "teams.edit.success": "Team updated successfully"
 }

--- a/client/src/i18n/locales/es-ES/teams.json
+++ b/client/src/i18n/locales/es-ES/teams.json
@@ -61,5 +61,10 @@
   "teams.members.success": "{count, plural, one {# cambio en miembros del equipo guardado} other {# cambios en miembros del equipo guardados}} correctamente",
   "teams.members.loading.sr": "Cargando miembros del equipo, espera...",
   "teams.members.error.load": "No se pudieron cargar los miembros del equipo",
-  "teams.members.error.save": "No se pudieron guardar los miembros del equipo"
+  "teams.members.error.save": "No se pudieron guardar los miembros del equipo",
+  "teams.edit.title": "Editar equipo",
+  "teams.edit.description": "Actualiza los datos y la configuración de visibilidad de tu equipo.",
+  "teams.edit.saving": "Guardando...",
+  "teams.edit.submit": "Guardar cambios",
+  "teams.edit.success": "Equipo actualizado correctamente"
 }

--- a/client/src/i18n/locales/pt-BR/teams.json
+++ b/client/src/i18n/locales/pt-BR/teams.json
@@ -61,5 +61,10 @@
   "teams.members.success": "{count, plural, one {# alteração de membros da equipe salva} other {# alterações de membros da equipe salvas}} com sucesso",
   "teams.members.loading.sr": "Carregando membros da equipe, aguarde...",
   "teams.members.error.load": "Falha ao carregar os membros da equipe",
-  "teams.members.error.save": "Falha ao salvar os membros da equipe"
+  "teams.members.error.save": "Falha ao salvar os membros da equipe",
+  "teams.edit.title": "Editar equipe",
+  "teams.edit.description": "Atualize os detalhes e as configurações de visibilidade da sua equipe.",
+  "teams.edit.saving": "Salvando...",
+  "teams.edit.submit": "Salvar alterações",
+  "teams.edit.success": "Equipe atualizada com sucesso"
 }

--- a/client/src/pages/Teams.test.tsx
+++ b/client/src/pages/Teams.test.tsx
@@ -546,4 +546,30 @@ describe("Teams", () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByText(/Are you sure you want to delete Team 0/)).toBeInTheDocument();
   });
+
+  it("opens the edit form pre-filled when Edit is clicked", async () => {
+    const user = userEvent.setup();
+
+    // The edit form mounts useTeamForm, which fetches the user directory, so the
+    // api.get mock must answer both the teams list and the users endpoint.
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path.includes("/auth/email/admin/users")) {
+        return Promise.resolve({ users: [] });
+      }
+      return Promise.resolve({ teams: createMockTeams(0, 1), nextCursor: null });
+    });
+
+    renderWithRouter(<Teams />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Team 0")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Actions for Team 0" }));
+    await user.click(await screen.findByRole("menuitem", { name: /^edit$/i }));
+
+    expect(await screen.findByRole("heading", { name: /edit team/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/add team name/i)).toHaveValue("Team 0");
+    expect(screen.getByRole("button", { name: /^save changes$/i })).toBeInTheDocument();
+  });
 });

--- a/client/src/pages/Teams.tsx
+++ b/client/src/pages/Teams.tsx
@@ -26,6 +26,7 @@ export function Teams() {
   const [createFormOpen, setCreateFormOpen] = useState(false);
   const [membersDialogOpen, setMembersDialogOpen] = useState(false);
   const [teamForMembers, setTeamForMembers] = useState<Team | null>(null);
+  const [teamToEdit, setTeamToEdit] = useState<Team | null>(null);
 
   const queryPath = useMemo(() => {
     const params = new URLSearchParams();
@@ -94,6 +95,17 @@ export function Teams() {
     [allTeams],
   );
 
+  const handleEdit = useCallback(
+    (teamId: string) => {
+      const team = allTeams.find((t) => t.id === teamId);
+      if (team) {
+        setCreateFormOpen(false);
+        setTeamToEdit(team);
+      }
+    },
+    [allTeams],
+  );
+
   const handleMembersSuccess = useCallback(async () => {
     try {
       await refetch();
@@ -142,13 +154,26 @@ export function Teams() {
     }
   }, [intl, refetch]);
 
+  const handleEditSuccess = useCallback(async () => {
+    toast.success(intl.formatMessage({ id: "teams.edit.success" }));
+    try {
+      await refetch();
+    } catch (refreshErr) {
+      console.error("Failed to refresh teams after update:", sanitizeError(refreshErr));
+    }
+  }, [intl, refetch]);
+
   return (
     <div className="p-6">
-      {createFormOpen ? (
+      {createFormOpen || teamToEdit ? (
         <TeamForm
-          isOpen={createFormOpen}
-          onToggle={() => setCreateFormOpen(false)}
-          onSuccess={handleCreateSuccess}
+          isOpen={createFormOpen || teamToEdit != null}
+          team={teamToEdit ?? undefined}
+          onToggle={() => {
+            setCreateFormOpen(false);
+            setTeamToEdit(null);
+          }}
+          onSuccess={teamToEdit ? handleEditSuccess : handleCreateSuccess}
         />
       ) : isLoading ? (
         <div
@@ -195,8 +220,9 @@ export function Teams() {
               <TeamsTable
                 teams={allTeams}
                 isLoading={false}
-                onDelete={handleDelete}
+                onEdit={handleEdit}
                 onManageMembers={handleManageMembers}
+                onDelete={handleDelete}
               />
 
               <div className="flex items-center justify-between mt-6">


### PR DESCRIPTION
Closes #5107 

### Summary

Adds the ability to edit an existing team from the Teams UI. The **Edit** action in each team row's dropdown now opens the team form pre-populated with the team's details; saving issues a `PUT /teams/{id}`. The form is reused for both create and edit, and the max-members selector was hardened to handle values the backend allows but the UI didn't previously surface.

### Changes

**Edit flow**
  - `TeamsTable`'s existing **Edit** menu item is now wired through `Teams.tsx` (`onEdit` → `teamToEdit`), opening `TeamForm` in edit mode.
  - `useTeamForm` accepts an optional `team`: in edit mode it pre-fills name/description/visibility/max-members and submits via a new `updateTeam()` API helper (`PUT /teams/{id}`) instead of `createTeam`.
  - Edit mode swaps the title, description, and submit-button copy ("Edit team" / "Save changes") and hides the member-management section — membership is managed through its own dedicated dialog, and the update endpoint doesn't touch members.
  - On success, the page shows an "updated" toast and refetches.

  **Max-members correctness**
  - The selector now renders its options dynamically. If a team's `max_members` falls outside the preset list (e.g. a custom cap set via the API), the current value is injected as a selectable option instead of the dropdown rendering blank.
  - `max_members` is only sent in the update when the user actually changes it. This preserves a team's existing value — including a `null` "no override" — rather than silently pinning it to the displayed default, matching the backend's `UNSET`/`model_fields_set` semantics.

  **i18n**
  - Added `teams.edit.*` keys (title, description, saving, submit, success) across `en-US`, `es-ES`, and `pt-BR`.
