### PR TITLE
feat(ui-rewrite): generate tool schemas from OpenAPI in Create and Edit REST Tool form

### DIFF
--- a/client/src/api/tools.test.ts
+++ b/client/src/api/tools.test.ts
@@ -185,4 +185,53 @@ describe("toolsApi", () => {
       await expect(toolsApi.deactivate("tool-abc-123")).rejects.toThrow("HTTP 403");
     });
   });
+
+  describe("generateSchemasFromOpenapi", () => {
+    it("POSTs to /v1/tools/generate-schemas-from-openapi and returns the schemas", async () => {
+      const body = {
+        message: "Schemas generated successfully",
+        success: true,
+        input_schema: { type: "object" },
+        output_schema: null,
+        spec_url: "https://api.example.com/openapi.json",
+      };
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const result = await toolsApi.generateSchemasFromOpenapi({
+        url: "https://api.example.com/v1/calculate",
+        request_type: "POST",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/v1/tools/generate-schemas-from-openapi"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({ "X-CSRF-Token": "test-csrf-token" }),
+          credentials: "same-origin", // pragma: allowlist secret
+        }),
+      );
+      expect(result).toEqual(body);
+    });
+
+    it("throws ApiError carrying the backend status on failure", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: false, message: "blocked" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      await expect(
+        toolsApi.generateSchemasFromOpenapi({
+          url: "https://api.example.com/v1/calculate",
+          request_type: "POST",
+        }),
+      ).rejects.toThrow("HTTP 400");
+    });
+  });
 });

--- a/client/src/api/tools.ts
+++ b/client/src/api/tools.ts
@@ -4,6 +4,32 @@
 
 import { api } from "./client";
 import type { Tool } from "@/types/tool";
+import type { GenerateSchemaRequest } from "@/generated/types/generateSchemaRequest";
+
+/**
+ * Request body for {@link toolsApi.generateSchemasFromOpenapi}.
+ *
+ * Re-exported from the generated OpenAPI client so the shape stays in lockstep
+ * with the backend contract (`url`, optional `request_type`, optional
+ * `openapi_url`).
+ */
+export type GenerateSchemasFromOpenapiInput = GenerateSchemaRequest;
+
+/**
+ * Response from `POST /v1/tools/generate-schemas-from-openapi`.
+ *
+ * The endpoint returns an untyped `JSONResponse` on the backend, so orval
+ * generates only `data: unknown` for it; this narrows that shape by hand.
+ */
+export interface GenerateSchemasFromOpenapiResult {
+  message: string;
+  success: boolean;
+  input_schema: Record<string, unknown> | null;
+  output_schema: Record<string, unknown> | null;
+  spec_url: string;
+  /** Set by the backend when the spec host requires authentication. */
+  requires_auth?: boolean;
+}
 
 /**
  * Validates tool ID to prevent path traversal and injection attacks
@@ -66,4 +92,20 @@ export const toolsApi = {
     const validId = validateToolId(id);
     return api.post(`/tools/${validId}/state?activate=false`);
   },
+
+  /**
+   * Generate input/output JSON schemas for a REST tool from its OpenAPI spec.
+   *
+   * Delegates to `POST /v1/tools/generate-schemas-from-openapi`, which fetches
+   * the OpenAPI 3.x document for the tool host, resolves the requested
+   * path + method, and returns the extracted schemas plus the `spec_url` it used.
+   * Requires the `tools.create` permission. Rejects with an {@link ApiError}
+   * carrying the backend status code (400/404/502/500) on failure.
+   *
+   * @param input - Tool URL, HTTP method, and optional spec URL / auth
+   */
+  generateSchemasFromOpenapi: (
+    input: GenerateSchemasFromOpenapiInput,
+  ): Promise<GenerateSchemasFromOpenapiResult> =>
+    api.post<GenerateSchemasFromOpenapiResult>("/v1/tools/generate-schemas-from-openapi", input),
 };

--- a/client/src/components/tools/ToolForm.test.tsx
+++ b/client/src/components/tools/ToolForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { render } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
@@ -256,6 +256,126 @@ describe("ToolForm", () => {
     });
   });
 
