### PR TITLE
chore(ui-rewrite): eliminate test console warnings and fix dialog accessibility

### DIFF
--- a/client/src/components/teams/TeamForm.test.tsx
+++ b/client/src/components/teams/TeamForm.test.tsx
@@ -136,15 +136,23 @@ describe("TeamForm", () => {
       await user.click(memberInput);
       await user.keyboard("alice");
       await user.click(await screen.findByRole("option", { name: /alice/i }));
-      expect(memberInput).toHaveValue("Alice (alice@example.com)");
+
+      await waitFor(() => {
+        expect(memberInput).toHaveValue("Alice (alice@example.com)");
+      });
 
       // Change the role from owner -> member (fires the role change handler).
       // The member row's role Select is the first select-trigger in the form.
       const roleTrigger = document.querySelectorAll<HTMLElement>('[data-slot="select-trigger"]')[0];
       expect(roleTrigger).toHaveTextContent("owner");
+
       await user.click(roleTrigger);
-      await user.click(await screen.findByRole("option", { name: /^member$/i }));
-      expect(roleTrigger).toHaveTextContent("member");
+      const memberOption = await screen.findByRole("option", { name: /^member$/i });
+      await user.click(memberOption);
+
+      await waitFor(() => {
+        expect(roleTrigger).toHaveTextContent("member");
+      });
     });
 
     it("adds and removes member rows", async () => {

--- a/client/src/components/ui/card-tag.test.tsx
+++ b/client/src/components/ui/card-tag.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { CardTag } from "./card-tag";
 
 describe("CardTag", () => {
@@ -25,7 +25,10 @@ describe("CardTag", () => {
     expect(trigger).not.toBeNull();
 
     // Radix opens the tooltip on focus, giving keyboard users the hint.
-    trigger!.focus();
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("More info");
+    await waitFor(async () => {
+      trigger!.focus();
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip).toHaveTextContent("More info");
+    });
   });
 });

--- a/client/src/components/ui/dialog.test.tsx
+++ b/client/src/components/ui/dialog.test.tsx
@@ -89,6 +89,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogOverlay data-testid="overlay" />
           </DialogContent>
         </Dialog>,
@@ -103,6 +104,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogOverlay data-testid="overlay" />
           </DialogContent>
         </Dialog>,
@@ -119,6 +121,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogOverlay data-testid="overlay" />
           </DialogContent>
         </Dialog>,
@@ -133,6 +136,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogOverlay data-testid="overlay" className="custom-overlay" />
           </DialogContent>
         </Dialog>,
@@ -148,6 +152,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogOverlay ref={ref} data-testid="overlay" />
           </DialogContent>
         </Dialog>,
@@ -163,6 +168,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <span>Dialog content</span>
           </DialogContent>
         </Dialog>,
@@ -176,6 +182,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <div data-testid="dialog-body">Test content</div>
           </DialogContent>
         </Dialog>,
@@ -189,6 +196,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent data-testid="content">
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -206,6 +214,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -221,6 +230,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -234,7 +244,11 @@ describe("Dialog Components", () => {
     it("should render accessibility label for close button", () => {
       render(
         <Dialog open={true}>
-          <DialogContent>Content</DialogContent>
+          <DialogContent>
+            <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
+            Content
+          </DialogContent>
         </Dialog>,
       );
 
@@ -248,6 +262,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent data-testid="content" className="custom-dialog">
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -263,6 +278,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent ref={ref}>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -276,6 +292,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             Content
           </DialogContent>
         </Dialog>,
@@ -360,6 +377,8 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogFooter data-testid="footer">
               <button>Cancel</button>
               <button>Save</button>
@@ -394,6 +413,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Dialog Title</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -406,6 +426,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle data-testid="title">Title</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -419,6 +440,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle data-testid="title">Title</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -435,6 +457,7 @@ describe("Dialog Components", () => {
             <DialogTitle data-testid="title" className="custom-title">
               Title
             </DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -449,6 +472,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle ref={ref}>Title</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -467,6 +491,7 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
             <DialogDescription>Dialog description</DialogDescription>
           </DialogContent>
         </Dialog>,
@@ -479,6 +504,7 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
             <DialogDescription data-testid="desc">Description</DialogDescription>
           </DialogContent>
         </Dialog>,
@@ -492,6 +518,7 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
             <DialogDescription data-testid="desc">Description</DialogDescription>
           </DialogContent>
         </Dialog>,
@@ -506,6 +533,7 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
             <DialogDescription data-testid="desc" className="custom-desc">
               Description
             </DialogDescription>
@@ -522,6 +550,7 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
             <DialogDescription ref={ref}>Description</DialogDescription>
           </DialogContent>
         </Dialog>,
@@ -541,6 +570,8 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogClose data-testid="close-btn">Close</DialogClose>
           </DialogContent>
         </Dialog>,
@@ -553,6 +584,8 @@ describe("Dialog Components", () => {
       render(
         <Dialog open={true}>
           <DialogContent>
+            <DialogTitle>Test</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
             <DialogClose data-testid="close-btn">Close</DialogClose>
           </DialogContent>
         </Dialog>,
@@ -609,11 +642,13 @@ describe("Dialog Components", () => {
           <Dialog open={true}>
             <DialogContent>
               <DialogTitle>Dialog 1</DialogTitle>
+              <DialogDescription>Description 1</DialogDescription>
             </DialogContent>
           </Dialog>
           <Dialog open={true}>
             <DialogContent>
               <DialogTitle>Dialog 2</DialogTitle>
+              <DialogDescription>Description 2</DialogDescription>
             </DialogContent>
           </Dialog>
         </div>,
@@ -628,6 +663,7 @@ describe("Dialog Components", () => {
         <Dialog open={true}>
           <DialogContent>
             <DialogTitle>Open Dialog</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );
@@ -638,6 +674,7 @@ describe("Dialog Components", () => {
         <Dialog open={false}>
           <DialogContent>
             <DialogTitle>Open Dialog</DialogTitle>
+            <DialogDescription>Test description</DialogDescription>
           </DialogContent>
         </Dialog>,
       );

--- a/client/src/components/ui/radio-group.test.tsx
+++ b/client/src/components/ui/radio-group.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { RadioGroup, RadioGroupItem } from "./radio-group";
@@ -342,11 +342,14 @@ describe("RadioGroup", () => {
       );
 
       const firstItem = container.querySelector('[role="radio"]') as HTMLElement;
-      firstItem.focus();
+      act(() => firstItem.focus());
 
       await user.keyboard("{ArrowRight}");
-      const itemsAfter = container.querySelectorAll('[role="radio"]');
-      expect(itemsAfter[1]).toHaveFocus();
+
+      await waitFor(() => {
+        const itemsAfter = container.querySelectorAll('[role="radio"]');
+        expect(itemsAfter[1]).toHaveFocus();
+      });
     });
 
     it("should support tab navigation", async () => {
@@ -377,10 +380,13 @@ describe("RadioGroup", () => {
       );
 
       const firstItem = container.querySelector('[role="radio"]') as HTMLElement;
-      firstItem.focus();
+      act(() => firstItem.focus());
 
       await user.keyboard(" ");
-      expect(onChange).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled();
+      });
     });
   });
 

--- a/client/src/components/ui/sheet.test.tsx
+++ b/client/src/components/ui/sheet.test.tsx
@@ -44,6 +44,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent>
           <SheetTitle>My Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -77,6 +78,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent>
           <SheetTitle className="custom-title">Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -116,6 +118,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent side="left">
           <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -127,6 +130,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent side="right">
           <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -138,6 +142,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent side="top">
           <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -149,6 +154,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent side="bottom">
           <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>,
     );
@@ -160,6 +166,7 @@ describe("Sheet Components", () => {
       <Sheet open={true}>
         <SheetContent>
           <SheetTitle>Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <SheetClose>Close</SheetClose>
         </SheetContent>
       </Sheet>,

--- a/client/src/components/users/DeleteUserDialog.tsx
+++ b/client/src/components/users/DeleteUserDialog.tsx
@@ -30,14 +30,10 @@ export function DeleteUserDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
-      <DialogContent
-        role="alertdialog"
-        aria-busy={isDeleting}
-        aria-describedby="delete-user-description"
-      >
+      <DialogContent role="alertdialog" aria-busy={isDeleting}>
         <DialogHeader>
           <DialogTitle>{intl.formatMessage({ id: "users.delete.dialog.title" })}</DialogTitle>
-          <DialogDescription id="delete-user-description">
+          <DialogDescription>
             {intl.formatMessage(
               { id: "users.delete.dialog.description" },
               { name: userName, email: userEmail },

--- a/client/src/components/users/UsersTable.test.tsx
+++ b/client/src/components/users/UsersTable.test.tsx
@@ -142,7 +142,7 @@ describe("UsersTable", () => {
 
   it("catches exception during date formatting", () => {
     const originalDate = global.Date;
-    const mockDate = vi.fn(() => {
+    const mockDate = vi.fn(function () {
       throw new Error("Date error");
     }) as unknown as typeof global.Date;
     mockDate.now = originalDate.now;

--- a/client/src/hooks/useTeamMembersForm.test.ts
+++ b/client/src/hooks/useTeamMembersForm.test.ts
@@ -223,10 +223,10 @@ describe("useTeamMembersForm", () => {
     expect(addTeamMember).not.toHaveBeenCalled();
   });
 
-  it("does not load members while the dialog is closed", () => {
+  it("does not load members while the dialog is closed", async () => {
     vi.mocked(listTeamMembers).mockResolvedValue([]);
 
-    renderHook(
+    const { result } = renderHook(
       () =>
         useTeamMembersForm({
           open: false,
@@ -236,6 +236,11 @@ describe("useTeamMembersForm", () => {
         }),
       { wrapper },
     );
+
+    // Wait for any potential state updates to settle
+    await waitFor(() => {
+      expect(result.current).toBeDefined();
+    });
 
     expect(listTeamMembers).not.toHaveBeenCalled();
   });

--- a/client/src/pages/Gateways.test.tsx
+++ b/client/src/pages/Gateways.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { renderWithProviders } from "@/test/test-utils";
@@ -702,8 +702,12 @@ describe("Gateways", () => {
     await user.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
-    // API promise is still pending at this point — resolve to unblock the test
-    resolveDelete();
+    // API promise is still pending at this point — resolve and flush the resulting
+    // state update inside act(...) so React doesn't warn about an unwrapped update.
+    await act(async () => {
+      resolveDelete();
+      await deletePromise;
+    });
   });
 
   it("blocks repeated delete requests while a deletion is pending", async () => {

--- a/client/src/pages/Prompts.test.tsx
+++ b/client/src/pages/Prompts.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
@@ -173,8 +173,12 @@ describe("Prompts", () => {
     const describedTrigger = within(card).getByText("Prompt 0").closest("button");
     expect(describedTrigger).not.toBeNull();
     // Radix opens the tooltip on focus, giving keyboard users the description.
-    describedTrigger?.focus();
-    expect(await screen.findByRole("tooltip")).toHaveTextContent("First prompt description.");
+    fireEvent.focus(describedTrigger as HTMLElement);
+
+    await waitFor(async () => {
+      const tooltip = await screen.findByRole("tooltip");
+      expect(tooltip).toHaveTextContent("First prompt description.");
+    });
 
     // "Prompt 1" has description "None", so it renders as a plain tag with no tooltip trigger.
     expect(within(card).getByText("Prompt 1").closest("button")).toBeNull();

--- a/client/src/pages/Resources.test.tsx
+++ b/client/src/pages/Resources.test.tsx
@@ -30,7 +30,7 @@ vi.mock("@/auth/AuthContext", () => ({
 import { toast } from "sonner";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
 import { Resources } from "./Resources";
@@ -273,7 +273,9 @@ describe("Resources", () => {
     expect(resourceBadge).not.toBeNull();
 
     // Focus the badge to trigger tooltip (Radix UI behavior)
-    resourceBadge!.focus();
+    await act(async () => {
+      resourceBadge!.focus();
+    });
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Description for resource 1");
   });
 
@@ -374,7 +376,9 @@ describe("Resources", () => {
     expect(badgeButton).not.toBeNull();
 
     // Focus to trigger tooltip
-    badgeButton!.focus();
+    await act(async () => {
+      badgeButton!.focus();
+    });
     expect(await screen.findByRole("tooltip")).toHaveTextContent("4 more resources");
   });
 
@@ -419,7 +423,9 @@ describe("Resources", () => {
     expect(badgeButton).not.toBeNull();
 
     // Focus to trigger tooltip
-    badgeButton!.focus();
+    await act(async () => {
+      badgeButton!.focus();
+    });
     expect(await screen.findByRole("tooltip")).toHaveTextContent("1 more resource");
   });
 

--- a/client/src/pages/Tools.test.tsx
+++ b/client/src/pages/Tools.test.tsx
@@ -7,7 +7,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
@@ -325,7 +325,7 @@ describe("Tools", () => {
     const trigger = screen.getByText("Tool 1").closest("button");
     expect(trigger).not.toBeNull();
     // Radix opens the tooltip on focus, giving keyboard users the description.
-    trigger?.focus();
+    fireEvent.focus(trigger as HTMLElement);
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Description for tool 1");
   });
 
@@ -511,7 +511,7 @@ describe("Tools", () => {
     // Should show +4 tag, with the remaining count exposed as an accessible tooltip
     const overflow = screen.getByText("+4");
     expect(overflow).toBeInTheDocument();
-    overflow.closest("button")?.focus();
+    fireEvent.focus(overflow.closest("button") as HTMLElement);
     expect(await screen.findByRole("tooltip")).toHaveTextContent("4 more tools");
   });
 
@@ -552,7 +552,7 @@ describe("Tools", () => {
     // Should show +1 tag, with the singular "tool" wording in the tooltip
     const overflow = screen.getByText("+1");
     expect(overflow).toBeInTheDocument();
-    overflow.closest("button")?.focus();
+    fireEvent.focus(overflow.closest("button") as HTMLElement);
     expect(await screen.findByRole("tooltip")).toHaveTextContent("1 more tool");
   });
 

--- a/client/src/router/index.test.tsx
+++ b/client/src/router/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AuthGuard, RouterProvider, Route, Redirect, useRouter } from ".";
 import { I18nProvider } from "../i18n";
@@ -195,8 +195,10 @@ describe("RouterProvider and useRouter", () => {
     renderWithRouter(<TestComponent />, "/app/test");
     expect(screen.getByText(/path: \/app\/test/)).toBeInTheDocument();
 
-    window.history.pushState({}, "", "/app/other");
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    act(() => {
+      window.history.pushState({}, "", "/app/other");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
 
     await waitFor(() => {
       expect(screen.getByText(/path: \/app\/other/)).toBeInTheDocument();

--- a/client/src/test/mocks/handlers.ts
+++ b/client/src/test/mocks/handlers.ts
@@ -111,4 +111,13 @@ export const handlers = [
       updated_at: new Date().toISOString(),
     });
   }),
+
+  // Default empty collections so page smoke tests that render these pages without
+  // an explicit override don't hit unhandled requests. Specific tests still
+  // override these via server.use(...).
+  http.get("*/prompts", () => HttpResponse.json([])),
+
+  http.get("*/resources", () => HttpResponse.json([])),
+
+  http.get("*/teams", () => HttpResponse.json({ teams: [] })),
 ];


### PR DESCRIPTION
### Summary

  Cleans up the noisy `stderr` output from the client test suite. The tests were already passing, but the run emitted a stream of React `act(...)` warnings, Radix "Missing `Description`" accessibility warnings, MSW unhandled-request errors, and a Vitest mock warning. This change silences all of them at the source and fixes one real accessibility bug in `DeleteUserDialog`.

No behavior changes to shipped code beyond the `DeleteUserDialog` a11y fix; the rest are test-only corrections.

Closes #5366 

### Changes

  #### Accessibility fix (product code)
  - **`DeleteUserDialog.tsx`** — stop hand-wiring `aria-describedby`/`id` on the dialog. The manual id replaced Radix's auto-generated description id, so Radix's own check couldn't find it and warned `Missing Description ...` on every open. Letting Radix auto-wire the `DialogDescription` fixes the warning and matches how every other dialog in the app is written.

  #### Silence Radix "Missing Description" warnings in tests
  - **`dialog.test.tsx`**, **`sheet.test.tsx`** — add a `DialogDescription` / `SheetDescription` (and a `Title` where missing) to the render trees so Radix no longer warns about undescribed content.

  #### Wrap React state updates in `act(...)`
  - **`Tools.test.tsx`**, **`Prompts.test.tsx`** — trigger Radix tooltips via `fireEvent.focus` instead of raw `.focus()` so the open is act-wrapped.
  - **`Resources.test.tsx`**, **`radio-group.test.tsx`** — wrap focus calls in `act(...)` (radio keyboard nav keeps real DOM focus) and assert via `waitFor`.
  - **`router/index.test.tsx`** — wrap the `popstate` dispatch in `act(...)`.
  - **`Gateways.test.tsx`** — resolve the pending delete promise inside `act(...)` and await it so the follow-up state update is flushed.
  - **`card-tag.test.tsx`**, **`TeamForm.test.tsx`**, **`useTeamMembersForm.test.ts`** — settle trailing async updates with `waitFor(...)`.

  #### Fix MSW unhandled-request errors
  - **`test/mocks/handlers.ts`** — add default empty-collection handlers for `/prompts`, `/resources`, and `/teams` so page smoke tests that render those pages without an explicit override don't hit unhandled requests. Specific tests still override via `server.use(...)`.

  #### Fix Vitest mock warning
  - **`UsersTable.test.tsx`** — the date-formatting test mocks `Date` and invokes it with `new`; switch the mock from an arrow function to a `function` expression so it can be used as a constructor (removes the `vi.fn() did not use 'function' or 'class'` warning).

  ### Result
  - Test suite stays green.
  - `npm run test:run` no longer emits `act(...)`, Radix description, MSW unhandled-request, or Vitest mock warnings for the touched files.