### PR TITLE
feat: publish dataplane resource URIs and capabilities

### DIFF
--- a/mcpgateway/services/dataplane_publisher.py
+++ b/mcpgateway/services/dataplane_publisher.py
@@ -58,8 +58,10 @@ class BackendConfig(TypedDict):
     url: str
     transport: str
     passthrough_headers: list[str]
+    capabilities: dict[str, Any]
     allowed_tool_names: list[str]
     allowed_resource_names: list[str]
+    allowed_resource_uris: list[str]
     allowed_prompt_names: list[str]
 
 
@@ -207,7 +209,8 @@ class DataplanePublisherService:
             gateways = user_data["gateways"]
             prompts = user_data["prompts"]
             resources = user_data["resources"]
-            resource_map = {resource["id"]: resource["name"] for resource in resources}
+            resource_names_by_id = {resource["id"]: resource["name"] for resource in resources}
+            resource_uris_by_id = {resource["id"]: resource["uri"] for resource in resources if resource.get("uri")}
 
             prompt_map = {prompt["id"]: prompt["name"] for prompt in prompts}
 
@@ -217,6 +220,7 @@ class DataplanePublisherService:
                     "url": gateway["url"],
                     "transport": gateway["transport"],
                     "passthrough_headers": gateway["passthrough_headers"] or [],
+                    "capabilities": gateway.get("capabilities") or {},
                 }
                 for gateway in gateways
             }
@@ -231,7 +235,8 @@ class DataplanePublisherService:
                     if gateway_config is None:
                         continue
 
-                    allowed_resource_names = [resource_map[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_map]
+                    allowed_resource_names = [resource_names_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_names_by_id]
+                    allowed_resource_uris = [resource_uris_by_id[resource_id] for resource_id in backend_items["resources"] if resource_id in resource_uris_by_id]
                     allowed_prompt_names = [prompt_map[prompt_id] for prompt_id in backend_items["prompts"] if prompt_id in prompt_map]
                     if not backend_items["tools"] and not allowed_resource_names and not allowed_prompt_names:
                         continue
@@ -240,6 +245,7 @@ class DataplanePublisherService:
                         **gateway_config,
                         "allowed_tool_names": backend_items["tools"],
                         "allowed_resource_names": allowed_resource_names,
+                        "allowed_resource_uris": allowed_resource_uris,
                         "allowed_prompt_names": allowed_prompt_names,
                     }
 
@@ -277,6 +283,7 @@ class DataplanePublisherService:
                         DbGateway.url,
                         DbGateway.transport,
                         DbGateway.passthrough_headers,
+                        DbGateway.capabilities,
                         DbGateway.owner_email,
                         DbGateway.team_id,
                         DbGateway.visibility,
@@ -284,7 +291,7 @@ class DataplanePublisherService:
                 ).all()
                 prompt_rows = db.execute(select(DbPrompt.id, DbPrompt.name, DbPrompt.owner_email, DbPrompt.team_id, DbPrompt.visibility).where(DbPrompt.enabled.is_(True))).all()
                 resource_rows = db.execute(
-                    select(DbResource.id, DbResource.name, DbResource.owner_email, DbResource.team_id, DbResource.visibility).where(
+                    select(DbResource.id, DbResource.name, DbResource.uri, DbResource.owner_email, DbResource.team_id, DbResource.visibility).where(
                         DbResource.enabled.is_(True),
                         DbResource.uri_template.is_(None),
                     )
@@ -342,12 +349,13 @@ class DataplanePublisherService:
                     "url": gateway.url,
                     "transport": gateway.transport,
                     "passthrough_headers": gateway.passthrough_headers,
+                    "capabilities": gateway.capabilities or {},
                 }
                 for gateway in gateway_rows
                 if self._filter_for_user(gateway, user_email, team_ids, is_admin=is_admin)
             ],
             "prompts": [{"id": prompt.id, "name": prompt.name} for prompt in prompt_rows if self._filter_for_user(prompt, user_email, team_ids, is_admin=is_admin)],
-            "resources": [{"id": resource.id, "name": resource.name} for resource in resource_rows if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)],
+            "resources": [{"id": resource.id, "name": resource.name, "uri": resource.uri} for resource in resource_rows if self._filter_for_user(resource, user_email, team_ids, is_admin=is_admin)],
         }
 
     @staticmethod

--- a/tests/unit/mcpgateway/services/test_dataplane_publisher.py
+++ b/tests/unit/mcpgateway/services/test_dataplane_publisher.py
@@ -168,6 +168,7 @@ async def test_full_payload_generation_with_mock_db():
     gateway1.url = "http://localhost:9000"
     gateway1.transport = "sse"
     gateway1.passthrough_headers = ["Authorization"]
+    gateway1.capabilities = {"resources": {"subscribe": True}}
     gateway1.owner_email = "user1@example.com"
     gateway1.team_id = "team1"
     gateway1.visibility = "public"
@@ -184,6 +185,7 @@ async def test_full_payload_generation_with_mock_db():
     resource1 = Mock()
     resource1.id = "r1"
     resource1.name = "Resource 1"
+    resource1.uri = "resource://one"
     resource1.owner_email = "user1@example.com"
     resource1.team_id = "team1"
     resource1.visibility = "public"
@@ -266,8 +268,10 @@ async def test_full_payload_generation_with_mock_db():
         assert backend["url"] == "http://localhost:9000"
         assert backend["transport"] == "sse"
         assert backend["passthrough_headers"] == ["Authorization"]
+        assert backend["capabilities"] == {"resources": {"subscribe": True}}
         assert backend["allowed_tool_names"] == ["public_tool", "private_tool"]
         assert backend["allowed_resource_names"] == ["Resource 1"]
+        assert backend["allowed_resource_uris"] == ["resource://one"]
         assert backend["allowed_prompt_names"] == ["Prompt 1"]
 
         # Verify user2 sees public server but not private server from user1
@@ -402,6 +406,7 @@ def test_create_payload_normalizes_null_passthrough_headers():
 
     backend = result["user@example.com"]["virtual_hosts"]["server1"]["backends"]["gateway1"]
     assert backend["passthrough_headers"] == []
+    assert backend["capabilities"] == {}
 
 
 def test_create_payload_handles_missing_references():


### PR DESCRIPTION
# ✨ Feature / Enhancement PR

## 🔗 Epic / Issue

N/A

---

## 🚀 Summary (1-2 sentences)

Adds resource URI allowlists and backend capability metadata to the experimental dataplane payload so Rust dataplane consumers can route resource operations by URI and derive virtual-server capabilities from control-plane state.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [x] Tests are included with the code they validate

---

## 🧪 Checks

- [x] `uv run ruff check mcpgateway/services/dataplane_publisher.py tests/unit/mcpgateway/services/test_dataplane_publisher.py` passes
- [x] `uv run pytest tests/unit/mcpgateway/services/test_dataplane_publisher.py` passes
- [x] CHANGELOG not required (not user-facing)

---

## 📓 Notes (optional)

This is an additive payload change: existing `allowed_resource_names` remains in place, while `allowed_resource_uris` and `capabilities` are available for dataplane consumers that need URI-based routing and conditional capability advertisement.