### PR TITLE
chore: update-release documentation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-09T13:57:15Z",
+  "generated_at": "2026-07-09T15:16:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,11 +382,7 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 5924,
-=======
-        "line_number": 6023,
->>>>>>> 810c7884b (fix ci failiures)
+        "line_number": 5922,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -394,11 +390,7 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 6421,
-=======
-        "line_number": 6520,
->>>>>>> 810c7884b (fix ci failiures)
+        "line_number": 6419,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,11 +398,7 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 6433,
-=======
-        "line_number": 6532,
->>>>>>> 810c7884b (fix ci failiures)
+        "line_number": 6431,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -418,11 +406,7 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 6505,
-=======
-        "line_number": 6604,
->>>>>>> 810c7884b (fix ci failiures)
+        "line_number": 6503,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -430,11 +414,7 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 7587,
-=======
-        "line_number": 7686,
->>>>>>> 810c7884b (fix ci failiures)
+        "line_number": 7585,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-09T14:58:28Z",
+  "generated_at": "2026-07-09T13:57:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -382,7 +382,11 @@
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
         "is_secret": false,
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 5924,
+=======
+        "line_number": 6023,
+>>>>>>> 810c7884b (fix ci failiures)
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -390,7 +394,11 @@
         "hashed_secret": "5932862bcd24dd27d0dc0407ec94fe9d6ea24aeb",
         "is_secret": false,
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 6421,
+=======
+        "line_number": 6520,
+>>>>>>> 810c7884b (fix ci failiures)
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -398,7 +406,11 @@
         "hashed_secret": "c77c805e32f173e4321ee9187de9c29cb3804513",
         "is_secret": false,
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 6433,
+=======
+        "line_number": 6532,
+>>>>>>> 810c7884b (fix ci failiures)
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -406,7 +418,11 @@
         "hashed_secret": "8fe3df8a68ddd0d4ab2214186cbb8e38ccd0e06a",
         "is_secret": false,
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 6505,
+=======
+        "line_number": 6604,
+>>>>>>> 810c7884b (fix ci failiures)
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -414,7 +430,11 @@
         "hashed_secret": "93ac8946882128457cd9e283b30ca851945e6690",
         "is_secret": false,
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 7587,
+=======
+        "line_number": 7686,
+>>>>>>> 810c7884b (fix ci failiures)
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -3563,8 +3563,6 @@ linting-helm-unittest:               ## 🧪  Helm template unit tests
 		fi; \
 		helm unittest $(CHART_DIR)"
 
