### PR TITLE
fix(security): validate all oauth_config URLs to prevent SSRF during gateway registration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(?x)( package-lock\\.json$ |Cargo\\.lock$ |uv\\.lock$ |go\\.sum$ |mcpgateway/sri_hashes\\.json$ )|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-07-09T15:16:14Z",
+  "generated_at": "2026-07-13T10:20:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4910,7 +4910,7 @@
         "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 592,
+        "line_number": 679,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/mcpgateway/schemas.py
+++ b/mcpgateway/schemas.py
@@ -146,7 +146,7 @@ def _validate_oauth_config_urls(v: Optional[Dict[str, Any]]) -> Optional[Dict[st
         return v
     if not isinstance(v, dict):
         raise ValueError("oauth_config must be an object")
-    for field_name in ("token_url", "authorization_url", "issuer", "authorization_server"):
+    for field_name in ("token_url", "authorization_url", "issuer", "authorization_server", "redirect_uri", "jwks_uri"):
         raw_value = v.get(field_name)
         if raw_value in (None, ""):
             continue

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -315,6 +315,11 @@ class OAuthManager:
         if isinstance(issuer, str) and issuer:
             runtime_credentials["issuer"] = validate_core_url(issuer, "OAuth config issuer")
 
+        for url_key in ("redirect_uri", "jwks_uri"):
+            url_value = runtime_credentials.get(url_key)
+            if isinstance(url_value, str) and url_value:
+                runtime_credentials[url_key] = validate_core_url(url_value, f"OAuth config {url_key}")
+
         auth_servers = runtime_credentials.get("authorization_servers")
         if auth_servers not in (None, ""):
             if not isinstance(auth_servers, list):
@@ -357,12 +362,16 @@ class OAuthManager:
         Returns:
             The HTTP response from the token endpoint.
         """
+        # SSRF defense: never follow redirects on token endpoints. The shared HTTP
+        # client sets follow_redirects=True, which would let a validated public
+        # token_url 302-redirect into an internal target (e.g. 169.254.169.254)
+        # after pre-fetch SSRF validation has already passed.
         if ca_certificate or client_cert or client_key:
             ssl_context = get_cached_ssl_context(ca_certificate, client_cert=client_cert, client_key=client_key)
             async with httpx.AsyncClient(verify=ssl_context) as client:
-                return await client.post(url, data=data, headers=headers, timeout=self.request_timeout)
+                return await client.post(url, data=data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
         client = await self._get_client()
-        return await client.post(url, data=data, headers=headers, timeout=self.request_timeout)
+        return await client.post(url, data=data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
 
     # Keys whose values must never be echoed in error messages or logs.
     _SENSITIVE_TOKEN_KEYS = frozenset({"access_token", "refresh_token", "id_token", "client_secret", "password", "subject_token"})
@@ -740,7 +749,7 @@ class OAuthManager:
         for attempt in range(self.max_retries):
             try:
                 client = await self._get_client()
-                response = await client.post(token_url, data=token_data, headers=headers, timeout=self.request_timeout)
+                response = await client.post(token_url, data=token_data, headers=headers, timeout=self.request_timeout, follow_redirects=False)
                 response.raise_for_status()
 
                 token_response = self._parse_token_response(response)
@@ -843,7 +852,8 @@ class OAuthManager:
 
         for attempt in range(self.max_retries):
             try:
-                response = await self._post_token_request(token_url, token_data, ca_certificate=ca_certificate, client_cert=client_cert, client_key=client_key)
+                client = await self._get_client()
+                response = await client.post(token_url, data=token_data, timeout=self.request_timeout, follow_redirects=False)
                 response.raise_for_status()
 
                 token_response = response.json()

--- a/mcpgateway/services/oauth_manager.py
+++ b/mcpgateway/services/oauth_manager.py
@@ -852,8 +852,13 @@ class OAuthManager:
 
         for attempt in range(self.max_retries):
             try:
-                client = await self._get_client()
-                response = await client.post(token_url, data=token_data, timeout=self.request_timeout, follow_redirects=False)
+                response = await self._post_token_request(
+                    token_url,
+                    token_data,
+                    ca_certificate=ca_certificate,
+                    client_cert=client_cert,
+                    client_key=client_key,
+                )
                 response.raise_for_status()
 
                 token_response = response.json()

--- a/tests/unit/mcpgateway/services/test_oauth_manager.py
+++ b/tests/unit/mcpgateway/services/test_oauth_manager.py
@@ -280,6 +280,93 @@ async def test_prepare_runtime_credentials_falls_back_when_decryption_fails(oaut
     assert runtime_credentials == credentials
 
 
+# ---------- SSRF deny-path regression tests (issue #407) ----------
+
+
+@pytest.mark.asyncio
+async def test_prepare_runtime_credentials_rejects_ssrf_token_url(oauth_manager):
+    """token_url in an always-blocked SSRF range (cloud metadata) is rejected at the service layer (defense-in-depth)."""
+    credentials = {"token_url": "http://169.254.169.254/latest/meta-data/"}
+
+    with (
+        patch("mcpgateway.services.oauth_manager.decrypt_oauth_config_for_runtime", new_callable=AsyncMock, return_value=credentials.copy()),
+        pytest.raises(ValueError, match="SSRF protection"),
+    ):
+        await oauth_manager._prepare_runtime_credentials(credentials, "client_credentials")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field_name", ["redirect_uri", "jwks_uri"])
+async def test_prepare_runtime_credentials_rejects_ssrf_redirect_and_jwks_uri(oauth_manager, field_name):
+    """redirect_uri and jwks_uri are validated against SSRF rules (Gap B)."""
+    credentials = {field_name: "http://169.254.169.254/latest/meta-data/"}
+
+    with (
+        patch("mcpgateway.services.oauth_manager.decrypt_oauth_config_for_runtime", new_callable=AsyncMock, return_value=credentials.copy()),
+        pytest.raises(ValueError, match="SSRF protection"),
+    ):
+        await oauth_manager._prepare_runtime_credentials(credentials, "client_credentials")
+
+
+@pytest.mark.asyncio
+async def test_prepare_runtime_credentials_allows_public_redirect_and_jwks_uri(oauth_manager):
+    """Public redirect_uri/jwks_uri pass validation and are returned unchanged."""
+    credentials = {
+        "redirect_uri": "https://gateway.example.com/oauth/callback",
+        "jwks_uri": "https://issuer.example.com/.well-known/jwks.json",
+    }
+
+    with patch("mcpgateway.services.oauth_manager.decrypt_oauth_config_for_runtime", new_callable=AsyncMock, return_value=credentials.copy()):
+        runtime_credentials = await oauth_manager._prepare_runtime_credentials(credentials, "authorization_code_exchange")
+
+    assert runtime_credentials["redirect_uri"] == "https://gateway.example.com/oauth/callback"
+    assert runtime_credentials["jwks_uri"] == "https://issuer.example.com/.well-known/jwks.json"
+
+
+@pytest.mark.asyncio
+async def test_post_token_request_disables_redirect_follow(oauth_manager):
+    """Gap A: token POST must set follow_redirects=False so a public token_url cannot 302 into an internal target."""
+    mock_response = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        await oauth_manager._post_token_request("https://auth.example.com/token", {"grant_type": "client_credentials"})
+
+    assert mock_client.post.call_args.kwargs["follow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_flow_disables_redirect_follow(oauth_manager):
+    """End-to-end: the client-credentials flow issues a non-redirect-following POST."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"access_token": "tok"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    with patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client):
+        await oauth_manager._client_credentials_flow({"client_id": "cid", "client_secret": "short", "token_url": "https://auth/token"})  # pragma: allowlist secret
+
+    assert mock_client.post.call_args.kwargs["follow_redirects"] is False
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_flow_ssrf_token_url_never_fetched(oauth_manager):
+    """A blocked token_url must fail validation before any HTTP call is made."""
+    mock_client = AsyncMock()
+    with (
+        patch.object(oauth_manager, "_get_client", new_callable=AsyncMock, return_value=mock_client),
+        patch("mcpgateway.services.oauth_manager.decrypt_oauth_config_for_runtime", new_callable=AsyncMock, side_effect=lambda cfg, **_: cfg),
+        pytest.raises(ValueError, match="SSRF protection"),
+    ):
+        await oauth_manager._client_credentials_flow(
+            {"client_id": "cid", "client_secret": "short", "token_url": "http://169.254.169.254/latest/meta-data/"}  # pragma: allowlist secret
+        )
+    mock_client.post.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_client_credentials_flow_decrypt_secret(oauth_manager):
     mock_response = MagicMock()

--- a/tests/unit/mcpgateway/test_config.py
+++ b/tests/unit/mcpgateway/test_config.py
@@ -669,6 +669,47 @@ def test_gateway_create_rejects_oauth_authorization_servers_with_blocked_urls():
     assert "SSRF protection" in str(exc_info.value)
 
 
+def test_gateway_create_rejects_ssrf_redirect_uri():
+    """Gateway creation should reject blocked oauth_config.redirect_uri (issue #407 Gap B)."""
+    with pytest.raises(ValidationError) as exc_info:
+        GatewayCreate(
+            name="blocked-oauth-redirect-uri",
+            url="https://example.com/sse",
+            auth_type="oauth",
+            oauth_config={
+                "grant_type": "authorization_code",
+                "client_id": "client-id",
+                "client_secret": "test-client-secret",  # pragma: allowlist secret
+                "authorization_url": "https://issuer.example/authorize",
+                "token_url": "https://issuer.example/token",
+                "redirect_uri": "http://169.254.169.254/latest/meta-data/",
+            },
+        )
+
+    assert "OAuth config redirect_uri" in str(exc_info.value)
+    assert "SSRF protection" in str(exc_info.value)
+
+
+def test_gateway_create_rejects_ssrf_jwks_uri():
+    """Gateway creation should reject blocked oauth_config.jwks_uri (issue #407 Gap B)."""
+    with pytest.raises(ValidationError) as exc_info:
+        GatewayCreate(
+            name="blocked-oauth-jwks-uri",
+            url="https://example.com/sse",
+            auth_type="oauth",
+            oauth_config={
+                "grant_type": "client_credentials",
+                "client_id": "client-id",
+                "client_secret": "test-client-secret",  # pragma: allowlist secret
+                "token_url": "https://issuer.example/token",
+                "jwks_uri": "http://169.254.169.254/.well-known/jwks.json",
+            },
+        )
+
+    assert "OAuth config jwks_uri" in str(exc_info.value)
+    assert "SSRF protection" in str(exc_info.value)
+
+
 def test_gateway_update_accepts_safe_public_oauth_token_url():
     """Gateway update should allow safe public OAuth token URLs."""
     from mcpgateway.schemas import GatewayUpdate


### PR DESCRIPTION
# Pull Request

Closes https://github.ibm.com/contextforge-org/internal_issues/issues/407

## Summary

Security hardening for OAuth gateway configuration handling. Extends the existing URL/SSRF validation applied to OAuth config so that all caller-supplied endpoint URLs are consistently checked, and tightens the outbound HTTP behavior of OAuth token requests.

## Changes

- **Broaden OAuth config URL validation** — `redirect_uri` and `jwks_uri` in `oauth_config` are now validated against the same core URL/SSRF rules already applied to `token_url`, `authorization_url`, `issuer`, and `authorization_server` (schema layer, on both create and update).
- **Defense-in-depth at runtime** — `oauth_manager._prepare_runtime_credentials()` re-validates `redirect_uri` and `jwks_uri` after decryption, matching the existing checks for the other endpoint URLs.
- **No redirect following on token endpoints** — OAuth token requests (`_post_token_request`, authorization-code exchange, RFC 8693 token exchange) now use `follow_redirects=False`, so a validated endpoint cannot be redirected to an unvalidated destination after the pre-request check.
- **Regression tests** — deny-path coverage for blocked URLs at both the schema and service layers, plus assertions that token POSTs do not follow redirects and that a blocked URL is never fetched.

## Type of Change

- [x] Bug fix / security hardening

## Verification

| Check       | Command                                                                 | Status |
|-------------|-------------------------------------------------------------------------|--------|
| Unit tests  | `pytest tests/unit/mcpgateway/services/test_oauth_manager.py tests/unit/mcpgateway/test_config.py` | ✅ 307 passed |
| OAuth suites | `pytest tests/unit/mcpgateway/test_oauth_manager.py tests/unit/mcpgateway/services/test_oauth_manager_pkce.py tests/unit/mcpgateway/services/test_gateway_service_oauth_comprehensive.py` | ✅ 260 passed |

## Checklist

- [x] Tests added for changes
- [x] No secrets or credentials committed
