### PR TITLE
test(protocol): remove xfail for GAP-001/GAP-002 — log and progress notifications now relayed

### DIFF
--- a/tests/live_gateway/protocol_compliance/COMPLIANCE_GAPS.md
+++ b/tests/live_gateway/protocol_compliance/COMPLIANCE_GAPS.md
@@ -84,52 +84,6 @@ the marker and the entry per the rules above.
 
 ---
 
-### GAP-001 — Server-initiated log notifications not delivered
-
-| | |
-|---|---|
-| **Targets affected** | `gateway_proxy`, `gateway_virtual` |
-| **Tests** | `test_logging.py::test_log_message_reaches_client`; secondary blocker for `test_notifications.py::test_tools_list_changed_notification_delivered` and `::test_resources_list_changed_notification_delivered` (primary GAP-008) |
-| **Spec** | [MCP 2025-11-25 — server `logging` capability](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging) |
-
-**Observed**: when an upstream tool calls `ctx.log(...)` during a tool
-invocation, the gateway accepts the upstream's `notifications/message`
-but does not relay it to the downstream client. The client's
-`log_handler` is never invoked.
-
-**Expected**: the spec requires the server to emit `notifications/message`
-to clients that subscribed via `logging/setLevel`. Federation should
-forward upstream-emitted log messages.
-
-**Why**: the log emitted during a tool call is a request-tied
-notification — it SHOULD ride the POST-correlated stream for that call.
-The gateway isn't relaying notifications on that stream. (Logs emitted
-*between* calls — e.g. in response to a `logging/setLevel` change —
-would ride the standalone stream, which #4205 also closes, but the
-test exercises the in-call path.)
-
----
-
-### GAP-002 — Progress notifications not delivered
-
-| | |
-|---|---|
-| **Targets affected** | `gateway_proxy`, `gateway_virtual` |
-| **Tests** | `test_utilities.py::test_progress_notifications_delivered`; secondary blocker for `test_notifications.py::test_tools_list_changed_notification_delivered` and `::test_resources_list_changed_notification_delivered` (primary GAP-008) |
-| **Spec** | [MCP 2025-11-25 — `progress` notifications](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress) |
-
-**Observed**: a tool calling `ctx.report_progress(...)` returns successfully,
-but the client's `progress_handler` is never invoked.
-
-**Expected**: with a `progressToken` on the request, the server must emit
-`notifications/progress` events the client can observe.
-
-**Why**: progress notifications are request-tied (the `progressToken`
-is scoped to one client request) and ride the POST-correlated stream
-of that request. Root cause is the gateway not relaying notifications
-on the POST-correlated stream — **not** #4205, which only closes the
-standalone GET stream that progress wouldn't have used anyway.
-
 ---
 
 ### GAP-003 — Client roots not forwarded to upstream
@@ -363,7 +317,7 @@ session that opened the subscription.
 not tied to any specific client request — per spec it rides the
 standalone stream (`GET /mcp/`). The gateway currently closes that
 stream with 405 (see #4205), so the notification has no channel to
-the client. Unlike the other server→client gaps (GAP-001/002/003/004/
+the client. Unlike the other server→client gaps (GAP-003/004/
 005), this one is genuinely about the standalone stream and #4205 is
 the correct blocker.
 
@@ -438,6 +392,18 @@ on this test.
 ---
 
 ## Closed gaps
+
+### GAP-001 — Server-initiated log notifications not delivered *(closed 2026-07-13)*
+
+**Was**: `test_logging.py::test_log_message_reaches_client` xfailed on `gateway_proxy` and `gateway_virtual` because the gateway did not relay `notifications/message` on the POST-correlated stream.
+
+**How closed**: Tests now pass on both gateway targets — the POST-correlated notification relay was fixed. `xfail_on` removed from `test_log_message_reaches_client`. Note: `test_logging_set_level_filters_below_threshold` retains its `xfail_on` (separate test with additional setLevel filtering assertions).
+
+### GAP-002 — Progress notifications not delivered *(closed 2026-07-13)*
+
+**Was**: `test_utilities.py::test_progress_notifications_delivered` xfailed on `gateway_proxy` and `gateway_virtual` because the gateway did not relay `notifications/progress` on the POST-correlated stream.
+
+**How closed**: Tests now pass on both gateway targets — same POST-correlated notification relay fix as GAP-001. `xfail_on` removed from `test_progress_notifications_delivered`.
 
 ### GAP-007 — `tools/list` pagination cap below upstream tool count *(closed 2026-04-18)*
 

--- a/tests/live_gateway/protocol_compliance/test_logging.py
+++ b/tests/live_gateway/protocol_compliance/test_logging.py
@@ -16,16 +16,8 @@ from .helpers.compliance import resolve_tool, xfail_on
 pytestmark = [pytest.mark.protocol_compliance, pytest.mark.mcp_server_features]
 
 
-async def test_log_message_reaches_client(connect, request) -> None:
+async def test_log_message_reaches_client(connect) -> None:
     """log_at_level delivers a logging/message notification to the client."""
-    xfail_on(
-        request,
-        "gateway_proxy",
-        "gateway_virtual",
-        reason=(
-            "GAP-001: log emitted during a tool call is a request-tied " "notification and should ride the POST-correlated stream of that " "call; gateway does not relay notifications on that stream."
-        ),
-    )
     received: list[tuple[str, str]] = []
 
     async def log_handler(msg):

--- a/tests/live_gateway/protocol_compliance/test_utilities.py
+++ b/tests/live_gateway/protocol_compliance/test_utilities.py
@@ -20,14 +20,8 @@ from .helpers.compliance import resolve_tool, xfail_on
 pytestmark = [pytest.mark.protocol_compliance, pytest.mark.mcp_utilities]
 
 
-async def test_progress_notifications_delivered(connect, request) -> None:
+async def test_progress_notifications_delivered(connect) -> None:
     """progress_reporter tool emits progress events observable on the client."""
-    xfail_on(
-        request,
-        "gateway_proxy",
-        "gateway_virtual",
-        reason=("GAP-002: gateway does not relay progress notifications on the " "POST-correlated stream of the originating tool call (spec § " "Listening for Messages from the Server)."),
-    )
     events: list[tuple[float, float | None, str | None]] = []
 
     async def on_progress(progress, total, message):


### PR DESCRIPTION
## Summary

The POST-correlated notification relay now works end-to-end on gateway targets, closing the two long-standing compliance gaps for request-tied notifications.

## Changes

- **Remove ** from  and  on  and  targets
- **Move GAP-001 and GAP-002** to Closed gaps in `COMPLIANCE_GAPS.md`
- **Update GAP-011** cross-reference to remove the now-closed gaps from its server→client gap enumeration
- Drop unused `request` parameter from both test signatures

## Gap Details

- **GAP-001** (Server-initiated log notifications): `notifications/message` emitted during a tool call now rides the POST-correlated stream through the gateway to the downstream client.
- **GAP-002** (Progress notifications): `notifications/progress` scoped to a `progressToken` now delivers on the POST-correlated stream of the originating request.

Both gaps shared the same root cause — the gateway was not relaying notifications on the POST-correlated stream.

## Notes

- `test_logging_set_level_filters_below_threshold` retains its `xfail_on` (separate test with additional `setLevel` filtering assertions).
- Tests co-blocked on GAP-001/002 in `test_notifications.py` remain xfailed under their primary blocker (GAP-008 — tool federation).