### PR TITLE
Fix templated resource proxy reads

### DIFF
--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2460,7 +2460,9 @@ class ResourceService(BaseService):
                         # it internally checks which uri matches the pattern of modified uri and fetches
                         # the one which matches else raises ResourceNotFoundError
                         try:
-                            template_user_email = user.get("email") if isinstance(user, dict) else user
+                            from mcpgateway.auth_context import get_user_email  # pylint: disable=import-outside-toplevel
+
+                            template_user_email = None if user is None else get_user_email(user)
                             content = (
                                 await self._read_template_resource(
                                     db,
@@ -2469,7 +2471,7 @@ class ResourceService(BaseService):
                                     user_email=template_user_email,
                                     token_teams=token_teams,
                                     server_id=server_id,
-                                    use_cache=False,
+                                    use_cache=True,
                                 )
                                 or None
                             )
@@ -2562,6 +2564,12 @@ class ResourceService(BaseService):
                     placeholder = getattr(content_obj, attr_name, None)
                     content_uri = getattr(content_obj, "uri", None)
                     if template_uri and requested_uri and placeholder is not None and content_uri is not None and str(placeholder) == str(requested_uri) and str(content_uri) == str(template_uri):
+                        logger.warning(
+                            "Resource template proxy read returned no content for requested URI '%s' from template '%s' via gateway '%s'",
+                            requested_uri,
+                            template_uri,
+                            getattr(resource_db_gateway, "id", None) or getattr(resource_db, "gateway_id", None),
+                        )
                         raise ResourceError(f"Resource template '{template_uri}' did not resolve URI '{requested_uri}'")
 
                 if isinstance(content, (ResourceContent, ResourceContents, TextContent)):

--- a/mcpgateway/services/resource_service.py
+++ b/mcpgateway/services/resource_service.py
@@ -2460,7 +2460,19 @@ class ResourceService(BaseService):
                         # it internally checks which uri matches the pattern of modified uri and fetches
                         # the one which matches else raises ResourceNotFoundError
                         try:
-                            content = await self._read_template_resource(db, uri) or None
+                            template_user_email = user.get("email") if isinstance(user, dict) else user
+                            content = (
+                                await self._read_template_resource(
+                                    db,
+                                    uri,
+                                    include_inactive=include_inactive,
+                                    user_email=template_user_email,
+                                    token_teams=token_teams,
+                                    server_id=server_id,
+                                    use_cache=False,
+                                )
+                                or None
+                            )
                             # ═══════════════════════════════════════════════════════════════════════════
                             # SECURITY: Fetch the template's DbResource record for access checking
                             # _read_template_resource returns ResourceContent with the template's ID
@@ -2539,6 +2551,19 @@ class ResourceService(BaseService):
                 # ResourceContents covers TextResourceContents and BlobResourceContents (MCP-compliant)
                 # ResourceContent is the legacy model for backwards compatibility
 
+                def _set_gateway_content(content_obj: Any, attr_name: str, resource_response: Any) -> None:
+                    """Apply gateway content or reject unresolved template placeholders."""
+                    if resource_response is not None:
+                        setattr(content_obj, attr_name, resource_response)
+                        return
+
+                    template_uri = getattr(resource_db, "uri_template", None) if resource_db else None
+                    requested_uri = uri if uri is not None else original_uri
+                    placeholder = getattr(content_obj, attr_name, None)
+                    content_uri = getattr(content_obj, "uri", None)
+                    if template_uri and requested_uri and placeholder is not None and content_uri is not None and str(placeholder) == str(requested_uri) and str(content_uri) == str(template_uri):
+                        raise ResourceError(f"Resource template '{template_uri}' did not resolve URI '{requested_uri}'")
+
                 if isinstance(content, (ResourceContent, ResourceContents, TextContent)):
                     # Metrics are recorded in read_resource finally block for all resources
                     resource_response = await self.invoke_resource(
@@ -2552,8 +2577,7 @@ class ResourceService(BaseService):
                         gateway_obj=resource_db_gateway,
                         server_id=server_id,
                     )