+  describe("Schema generation from OpenAPI", () => {
+    it("shows the 'Generated from' caption with the returned spec_url", async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json({
+            success: true,
+            input_schema: { type: "object", properties: {} },
+            output_schema: null,
+            spec_url: "https://api.example.com/openapi.json",
+            message: "ok",
+          }),
+        ),
+      );
+      renderForm();
+
+      await user.type(screen.getByLabelText(/URL/), "https://api.example.com/endpoint");
+      await user.click(screen.getByRole("button", { name: /Generate/i }));
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Generated from https:\/\/api\.example\.com\/openapi\.json/i),
+        ).toBeInTheDocument(),
+      );
+    });
+
+    it("confirms before overwriting an existing manually-entered schema", async () => {
+      const user = userEvent.setup();
+      const postSpy = vi.fn(() =>
+        HttpResponse.json({
+          success: true,
+          input_schema: { type: "object", properties: {} },
+          output_schema: null,
+          spec_url: "https://api.example.com/openapi.json",
+          message: "ok",
+        }),
+      );
+      server.use(http.post("*/v1/tools/generate-schemas-from-openapi", postSpy));
+      renderForm();
+
+      await user.type(screen.getByLabelText(/URL/), "https://api.example.com/endpoint");
+      // Seed a manual schema so the generate button must confirm first.
+      await user.click(screen.getByRole("button", { name: /Add manually/i }));
+
+      await user.click(screen.getByRole("button", { name: /Generate/i }));
+
+      // The API is not called until the user confirms the overwrite.
+      const dialog = await screen.findByRole("dialog");
+      expect(postSpy).not.toHaveBeenCalled();
+
+      await user.click(within(dialog).getByRole("button", { name: /Replace/i }));
+
+      await waitFor(() => expect(postSpy).toHaveBeenCalledOnce());
+    });
+
+    it("does not confirm when both schema fields are empty", async () => {
+      const user = userEvent.setup();
+      const postSpy = vi.fn(() =>
+        HttpResponse.json({
+          success: true,
+          input_schema: { type: "object", properties: {} },
+          output_schema: null,
+          spec_url: "https://api.example.com/openapi.json",
+          message: "ok",
+        }),
+      );
+      server.use(http.post("*/v1/tools/generate-schemas-from-openapi", postSpy));
+      renderForm();
+
+      await user.type(screen.getByLabelText(/URL/), "https://api.example.com/endpoint");
+      await user.click(screen.getByRole("button", { name: /Generate/i }));
+
+      await waitFor(() => expect(postSpy).toHaveBeenCalledOnce());
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("switches the button label to Regenerate after a successful generation", async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json({
+            success: true,
+            input_schema: { type: "object", properties: {} },
+            output_schema: null,
+            spec_url: "https://api.example.com/openapi.json",
+            message: "ok",
+          }),
+        ),
+      );
+      renderForm();
+
+      await user.type(screen.getByLabelText(/URL/), "https://api.example.com/endpoint");
+      await user.click(screen.getByRole("button", { name: /^Generate$/i }));
+
+      await waitFor(() =>
+        expect(screen.getByRole("button", { name: /Regenerate/i })).toBeInTheDocument(),
+      );
+    });
+
+    it("announces a generation failure via an assertive alert", async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json(
+            { success: false, message: "OpenAPI spec server returned HTTP 502" },
+            { status: 502 },
+          ),
+        ),
+      );
+      renderForm();
+
+      await user.type(screen.getByLabelText(/URL/), "https://api.example.com/endpoint");
+      await user.click(screen.getByRole("button", { name: /Generate/i }));
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveAttribute("aria-live", "assertive");
+      expect(alert).toHaveTextContent(/Couldn't fetch the OpenAPI spec/i);
+    });
+  });
+
   describe("Edit mode (tool prop provided)", () => {
     beforeEach(() => {
       server.use(
@@ -296,6 +416,30 @@ describe("ToolForm", () => {
     it("shows request type radio group for REST tools", () => {
       renderForm({ tool: createMockTool({ integrationType: "REST", requestType: "POST" }) });
       expect(screen.getByRole("radiogroup", { name: "Request type" })).toBeInTheDocument();
+    });
+
+    it("shows the Generate button when editing a REST tool", () => {
+      renderForm({ tool: createMockTool({ integrationType: "REST", requestType: "POST" }) });
+      expect(screen.getByRole("button", { name: /Generate/i })).toBeInTheDocument();
+    });
+
+    it("does not show the Generate button when editing an MCP tool", () => {
+      renderForm({
+        tool: createMockTool({ integrationType: "MCP", requestType: "STREAMABLEHTTP" }),
+      });
+      expect(screen.queryByRole("button", { name: /Generate/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Regenerate/i })).not.toBeInTheDocument();
+    });
+
+    it("does not show the Add manually button when editing", () => {
+      renderForm({ tool: createMockTool() });
+      expect(screen.queryByRole("button", { name: /Add manually/i })).not.toBeInTheDocument();
+    });
+
+    it("always shows the input and output schema fields when editing, even with no schema", () => {
+      renderForm({ tool: createMockTool() });
+      expect(screen.getByLabelText(/Input schema/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/Output schema/)).toBeInTheDocument();
     });
 
     it("calls onSuccess after successful tool update", async () => {

--- a/client/src/components/tools/ToolForm.tsx
+++ b/client/src/components/tools/ToolForm.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ToolAdvancedSettings } from "@/components/tools/ToolAdvancedSettings";
+import { ConfirmDialog } from "@/components/servers/ConfirmDialog";
 import { useToolForm, type RequestType, type SchemaMode, type AuthType } from "@/hooks/useToolForm";
 import type { Tool } from "@/types/tool";
 import type { Visibility } from "@/types/server";
@@ -62,6 +63,7 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
   const intl = useIntl();
   const [copiedInput, setCopiedInput] = useState(false);
   const [copiedOutput, setCopiedOutput] = useState(false);
+  const [showOverwriteConfirm, setShowOverwriteConfirm] = useState(false);
 
   const isEditMode = Boolean(tool);
 
@@ -89,6 +91,7 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
     schemaMode,
     openApiSpecUrl,
     showSpecUrlInput,
+    generatedSpecUrl,
     errors,
     isValid,
     isSubmitting,
@@ -149,6 +152,20 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
 
   const handleCancel = () => {
     onToggle();
+  };
+
+  // Schema generation reads an OpenAPI spec, so it only applies to REST tools.
+  // This form only ever creates REST tools, so "MCP" appears only when editing.
+  const showGenerate = integrationType === "REST";
+
+  // Guard against silently clobbering schemas the user has already entered:
+  // confirm first whenever either schema field is non-empty.
+  const handleGenerateClick = () => {
+    if (inputSchema.trim() || outputSchema.trim()) {
+      setShowOverwriteConfirm(true);
+    } else {
+      void generateSchema();
+    }
   };
 
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -285,45 +302,63 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
                 <p className="text-sm text-neutral-600 dark:text-neutral-400">
                   {intl.formatMessage({ id: "tools.form.schema.description" })}
                 </p>
-                <div className="flex gap-3">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="flex-1 gap-2"
-                    disabled={isGeneratingSchema || !url.trim()}
-                    onClick={() => void generateSchema()}
-                  >
-                    {schemaMode === "generated" ? (
-                      <RefreshCw
-                        className={`h-4 w-4 ${isGeneratingSchema ? "animate-spin" : ""}`}
-                      />
-                    ) : (
-                      <Zap className={`h-4 w-4 ${isGeneratingSchema ? "animate-pulse" : ""}`} />
+                {/* Generate reads an OpenAPI spec (REST only); "Add manually"
+                    reveals the fields in add-mode (when editing they're always
+                    shown below). */}
+                {showGenerate && (
+                  <div className="flex gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="flex-1 gap-2"
+                      disabled={isGeneratingSchema || !url.trim() || !requestType}
+                      onClick={handleGenerateClick}
+                    >
+                      {schemaMode === "generated" ? (
+                        <RefreshCw
+                          className={`h-4 w-4 ${isGeneratingSchema ? "animate-spin" : ""}`}
+                        />
+                      ) : (
+                        <Zap className={`h-4 w-4 ${isGeneratingSchema ? "animate-pulse" : ""}`} />
+                      )}
+                      {isGeneratingSchema
+                        ? intl.formatMessage({ id: "tools.form.schema.generating" })
+                        : schemaMode === "generated"
+                          ? intl.formatMessage({ id: "tools.form.schema.regenerate" })
+                          : intl.formatMessage({ id: "tools.form.schema.generate" })}
+                    </Button>
+                    {!isEditMode && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="flex-1"
+                        onClick={() => {
+                          setSchemaMode("manual");
+                          if (!inputSchema.trim()) {
+                            setInputSchema('{\n  "type": "object",\n  "properties": {}\n}');
+                          }
+                        }}
+                      >
+                        {intl.formatMessage({ id: "tools.form.schema.addManually" })}
+                      </Button>
                     )}
-                    {isGeneratingSchema
-                      ? intl.formatMessage({ id: "tools.form.schema.generating" })
-                      : schemaMode === "generated"
-                        ? intl.formatMessage({ id: "tools.form.schema.regenerate" })
-                        : intl.formatMessage({ id: "tools.form.schema.generate" })}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="flex-1"
-                    onClick={() => {
-                      setSchemaMode("manual");
-                      if (!inputSchema.trim()) {
-                        setInputSchema('{\n  "type": "object",\n  "properties": {}\n}');
-                      }
-                    }}
-                  >
-                    {intl.formatMessage({ id: "tools.form.schema.addManually" })}
-                  </Button>
-                </div>
+                  </div>
+                )}
+
+                {schemaMode === "generated" && generatedSpecUrl && !errors.schema && (
+                  <p aria-live="polite" className="text-xs text-neutral-500 dark:text-neutral-400">
+                    {intl.formatMessage(
+                      { id: "tools.form.schema.generatedFrom" },
+                      { specUrl: generatedSpecUrl },
+                    )}
+                  </p>
+                )}
 
                 {errors.schema && (
                   <div className="space-y-2">
-                    <p className="text-sm text-red-500">{errors.schema}</p>
+                    <p role="alert" aria-live="assertive" className="text-sm text-red-500">
+                      {errors.schema}
+                    </p>
                     {showSpecUrlInput && (
                       <div className="space-y-1">
                         <label
@@ -346,7 +381,9 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
                   </div>
                 )}
 
-                {schemaMode !== "none" && (
+                {/* In edit mode the schemas are the thing being edited, so the
+                    fields are always visible even when empty. */}
+                {(isEditMode || schemaMode !== "none") && (
                   <div className="space-y-4">
                     <div className="space-y-1.5">
                       <label
@@ -498,6 +535,16 @@ export function ToolForm({ isOpen, onToggle, onSuccess, tool }: ToolFormProps) {
           </form>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={showOverwriteConfirm}
+        onOpenChange={setShowOverwriteConfirm}
+        title={intl.formatMessage({ id: "tools.form.schema.overwrite.title" })}
+        description={intl.formatMessage({ id: "tools.form.schema.overwrite.description" })}
+        confirmLabel={intl.formatMessage({ id: "tools.form.schema.overwrite.confirm" })}
+        cancelLabel={intl.formatMessage({ id: "tools.form.cancel" })}
+        onConfirm={() => void generateSchema()}
+      />
     </>
   );
 }

--- a/client/src/hooks/useGenerateSchemaFromOpenapi.test.ts
+++ b/client/src/hooks/useGenerateSchemaFromOpenapi.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook as rtlRenderHook, act, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
+import enMessages from "@/i18n/locales/en-US";
+import { useGenerateSchemaFromOpenapi } from "./useGenerateSchemaFromOpenapi";
+
+const ENDPOINT = "*/v1/tools/generate-schemas-from-openapi";
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    IntlProvider,
+    { locale: "en", defaultLocale: "en", messages: enMessages },
+    children,
+  );
+
+const renderHook = <Result, Props>(render: (initialProps: Props) => Result) =>
+  rtlRenderHook(render, { wrapper });
+
+function okResponse(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json({
+    success: true,
+    input_schema: null,
+    output_schema: null,
+    spec_url: "https://api.example.com/openapi.json",
+    message: "ok",
+    ...overrides,
+  });
+}
+
+describe("useGenerateSchemaFromOpenapi", () => {
+  describe("URL guarding", () => {
+    it.each(["javascript:alert(1)", "ftp://files.example.com/spec.json", "not-a-url", "   "])(
+      "does not call the API for %s and does not report success",
+      async (badUrl) => {
+        const postSpy = vi.fn(() => okResponse());
+        server.use(http.post(ENDPOINT, postSpy));
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+        await act(async () => {
+          await result.current.generate({
+            url: badUrl,
+            requestType: "POST",
+            onSuccess,
+            onError,
+          });
+        });
+
+        expect(postSpy).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(result.current.isGenerating).toBe(false);
+      },
+    );
+  });
+
+  describe("request payload", () => {
+    it("sends only url and request_type when no spec URL is set", async () => {
+      let body: Record<string, unknown> | undefined;
+      server.use(
+        http.post(ENDPOINT, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>;
+          return okResponse();
+        }),
+      );
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "PUT",
+          onSuccess: vi.fn(),
+        });
+      });
+
+      await waitFor(() => expect(body).toBeDefined());
+      expect(body).toEqual({ url: "https://api.example.com/endpoint", request_type: "PUT" });
+    });
+
+    it("excludes a non-http spec URL from the request", async () => {
+      let body: Record<string, unknown> | undefined;
+      server.use(
+        http.post(ENDPOINT, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>;
+          return okResponse();
+        }),
+      );
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      act(() => result.current.setOpenApiSpecUrl("ftp://bad.example.com/spec.json"));
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "GET",
+          onSuccess: vi.fn(),
+        });
+      });
+
+      await waitFor(() => expect(body).toBeDefined());
+      expect(body?.openapi_url).toBeUndefined();
+    });
+
+    it("includes a valid https spec URL in the request", async () => {
+      let body: Record<string, unknown> | undefined;
+      server.use(
+        http.post(ENDPOINT, async ({ request }) => {
+          body = (await request.json()) as Record<string, unknown>;
+          return okResponse();
+        }),
+      );
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      act(() => result.current.setOpenApiSpecUrl("https://api.example.com/openapi.json"));
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "GET",
+          onSuccess: vi.fn(),
+        });
+      });
+
+      await waitFor(() => expect(body).toBeDefined());
+      expect(body?.openapi_url).toBe("https://api.example.com/openapi.json");
+    });
+  });
+
+  describe("success", () => {
+    it("pretty-prints schemas, exposes the spec URL, and calls onSuccess", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          okResponse({
+            input_schema: { type: "object", properties: { a: { type: "string" } } },
+            output_schema: { type: "object" },
+          }),
+        ),
+      );
+      const onSuccess = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess,
+        });
+      });
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+      expect(onSuccess).toHaveBeenCalledWith({
+        inputSchema: JSON.stringify(
+          { type: "object", properties: { a: { type: "string" } } },
+          null,
+          2,
+        ),
+        outputSchema: JSON.stringify({ type: "object" }, null, 2),
+        specUrl: "https://api.example.com/openapi.json",
+      });
+      expect(result.current.generatedSpecUrl).toBe("https://api.example.com/openapi.json");
+    });
+
+    it("passes empty strings for null schemas", async () => {
+      server.use(http.post(ENDPOINT, () => okResponse()));
+      const onSuccess = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess,
+        });
+      });
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledOnce());
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ inputSchema: "", outputSchema: "" }),
+      );
+    });
+  });
+
+  describe("error status mapping", () => {
+    const cases: Array<{ status: number; expected: string }> = [
+      { status: 400, expected: "URL not reachable from the gateway (blocked by SSRF protection)" },
+      {
+        status: 502,
+        expected: "Couldn't fetch the OpenAPI spec — check that the URL is correct and reachable",
+      },
+      {
+        status: 500,
+        expected: "Something went wrong while generating the schema. Please try again.",
+      },
+    ];
+
+    it.each(cases)(
+      "maps HTTP $status to a clear message and reveals the spec-URL fallback",
+      async ({ status, expected }) => {
+        server.use(
+          http.post(ENDPOINT, () =>
+            HttpResponse.json({ success: false, message: "backend detail" }, { status }),
+          ),
+        );
+        const onError = vi.fn();
+        const onSuccess = vi.fn();
+
+        const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+        await act(async () => {
+          await result.current.generate({
+            url: "https://api.example.com/endpoint",
+            requestType: "POST",
+            onSuccess,
+            onError,
+          });
+        });
+
+        await waitFor(() => expect(onError).toHaveBeenCalledWith(expected));
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.showSpecUrlInput).toBe(true);
+        expect(result.current.generatedSpecUrl).toBe("");
+      },
+    );
+
+    it("maps a 502 wrapping an upstream 401 to an auth-required message", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          HttpResponse.json(
+            { success: false, message: "OpenAPI spec server returned HTTP 401" },
+            { status: 502 },
+          ),
+        ),
+      );
+      const onError = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess: vi.fn(),
+          onError,
+        });
+      });
+
+      await waitFor(() =>
+        expect(onError).toHaveBeenCalledWith(expect.stringContaining("requires authentication")),
+      );
+    });
+
+    it("maps HTTP 404 to a message including the path and method", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          HttpResponse.json({ success: false, message: "not found" }, { status: 404 }),
+        ),
+      );
+      const onError = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/v1/calculate",
+          requestType: "POST",
+          onSuccess: vi.fn(),
+          onError,
+        });
+      });
+
+      await waitFor(() =>
+        expect(onError).toHaveBeenCalledWith(
+          "The path /v1/calculate with method POST is not in the OpenAPI spec",
+        ),
+      );
+    });
+
+    it("calls onRequiresAuth when the backend reports requires_auth", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          HttpResponse.json(
+            { success: false, message: "auth", requires_auth: true },
+            { status: 400 },
+          ),
+        ),
+      );
+      const onRequiresAuth = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess: vi.fn(),
+          onError: vi.fn(),
+          onRequiresAuth,
+        });
+      });
+
+      await waitFor(() => expect(onRequiresAuth).toHaveBeenCalledOnce());
+    });
+
+    it("reports a success:false body through onError and reveals the fallback", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          HttpResponse.json({ success: false, message: "Custom backend message" }),
+        ),
+      );
+      const onError = vi.fn();
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess: vi.fn(),
+          onError,
+        });
+      });
+
+      await waitFor(() => expect(onError).toHaveBeenCalledWith("Custom backend message"));
+      expect(result.current.showSpecUrlInput).toBe(true);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears generatedSpecUrl, spec URL input, and the fallback flag", async () => {
+      server.use(
+        http.post(ENDPOINT, () =>
+          HttpResponse.json({ success: false, message: "boom" }, { status: 500 }),
+        ),
+      );
+
+      const { result } = renderHook(() => useGenerateSchemaFromOpenapi());
+
+      act(() => result.current.setOpenApiSpecUrl("https://api.example.com/openapi.json"));
+      await act(async () => {
+        await result.current.generate({
+          url: "https://api.example.com/endpoint",
+          requestType: "POST",
+          onSuccess: vi.fn(),
+          onError: vi.fn(),
+        });
+      });
+      await waitFor(() => expect(result.current.showSpecUrlInput).toBe(true));
+
+      act(() => result.current.reset());
+
+      expect(result.current.showSpecUrlInput).toBe(false);
+      expect(result.current.openApiSpecUrl).toBe("");
+      expect(result.current.generatedSpecUrl).toBe("");
+    });
+  });
+});

