### PR TITLE
feat(oauth): add per-user OAuth connections view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1573,7 +1573,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # MCPGATEWAY_UI_EMBEDDED=false
 
 # Comma-separated list of UI sections to hide
-# Valid values: overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings
+# Valid values: overview, servers, gateways, oauth-connections, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings
 # Example: MCPGATEWAY_UI_HIDE_SECTIONS=prompts,resources,teams
 # MCPGATEWAY_UI_HIDE_SECTIONS=
 

--- a/.env.example
+++ b/.env.example
@@ -1665,7 +1665,7 @@ VALIDATE_TOKEN_ENVIRONMENT=true
 # MCPGATEWAY_UI_EMBEDDED=false
 
 # Comma-separated list of UI sections to hide
-# Valid values: overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings
+# Valid values: overview, servers, gateways, oauth-connections, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings
 # Example: MCPGATEWAY_UI_HIDE_SECTIONS=prompts,resources,teams
 # MCPGATEWAY_UI_HIDE_SECTIONS=
 

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -27,12 +27,13 @@ This document describes how the Admin UI initiates OAuth 2.0 Authorization Code 
 - Tokens are stored per gateway and app user (email) in `oauth_tokens`, encrypted with `AUTH_ENCRYPTION_SECRET`.
 - Refresh tokens are used when access tokens are near expiry; invalid refresh tokens are cleared.
 - DCR auto-registration can run during `/oauth/authorize/{gateway_id}` when `issuer` is set and `client_id` is missing.
+- Per-user token listing: the admin UI "OAuth Connections" tab and `GET /oauth/connections` show each user's own connection status (connected, expiry, scopes) per Authorization Code gateway, without exposing token material.
 
 ### Known gaps and constraints
 
 - `oauth_store_tokens` and `oauth_auto_refresh` checkboxes exist in the UI but are not persisted or enforced by the backend.
 - `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD` is defined but PKCE is always S256 today.