-                    if resource_response:
-                        setattr(content, "text", resource_response)
+                    _set_gateway_content(content, "text", resource_response)
                 # If content is any object that quacks like content
                 elif hasattr(content, "text") or hasattr(content, "blob"):
                     # Metrics are recorded in read_resource finally block for all resources
@@ -2569,8 +2593,7 @@ class ResourceService(BaseService):
                             gateway_obj=resource_db_gateway,
                             server_id=server_id,
                         )
-                        if resource_response:
-                            setattr(content, "blob", resource_response)
+                        _set_gateway_content(content, "blob", resource_response)
                     elif hasattr(content, "text"):
                         resource_response = await self.invoke_resource(
                             db,
@@ -2583,8 +2606,7 @@ class ResourceService(BaseService):
                             gateway_obj=resource_db_gateway,
                             server_id=server_id,
                         )
-                        if resource_response:
-                            setattr(content, "text", resource_response)
+                        _set_gateway_content(content, "text", resource_response)
                 # Normalize primitive types to ResourceContent
                 elif isinstance(content, bytes):
                     content = ResourceContent(type="resource", id=str(resource_id), uri=original_uri, blob=content)
@@ -3757,7 +3779,16 @@ class ResourceService(BaseService):
 
         return "application/octet-stream"
 
-    async def _read_template_resource(self, db: Session, uri: str, include_inactive: Optional[bool] = False) -> ResourceContent:
+    async def _read_template_resource(
+        self,
+        db: Session,
+        uri: str,
+        include_inactive: Optional[bool] = False,
+        user_email: Optional[str] = None,
+        token_teams: Optional[List[str]] = None,
+        server_id: Optional[str] = None,
+        use_cache: bool = True,
+    ) -> ResourceContent:
         """
         Read a templated resource.
 
@@ -3765,6 +3796,10 @@ class ResourceService(BaseService):
             db: Database session.
             uri: Template URI with parameters.
             include_inactive: Whether to include inactive resources in DB lookups.
+            user_email: Email of the requesting user for scoped template lookup.
+            token_teams: Teams from the request token for scoped template lookup.
+            server_id: Optional virtual server ID for scoped template lookup.
+            use_cache: Whether to reuse the unscoped template cache.
 
         Returns:
             ResourceContent: The resolved content from the matching template.
@@ -3776,12 +3811,22 @@ class ResourceService(BaseService):
         """
         # Find matching template # DRT BREAKPOINT
         template = None
-        if not self._template_cache:
-            logger.info("_template_cache is empty, fetching exisitng resource templates")
-            resource_templates = await self.list_resource_templates(db=db, include_inactive=include_inactive)
-            for i in resource_templates:
-                self._template_cache[i.name] = i
-        for cached in self._template_cache.values():
+        scoped_lookup = server_id is not None or user_email is not None or token_teams is not None
+        if not use_cache or scoped_lookup or not self._template_cache:
+            logger.info("Fetching resource templates for template URI resolution")
+            resource_templates = await self.list_resource_templates(
+                db=db,
+                include_inactive=include_inactive,
+                user_email=user_email,
+                token_teams=token_teams,
+                server_id=server_id,
+            )
+            if use_cache and not scoped_lookup:
+                for i in resource_templates:
+                    self._template_cache[i.name] = i
+        else:
+            resource_templates = list(self._template_cache.values())
+        for cached in resource_templates:
             if self._uri_matches_template(uri, cached.uri_template):
                 template = cached
                 break

--- a/mcpgateway/transports/streamablehttp_transport.py
+++ b/mcpgateway/transports/streamablehttp_transport.py
@@ -85,7 +85,7 @@ from mcpgateway.services.metrics import (
 from mcpgateway.services.oauth_manager import OAuthEnforcementUnavailableError, OAuthRequiredError
 from mcpgateway.services.permission_service import PermissionService
 from mcpgateway.services.prompt_service import PromptService
-from mcpgateway.services.resource_service import ResourceService
+from mcpgateway.services.resource_service import ResourceError, ResourceNotFoundError, ResourceService
 from mcpgateway.services.tool_service import ToolService
 from mcpgateway.transports.context import UserContext
 from mcpgateway.transports.redis_event_store import RedisEventStore
@@ -2652,6 +2652,8 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
                     token_teams=token_teams,
                     meta_data=meta_data,
                 )