--- a/client/src/hooks/useGenerateSchemaFromOpenapi.ts
+++ b/client/src/hooks/useGenerateSchemaFromOpenapi.ts
@@ -1,0 +1,177 @@
+import { useCallback, useState } from "react";
+import { useIntl } from "react-intl";
+import { ApiError } from "@/api/client";
+import { toolsApi } from "@/api/tools";
+
+/**
+ * Result handed to {@link GenerateArgs.onSuccess} when generation succeeds.
+ *
+ * `inputSchema` / `outputSchema` are pretty-printed JSON strings ready to drop
+ * straight into the form's textareas (empty string when the backend returned
+ * `null` for that schema).
+ */
+export interface GeneratedSchemas {
+  inputSchema: string;
+  outputSchema: string;
+  specUrl: string;
+}
+
+export interface GenerateArgs {
+  /** The tool URL (identifies the OpenAPI path + host). */
+  url: string;
+  /** HTTP method to look up in the spec. */
+  requestType: string;
+  /** Called with the pretty-printed schemas when generation succeeds. */
+  onSuccess: (result: GeneratedSchemas) => void;
+  /** Called with a localized, user-facing message when generation fails. */
+  onError?: (message: string) => void;
+  /** Called when the backend reports the spec host needs authentication. */
+  onRequiresAuth?: () => void;
+}
+
+export interface UseGenerateSchemaFromOpenapiReturn {
+  isGenerating: boolean;
+  /** The `spec_url` the backend used, once generation has succeeded. */
+  generatedSpecUrl: string;
+  /** Optional direct OpenAPI spec URL the user can supply as a fallback. */
+  openApiSpecUrl: string;
+  setOpenApiSpecUrl: (value: string) => void;
+  /** Whether the direct-spec-URL fallback input should be shown. */
+  showSpecUrlInput: boolean;
+  generate: (args: GenerateArgs) => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * Returns a validated `https?:` URL string, or `undefined` when the input is
+ * empty or not a fetchable web URL.
+ */
+function safeHttpUrl(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Encapsulates the "Generate schemas from OpenAPI" async flow: URL guarding,
+ * the API call, and mapping the backend's typed HTTP status codes to clear
+ * copy. Outcomes are reported through callbacks so the caller (the tool form)
+ * stays the single owner of the editable schema fields.
+ */
+export function useGenerateSchemaFromOpenapi(): UseGenerateSchemaFromOpenapiReturn {
+  const intl = useIntl();
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generatedSpecUrl, setGeneratedSpecUrl] = useState("");
+  const [openApiSpecUrl, setOpenApiSpecUrl] = useState("");
+  const [showSpecUrlInput, setShowSpecUrlInput] = useState(false);
+
+  const reset = useCallback(() => {
+    setIsGenerating(false);
+    setGeneratedSpecUrl("");
+    setOpenApiSpecUrl("");
+    setShowSpecUrlInput(false);
+  }, []);
+
+  const generate = useCallback(
+    async ({ url, requestType, onSuccess, onError, onRequiresAuth }: GenerateArgs) => {
+      // Guard: only ever call the backend for a fetchable web URL. Bail out
+      // silently (no error) for empty/non-http/malformed URLs.
+      const safeUrl = safeHttpUrl(url);
+      if (!safeUrl) return;
+
+      const safeSpecUrl = safeHttpUrl(openApiSpecUrl);
+
+      setIsGenerating(true);
+      try {
+        const result = await toolsApi.generateSchemasFromOpenapi({
+          url: safeUrl,
+          request_type: requestType,
+          ...(safeSpecUrl ? { openapi_url: safeSpecUrl } : {}),
+        });
+
+        if (result.success) {
+          setGeneratedSpecUrl(result.spec_url ?? "");
+          onSuccess({
+            inputSchema: result.input_schema ? JSON.stringify(result.input_schema, null, 2) : "",
+            outputSchema: result.output_schema ? JSON.stringify(result.output_schema, null, 2) : "",
+            specUrl: result.spec_url ?? "",
+          });
+        } else {
+          setGeneratedSpecUrl("");
+          setShowSpecUrlInput(true);
+          onError?.(
+            result.message || intl.formatMessage({ id: "tools.form.error.generateSchemaFailed" }),
+          );
+        }
+      } catch (error) {
+        setGeneratedSpecUrl("");
+        // Offer the direct-spec-URL fallback whenever generation fails, so the
+        // user can point at a reachable OpenAPI document and retry.
+        setShowSpecUrlInput(true);
+
+        // Map the backend's typed HTTP status codes to clear, actionable copy.
+        let message = intl.formatMessage({ id: "tools.form.error.generateSchemaUrl" });
+        if (error instanceof ApiError) {
+          const body = error.body as { message?: string; requires_auth?: boolean } | undefined;
+          if (body?.requires_auth) {
+            onRequiresAuth?.();
+          }
+          switch (error.status) {
+            case 400:
+              message = intl.formatMessage({ id: "tools.form.error.generateSchema.ssrf" });
+              break;
+            case 404: {
+              let path = safeUrl;
+              try {
+                path = new URL(safeUrl).pathname || path;
+              } catch {
+                // Keep the raw URL when it cannot be parsed.
+              }
+              message = intl.formatMessage(
+                { id: "tools.form.error.generateSchema.notFound" },
+                { path, method: requestType },
+              );
+              break;
+            }
+            case 502: {
+              // The backend wraps an upstream 401/403 from the spec host as a
+              // 502 ("OpenAPI spec server returned HTTP 401"). Surface that as
+              // an auth problem rather than a generic "unreachable" message.
+              const upstream = body?.message ?? "";
+              message = /\bHTTP (401|403)\b/.test(upstream)
+                ? intl.formatMessage({ id: "tools.form.error.generateSchema.specAuthRequired" })
+                : intl.formatMessage({ id: "tools.form.error.generateSchema.fetchFailed" });
+              break;
+            }
+            case 500:
+              message = intl.formatMessage({ id: "tools.form.error.generateSchema.generic" });
+              break;
+            default:
+              if (body?.message) {
+                message = body.message;
+              }
+          }
+        }
+        onError?.(message);
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [openApiSpecUrl, intl],
+  );
+
+  return {
+    isGenerating,
+    generatedSpecUrl,
+    openApiSpecUrl,
+    setOpenApiSpecUrl,
+    showSpecUrlInput,
+    generate,
+    reset,
+  };
+}

--- a/client/src/hooks/useToolForm.test.ts
+++ b/client/src/hooks/useToolForm.test.ts
@@ -176,72 +176,64 @@ describe("useToolForm", () => {
     });
   });
 
-  describe("generateSchema – custom header sanitization", () => {
-    it("strips control characters from custom header key and value (multi-header path)", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
+  // The generation flow itself (payload shape, status→message mapping, spec-URL
+  // fallback) is unit-tested in useGenerateSchemaFromOpenapi.test.ts. These
+  // tests cover only the form's wiring: applying results and surfacing errors.
+  describe("generateSchema – form integration", () => {
+    it("applies the generated schemas and spec URL to the form fields", async () => {
       server.use(
-        http.post("*/v1/tools/generate-schemas-from-openapi", async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json({
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json({
             success: true,
-            input_schema: null,
-            output_schema: null,
+            input_schema: { type: "object", properties: { a: { type: "string" } } },
+            output_schema: { type: "object" },
+            spec_url: "https://api.example.com/openapi.json",
             message: "ok",
-          });
-        }),
+          }),
+        ),
       );
 
       const { result } = renderHook(() => useToolForm());
 
       act(() => {
         result.current.setUrl("https://api.example.com/endpoint");
-        result.current.setAuthType("custom");
-        result.current.setCustomHeaders([
-          { id: "1", key: "X-Api-Key\r\nInjected: evil", value: "value\x00with\x1fnull" },
-        ]);
       });
 
       await act(async () => {
         await result.current.generateSchema();
       });
 
-      await waitFor(() => expect(capturedBody).toBeDefined());
-      const headers = capturedBody?.auth_headers as Array<{ key: string; value: string }>;
-      expect(headers[0].key).toBe("X-Api-KeyInjected: evil");
-      expect(headers[0].value).toBe("valuewithnull");
+      await waitFor(() => expect(result.current.schemaMode).toBe("generated"));
+      expect(result.current.generatedSpecUrl).toBe("https://api.example.com/openapi.json");
+      expect(result.current.inputSchema).toBe(
+        JSON.stringify({ type: "object", properties: { a: { type: "string" } } }, null, 2),
+      );
+      expect(result.current.outputSchema).toBe(JSON.stringify({ type: "object" }, null, 2));
     });
 
-    it("strips control characters from custom header key and value (single-header path)", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
+    it("surfaces a mapped generation error in errors.schema and reveals the fallback", async () => {
       server.use(
-        http.post("*/v1/tools/generate-schemas-from-openapi", async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json({
-            success: true,
-            input_schema: null,
-            output_schema: null,
-            message: "ok",
-          });
-        }),
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json({ success: false, message: "backend detail" }, { status: 502 }),
+        ),
       );
 
-      const { result } = renderHook(() => useToolForm({ maxCustomHeaders: 1 }));
+      const { result } = renderHook(() => useToolForm());
 
       act(() => {
         result.current.setUrl("https://api.example.com/endpoint");
-        result.current.setAuthType("custom");
-        result.current.setCustomHeaders([
-          { id: "1", key: "X-Api-Key\r\nInjected: evil", value: "value\x00with\x1fnull" },
-        ]);
       });
 
       await act(async () => {
         await result.current.generateSchema();
       });
 
-      await waitFor(() => expect(capturedBody).toBeDefined());
-      expect(capturedBody?.auth_header_key).toBe("X-Api-KeyInjected: evil");
-      expect(capturedBody?.auth_header_value).toBe("valuewithnull");
+      await waitFor(() =>
+        expect(result.current.errors.schema).toBe(
+          "Couldn't fetch the OpenAPI spec — check that the URL is correct and reachable",
+        ),
+      );
+      expect(result.current.showSpecUrlInput).toBe(true);
     });
   });
 
@@ -839,6 +831,40 @@ describe("useToolForm", () => {
       expect(result.current.authType).toBe("none");
       expect(result.current.bearerToken).toBe("");
       expect(result.current.visibility).toBe("public");
+    });
+
+    it("clears schema-generation state on reset", async () => {
+      server.use(
+        http.post("*/v1/tools/generate-schemas-from-openapi", () =>
+          HttpResponse.json({
+            success: true,
+            input_schema: { type: "object", properties: {} },
+            output_schema: null,
+            spec_url: "https://api.example.com/openapi.json",
+            message: "ok",
+          }),
+        ),
+      );
+
+      const { result } = renderHook(() => useToolForm());
+
+      act(() => {
+        result.current.setUrl("https://api.example.com/endpoint");
+        result.current.setOpenApiSpecUrl("https://api.example.com/openapi.json");
+      });
+      await act(async () => {
+        await result.current.generateSchema();
+      });
+      await waitFor(() => expect(result.current.generatedSpecUrl).not.toBe(""));
+
+      act(() => {
+        result.current.resetForm();
+      });
+
+      expect(result.current.schemaMode).toBe("none");
+      expect(result.current.generatedSpecUrl).toBe("");
+      expect(result.current.openApiSpecUrl).toBe("");
+      expect(result.current.showSpecUrlInput).toBe(false);
     });
   });
 });

