### PR TITLE
fix(ci): remove deleted a2a-echo-agent from docker-scan workflow and fix Makefile actionlint quote

### DIFF
--- a/.github/workflows/docker-scan-required.yml
+++ b/.github/workflows/docker-scan-required.yml
@@ -22,8 +22,6 @@ on:
     branches: ["main"]
     paths-ignore:
       - 'Containerfile'
-      - 'Containerfile'
-      - 'Containerfile.scratch'
       - 'infra/nginx/**'
       - 'mcp-servers/python/python_sandbox_server/**'
       - 'mcpgateway/**'

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -27,7 +27,6 @@ on:
     paths:
       - 'Containerfile'
       - 'infra/nginx/**'
-      - 'a2a-agents/rust/a2a-echo-agent/**'
       - 'mcp-servers/python/python_sandbox_server/**'
       - 'mcpgateway/**'
       - 'plugins/**'
@@ -100,10 +99,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: a2a-echo-agent
-            context: .
-            file: a2a-agents/rust/a2a-echo-agent/Dockerfile
-            tag: mcp-context-forge-a2a-echo-agent:scan
           - name: python-sandbox
             context: mcp-servers/python/python_sandbox_server
             file: mcp-servers/python/python_sandbox_server/docker/Dockerfile.sandbox

--- a/Makefile
+++ b/Makefile
@@ -3463,7 +3463,7 @@ linting-python-env:
 linting-workflow-actionlint:         ## 🧭  GitHub Actions workflow linting
 	@echo "🧭 actionlint ($(LINT_ZIZMOR_TARGET); shellcheck integration disabled)..."
 	@command -v go >/dev/null 2>&1 || { echo "❌ go not found"; exit 1; }
-	@go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck="
+	@go run github.com/rhysd/actionlint/cmd/actionlint@latest -shellcheck=""
 
 .PHONY: linting-workflow-zizmor
 linting-workflow-zizmor:             ## 🔐  GitHub Actions security linting


### PR DESCRIPTION
# Pull Request

## 🔗 Related Issue

N/A — build tooling and CI workflow fixes.

---

## 📝 Summary

Three related CI/tooling fixes:

1. **Docker Security Scan workflow** (`.github/workflows/docker-scan.yml`): The `container-smoke` job matrix included an `a2a-echo-agent` entry that pointed to `a2a-agents/rust/a2a-echo-agent/Dockerfile`. That directory was removed in #5425 (moved to `contextforge-examples`), causing the smoke test to fail immediately with `lstat a2a-agents: no such file or directory`. The stale matrix entry and its corresponding `pull_request` path trigger have been removed.

2. **Docker Scan Required workflow** (`.github/workflows/docker-scan-required.yml`): Cleaned up the `paths-ignore` list — removed a duplicate `'Containerfile'` entry and a `'Containerfile.scratch'` entry for a file that does not exist in the repo.

3. **Makefile actionlint target**: The `linting-workflow-actionlint` invocation passed `-shellcheck="` with an unterminated quote, breaking the shell command. Closed the quote (`-shellcheck=""`) so actionlint runs with shellcheck disabled as intended.

---

## 📏 Reviewability

- [x] This PR has one clear purpose
- [ ] The linked issue is not labeled `triage`
- [x] Unrelated bugs or improvements are tracked in separate issues/PRs
- [ ] Tests are included with the code they validate
- [x] If AI-assisted, I understand and can explain the generated changes

---

## 🏷️ Type of Change

- [x] Bug fix
- [ ] Feature / Enhancement
- [ ] Documentation
- [ ] Refactor
- [x] Chore (deps, CI, tooling)
- [ ] Other (describe below)

---

## 🧪 Verification

- Docker Security Scan workflow no longer attempts to build the deleted `a2a-agents/rust/a2a-echo-agent/Dockerfile`; only the `python-sandbox` smoke test remains.
- Makefile actionlint target runs cleanly:
  ```bash
  make linting-workflow-actionlint
  ```

---

## ✅ Checklist

- [x] Code formatted (`make black isort pre-commit`)
- [ ] Tests added/updated for changes (not applicable — CI/Makefile-only changes)
- [ ] Documentation updated (if applicable)
- [x] No secrets or credentials committed

---

## 📓 Notes (optional)

Changes are confined to `.github/workflows/docker-scan.yml`, `.github/workflows/docker-scan-required.yml`, and `Makefile`.