+            except (ResourceError, ResourceNotFoundError):
+                raise
             except Exception as e:
                 logger.exception("Error reading resource '%s': %s", resource_uri, e)
                 return ""
@@ -2667,6 +2669,8 @@ async def read_resource(resource_uri: str) -> Union[str, bytes]:
             # No content found
             logger.warning("No content returned by resource: %s", resource_uri)
             return ""
+    except (ResourceError, ResourceNotFoundError):
+        raise
     except Exception as e:
         logger.exception("Error reading resource '%s': %s", resource_uri, e)
         return ""

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -5664,6 +5664,51 @@ class TestReadResourceCoverageEdges:
         assert out.text == '{"user_id":"7","name":"User 7"}'
 
     @pytest.mark.asyncio
+    async def test_read_resource_template_unscoped_lookup_uses_existing_cache(self):
+        """Unscoped template reads reuse cached templates."""
+        # First-Party
+        from mcpgateway.common.models import ResourceTemplate
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        cached_template = ResourceTemplate(
+            id="cached-tmpl",
+            uriTemplate="reference://users/{user_id}",
+            name="users",
+            description=None,
+            mime_type="text/plain",
+        )
+        svc._template_cache = {"users": cached_template}
+
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "cached-tmpl"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        # 1) URI lookup miss, 2) inactivity check miss, 3) cached-template inactivity check miss, 4) template access-check fetch
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, None, template_db]
+
+        with (
+            patch.object(svc, "list_resource_templates", new_callable=AsyncMock, return_value=[]) as list_templates,
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value='{"user_id":"7","name":"Cached User"}'),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        list_templates.assert_not_awaited()
+        assert out.id == "cached-tmpl"
+        assert out.text == '{"user_id":"7","name":"Cached User"}'
+
+    @pytest.mark.asyncio
     async def test_read_resource_template_proxy_none_response_raises(self):
         """Templated proxy reads fail when gateway resolution returns no content."""
         # First-Party
@@ -5729,6 +5774,80 @@ class TestReadResourceCoverageEdges:
             out = await svc.read_resource(db, resource_uri="reference://users/7")
 
         assert out.text == ""
+
+    @pytest.mark.asyncio
+    async def test_read_resource_template_proxy_blob_none_response_raises(self, caplog):
+        """Templated proxy blob reads fail when gateway resolution returns no content."""
+        # Standard
+        from types import SimpleNamespace
+
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "tmpl-1"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        content = SimpleNamespace(id="tmpl-1", uri="reference://users/{user_id}", blob="reference://users/7")
+
+        with (
+            patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=None),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+            caplog.at_level("WARNING", logger="mcpgateway.services.resource_service"),
+        ):
+            with pytest.raises(ResourceError, match="did not resolve URI"):
+                await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert "Resource template proxy read returned no content" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_read_resource_template_proxy_allows_empty_blob_response(self):
+        """Templated proxy blob reads preserve an intentionally empty response."""
+        # Standard
+        from types import SimpleNamespace
+
+        # First-Party
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "tmpl-1"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        content = SimpleNamespace(id="tmpl-1", uri="reference://users/{user_id}", blob="reference://users/7")
+
+        with (
+            patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=b""),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.blob == b""
 
     @pytest.mark.asyncio
     async def test_read_resource_resource_id_fallback_include_inactive_true_bytes_content_records_metric_failure(self):