--- a/client/src/hooks/useToolForm.ts
+++ b/client/src/hooks/useToolForm.ts
@@ -1,8 +1,8 @@
 import { useState, useCallback, useMemo, type FormEvent } from "react";
 import { useIntl } from "react-intl";
 import { z } from "zod";
-import { api } from "@/api/client";
 import { useQuery } from "@/hooks/useQuery";
+import { useGenerateSchemaFromOpenapi } from "@/hooks/useGenerateSchemaFromOpenapi";
 import type { Visibility } from "@/types/server";
 import { sanitizeString, sanitizeUrl, sanitizePassword, sanitizeToken } from "@/lib/sanitize";
 
@@ -181,6 +181,7 @@ export interface UseToolFormReturn {
   schemaMode: SchemaMode;
   openApiSpecUrl: string;
   showSpecUrlInput: boolean;
+  generatedSpecUrl: string;
   errors: FormErrors;
   isValid: boolean;
   isSubmitting: boolean;
@@ -305,11 +306,21 @@ export function useToolForm({
   const [outputSchema, setOutputSchema] = useState(
     initialValues?.outputSchema ?? initialState.outputSchema,
   );
-  const [isGeneratingSchema, setIsGeneratingSchema] = useState(false);
   const [schemaMode, setSchemaMode] = useState<SchemaMode>(initialValues?.schemaMode ?? "none");
-  const [openApiSpecUrl, setOpenApiSpecUrl] = useState("");
-  const [showSpecUrlInput, setShowSpecUrlInput] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
+
+  // The OpenAPI schema-generation async flow lives in its own hook; this form
+  // stays the owner of the editable schema fields and applies results via the
+  // success callback below.
+  const {
+    isGenerating: isGeneratingSchema,
+    generatedSpecUrl,
+    openApiSpecUrl,
+    setOpenApiSpecUrl,
+    showSpecUrlInput,
+    generate,
+    reset: resetSchemaGeneration,
+  } = useGenerateSchemaFromOpenapi();
 
   // Use useQuery for POST request to create tool
   const { execute: createTool, isLoading: isCreating } = useQuery<unknown, ApiToolPayload>(
@@ -333,106 +344,19 @@ export function useToolForm({
   const isSubmitting = isCreating || isUpdating;
 
   const generateSchema = useCallback(async () => {
-    if (!url.trim()) return;
-    try {
-      const parsed = new URL(url.trim());
-      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
-    } catch {
-      return;
-    }
-    const safeSpecUrl = (() => {
-      if (!openApiSpecUrl.trim()) return undefined;
-      try {
-        const u = new URL(openApiSpecUrl.trim());
-        return u.protocol === "http:" || u.protocol === "https:"
-          ? openApiSpecUrl.trim()
-          : undefined;
-      } catch {
-        return undefined;
-      }
-    })();
-    setIsGeneratingSchema(true);
     setErrors((prev) => ({ ...prev, schema: undefined }));
-    try {
-      const payload: Record<string, unknown> = {
-        url: url.trim(),
-        request_type: requestType,
-        ...(safeSpecUrl ? { openapi_url: safeSpecUrl } : {}),
-      };
-
-      if (authType === "bearer" && bearerToken.trim()) {
-        payload.auth_type = "bearer";
-        payload.auth_token = bearerToken;
-      } else if (authType === "basic") {
-        payload.auth_type = "basic";
-        payload.auth_username = authUsername;
-        payload.auth_password = authPassword;
-      } else if (authType === "custom") {
-        const validHeaders = customHeaders.filter((h) => h.key.trim());
-        if (validHeaders.length > 0) {
-          payload.auth_type = "authheaders";
-          if (maxCustomHeaders === 1) {
-            payload.auth_header_key = sanitizeString(validHeaders[0].key, 200);
-            payload.auth_header_value = sanitizeString(validHeaders[0].value, 1000);
-          } else {
-            payload.auth_headers = validHeaders.map((h) => ({
-              key: sanitizeString(h.key, 200),
-              value: sanitizeString(h.value, 1000),
-            }));
-          }
-        }
-      }
-
-      const result = await api.post<{
-        success: boolean;
-        input_schema: Record<string, unknown> | null;
-        output_schema: Record<string, unknown> | null;
-        message: string;
-        requires_auth?: boolean;
-      }>("/v1/tools/generate-schemas-from-openapi", payload);
-      if (result.success) {
-        setInputSchema(result.input_schema ? JSON.stringify(result.input_schema, null, 2) : "");
-        setOutputSchema(result.output_schema ? JSON.stringify(result.output_schema, null, 2) : "");
+    await generate({
+      url,
+      requestType,
+      onSuccess: ({ inputSchema: input, outputSchema: output }) => {
+        setInputSchema(input);
+        setOutputSchema(output);
         setSchemaMode("generated");
-      } else {
-        setErrors((prev) => ({
-          ...prev,
-          schema:
-            result.message || intl.formatMessage({ id: "tools.form.error.generateSchemaFailed" }),
-        }));
-      }
-    } catch (error) {
-      let message = intl.formatMessage({ id: "tools.form.error.generateSchemaUrl" });
-      let requiresAuth = false;
-      if (error && typeof error === "object" && "body" in error) {
-        const err = error as { body?: { message?: string; requires_auth?: boolean } };
-        if (err.body?.message) {
-          message = err.body.message;
-        }
-        if (err.body?.requires_auth) {
-          requiresAuth = true;
-        }
-      }
-      if (requiresAuth) {
-        setAdvancedOpen(true);
-        setShowSpecUrlInput(true);
-      }
-      setErrors((prev) => ({ ...prev, schema: message }));
-    } finally {
-      setIsGeneratingSchema(false);
-    }
-  }, [
-    url,
-    requestType,
-    authType,
-    bearerToken,
-    authUsername,
-    authPassword,
-    customHeaders,
-    openApiSpecUrl,
-    maxCustomHeaders,
-    intl,
-  ]);
+      },
+      onError: (message) => setErrors((prev) => ({ ...prev, schema: message })),
+      onRequiresAuth: () => setAdvancedOpen(true),
+    });
+  }, [generate, url, requestType]);
 
   const getFormData = useCallback((): ApiToolPayload => {
     const AUTH_TYPE_TO_API: Record<AuthType, string> = {
@@ -599,10 +523,9 @@ export function useToolForm({
     setInputSchema(initialState.inputSchema);
     setOutputSchema(initialState.outputSchema);
     setSchemaMode("none");
-    setOpenApiSpecUrl("");
-    setShowSpecUrlInput(false);
+    resetSchemaGeneration();
     setErrors({});
-  }, []);
+  }, [resetSchemaGeneration]);
 
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>, onSuccess?: (response?: unknown) => void) => {
@@ -789,6 +712,7 @@ export function useToolForm({
     schemaMode,
     openApiSpecUrl,
     showSpecUrlInput,
+    generatedSpecUrl,
     errors,
     isValid,
     isSubmitting,

--- a/client/src/i18n/locales/en-US/tools.json
+++ b/client/src/i18n/locales/en-US/tools.json
@@ -75,6 +75,10 @@
   "tools.form.schema.addManually": "+ Add manually",
   "tools.form.schema.specUrlLabel": "Or provide a direct OpenAPI spec URL",
   "tools.form.schema.specUrlPlaceholder": "https://api.example.com/openapi.json",
+  "tools.form.schema.generatedFrom": "Generated from {specUrl}",
+  "tools.form.schema.overwrite.title": "Replace existing schema?",
+  "tools.form.schema.overwrite.description": "Generating from OpenAPI will overwrite the input and output schemas you've already entered. Do you want to continue?",
+  "tools.form.schema.overwrite.confirm": "Replace",
   "tools.form.inputSchema": "Input schema",
   "tools.form.outputSchema": "Output schema",
   "tools.form.copyInputSchema": "Copy input schema",
@@ -98,6 +102,11 @@
   "tools.form.error.invalidValue": "Invalid value",
   "tools.form.error.generateSchemaFailed": "Failed to generate schema",
   "tools.form.error.generateSchemaUrl": "Failed to generate schema. Check the URL and try again.",
+  "tools.form.error.generateSchema.ssrf": "URL not reachable from the gateway (blocked by SSRF protection)",
+  "tools.form.error.generateSchema.notFound": "The path {path} with method {method} is not in the OpenAPI spec",
+  "tools.form.error.generateSchema.fetchFailed": "Couldn't fetch the OpenAPI spec — check that the URL is correct and reachable",
+  "tools.form.error.generateSchema.specAuthRequired": "The OpenAPI spec endpoint requires authentication (returned 401/403). The gateway fetches the spec without credentials — provide a direct URL to a reachable spec, or add the schemas manually.",
+  "tools.form.error.generateSchema.generic": "Something went wrong while generating the schema. Please try again.",
   "tools.form.error.updateFailed": "Failed to update tool. Please try again.",
   "tools.form.error.createFailed": "Failed to create tool. Please try again."
 }

--- a/client/src/i18n/locales/es-ES/tools.json
+++ b/client/src/i18n/locales/es-ES/tools.json
@@ -75,6 +75,10 @@
   "tools.form.schema.addManually": "+ Añadir manualmente",
   "tools.form.schema.specUrlLabel": "O proporcione una URL directa de especificación OpenAPI",
   "tools.form.schema.specUrlPlaceholder": "https://api.ejemplo.com/openapi.json",
+  "tools.form.schema.generatedFrom": "Generado a partir de {specUrl}",
+  "tools.form.schema.overwrite.title": "¿Reemplazar el esquema existente?",
+  "tools.form.schema.overwrite.description": "Generar desde OpenAPI sobrescribirá los esquemas de entrada y salida que ya has introducido. ¿Deseas continuar?",
+  "tools.form.schema.overwrite.confirm": "Reemplazar",
   "tools.form.inputSchema": "Esquema de entrada",
   "tools.form.outputSchema": "Esquema de salida",
   "tools.form.copyInputSchema": "Copiar esquema de entrada",
@@ -98,6 +102,11 @@
   "tools.form.error.invalidValue": "Valor no válido",
   "tools.form.error.generateSchemaFailed": "Error al generar el esquema",
   "tools.form.error.generateSchemaUrl": "Error al generar el esquema. Compruebe la URL e inténtelo de nuevo.",
+  "tools.form.error.generateSchema.ssrf": "La URL no es accesible desde la puerta de enlace (bloqueada por la protección SSRF)",
+  "tools.form.error.generateSchema.notFound": "La ruta {path} con el método {method} no está en la especificación OpenAPI",
+  "tools.form.error.generateSchema.fetchFailed": "No se pudo obtener la especificación OpenAPI: compruebe que la URL sea correcta y accesible",
+  "tools.form.error.generateSchema.specAuthRequired": "El punto de acceso de la especificación OpenAPI requiere autenticación (devolvió 401/403). La puerta de enlace obtiene la especificación sin credenciales: proporcione una URL directa a una especificación accesible o añada los esquemas manualmente.",
+  "tools.form.error.generateSchema.generic": "Algo salió mal al generar el esquema. Por favor, inténtelo de nuevo.",
   "tools.form.error.updateFailed": "Error al actualizar la herramienta. Por favor, inténtelo de nuevo.",
   "tools.form.error.createFailed": "Error al crear la herramienta. Por favor, inténtelo de nuevo."
 }

--- a/client/src/i18n/locales/pt-BR/tools.json
+++ b/client/src/i18n/locales/pt-BR/tools.json
@@ -75,6 +75,10 @@
   "tools.form.schema.addManually": "+ Adicionar manualmente",
   "tools.form.schema.specUrlLabel": "Ou forneça uma URL direta da especificação OpenAPI",
   "tools.form.schema.specUrlPlaceholder": "https://api.exemplo.com/openapi.json",
+  "tools.form.schema.generatedFrom": "Gerado a partir de {specUrl}",
+  "tools.form.schema.overwrite.title": "Substituir o esquema existente?",
+  "tools.form.schema.overwrite.description": "Gerar a partir do OpenAPI substituirá os esquemas de entrada e saída que você já inseriu. Deseja continuar?",
+  "tools.form.schema.overwrite.confirm": "Substituir",
   "tools.form.inputSchema": "Esquema de entrada",
   "tools.form.outputSchema": "Esquema de saída",
   "tools.form.copyInputSchema": "Copiar esquema de entrada",
@@ -98,6 +102,11 @@
   "tools.form.error.invalidValue": "Valor inválido",
   "tools.form.error.generateSchemaFailed": "Falha ao gerar o esquema",
   "tools.form.error.generateSchemaUrl": "Falha ao gerar o esquema. Verifique a URL e tente novamente.",
+  "tools.form.error.generateSchema.ssrf": "URL inacessível a partir do gateway (bloqueada pela proteção SSRF)",
+  "tools.form.error.generateSchema.notFound": "O caminho {path} com o método {method} não está na especificação OpenAPI",
+  "tools.form.error.generateSchema.fetchFailed": "Não foi possível obter a especificação OpenAPI — verifique se a URL está correta e acessível",
+  "tools.form.error.generateSchema.specAuthRequired": "O endpoint da especificação OpenAPI requer autenticação (retornou 401/403). O gateway obtém a especificação sem credenciais — forneça uma URL direta para uma especificação acessível ou adicione os esquemas manualmente.",
+  "tools.form.error.generateSchema.generic": "Algo deu errado ao gerar o esquema. Tente novamente.",
   "tools.form.error.updateFailed": "Falha ao atualizar a ferramenta. Tente novamente.",
   "tools.form.error.createFailed": "Falha ao criar a ferramenta. Tente novamente."
 }


### PR DESCRIPTION
### Summary

Adds one-click input/output schema generation from an OpenAPI spec to the Create REST Tool form. Users can auto-populate the schema fields from a tool's OpenAPI document, regenerate, or fall back to manual entry. Wires the UI to the `POST /v1/tools/generate-schemas-from-openapi` endpoint.

Closes #4861, #4860. Uses the endpoint added in #5142.

https://github.com/user-attachments/assets/cf4fa895-f5b7-4f41-a28c-45939edda8f2

### The Generate button

- **Visibility**: shown for REST tools only (`integrationType === "REST"`) — hidden for MCP tools, since generation reads an OpenAPI spec. This form only ever creates REST tools, so in add mode it's always shown; in edit mode it's shown for REST tools and hidden for MCP.
- **Disabled** until a URL is provided (also guarded by request type, which is always set), matching the endpoint's required inputs.
- **Loading state**: while the request runs (up to ~10s) the button shows a spinner and a "Generating…" label and is disabled to prevent duplicate calls.
- **Label change**: after a successful generation it switches from **Generate** to **Regenerate**.
- **Overwrite guard**: clicking it when either schema field already has content prompts a confirmation before replacing, so manual edits aren't clobbered silently.

### What's included

**API client** (`client/src/api/tools.ts`)
- `toolsApi.generateSchemasFromOpenapi()` calling `POST /v1/tools/generate-schemas-from-openapi`. The request type is re-exported from the generated `GenerateSchemaRequest`; the response is narrowed by hand (the endpoint returns an untyped `JSONResponse`).

**New hook** (`client/src/hooks/useGenerateSchemaFromOpenapi.ts`)
- Encapsulates the async flow: `http(s)`-only URL guarding, the API call, and mapping the backend's typed HTTP statuses (400 SSRF / 404 path+method / 502 fetch / 500) to clear, localized messages. A 502 that wraps an upstream 401/403 is surfaced as an auth-specific message. Reports outcomes via `onSuccess` / `onError` / `onRequiresAuth` callbacks so the form remains the single owner of the editable schema fields.

**Form integration** (`useToolForm.ts`, `ToolForm.tsx`)
- Pretty-prints returned schemas into the fields and shows a `Generated from {spec_url}` caption.
- On failure, reveals a direct OpenAPI spec-URL fallback input; errors are announced via `role="alert"`.
- In edit mode the schema fields are always visible and "Add manually" is hidden (add-mode affordance only).

**i18n**
- New keys added to `en-US`, `es-ES`, and `pt-BR`.