-- No admin UI to list or revoke stored OAuth tokens per user.
+- No admin UI to revoke stored OAuth tokens per user (listing exists via the "OAuth Connections" tab; revocation is tracked in #5501).
 - Token cleanup is a helper method only; there is no scheduler invoking it.
 
 ## Architecture Overview
@@ -260,5 +261,5 @@ For user authentication and RBAC configuration, see [RBAC Configuration](../mana
 
 - Wire `oauth_store_tokens` and `oauth_auto_refresh` to backend behavior.
 - Make PKCE method configurable using `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD`.
-- Add admin UI for token status and revocation.
+- Add token revocation to the OAuth Connections view (per-user status listing shipped; revocation is tracked in #5501).
 - Schedule periodic cleanup of expired OAuth tokens.

--- a/docs/docs/architecture/oauth-authorization-code-ui-design.md
+++ b/docs/docs/architecture/oauth-authorization-code-ui-design.md
@@ -27,12 +27,13 @@ This document describes how the Admin UI initiates OAuth 2.0 Authorization Code 
 - Tokens are stored per gateway and app user (email) in `oauth_tokens`, encrypted with `AUTH_ENCRYPTION_SECRET`.
 - Refresh tokens are used when access tokens are near expiry; invalid refresh tokens are cleared.
 - DCR auto-registration can run during `/oauth/authorize/{gateway_id}` when `issuer` is set and `client_id` is missing.
+- Per-user token listing: the admin UI "OAuth Connections" tab and `GET /oauth/connections` show each user's own connection status (connected, expiry, scopes) per Authorization Code gateway, without exposing token material.
 
 ### Known gaps and constraints
 
 - `oauth_store_tokens` and `oauth_auto_refresh` checkboxes exist in the UI but are not persisted or enforced by the backend.
 - `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD` is defined but PKCE is always S256 today.
-- No admin UI to list or revoke stored OAuth tokens per user.
+- No admin UI to revoke stored OAuth tokens per user (listing exists via the "OAuth Connections" tab; revocation is tracked in #5501).
 - Token cleanup is a helper method only; there is no scheduler invoking it.
 
 ## Architecture Overview
@@ -325,5 +326,5 @@ For user authentication and RBAC configuration, see [RBAC Configuration](../mana
 
 - Wire `oauth_store_tokens` and `oauth_auto_refresh` to backend behavior.
 - Make PKCE method configurable using `OAUTH_PREFERRED_CODE_CHALLENGE_METHOD`.
-- Add admin UI for token status and revocation.
+- Add token revocation to the OAuth Connections view (per-user status listing shipped; revocation is tracked in #5501).
 - Schedule periodic cleanup of expired OAuth tokens.

--- a/docs/docs/manage/configuration.md
+++ b/docs/docs/manage/configuration.md
@@ -172,7 +172,7 @@ For detailed guidance on embedding and section customization, see [Admin UI Cust
 | `MCPGATEWAY_ADMIN_API_ENABLED` | Enable API endpoints for admin ops     | `false` | bool    |
 | `MCPGATEWAY_UI_AIRGAPPED`      | Use local CDN assets for airgapped deployments | `false` | bool |
 | `MCPGATEWAY_UI_EMBEDDED`       | Embedded UI mode (hides logout + team selector by default) | `false` | bool |
-| `MCPGATEWAY_UI_HIDE_SECTIONS`  | CSV/JSON list of UI sections to hide (overview, servers, gateways, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings) | `[]` | CSV/JSON list |
+| `MCPGATEWAY_UI_HIDE_SECTIONS`  | CSV/JSON list of UI sections to hide (overview, servers, gateways, oauth-connections, tools, prompts, resources, roots, mcp-registry, metrics, plugins, export-import, logs, version-info, maintenance, teams, users, agents, tokens, settings) | `[]` | CSV/JSON list |
 | `MCPGATEWAY_UI_HIDE_HEADER_ITEMS` | CSV/JSON list of header items to hide (logout, team_selector, user_identity, theme_toggle) | `[]` | CSV/JSON list |
 | `MCPGATEWAY_BULK_IMPORT_ENABLED` | Enable bulk import endpoint for tools | `true`  | bool    |
 | `MCPGATEWAY_BULK_IMPORT_MAX_TOOLS` | Maximum number of tools per bulk import request | `200` | int |

--- a/docs/docs/manage/oauth.md
+++ b/docs/docs/manage/oauth.md
@@ -185,6 +185,36 @@ OAuth tokens are stored per gateway and user for the Authorization Code flow to 
 
 ---
 
+## Viewing Your OAuth Connections
+
+Each user can review their own OAuth authorization status across every Authorization Code gateway they have access to:
+
+- **Admin UI**: the **OAuth Connections** tab lists each accessible OAuth gateway with a Connected / Expired / Not connected status pill and an Authorize (or Re-authorize) link per gateway.
+- **API**: `GET /oauth/connections` returns the same data for the authenticated user:
+
+```json
+{
+  "connections": [
+    {
+      "gateway_id": "abc123",
+      "name": "GitHub MCP",
+      "url": "https://github-mcp.example.com/mcp",
+      "description": "GitHub tools",
+      "connected": true,
+      "expires_at": "2026-07-11T00:00:00+00:00",
+      "is_expired": false,
+      "scopes": ["repo"],
+      "updated_at": "2026-07-10T00:00:00+00:00",
+      "authorize_url": "/oauth/authorize/abc123"
+    }
+  ]
+}
+```
+
+Only connection metadata is returned - token material never leaves the server.
+
+---
+
 ## Provider Examples
 
 ### GitHub (Authorization Code)

--- a/docs/docs/manage/oauth.md
+++ b/docs/docs/manage/oauth.md
@@ -364,6 +364,36 @@ Authorization Code gateways use **per-user** tokens — there is no platform-lev
 
 ---
 
+## Viewing Your OAuth Connections
+
+Each user can review their own OAuth authorization status across every Authorization Code gateway they have access to:
+
+- **Admin UI**: the **OAuth Connections** tab lists each accessible OAuth gateway with a Connected / Expired / Not connected status pill and an Authorize (or Re-authorize) link per gateway.
+- **API**: `GET /oauth/connections` returns the same data for the authenticated user:
+
+```json
+{
+  "connections": [
+    {
+      "gateway_id": "abc123",
+      "name": "GitHub MCP",
+      "url": "https://github-mcp.example.com/mcp",
+      "description": "GitHub tools",
+      "connected": true,
+      "expires_at": "2026-07-11T00:00:00+00:00",
+      "is_expired": false,
+      "scopes": ["repo"],
+      "updated_at": "2026-07-10T00:00:00+00:00",
+      "authorize_url": "/oauth/authorize/abc123"
+    }
+  ]
+}
+```
+
+Only connection metadata is returned - token material never leaves the server.
+
+---
+
 ## Provider Examples
 
 ### GitHub (Authorization Code)

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -104,6 +104,7 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import utc_now
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, get_current_user_with_permissions, require_any_permission, require_permission
 from mcpgateway.routers.email_auth import create_access_token
+from mcpgateway.routers.oauth_router import build_user_oauth_connections
 from mcpgateway.schemas import (
     A2AAgentCreate,
     A2AAgentRead,
@@ -231,6 +232,7 @@ UI_SECTION_TO_TABS: Dict[str, tuple[str, ...]] = {
     "overview": ("overview",),
     "servers": ("catalog",),
     "gateways": ("gateways",),
+    "oauth-connections": ("oauth-connections",),
     "tools": ("tools", "tool-ops"),
     "prompts": ("prompts",),
     "resources": ("resources",),
@@ -273,6 +275,7 @@ SECTION_PERMISSIONS: Dict[str, Optional[str]] = {
     "resources": "resources.read",
     "prompts": "prompts.read",
     "gateways": "gateways.read",
+    "oauth-connections": "gateways.read",
     # Team management sections
     "teams": "teams.read",
     "tokens": "tokens.read",
@@ -307,6 +310,7 @@ _SECTION_TO_ROUTE_PATH: Dict[str, str] = {
     "resources": "/admin/resources/partial",
     "prompts": "/admin/prompts/partial",
     "gateways": "/admin/gateways/partial",
+    "oauth-connections": "/admin/oauth-connections/partial",
     "teams": "/admin/teams/partial",
     "tokens": "/admin/tokens/partial",
     "agents": "/admin/a2a/partial",
@@ -9679,6 +9683,52 @@ async def admin_gateways_partial_html(
             "current_user_email": user_email,
             "is_admin": _is_admin,
             "user_team_roles": _team_roles,
+        },
+    )
+
+
+@admin_router.get("/oauth-connections/partial", response_class=HTMLResponse)
+@require_permission("gateways.read", allow_admin_bypass=False)
+async def admin_oauth_connections_partial_html(
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+):
+    """Return the OAuth connections HTML partial for the admin UI.
+
+    This HTMX endpoint lists every OAuth gateway using the Authorization Code
+    flow that the current user can see, together with the user's own
+    connection status (connected, expired, or not connected) and an authorize
+    link per row. The data assembly is shared with ``GET /oauth/connections``
+    via :func:`build_user_oauth_connections`.
+
+    Args:
+        request (Request): FastAPI request object used by the template engine.
+        db (Session): Database session (dependency-injected).
+        user: Authenticated user object from dependency injection.
+
+    Returns:
+        TemplateResponse: Rendered OAuth connections partial.
+    """
+    user_email = get_user_email(user)
+    is_admin = bool(user.get("is_admin", False) if isinstance(user, dict) else getattr(user, "is_admin", False))
+    if isinstance(user, dict) and user.get("token_teams") is not None:
+        # Team-scoped API tokens must not widen visibility via admin status.
+        is_admin = False
+    team_ids = await _get_user_team_ids(user, db)
+
+    root_path = _resolve_root_path(request)
+    connections = await build_user_oauth_connections(db, user_email=user_email, is_admin=is_admin, team_ids=team_ids, root_path=root_path)
+
+    LOGGER.debug(f"User {user_email} requested OAuth connections partial ({len(connections)} gateways)")
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "oauth_connections_partial.html",
+        {
+            "request": request,
+            "connections": connections,
+            "root_path": root_path,
         },
     )
 

--- a/mcpgateway/admin.py
+++ b/mcpgateway/admin.py
@@ -111,6 +111,7 @@ from mcpgateway.db import Tool as DbTool
 from mcpgateway.db import utc_now
 from mcpgateway.middleware.rbac import _ACCESS_DENIED_MSG, get_current_user_with_permissions, require_any_permission, require_permission
 from mcpgateway.routers.email_auth import create_access_token
+from mcpgateway.routers.oauth_router import build_user_oauth_connections
 from mcpgateway.schemas import (
     _encode_auth_headers_list,
     A2AAgentCreate,
@@ -241,6 +242,7 @@ UI_SECTION_TO_TABS: Dict[str, tuple[str, ...]] = {
     "overview": ("overview",),
     "servers": ("catalog",),
     "gateways": ("gateways",),
+    "oauth-connections": ("oauth-connections",),
     "tools": ("tools", "tool-ops"),
     "prompts": ("prompts",),
     "resources": ("resources",),
@@ -283,6 +285,7 @@ SECTION_PERMISSIONS: Dict[str, Optional[str]] = {
     "resources": "resources.read",
     "prompts": "prompts.read",
     "gateways": "gateways.read",
+    "oauth-connections": "gateways.read",
     # Team management sections
     "teams": "teams.read",
     "tokens": "tokens.read",
@@ -317,6 +320,7 @@ _SECTION_TO_ROUTE_PATH: Dict[str, str] = {
     "resources": "/admin/resources/partial",
     "prompts": "/admin/prompts/partial",
     "gateways": "/admin/gateways/partial",
+    "oauth-connections": "/admin/oauth-connections/partial",
     "teams": "/admin/teams/partial",
     "tokens": "/admin/tokens/partial",
     "agents": "/admin/a2a/partial",
@@ -9838,6 +9842,52 @@ async def admin_gateways_partial_html(
             "current_user_email": user_email,
             "is_admin": _is_admin,
             "user_team_roles": _team_roles,
+        },
+    )
+
+
+@admin_router.get("/oauth-connections/partial", response_class=HTMLResponse)
+@require_permission("gateways.read", allow_admin_bypass=False)
+async def admin_oauth_connections_partial_html(
+    request: Request,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user_with_permissions),
+):
+    """Return the OAuth connections HTML partial for the admin UI.
+
+    This HTMX endpoint lists every OAuth gateway using the Authorization Code
+    flow that the current user can see, together with the user's own
+    connection status (connected, expired, or not connected) and an authorize
+    link per row. The data assembly is shared with ``GET /oauth/connections``
+    via :func:`build_user_oauth_connections`.
+
+    Args:
+        request (Request): FastAPI request object used by the template engine.
+        db (Session): Database session (dependency-injected).
+        user: Authenticated user object from dependency injection.
+
+    Returns:
+        TemplateResponse: Rendered OAuth connections partial.
+    """
+    user_email = get_user_email(user)
+    is_admin = bool(user.get("is_admin", False) if isinstance(user, dict) else getattr(user, "is_admin", False))
+    if isinstance(user, dict) and user.get("token_teams") is not None:
+        # Team-scoped API tokens must not widen visibility via admin status.
+        is_admin = False
+    team_ids = await _get_user_team_ids(user, db)
+
+    root_path = _resolve_root_path(request)
+    connections = await build_user_oauth_connections(db, user_email=user_email, is_admin=is_admin, team_ids=team_ids, root_path=root_path)
+
+    LOGGER.debug(f"User {user_email} requested OAuth connections partial ({len(connections)} gateways)")
+
+    return request.app.state.templates.TemplateResponse(
+        request,
+        "oauth_connections_partial.html",
+        {
+            "request": request,
+            "connections": connections,
+            "root_path": root_path,
         },
     )
 

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -135,6 +135,7 @@ UI_HIDABLE_SECTIONS = frozenset(
         "overview",
         "servers",
         "gateways",
+        "oauth-connections",
         "tools",
         "prompts",
         "resources",

--- a/mcpgateway/config.py
+++ b/mcpgateway/config.py
@@ -136,6 +136,7 @@ UI_HIDABLE_SECTIONS = frozenset(
         "overview",
         "servers",
         "gateways",
+        "oauth-connections",
         "tools",
         "prompts",
         "resources",

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse, urlunparse
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -927,6 +927,151 @@ async def get_oauth_status(
     except Exception as e:
         logger.error(f"Failed to get OAuth status: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to get OAuth status")
+
+
+async def _resolve_user_team_ids(user_email: str, current_user: EmailUserResponse | dict, db: Session) -> list[str]:
+    """Return the team IDs used for gateway visibility filtering.
+
+    Explicit ``token_teams`` scope (API tokens) takes precedence so a
+    team-scoped token cannot list gateways outside its restrictions;
+    otherwise the user's active team memberships are looked up.
+
+    Args:
+        user_email: Lowercased email of the requesting user.
+        current_user: Authenticated user context.
+        db: Active database session.
+
+    Returns:
+        Team ID list for the requester.
+    """
+    if isinstance(current_user, dict) and current_user.get("token_teams") is not None:
+        team_ids: list[str] = []
+        for team in current_user["token_teams"]:
+            if isinstance(team, dict):
+                team_id = team.get("id")
+                if isinstance(team_id, str) and team_id:
+                    team_ids.append(team_id)
+            elif isinstance(team, str) and team:
+                team_ids.append(team)
+        return team_ids
+
+    # First-Party
+    from mcpgateway.services.team_management_service import TeamManagementService
+
+    team_service = TeamManagementService(db)
+    user_teams = await team_service.get_user_teams(user_email)
+    return [team.id for team in user_teams]
+
+
+async def build_user_oauth_connections(db: Session, user_email: str, is_admin: bool, team_ids: list[str], root_path: str) -> list[Dict[str, Any]]:
+    """Assemble the current user's OAuth connection entries.
+
+    Lists every OAuth gateway using the Authorization Code flow that the user
+    can see (owned, team-visible, or public; unrestricted admins see all),
+    merged with the user's own stored token status for each gateway. Entries
+    never contain token material — only connection metadata such as expiry
+    and scopes. Shared by the ``GET /oauth/connections`` endpoint and the
+    admin UI "OAuth Connections" partial.
+
+    Args:
+        db: Active database session.
+        user_email: Lowercased email of the requesting user.
+        is_admin: Whether the requester has unrestricted admin visibility.
+        team_ids: Team IDs the requester belongs to (or the token scope).
+        root_path: Application root path used to mint authorize URLs.
+
+    Returns:
+        Connection entry dictionaries sorted by gateway name.
+    """
+    query = select(Gateway).where(Gateway.auth_type == "oauth")
+    if not is_admin:
+        access_conditions = [
+            Gateway.owner_email == user_email,
+            Gateway.visibility == "public",
+        ]
+        if team_ids:
+            access_conditions.append(and_(Gateway.team_id.in_(team_ids), Gateway.visibility.in_(["team", "public"])))
+        query = query.where(or_(*access_conditions))
+
+    gateways = db.execute(query).scalars().all()
+
+    # oauth_config is a JSON column; filter the grant type in Python for
+    # portability across SQLite and PostgreSQL (gateway counts are small).
+    authorization_code_gateways = [gateway for gateway in gateways if (gateway.oauth_config or {}).get("grant_type") == "authorization_code"]
+
+    token_info_by_gateway = await TokenStorageService(db).list_user_token_info(user_email)
+
+    connections = []
+    for gateway in authorization_code_gateways:
+        token_info = token_info_by_gateway.get(gateway.id)
+        connections.append(
+            {
+                "gateway_id": gateway.id,
+                "name": gateway.name,
+                "url": gateway.url,
+                "description": gateway.description,
+                "connected": token_info is not None,
+                "expires_at": token_info.get("expires_at") if token_info else None,
+                "is_expired": token_info.get("is_expired", False) if token_info else False,
+                "scopes": token_info.get("scopes") if token_info else None,
+                "updated_at": token_info.get("updated_at") if token_info else None,
+                "authorize_url": f"{root_path}/oauth/authorize/{gateway.id}",
+            }
+        )
+
+    connections.sort(key=lambda connection: (connection["name"] or "").lower())
+    return connections
+
+
+@oauth_router.get("/connections")
+async def list_oauth_connections(
+    request: Request,
+    current_user: dict = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> dict:
+    """List the current user's OAuth connections across accessible gateways.
+
+    Returns every OAuth gateway using the Authorization Code flow that the
+    requesting user can see, together with the user's own connection status
+    for each gateway (connected, expiry, scopes) and the authorize URL to
+    start or repeat the flow. Token material is never included.
+
+    Args:
+        request: The FastAPI request object (used for root path resolution).
+        current_user: Authenticated user (enforces authentication).
+        db: Database session.
+
+    Returns:
+        Dict with a ``connections`` list of per-gateway connection entries.
+
+    Raises:
+        HTTPException: If not authenticated or listing fails.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(list_oauth_connections)
+        True
+    """
+    try:
+        user_email = _extract_user_email(current_user)
+        if not user_email:
+            raise HTTPException(status_code=401, detail="User authentication required")
+
+        is_admin = _extract_is_admin(current_user)
+        if isinstance(current_user, dict) and current_user.get("token_teams") is not None:
+            # Team-scoped API tokens must not widen visibility via admin status.
+            is_admin = False
+
+        team_ids = await _resolve_user_team_ids(user_email, current_user, db)
+        connections = await build_user_oauth_connections(db, user_email=user_email, is_admin=is_admin, team_ids=team_ids, root_path=resolve_root_path(request))
+
+        return {"connections": connections}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to list OAuth connections: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to list OAuth connections")
 
 
 @oauth_router.post("/fetch-tools/{gateway_id}")

--- a/mcpgateway/routers/oauth_router.py
+++ b/mcpgateway/routers/oauth_router.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 # Third-Party
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 # First-Party
@@ -1078,6 +1078,153 @@ async def get_oauth_status(
     except Exception as e:
         logger.error(f"Failed to get OAuth status: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to get OAuth status")
+
+
+async def _resolve_user_team_ids(user_email: str, current_user: EmailUserResponse | dict, db: Session) -> list[str]:
+    """Return the team IDs used for gateway visibility filtering.
+
+    Explicit ``token_teams`` scope (API tokens) takes precedence so a
+    team-scoped token cannot list gateways outside its restrictions;
+    otherwise the user's active team memberships are looked up.
+
+    Args:
+        user_email: Lowercased email of the requesting user.
+        current_user: Authenticated user context.
+        db: Active database session.
+
+    Returns:
+        Team ID list for the requester.
+    """
+    if isinstance(current_user, dict) and current_user.get("token_teams") is not None:
+        team_ids: list[str] = []
+        for team in current_user["token_teams"]:
+            if isinstance(team, dict):
+                team_id = team.get("id")
+                if isinstance(team_id, str) and team_id:
+                    team_ids.append(team_id)
+            elif isinstance(team, str) and team:
+                team_ids.append(team)
+        return team_ids
+
+    # First-Party
+    from mcpgateway.services.team_management_service import TeamManagementService
+
+    team_service = TeamManagementService(db)
+    user_teams = await team_service.get_user_teams(user_email)
+    return [team.id for team in user_teams]
+
+
+async def build_user_oauth_connections(db: Session, user_email: str, is_admin: bool, team_ids: list[str], root_path: str) -> list[Dict[str, Any]]:
+    """Assemble the current user's OAuth connection entries.
+
+    Lists every OAuth gateway using the Authorization Code flow that the user
+    can see (owned, team-visible, or public; unrestricted admins see all),
+    merged with the user's own stored token status for each gateway. Entries
+    never contain token material — only connection metadata such as expiry
+    and scopes. Shared by the ``GET /oauth/connections`` endpoint and the
+    admin UI "OAuth Connections" partial.
+
+    Args:
+        db: Active database session.
+        user_email: Lowercased email of the requesting user.
+        is_admin: Whether the requester has unrestricted admin visibility.
+        team_ids: Team IDs the requester belongs to (or the token scope).
+        root_path: Application root path used to mint authorize URLs.
+
+    Returns:
+        Connection entry dictionaries sorted by gateway name.
+    """
+    query = select(Gateway).where(Gateway.auth_type == "oauth")
+    if not is_admin:
+        access_conditions = [
+            Gateway.owner_email == user_email,
+            Gateway.visibility == "public",
+        ]
+        if team_ids:
+            access_conditions.append(and_(Gateway.team_id.in_(team_ids), Gateway.visibility.in_(["team", "public"])))
+        query = query.where(or_(*access_conditions))
+
+    gateways = db.execute(query).scalars().all()
+
+    # oauth_config is a JSON column; filter the grant type in Python for
+    # portability across SQLite and PostgreSQL (gateway counts are small).
+    authorization_code_gateways = [gateway for gateway in gateways if (gateway.oauth_config or {}).get("grant_type") == "authorization_code"]
+
+    token_info_by_gateway = await TokenStorageService(db).list_user_token_info(user_email)
+
+    connections = []
+    for gateway in authorization_code_gateways:
+        token_info = token_info_by_gateway.get(gateway.id)
+        connections.append(
+            {
+                "gateway_id": gateway.id,
+                "name": gateway.name,
+                "url": gateway.url,
+                "description": gateway.description,
+                "connected": token_info is not None,
+                "expires_at": token_info.get("expires_at") if token_info else None,
+                "is_expired": token_info.get("is_expired", False) if token_info else False,
+                "scopes": token_info.get("scopes") if token_info else None,
+                "updated_at": token_info.get("updated_at") if token_info else None,
+                "authorize_url": f"{root_path}/oauth/authorize/{gateway.id}",
+            }
+        )
+
+    connections.sort(key=lambda connection: (connection["name"] or "").lower())
+    return connections
+
+
+@oauth_router.get("/connections")
+async def list_oauth_connections(
+    request: Request,
+    current_user: dict = Depends(get_current_user_with_permissions),
+    db: Session = Depends(get_db),
+) -> dict:
+    """List the current user's OAuth connections across accessible gateways.
+
+    Returns every OAuth gateway using the Authorization Code flow that the
+    requesting user can see, together with the user's own connection status
+    for each gateway (connected, expiry, scopes) and the authorize URL to
+    start or repeat the flow. Token material is never included.
+
+    Args:
+        request: The FastAPI request object (used for root path resolution).
+        current_user: Authenticated user (enforces authentication).
+        db: Database session.
+
+    Returns:
+        Dict with a ``connections`` list of per-gateway connection entries.
+
+    Raises:
+        HTTPException: If not authenticated or listing fails.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.iscoroutinefunction(list_oauth_connections)
+        True
+    """
+    try:
+        user_email = get_user_email(current_user)
+        if user_email == "unknown" or not user_email.strip():
+            raise HTTPException(status_code=401, detail="User authentication required")
+        # Normalize so lookups match stored token rows regardless of case and whitespace
+        user_email = user_email.strip().lower()
+
+        is_admin = _extract_is_admin(current_user)
+        if isinstance(current_user, dict) and current_user.get("token_teams") is not None:
+            # Team-scoped API tokens must not widen visibility via admin status.
+            is_admin = False
+
+        team_ids = await _resolve_user_team_ids(user_email, current_user, db)
+        connections = await build_user_oauth_connections(db, user_email=user_email, is_admin=is_admin, team_ids=team_ids, root_path=resolve_root_path(request))
+
+        return {"connections": connections}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to list OAuth connections: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to list OAuth connections")
 
 
 @oauth_router.post("/fetch-tools/{gateway_id}")

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -521,6 +521,66 @@ class TokenStorageService:
             logger.error("Failed to get token info: %s", str(e))
             return None
 
+    async def list_user_token_info(self, app_user_email: str) -> Dict[str, Dict[str, Any]]:
+        """List stored OAuth token information for a user across all gateways.
+
+        Uses a single query over ``oauth_tokens`` and returns the same
+        per-token info shape as :meth:`get_token_info`, keyed by gateway ID.
+        Token material (access/refresh tokens) is never included.
+
+        Args:
+            app_user_email: ContextForge user email
+
+        Returns:
+            Mapping of gateway ID to token information dictionaries. Empty
+            when the user has no stored tokens or the lookup fails.
+
+        Examples:
+            >>> from types import SimpleNamespace
+            >>> from datetime import datetime, timedelta
+            >>> svc = TokenStorageService(None)
+            >>> now = datetime.now(tz=timezone.utc)
+            >>> future = now + timedelta(seconds=60)
+            >>> rec = SimpleNamespace(gateway_id='g1', user_id='u1', app_user_email='u1@example.com', token_type='bearer', expires_at=future, scopes=['s1'], created_at=now, updated_at=now)
+            >>> class _Res:
+            ...     def scalars(self):
+            ...         return self
+            ...     def all(self):
+            ...         return [rec]
+            >>> class _DB:
+            ...     def execute(self, *_args, **_kw):
+            ...         return _Res()
+            >>> svc.db = _DB()
+            >>> import asyncio
+            >>> info = asyncio.run(svc.list_user_token_info('u1@example.com'))
+            >>> sorted(info)
+            ['g1']
+            >>> info['g1']['user_id']
+            'u1'
+            >>> isinstance(info['g1']['is_expired'], bool)
+            True
+        """
+        try:
+            token_records = self.db.execute(select(OAuthToken).where(OAuthToken.app_user_email == app_user_email)).scalars().all()
+
+            return {
+                token_record.gateway_id: {
+                    "user_id": token_record.user_id,  # OAuth provider user ID
+                    "app_user_email": token_record.app_user_email,  # ContextForge user
+                    "token_type": token_record.token_type,
+                    "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None,
+                    "scopes": token_record.scopes,
+                    "created_at": token_record.created_at.isoformat(),
+                    "updated_at": token_record.updated_at.isoformat(),
+                    "is_expired": self._is_token_expired(token_record, 0),
+                }
+                for token_record in token_records
+            }
+
+        except Exception as e:
+            logger.error("Failed to list token info for user: %s", str(e))
+            return {}
+
     async def revoke_user_tokens(self, gateway_id: str, app_user_email: str) -> bool:
         """Revoke OAuth tokens for a specific user.
 

--- a/mcpgateway/services/token_storage_service.py
+++ b/mcpgateway/services/token_storage_service.py
@@ -647,6 +647,66 @@ class TokenStorageService:
             logger.error("Failed to get token info: %s", str(e))
             return None
 
+    async def list_user_token_info(self, app_user_email: str) -> Dict[str, Dict[str, Any]]:
+        """List stored OAuth token information for a user across all gateways.
+
+        Uses a single query over ``oauth_tokens`` and returns the same
+        per-token info shape as :meth:`get_token_info`, keyed by gateway ID.
+        Token material (access/refresh tokens) is never included.
+
+        Args:
+            app_user_email: ContextForge user email
+
+        Returns:
+            Mapping of gateway ID to token information dictionaries. Empty
+            when the user has no stored tokens or the lookup fails.
+
+        Examples:
+            >>> from types import SimpleNamespace
+            >>> from datetime import datetime, timedelta
+            >>> svc = TokenStorageService(None)
+            >>> now = datetime.now(tz=timezone.utc)
+            >>> future = now + timedelta(seconds=60)
+            >>> rec = SimpleNamespace(gateway_id='g1', user_id='u1', app_user_email='u1@example.com', token_type='bearer', expires_at=future, scopes=['s1'], created_at=now, updated_at=now)
+            >>> class _Res:
+            ...     def scalars(self):
+            ...         return self
+            ...     def all(self):
+            ...         return [rec]
+            >>> class _DB:
+            ...     def execute(self, *_args, **_kw):
+            ...         return _Res()
+            >>> svc.db = _DB()
+            >>> import asyncio
+            >>> info = asyncio.run(svc.list_user_token_info('u1@example.com'))
+            >>> sorted(info)
+            ['g1']
+            >>> info['g1']['user_id']
+            'u1'
+            >>> isinstance(info['g1']['is_expired'], bool)
+            True
+        """
+        try:
+            token_records = self.db.execute(select(OAuthToken).where(OAuthToken.app_user_email == app_user_email)).scalars().all()
+
+            return {
+                token_record.gateway_id: {
+                    "user_id": token_record.user_id,  # OAuth provider user ID
+                    "app_user_email": token_record.app_user_email,  # ContextForge user
+                    "token_type": token_record.token_type,
+                    "expires_at": token_record.expires_at.isoformat() if token_record.expires_at else None,
+                    "scopes": token_record.scopes,
+                    "created_at": token_record.created_at.isoformat(),
+                    "updated_at": token_record.updated_at.isoformat(),
+                    "is_expired": self._is_token_expired(token_record, 0),
+                }
+                for token_record in token_records
+            }
+
+        except Exception as e:
+            logger.error("Failed to list token info for user: %s", str(e))
+            return {}
+
     async def revoke_user_tokens(self, gateway_id: str, app_user_email: str) -> bool:
         """Revoke OAuth tokens for a specific user.
 

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -400,6 +400,15 @@
               <span x-show="!sidebarCollapsed">MCP Servers</span>
             </a>
             {% endif %}
+            {% if 'oauth-connections' not in hidden_sections %}
+            <a href="#oauth-connections" id="tab-oauth-connections" data-testid="oauth-connections-tab"
+               class="sidebar-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors"
+               :class="{ 'justify-center': sidebarCollapsed }"
+               data-action-click="showTab" data-arg0="oauth-connections">
+              <span class="sidebar-icon text-lg" :class="{ 'mr-3': !sidebarCollapsed }">🔐</span>
+              <span x-show="!sidebarCollapsed">OAuth Connections</span>
+            </a>
+            {% endif %}
             {% if 'servers' not in hidden_sections %}
             <a href="#catalog" id="tab-catalog" data-testid="servers-tab"
                class="sidebar-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors"
@@ -5985,6 +5994,45 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
       </div>
 
       {% endif %}
+      <!-- OAuth Connections Panel -->
+      {% if 'oauth-connections' not in hidden_sections %}
+      <div id="oauth-connections-panel" class="tab-panel hidden">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-2xl font-bold dark:text-gray-200">
+            OAuth Connections
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Your personal OAuth authorization status for each OAuth-enabled MCP
+            server you can access.
+          </p>
+        </div>
+
+        <div class="bg-white shadow rounded-lg p-6 mb-8 dark:bg-gray-800">
+          <div id="oauth-connections-table-wrapper" class="overflow-x-auto">
+            <!-- Table will be loaded via HTMX -->
+            <div id="oauth-connections-table"
+                 hx-get="{{ root_path }}/admin/oauth-connections/partial"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"
+                 hx-indicator="#oauth-connections-loading">
+
+            </div>
+          </div>
+
+          <!-- Loading Indicator for HTMX -->
+          <div id="oauth-connections-loading" class="htmx-indicator">
+            <div class="flex items-center justify-center p-4">
+              <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span class="ml-2 text-gray-600 dark:text-gray-400">Loading OAuth connections...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
       <!-- Teams Panel -->
       {% if email_auth_enabled and 'teams' not in hidden_sections %}
       <div id="teams-panel" class="tab-panel hidden">

--- a/mcpgateway/templates/admin.html
+++ b/mcpgateway/templates/admin.html
@@ -291,6 +291,15 @@
               <span x-show="!sidebarCollapsed">MCP Servers</span>
             </a>
             {% endif %}
+            {% if 'oauth-connections' not in hidden_sections %}
+            <a href="#oauth-connections" id="tab-oauth-connections" data-testid="oauth-connections-tab"
+               class="sidebar-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors"
+               :class="{ 'justify-center': sidebarCollapsed }"
+               data-action-click="showTab" data-arg0="oauth-connections">
+              <span class="sidebar-icon text-lg" :class="{ 'mr-3': !sidebarCollapsed }">🔐</span>
+              <span x-show="!sidebarCollapsed">OAuth Connections</span>
+            </a>
+            {% endif %}
             {% if 'servers' not in hidden_sections %}
             <a href="#catalog" id="tab-catalog" data-testid="servers-tab"
                class="sidebar-link group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-colors"
@@ -5912,6 +5921,45 @@ Hello &#123;&#123; name &#125;&#125;, welcome to &#123;&#123; company &#125;&#12
       </div>
 
       {% endif %}
+      <!-- OAuth Connections Panel -->
+      {% if 'oauth-connections' not in hidden_sections %}
+      <div id="oauth-connections-panel" class="tab-panel hidden">
+        <div class="flex justify-between items-center mb-4">
+          <h2 class="text-2xl font-bold dark:text-gray-200">
+            OAuth Connections
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+            Your personal OAuth authorization status for each OAuth-enabled MCP
+            server you can access.
+          </p>
+        </div>
+
+        <div class="bg-white shadow rounded-lg p-6 mb-8 dark:bg-gray-800">
+          <div id="oauth-connections-table-wrapper" class="overflow-x-auto">
+            <!-- Table will be loaded via HTMX -->
+            <div id="oauth-connections-table"
+                 hx-get="{{ root_path }}/admin/oauth-connections/partial"
+                 hx-trigger="load"
+                 hx-swap="outerHTML"
+                 hx-indicator="#oauth-connections-loading">
+
+            </div>
+          </div>
+
+          <!-- Loading Indicator for HTMX -->
+          <div id="oauth-connections-loading" class="htmx-indicator">
+            <div class="flex items-center justify-center p-4">
+              <svg class="animate-spin h-8 w-8 text-indigo-600 dark:text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              <span class="ml-2 text-gray-600 dark:text-gray-400">Loading OAuth connections...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
       <!-- Teams Panel -->
       {% if email_auth_enabled and 'teams' not in hidden_sections %}
       <div id="teams-panel" class="tab-panel hidden">

--- a/mcpgateway/templates/oauth_connections_partial.html
+++ b/mcpgateway/templates/oauth_connections_partial.html
@@ -1,0 +1,60 @@
+<!-- htmlhint doctype-first:false -->
+<table id="oauth-connections-table" class="min-w-full divide-y divide-gray-200">
+  <thead class="bg-gray-50 dark:bg-gray-700">
+    <tr>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Gateway</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Description</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Status</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Expires</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Scopes</th>
+      <th class="px-6 py-3 text-left text-xs font-medium text-gray-800 dark:text-gray-200 uppercase tracking-wider">Actions</th>
+    </tr>
+  </thead>
+  <tbody id="oauth-connections-table-body" class="bg-white divide-y divide-gray-200 dark:bg-gray-900 dark:divide-gray-700">
+    {% for connection in connections %}
+    <tr id="oauth-connection-row-{{ connection.gateway_id }}" data-connected="{{ connection.connected|lower }}">
+      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-100">
+        {{ connection.name }}
+        <div class="text-xs font-normal text-gray-500 dark:text-gray-400 whitespace-normal break-all max-w-xs">{{ connection.url }}</div>
+      </td>
+      <td class="px-6 py-4 whitespace-normal break-words text-sm text-gray-500 dark:text-gray-300 max-w-xs">
+        {% if connection.description %}{{ connection.description }}{% else %}<span class="text-gray-400">N/A</span>{% endif %}
+      </td>
+      <td class="px-6 py-4 whitespace-nowrap text-sm">
+        {% if connection.connected and not connection.is_expired %}
+        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Connected</span>
+        {% elif connection.connected %}
+        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Expired</span>
+        {% else %}
+        <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">Not connected</span>
+        {% endif %}
+      </td>
+      <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+        {% if connection.expires_at %}{{ connection.expires_at[:19] }}{% elif connection.connected %}No expiry{% else %}<span class="text-gray-400">N/A</span>{% endif %}
+      </td>
+      <td class="px-6 py-4 whitespace-nowrap">
+        {% if connection.scopes %}
+          {% for scope in connection.scopes %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1">{{ scope }}</span>
+          {% endfor %}
+        {% else %}
+          <span class="text-gray-500 dark:text-gray-300 text-xs">None</span>
+        {% endif %}
+      </td>
+      <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+        <a href="{{ root_path }}/oauth/authorize/{{ connection.gateway_id }}"
+           class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300">
+          {% if connection.connected %}🔐 Re-authorize{% else %}🔐 Authorize{% endif %}
+        </a>
+      </td>
+    </tr>
+    {% else %}
+    <tr>
+      <td colspan="6" class="px-6 py-12 text-center">
+        <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-white">No OAuth connections available</h3>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">No accessible MCP servers are configured for the OAuth Authorization Code flow.</p>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1495,6 +1495,84 @@ class TestOAuthAccessHelpers:
         assert exc_info.value.status_code == 403
 
 
+class TestListOAuthConnections:
+    """Tests for the GET /oauth/connections endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_merges_token_status(self, mock_db, mock_request):
+        """Connected and not-connected gateways merge; non-authorization-code gateways are excluded."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        connected_gateway = SimpleNamespace(id="gw-a", name="Alpha MCP", url="https://alpha.example.com/mcp", description="Alpha tools", oauth_config={"grant_type": "authorization_code"})
+        unconnected_gateway = SimpleNamespace(id="gw-b", name="Beta MCP", url="https://beta.example.com/mcp", description=None, oauth_config={"grant_type": "authorization_code"})
+        client_credentials_gateway = SimpleNamespace(id="gw-c", name="Gamma MCP", url="https://gamma.example.com/mcp", description=None, oauth_config={"grant_type": "client_credentials"})
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [unconnected_gateway, connected_gateway, client_credentials_gateway]
+
+        token_info = {
+            "gw-a": {
+                "user_id": "provider-user",
+                "app_user_email": "user@example.com",
+                "token_type": "Bearer",
+                "expires_at": "2026-07-11T00:00:00+00:00",
+                "scopes": ["read", "write"],
+                "created_at": "2026-07-10T00:00:00+00:00",
+                "updated_at": "2026-07-10T00:00:00+00:00",
+                "is_expired": False,
+            }
+        }
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage_class.return_value.list_user_token_info = AsyncMock(return_value=token_info)
+
+            result = await list_oauth_connections(mock_request, {"email": "user@example.com", "is_admin": False, "token_teams": ["team-1"]}, mock_db)
+
+        connections = result["connections"]
+        # Sorted by name; the client_credentials gateway is excluded.
+        assert [connection["gateway_id"] for connection in connections] == ["gw-a", "gw-b"]
+
+        connected, unconnected = connections
+        assert connected["connected"] is True
+        assert connected["expires_at"] == "2026-07-11T00:00:00+00:00"
+        assert connected["is_expired"] is False
+        assert connected["scopes"] == ["read", "write"]
+        assert connected["updated_at"] == "2026-07-10T00:00:00+00:00"
+        assert connected["authorize_url"].endswith("/oauth/authorize/gw-a")
+        assert unconnected["connected"] is False
+        assert unconnected["expires_at"] is None
+        assert unconnected["is_expired"] is False
+        assert unconnected["scopes"] is None
+        # Token material must never appear in the response.
+        for connection in connections:
+            assert "access_token" not in connection
+            assert "refresh_token" not in connection
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_requires_authenticated_email(self, mock_db, mock_request):
+        """Requests without a resolvable user email are rejected with 401."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_oauth_connections(mock_request, {"is_admin": False}, mock_db)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_wraps_unexpected_errors(self, mock_db, mock_request):
+        """Unexpected failures surface as a generic 500 without leaking details."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        mock_db.execute.side_effect = RuntimeError("boom")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_oauth_connections(mock_request, {"email": "user@example.com", "is_admin": False, "token_teams": []}, mock_db)
+
+        assert exc_info.value.status_code == 500
+        assert "Failed to list OAuth connections" in str(exc_info.value.detail)
+
+
 class TestRFC8707ResourceNormalization:
     """Test cases for RFC 8707 resource URL normalization."""
 

--- a/tests/unit/mcpgateway/routers/test_oauth_router.py
+++ b/tests/unit/mcpgateway/routers/test_oauth_router.py
@@ -1403,6 +1403,84 @@ class TestOAuthAccessHelpers:
         assert exc_info.value.status_code == 403
 
 
+class TestListOAuthConnections:
+    """Tests for the GET /oauth/connections endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_merges_token_status(self, mock_db, mock_request):
+        """Connected and not-connected gateways merge; non-authorization-code gateways are excluded."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        connected_gateway = SimpleNamespace(id="gw-a", name="Alpha MCP", url="https://alpha.example.com/mcp", description="Alpha tools", oauth_config={"grant_type": "authorization_code"})
+        unconnected_gateway = SimpleNamespace(id="gw-b", name="Beta MCP", url="https://beta.example.com/mcp", description=None, oauth_config={"grant_type": "authorization_code"})
+        client_credentials_gateway = SimpleNamespace(id="gw-c", name="Gamma MCP", url="https://gamma.example.com/mcp", description=None, oauth_config={"grant_type": "client_credentials"})
+        mock_db.execute.return_value.scalars.return_value.all.return_value = [unconnected_gateway, connected_gateway, client_credentials_gateway]
+
+        token_info = {
+            "gw-a": {
+                "user_id": "provider-user",
+                "app_user_email": "user@example.com",
+                "token_type": "Bearer",
+                "expires_at": "2026-07-11T00:00:00+00:00",
+                "scopes": ["read", "write"],
+                "created_at": "2026-07-10T00:00:00+00:00",
+                "updated_at": "2026-07-10T00:00:00+00:00",
+                "is_expired": False,
+            }
+        }
+
+        with patch("mcpgateway.routers.oauth_router.TokenStorageService") as mock_token_storage_class:
+            mock_token_storage_class.return_value.list_user_token_info = AsyncMock(return_value=token_info)
+
+            result = await list_oauth_connections(mock_request, {"email": "user@example.com", "is_admin": False, "token_teams": ["team-1"]}, mock_db)
+
+        connections = result["connections"]
+        # Sorted by name; the client_credentials gateway is excluded.
+        assert [connection["gateway_id"] for connection in connections] == ["gw-a", "gw-b"]
+
+        connected, unconnected = connections
+        assert connected["connected"] is True
+        assert connected["expires_at"] == "2026-07-11T00:00:00+00:00"
+        assert connected["is_expired"] is False
+        assert connected["scopes"] == ["read", "write"]
+        assert connected["updated_at"] == "2026-07-10T00:00:00+00:00"
+        assert connected["authorize_url"].endswith("/oauth/authorize/gw-a")
+        assert unconnected["connected"] is False
+        assert unconnected["expires_at"] is None
+        assert unconnected["is_expired"] is False
+        assert unconnected["scopes"] is None
+        # Token material must never appear in the response.
+        for connection in connections:
+            assert "access_token" not in connection
+            assert "refresh_token" not in connection
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_requires_authenticated_email(self, mock_db, mock_request):
+        """Requests without a resolvable user email are rejected with 401."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_oauth_connections(mock_request, {"is_admin": False}, mock_db)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_list_oauth_connections_wraps_unexpected_errors(self, mock_db, mock_request):
+        """Unexpected failures surface as a generic 500 without leaking details."""
+        # First-Party
+        from mcpgateway.routers.oauth_router import list_oauth_connections
+
+        mock_db.execute.side_effect = RuntimeError("boom")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await list_oauth_connections(mock_request, {"email": "user@example.com", "is_admin": False, "token_teams": []}, mock_db)
+
+        assert exc_info.value.status_code == 500
+        assert "Failed to list OAuth connections" in str(exc_info.value.detail)
+
+
 class TestOAuthRouterAdditionalCoverage:
     """Additional coverage for OAuth router branches."""
 

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -144,6 +144,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_logout_get,
     admin_logout_post,
     admin_metrics_partial_html,
+    admin_oauth_connections_partial_html,
     admin_prompts_partial_html,
     admin_revoke_token,
     admin_reject_join_request,
@@ -12251,6 +12252,49 @@ async def test_admin_gateways_partial_html_default_includes_inactive(monkeypatch
     assert isinstance(response, HTMLResponse)
     context = mock_request.app.state.templates.TemplateResponse.call_args[0][2]
     assert context["query_params"]["include_inactive"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_admin_oauth_connections_partial_html_renders(monkeypatch, mock_request, mock_db):
+    """Render the per-user OAuth connections partial via the shared data assembly."""
+    setup_team_service(monkeypatch, ["team-1"])
+    connections = [{"gateway_id": "gw-1", "name": "Gateway 1", "connected": True}]
+    build_mock = AsyncMock(return_value=connections)
+    monkeypatch.setattr("mcpgateway.admin.build_user_oauth_connections", build_mock)
+
+    mock_request.headers = {}
+    response = await admin_oauth_connections_partial_html(
+        mock_request,
+        db=mock_db,
+        user={"email": "user@example.com", "db": mock_db},
+    )
+    assert isinstance(response, HTMLResponse)
+    _args, kwargs = build_mock.call_args
+    assert kwargs["user_email"] == "user@example.com"
+    assert kwargs["is_admin"] is False
+    assert kwargs["team_ids"] == ["team-1"]
+    template_call = mock_request.app.state.templates.TemplateResponse.call_args
+    assert template_call[0][1] == "oauth_connections_partial.html"
+    assert template_call[0][2]["connections"] == connections
+
+
+@pytest.mark.asyncio
+async def test_admin_oauth_connections_partial_html_scoped_token_disables_admin_bypass(monkeypatch, mock_request, mock_db):
+    """A team-scoped token must not widen visibility via the admin flag."""
+    setup_team_service(monkeypatch, ["team-1"])
+    build_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr("mcpgateway.admin.build_user_oauth_connections", build_mock)
+
+    mock_request.headers = {}
+    response = await admin_oauth_connections_partial_html(
+        mock_request,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db, "is_admin": True, "token_teams": ["team-1"]},
+    )
+    assert isinstance(response, HTMLResponse)
+    _args, kwargs = build_mock.call_args
+    assert kwargs["is_admin"] is False
+    assert kwargs["team_ids"] == ["team-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcpgateway/test_admin.py
+++ b/tests/unit/mcpgateway/test_admin.py
@@ -144,6 +144,7 @@ from mcpgateway.admin import (  # admin_get_metrics,
     admin_logout_get,
     admin_logout_post,
     admin_metrics_partial_html,
+    admin_oauth_connections_partial_html,
     admin_prompts_partial_html,
     admin_revoke_token,
     admin_reject_join_request,
@@ -12540,6 +12541,49 @@ async def test_admin_gateways_partial_html_default_includes_inactive(monkeypatch
     assert isinstance(response, HTMLResponse)
     context = mock_request.app.state.templates.TemplateResponse.call_args[0][2]
     assert context["query_params"]["include_inactive"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_admin_oauth_connections_partial_html_renders(monkeypatch, mock_request, mock_db):
+    """Render the per-user OAuth connections partial via the shared data assembly."""
+    setup_team_service(monkeypatch, ["team-1"])
+    connections = [{"gateway_id": "gw-1", "name": "Gateway 1", "connected": True}]
+    build_mock = AsyncMock(return_value=connections)
+    monkeypatch.setattr("mcpgateway.admin.build_user_oauth_connections", build_mock)
+
+    mock_request.headers = {}
+    response = await admin_oauth_connections_partial_html(
+        mock_request,
+        db=mock_db,
+        user={"email": "user@example.com", "db": mock_db},
+    )
+    assert isinstance(response, HTMLResponse)
+    _args, kwargs = build_mock.call_args
+    assert kwargs["user_email"] == "user@example.com"
+    assert kwargs["is_admin"] is False
+    assert kwargs["team_ids"] == ["team-1"]
+    template_call = mock_request.app.state.templates.TemplateResponse.call_args
+    assert template_call[0][1] == "oauth_connections_partial.html"
+    assert template_call[0][2]["connections"] == connections
+
+
+@pytest.mark.asyncio
+async def test_admin_oauth_connections_partial_html_scoped_token_disables_admin_bypass(monkeypatch, mock_request, mock_db):
+    """A team-scoped token must not widen visibility via the admin flag."""
+    setup_team_service(monkeypatch, ["team-1"])
+    build_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr("mcpgateway.admin.build_user_oauth_connections", build_mock)
+
+    mock_request.headers = {}
+    response = await admin_oauth_connections_partial_html(
+        mock_request,
+        db=mock_db,
+        user={"email": "admin@example.com", "db": mock_db, "is_admin": True, "token_teams": ["team-1"]},
+    )
+    assert isinstance(response, HTMLResponse)
+    _args, kwargs = build_mock.call_args
+    assert kwargs["is_admin"] is False
+    assert kwargs["team_ids"] == ["team-1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# feat(oauth): add per-user OAuth connections view

Resolves #5592

## Summary

Adds a per-user "OAuth Connections" view in two layers:

1. **API** — `GET /oauth/connections` returns, for the authenticated user, every OAuth
   Authorization Code gateway they can see (owned, team-visible, or public; unrestricted
   admins see all), merged with the user's own stored token status:

   ```json
   {
     "connections": [
       {
         "gateway_id": "abc123",
         "name": "GitHub MCP",
         "url": "https://github-mcp.example.com/mcp",
         "description": "GitHub tools",
         "connected": true,
         "expires_at": "2026-07-11T00:00:00+00:00",
         "is_expired": false,
         "scopes": ["repo"],
         "updated_at": "2026-07-10T00:00:00+00:00",
         "authorize_url": "/oauth/authorize/abc123"
       }
     ]
   }
   ```

   Token material (access/refresh tokens) is never selected into results or returned.

2. **Admin UI** — a new "OAuth Connections" tab (HTMX partial, no new JS) listing those
   gateways with a Connected / Expired / Not connected status pill, expiry, scopes, and an
   Authorize / Re-authorize link per row. The tab is gated on `gateways.read` (validated by
   the startup `SECTION_PERMISSIONS` check) and is hideable via
   `MCPGATEWAY_UI_HIDE_SECTIONS=oauth-connections`.

## Motivation

Requested in #5592. Today a user who has authorized several OAuth gateways has no way to
see which gateways they are connected to, whether their tokens have expired, or where to
go to re-authorize — token state is only visible in the `oauth_tokens` table. This is the
per-user counterpart of the admin-level token visibility work discussed in #782, and the
natural future host for per-user disconnect/revocation (#5501 — intentionally out of scope
here; the docs still list revocation as a known gap).

## Implementation notes

- `TokenStorageService.list_user_token_info(app_user_email)` — one query over
  `oauth_tokens`, returning the same field shape as `get_token_info()` keyed by gateway id.
- `build_user_oauth_connections()` in `oauth_router.py` is shared by the API endpoint and
  the admin partial, so the two surfaces cannot drift.
- Gateway visibility mirrors the admin gateways-partial access conditions (owner / team /
  public via a single SQL query); `grant_type` is filtered in Python since `oauth_config`
  is a JSON column (portable across SQLite/Postgres, gateway counts are small).
- Team-scoped API tokens never widen visibility through admin status (mirrors
  `get_hidden_sections_for_user` semantics).

## Screenshots

Captured from a local run of this branch (SQLite, seeded with one connected, one expired,
and one not-connected Authorization Code gateway for the admin user):

**Light mode**

![OAuth Connections tab, light mode](https://raw.githubusercontent.com/christophercolumbusdog/mcp-context-forge/assets/oauth-connections/oauth-connections-light.png)

**Dark mode**

![OAuth Connections tab, dark mode](https://raw.githubusercontent.com/christophercolumbusdog/mcp-context-forge/assets/oauth-connections/oauth-connections-dark.png)

On the same running instance, `GET /oauth/connections` (session auth) returned 200 with the
three entries in the documented shape — `connected=true, is_expired=false` (GitHub),
`connected=true, is_expired=true` (Atlassian), `connected=false` (GitLab) — and no token
material.

## Testing

New tests (direct-call style, matching siblings):

- `tests/unit/mcpgateway/routers/test_oauth_router.py::TestListOAuthConnections` — connected +
  not-connected merge with non-authorization-code gateways excluded, 401 without email,
  500 wrapping.
- `tests/unit/mcpgateway/test_admin.py` — partial renders via shared assembly; scoped-token
  admin does not bypass visibility.
- Doctest on `list_user_token_info` plus an end-to-end check of the query/merge against a
  real SQLite session (visibility filter, grant-type filter, token merge, root-path URL).

```
tests/unit/mcpgateway/routers/test_oauth_router.py .... 114 passed, 1 warning in 0.43s
  (-k Connections: 3 passed, 111 deselected)
tests/unit/mcpgateway/test_admin.py .................... 1193 passed (full file, exit 0)
  (-k oauth_connections: 2 passed, 1191 deselected)
tests/unit/mcpgateway/services/test_token_storage_service.py + --doctest-modules
  (token_storage_service.py, oauth_router.py) ......... 62 passed, 1 warning in 0.44s
tests/unit/mcpgateway/test_admin_menu_visibility.py
tests/unit/mcpgateway/test_admin_permission_helpers.py
tests/unit/mcpgateway/test_config.py ................... 210 passed, 1 warning in 2.33s
CI=1 validate_section_permissions(admin_router) ........ passed (17 mapped sections verified)
```

`ruff check` / `black --check` / `isort --check` on the changed files report only findings
that pre-exist on `main` (verified by diffing against a stash of the changes); all hunks
introduced here are clean.

## Note for maintainers

The commit contains both the API endpoint and the admin UI tab. If you'd prefer them split
into two commits (API first, UI second) for review or cherry-picking, I'm happy to rework
the branch.