--- a/tests/unit/mcpgateway/services/test_resource_service.py
+++ b/tests/unit/mcpgateway/services/test_resource_service.py
@@ -1846,7 +1846,13 @@ class TestResourceTemplates:
 
         # Create a valid ResourceTemplate object
         template_obj = ResourceTemplate(
-            id="1", uriTemplate="test://template/{id}", name="template", description="Test template", mime_type="text/plain", annotations=None, _meta=None  # alias for uri_template
+            id="1",
+            uriTemplate="test://template/{id}",
+            name="template",
+            description="Test template",
+            mime_type="text/plain",
+            annotations=None,
+            _meta=None,  # alias for uri_template
         )
 
         # Pre-load template cache
@@ -1857,7 +1863,6 @@ class TestResourceTemplates:
 
         # Patch match + extraction to force an error
         with patch.object(service, "_uri_matches_template", return_value=True), patch.object(service, "_extract_template_params", side_effect=Exception("Template error")):
-
             # Assert failure path
             with pytest.raises(ResourceError) as exc_info:
                 await service._read_template_resource(db, uri)
@@ -1892,7 +1897,6 @@ class TestResourceTemplates:
         service._template_cache = {"binary": template}
 
         with patch.object(service, "_uri_matches_template", return_value=True), patch.object(service, "_extract_template_params", return_value={"id": "123"}):
-
             with pytest.raises(ResourceError) as exc_info:
                 await service._read_template_resource(db, uri)
 
@@ -5592,10 +5596,96 @@ class TestReadResourceCoverageEdges:
         template_db.owner_email = None
         template_db.team_id = None
 
-        # 1) URI lookup miss, 2) inactivity check miss, 3) template access-check fetch
-        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        # 1) URI lookup miss, 2) inactivity check miss, 3) inactive template miss, 4) template access-check fetch
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, None, template_db]
 
         content = ResourceContent(type="resource", id="tmpl-1", uri="greetme://morning/{name}", text="greetme://morning/John")
+
+        with (
+            patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value="resolved template"),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="greetme://morning/John", include_inactive=True)
+        assert out.id == "tmpl-1"
+        assert out.text == "resolved template"
+
+    @pytest.mark.asyncio
+    async def test_read_resource_template_scoped_lookup_ignores_stale_cache(self):
+        """Scoped template reads fetch fresh templates instead of using stale cache entries."""
+        # First-Party
+        from mcpgateway.common.models import ResourceTemplate
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        stale_template = ResourceTemplate(
+            id="stale-tmpl",
+            uriTemplate="reference://users/{user_id}",
+            name="users",
+            description=None,
+            mime_type="text/plain",
+        )
+        fresh_template = ResourceTemplate(
+            id="fresh-tmpl",
+            uriTemplate="reference://users/{user_id}",
+            name="users",
+            description=None,
+            mime_type="text/plain",
+        )
+        svc._template_cache = {"users": stale_template}
+
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "fresh-tmpl"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        # 1) URI lookup miss, 2) inactivity check miss, 3) inactive template miss, 4) template access-check fetch
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, None, template_db]
+
+        with (
+            patch.object(svc, "list_resource_templates", new_callable=AsyncMock, return_value=[fresh_template]) as list_templates,
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value='{"user_id":"7","name":"User 7"}'),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7", user="user@example.com", token_teams=[])
+
+        list_templates.assert_awaited_once()
+        assert out.id == "fresh-tmpl"
+        assert out.text == '{"user_id":"7","name":"User 7"}'
+
+    @pytest.mark.asyncio
+    async def test_read_resource_template_proxy_none_response_raises(self):
+        """Templated proxy reads fail when gateway resolution returns no content."""
+        # First-Party
+        from mcpgateway.common.models import ResourceContent
+        from mcpgateway.services.resource_service import ResourceError, ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "tmpl-1"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        content = ResourceContent(type="resource", id="tmpl-1", uri="reference://users/{user_id}", text="reference://users/7")
 
         with (
             patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
@@ -5603,8 +5693,42 @@ class TestReadResourceCoverageEdges:
             patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=None),
             patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
         ):