-
-
 .PHONY: linting-security-checkov
 linting-security-checkov:            ## 🛡️  IaC security scanning with Checkov
 	@echo "🛡️ checkov scan of $(LINT_CHECKOV_TARGET)..."

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -10,8 +10,8 @@ This document describes the complete release process for ContextForge, from pre-
 |-------|-------|
 | [1. Version Update](#1-version-update) | Bump version, update references, CHANGELOG, roadmap, security advisories, base images |
 | [2. Python Dependency Updates](#2-python-dependency-updates) | Update pyproject.toml/requirements.txt, pip-audit |
-| [3. Rust, Go & JS Dependency Updates](#3-rust-go-javascript-dependency-updates) | cargo update, go get -u, npm update |
-| [4. Quality Gates](#4-quality-gates) | Code formatting, linting, secrets scanning, security analysis |
+| [3. Rust & JS Dependency Updates](#3-rust-go-javascript-dependency-updates) | cargo update, npm update |
+| [4. Quality Gates](#4-quality-gates) | Package metadata validation, secrets scanning (pre-commit/CI handle the rest) |
 | [5. Test Gates](#5-test-gates) | Unit tests, JS tests, UI tests, MCP tests, load tests |
 | [6. Build Verification](#6-build-verification) | Docker build, compose stack, embedded mode, package validation |
 | [7. SSO Verification](#7-sso-verification) | Keycloak SSO login flow |
@@ -189,7 +189,7 @@ make test
 
 ---
 
-## 3. Rust, Go & JavaScript Dependency Updates
+## 3. Rust & JavaScript Dependency Updates
 
 Update non-Python dependencies across the repository.
 
@@ -240,34 +240,7 @@ At the end of Rust supply-chain vetting, prune stale cargo-vet exemptions:
 cargo vet prune
 ```
 
-### 3.3 Go dependencies
-
-1. Update `go.mod` and `go.sum` for all Go modules:
-
-```bash
-find . -path "./mcp-servers/templates" -prune -o -name "go.mod" -type f -print | while read -r mod_file; do
-  dir=$(dirname "$mod_file")
-  echo "Updating Go dependencies in $dir"
-  (cd "$dir" && go get -u ./... && go mod tidy)
-done
-```
-
-2. Update `LINT_GO_TOOLCHAIN ?= go1.26.4` appropriately in the _root_/Makefile
-3. Update Dockerfile e.g. `FROM golang:1.26.4`
-
-Verify Go code compiles and passes security checks:
-
-```bash
-make linting-go-gosec
-make linting-go-govulncheck
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `linting-go-gosec` | Security static analysis across all Go modules |
-| `linting-go-govulncheck` | Known vulnerability scanning in Go dependencies |
-
-### 3.4 JavaScript dependencies (npm)
+### 3.3 JavaScript dependencies (npm)
 
 Update `package.json` and verify the frontend builds and passes linting:
 
@@ -284,7 +257,7 @@ make lint-web
 make test-js-coverage
 ```
 
-### 3.5 Frontend CDN dependencies
+### 3.4 Frontend CDN dependencies
 
 The Admin UI loads frontend libraries (Tailwind, Chart.js, CodeMirror, Font Awesome, Marked, DOMPurify) from CDNs at runtime, with pinned versions in three places that must be kept in sync. **Note:** HTMX and Alpine.js are bundled via npm/Vite and no longer loaded from CDN.
 
@@ -334,7 +307,7 @@ The Admin UI loads frontend libraries (Tailwind, Chart.js, CodeMirror, Font Awes
 !!! warning "Three files must stay in sync"
     A version bump in `cdn_resources.py` without matching changes in `download-cdn-assets.sh` and the HTML templates will cause SRI verification failures or broken airgapped builds. Always update all three together.
 
-### 3.6 Rebuild containers
+### 3.5 Rebuild containers
 
 After updating all dependency ecosystems, rebuild the production container from scratch to verify everything integrates:
 
@@ -346,86 +319,33 @@ make docker-prod DOCKER_BUILD_ARGS="--no-cache"
 
 ## 4. Quality Gates
 
-All formatting and linting checks must pass with zero errors.
-
-### 4.1 Code formatting
-
-```bash
-make ruff-format
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `ruff-format` | Formats Python code (includes import sorting and unused code removal) |
+The steps below are the quality gates that require a human to run at release time. Formatting (`ruff-format`), import sorting, YAML/TOML/JSON syntax checks, and docstring coverage are all enforced by pre-commit hooks on every commit and are not repeated here. Python linters (`ruff`, `bandit`, `interrogate`, `pylint`), web linting, and config-file linting run in CI on every PR.
 
 !!! note "Pre-commit hooks run automatically"
-    The configured pre-commit hooks (whitespace, EOF fixers, detect-secrets, AST checks, etc.) are enforced at commit time and in CI — they do not need a dedicated release step. If a release commit passes pre-commit locally it will pass in CI; otherwise investigate before tagging.
+    `ruff-format`, `ruff-check`, `bandit`, `interrogate`, `detect-secrets`, `yamllint`, `check-yaml`, `check-toml`, and `check-json` all run as pre-commit hooks and in CI. They do not need a dedicated manual release step. `check-headers` also runs as a pre-commit hook but is not yet in CI — it remains a manual release step (§4.3) until a CI job is added.
 
-### 4.2 Python linters
-
-```bash
-make ruff vulture bandit interrogate pylint verify
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `ruff` | PEP 8 style, pyflakes, docstrings, pylint rules (E3, E4, E7, E9, F, D1, D417, PL) |
-| `vulture` | Dead code detection (unused functions, variables, imports) |
-| `bandit` | Security vulnerabilities in Python code |
-| `interrogate` | Docstring coverage (must meet threshold) |
-| `pylint` | Code quality score (must be ≥ 10, fails on errors) |
-| `verify` | Package metadata validation (twine, check-manifest, pyroma) |
-
-### 4.3 Configuration file validation
+### 4.1 Package metadata validation
 
 ```bash
-make yamllint tomllint jsonlint
+make verify
 ```
 
-| Target | What it checks |
-|--------|----------------|
-| `yamllint` | YAML syntax and style (compose files, CI workflows, plugin config) |
-| `tomllint` | TOML syntax (`pyproject.toml`, Rust `Cargo.toml`) |
-| `jsonlint` | JSON syntax (`package.json`, test fixtures, schemas) |
+Validates the wheel and sdist with twine, check-manifest, and pyroma. This is not yet wired into a CI job and must be run manually before tagging.
 
-### 4.4 Web code linters
+### 4.2 Secrets scanning
 
 ```bash
-make lint-web
+make detect-secrets-scan
 ```
 
-Runs eslint, nodejsscan, htmlhint, stylelint, retire.js, and npm audit against the frontend code.
+Re-runs the full baseline scan across all tracked files against `.secrets.baseline`. `detect-secrets` also runs as a pre-commit hook on every commit, but a fresh full-tree scan immediately before tagging is the last line of defence.
 
-### 4.5 Secrets scanning
-
-```bash
-make dodgy detect-secrets-scan
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `dodgy` | Hardcoded passwords, suspicious code patterns, secret-like strings |
-| `detect-secrets-scan` | Scans tracked files for secrets against the `.secrets.baseline` allowlist |
-
-**Acceptance criteria:** No secrets or credentials detected. Any false positives are triaged via `make detect-secrets-audit` and recorded in `.secrets.baseline`. `detect-secrets` also runs automatically as a pre-commit hook on every change, so most regressions are caught before merge.
+**Acceptance criteria:** No unaudited secrets detected. Any false positives are triaged via `make detect-secrets-audit` and recorded in `.secrets.baseline`.
 
 !!! warning "Run before tagging"
     Secrets in git history survive even after deletion from the working tree. Always run the secrets-scan gate before creating a release tag.
 
-### 4.6 Security best practices
-
-```bash
-make devskim prospector
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `devskim` | Microsoft DevSkim security anti-patterns (crypto misuse, injection, hardcoded creds) |
-| `prospector` | Comprehensive multi-tool analysis (pylint, pyflakes, mccabe, dodgy, pep8, pep257) |
-
-Review the output for any high-severity findings. DevSkim results are also written to `devskim-results.sarif` for integration with CI dashboards.
-
-### 4.7 License header compliance
+### 4.3 License header compliance
 
 ```bash
 make check-headers
@@ -516,23 +436,7 @@ make docker-prod DOCKER_BUILD_ARGS="--no-cache"
 
 This builds the lite production image with Docker Content Trust enabled.
 
-### 6.2 Containerfile linting and image scanning
-
-Lint the Dockerfiles for best-practice violations, then scan the built image for vulnerabilities and CIS benchmark compliance:
-
-```bash
-make hadolint dockle security-scan
-```
-
-| Target | What it checks |
-|--------|----------------|
-| `hadolint` | Dockerfile best practices and shell linting for `Containerfile.*` and any `Dockerfile.*` |
-| `dockle` | CIS Docker Benchmark compliance and image best practices (runs against the built image via tarball) |
-| `security-scan` | Show current local container review guidance |
-
-**Acceptance criteria:** Review the generated SBOM and any separately-run container scan results before publishing. No errors from `hadolint` (warnings are acceptable if documented). No failures from `dockle` at warn level.
-
-### 6.3 Compose stack validation
+### 6.2 Compose stack validation
 
 Bring up the full stack with the testing profile and verify all services are healthy:
 
@@ -549,7 +453,7 @@ make compose-ps
 !!! warning "Run compose tests before tearing down"
     The UI tests, MCP tests, and load tests in [Section 5](#5-test-gates) require this stack to be running. Run all compose-dependent tests before calling `make compose-clean`.
 
-### 6.4 Embedded mode verification
+### 6.3 Embedded mode verification
 
 Verify the gateway works correctly in embedded/iframe mode with benchmark servers:
 
@@ -578,7 +482,7 @@ Tear down when done:
 make embedded-down
 ```
 
-### 6.5 Python package build
+### 6.4 Python package build
 
 ```bash
 make dist
@@ -1491,12 +1395,11 @@ python .github/tools/update_dependencies.py --file pyproject.toml
 make install-dev
 make pip-audit
 
-# 2. Rust / Go / JS / CDN dependency updates
+# 2. Rust / JS / CDN dependency updates
 cargo update --workspace
-# ... go get -u ./... && go mod tidy for all go.mod dirs ...
-make linting-go-gosec linting-go-govulncheck
+make rust-vet
 npm update && npm audit && npm audit fix
-make lint-web test-js-coverage
+make test-js-coverage
 # CDN deps: update versions in cdn_resources.py, download-cdn-assets.sh, templates/*.html
 make sri-generate sri-verify
 
@@ -1504,22 +1407,17 @@ make sri-generate sri-verify
 make docker-prod DOCKER_BUILD_ARGS="--no-cache"
 make test
 
-# 4. Format, lint & security
-make ruff-format
-make ruff vulture bandit interrogate pylint verify
-make yamllint tomllint jsonlint
-make lint-web
-make dodgy detect-secrets-scan
-make devskim prospector
+# 4. Quality gates (pre-commit/CI handle formatting and linting)
+make verify
+make detect-secrets-scan
 make check-headers
 
 # 5. Unit tests
 make coverage
 make test-js-coverage
 
-# 6. Build, Containerfile lint & compose stack
+# 6. Build & compose stack
 make docker-prod DOCKER_BUILD_ARGS="--no-cache"
-make hadolint dockle security-scan
 make testing-down compose-clean testing-up
 
 # 7. Integration tests (compose stack must be running)

--- a/docs/docs/development/release-management.md
+++ b/docs/docs/development/release-management.md
@@ -118,49 +118,49 @@ make docker-prod DOCKER_BUILD_ARGS="--no-cache"
 Update all Python dependencies across the repository before cutting a release. This ensures the release ships with current, patched versions.
 
 ### 2.1 Update CPEX dependencies
-Update the `[tool.uv.exclude-newer-package]` section of `pyproject.toml` file to the current date/time and execute
-`uv lock --upgrade` to get the latest depenencies and update the uv.lock file.
 
-### 2.2 Update dependencies with `update_dependencies.py`
+Update the `[tool.uv.sources]` / `[tool.uv.exclude-newer-package]` section of the root `pyproject.toml` to the current date/time, then run:
 
 ```bash
-find . -path "./mcp-servers/templates" -prune -o -path "*/.venv" -prune -o -name "pyproject.toml" -type f -print | while read -r toml_file; do
-  dir=$(dirname "$toml_file")
-  echo "Updating dependencies in $dir"
-  (cd "$dir" && uv lock --upgrade)
-done
+uv lock --upgrade
 ```
 
-!!! Optional: The above step may not update all dependencies as expected. Run the following command to update all dependencies in pyproject.toml files and not work from dynamic versions.
-The repository includes an async dependency updater at `.github/tools/update_dependencies.py`. Run it against every `pyproject.toml` and `requirements.txt` in the tree:
+### 2.2 Update all `pyproject.toml` lockfiles and `requirements.txt` files
+
+The snippet below auto-discovers every `pyproject.toml` and `requirements.txt` in the repository, skipping generated templates and virtual-environment directories. No hardcoded path list means newly added or deleted sub-projects are picked up automatically.
 
 ```bash
+# uv-sync + lockfile upgrade for every pyproject.toml
+# Skips: mcp-servers/templates (generated), .venv dirs, Rust crates (no uv)
+find . \
+  -path "./mcp-servers/templates" -prune -o \
+  -path "*/.venv" -prune -o \
+  -path "*/target" -prune -o \
+  -path "./.cache" -prune -o \
+  -name "pyproject.toml" -type f -print \
+| while read -r toml_file; do
+    dir=$(dirname "$toml_file")
+    echo "==> $dir"
+    uv-upsync --project "$dir" 2>/dev/null || true
+    uv lock --upgrade --exclude-newer "10 days" --project "$dir"
+  done
 
-# Main project
-python .github/tools/update_dependencies.py --file pyproject.toml
-
-# MCP servers
-python .github/tools/update_dependencies.py --file mcp-servers/python/data_analysis_server/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/graphviz_server/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/mcp-rss-search/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/python_sandbox_server/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/mcp_eval_server/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/url_to_markdown_server/pyproject.toml
-python .github/tools/update_dependencies.py --file mcp-servers/python/output_schema_test_server/pyproject.toml
-
-# External plugins
-python .github/tools/update_dependencies.py --file plugins/external/cedar/pyproject.toml
-python .github/tools/update_dependencies.py --file plugins/external/llmguard/pyproject.toml
-python .github/tools/update_dependencies.py --file plugins/external/opa/pyproject.toml
-
-# Requirements files
-python .github/tools/update_dependencies.py --file docs/requirements.txt
-python .github/tools/update_dependencies.py --file tests/load/requirements.txt
-python .github/tools/update_dependencies.py --file tests/populate/requirements.txt
+# requirements.txt files (docs, tests)
+find . \
+  -path "*/.venv" -prune -o \
+  -path "./.cache" -prune -o \
+  -name "requirements.txt" -type f -print \
+| while read -r req_file; do
+    echo "==> $req_file"
+    python .github/tools/update_dependencies.py --file "$req_file"
+  done
 ```
 
-!!! tip "Dry-run first"
-    Use `--dry-run` to preview changes before applying: `python .github/tools/update_dependencies.py --file pyproject.toml --dry-run`
+!!! tip "Dry-run the requirements updater first"
+    Use `--dry-run` to preview changes before applying:
+    ```bash
+    python .github/tools/update_dependencies.py --file docs/requirements.txt --dry-run
+    ```
 
 ### 2.3 Reinstall and verify
 


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

Closes #5568
Closes #5587 

---

## 📝 Summary

Cleans up the release management by removing steps that are already enforced earlier in the dev workflow (pre-commit or CI) or provide no blocking signal. The release checklist now reflects only what a human actually needs to run at release time.

**`docs/docs/development/release-management.md`**
- §3: Removed Go dependency update steps (`go get -u`, `go mod tidy`, `linting-go-gosec`, `linting-go-govulncheck`). The codebase has no first-party Go source — Go modules only exist in `mcp-servers/` and `a2a-agents/` templates. Section renamed to "Rust & JavaScript Dependency Updates".
- §4: Collapsed 7 subsections to 3. Removed `ruff-format` (pre-commit), Python linters `ruff`/`bandit`/`interrogate`/`pylint` (pre-commit + CI), `yamllint`/`tomllint`/`jsonlint` (pre-commit + CI), `lint-web` (CI), `dodgy` (non-blocking, fully subsumed by `detect-secrets`), `devskim`/`prospector` (noisy, duplicated by `bandit`/`ruff`/`semgrep`). Retained: `make verify` (no CI job yet), `make detect-secrets-scan` (full-tree rescan, distinct from the per-commit pre-commit hook), `make check-headers` (pre-commit hook exists but no CI job yet).
- §6: Removed `hadolint`/`dockle`/`security-scan` manual step — Containerfile linting moves to CI.
- Quick Reference: Updated to match all removals above.


---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [x] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🏷️ Type of Change

- [x] Chore (deps, CI, tooling)
- [x] Documentation

---

## 🧪 Verification

| Check | Command | Status |
|---|---|---|
| No broken Makefile targets | `make linting-full` | Targets removed from `LINTING_FULL_TARGETS`; remaining targets unaffected |
| Pre-commit passes | `pre-commit run --all-files` | New `check-headers` hook wired to existing `fix_file_headers.py --check` |
| Doc builds cleanly | `cd docs && make serve` | No broken anchors; section numbering consistent |
| Quick Reference matches doc body | Manual review | §4 block now shows `make verify`, `make detect-secrets-scan`, `make check-headers` |

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

**Why `dodgy` was removed:** It exits with `|| true` (non-blocking), scans only for variable-name patterns like `password = "..."`, and its entire signal is subsumed by IBM `detect-secrets` which already runs as a pre-commit hook on every commit and as `make detect-secrets-scan` before tagging. Removing it does not reduce security posture.

**Why `detect-secrets-scan` was kept despite the pre-commit hook:** The pre-commit hook runs `detect-secrets-hook` which only checks *staged files*. `make detect-secrets-scan` runs `detect-secrets scan --update` against the *entire tracked tree* and rewrites `.secrets.baseline`. These are distinct operations; the full-tree scan before tagging is the correct last line of defence.

**Go modules not removed:** Only the release-gate references are removed. `mcp-servers/` and `a2a-agents/` Go modules remain untouched. If Go scanning coverage is needed in future, a dedicated CI workflow (not a manual release step) is the right home.