-            out = await svc.read_resource(db, resource_uri="greetme://morning/John", include_inactive=True)
-        assert out.id == "tmpl-1"
+            with pytest.raises(ResourceError, match="did not resolve URI"):
+                await svc.read_resource(db, resource_uri="reference://users/7")
+
+    @pytest.mark.asyncio
+    async def test_read_resource_template_proxy_allows_empty_text_response(self):
+        """Templated proxy reads preserve an intentionally empty text response."""
+        # First-Party
+        from mcpgateway.common.models import ResourceContent
+        from mcpgateway.services.resource_service import ResourceService
+
+        svc = ResourceService()
+        db = MagicMock()
+        db.commit = MagicMock()
+
+        template_db = MagicMock()
+        template_db.id = "tmpl-1"
+        template_db.uri = "reference://users/{user_id}"
+        template_db.uri_template = "reference://users/{user_id}"
+        template_db.enabled = True
+        template_db.visibility = "public"
+        template_db.owner_email = None
+        template_db.team_id = None
+        template_db.gateway_id = "gateway-1"
+
+        db.execute.return_value.scalar_one_or_none.side_effect = [None, None, template_db]
+        content = ResourceContent(type="resource", id="tmpl-1", uri="reference://users/{user_id}", text="reference://users/7")
+
+        with (
+            patch.object(svc, "_read_template_resource", new_callable=AsyncMock, return_value=content),
+            patch.object(svc, "_check_resource_access", new_callable=AsyncMock, return_value=True),
+            patch.object(svc, "invoke_resource", new_callable=AsyncMock, return_value=""),
+            patch("mcpgateway.services.metrics_buffer_service.get_metrics_buffer_service", return_value=MagicMock()),
+        ):
+            out = await svc.read_resource(db, resource_uri="reference://users/7")
+
+        assert out.text == ""
 
     @pytest.mark.asyncio
     async def test_read_resource_resource_id_fallback_include_inactive_true_bytes_content_records_metric_failure(self):

--- a/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
+++ b/tests/unit/mcpgateway/transports/test_streamablehttp_transport.py
@@ -1818,6 +1818,30 @@ async def test_read_resource_service_exception(monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_read_resource_service_resource_error_propagates(monkeypatch):
+    """Resource service failures propagate as MCP-level resource errors."""
+    # Third-Party
+    from pydantic import AnyUrl
+
+    # First-Party
+    from mcpgateway.services.resource_service import ResourceError
+    from mcpgateway.transports.streamablehttp_transport import read_resource, resource_service
+
+    mock_db = MagicMock()
+
+    @asynccontextmanager
+    async def fake_get_db():
+        yield mock_db
+
+    monkeypatch.setattr("mcpgateway.transports.streamablehttp_transport.get_db", fake_get_db)
+    monkeypatch.setattr(resource_service, "read_resource", AsyncMock(side_effect=ResourceError("template did not resolve")))
+
+    test_uri = AnyUrl("file:///template.txt")
+    with pytest.raises(ResourceError, match="template did not resolve"):
+        await read_resource(test_uri)
+
+
+@pytest.mark.asyncio
 async def test_read_resource_outer_exception(monkeypatch, caplog):
     """Test read_resource returns empty string and logs exception from outer try-catch."""
     # Standard


### PR DESCRIPTION
## Summary
- Bypass stale unscoped template cache for live `read_resource()` template resolution so scoped/authenticated reads use current template rows.
- Preserve empty upstream resource responses by checking `is not None` instead of truthiness.
- Fail templated proxy reads when gateway resolution returns no content instead of returning the expanded URI placeholder as resource text.

## Root cause
`read_resource()` resolved templated resources through `_template_cache`, which is keyed only by template name and can be stale or unscoped during gateway federation. When the subsequent gateway read returned `None`, the placeholder text such as `reference://users/7` was left in the response, causing clients expecting JSON to parse the URI string.

## Validation
- `uv run pytest tests/unit/mcpgateway/services/test_resource_service.py -q`
- `uv run ruff check mcpgateway/services/resource_service.py tests/unit/mcpgateway/services/test_resource_service.py`
- `uv run pre-commit run interrogate --files mcpgateway/services/resource_service.py tests/unit/mcpgateway/services/test_resource_service.py`
- Commit hooks passed.
