### PR TITLE
feat(ui-rewrite): wire Test Connection to POST /v1/mcp-servers/test API endpoint

### DIFF
--- a/client/src/api/servers.ts
+++ b/client/src/api/servers.ts
@@ -7,6 +7,7 @@
 
 import { api } from "./client";
 import type { ServersResponse, MCPServer } from "../types/server";
+import type { GatewayTestRequest, GatewayTestResponse } from "@/generated/types";
 
 const serverByIdRequestCache = new Map<string, Promise<MCPServer>>();
 
@@ -100,6 +101,21 @@ export const serversApi = {
   testConnection: (id: string): Promise<{ success: boolean; message: string }> => {
     const validId = validateServerId(id);
     return api.post(`/gateways/${validId}/test`, {});
+  },
+
+  /**
+   * Test ad-hoc connectivity to an MCP server / gateway URL.
+   *
+   * Unlike {@link testConnection} (which pings an already-registered server by
+   * ID), this sends a caller-supplied request (URL, method, path, headers, body)
+   * to the v1 REST endpoint and returns the upstream response. The React UI must
+   * use this rather than the legacy /admin/gateways/test route.
+   */
+  testConnectivity: (
+    request: GatewayTestRequest,
+    signal?: AbortSignal,
+  ): Promise<GatewayTestResponse> => {
+    return api.post("/v1/mcp-servers/test", request, { signal });
   },
 
   /**

--- a/client/src/components/servers/TestConnectionDialog.test.tsx
+++ b/client/src/components/servers/TestConnectionDialog.test.tsx
@@ -337,6 +337,71 @@ describe("TestConnectionDialog", () => {
     });
   });
 
+  it("renders the URL error inline and marks the field invalid", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const urlField = screen.getByLabelText(/^url/i);
+    await user.clear(urlField);
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => expect(urlField).toHaveAttribute("aria-invalid", "true"));
+    // The error is associated with the field for assistive tech.
+    expect(urlField).toHaveAttribute("aria-describedby", "url-error");
+    expect(screen.getByText(/url is required/i)).toHaveAttribute("id", "url-error");
+  });
+
+  it("validates a field on blur, before any submit", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const urlField = screen.getByLabelText(/^url/i);
+    await user.clear(urlField);
+    await user.type(urlField, "not-a-url");
+    await user.tab(); // blur
+
+    await waitFor(() => {
+      expect(screen.getByText(/url must start with http/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clears a field's error as soon as it is edited", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const urlField = screen.getByLabelText(/^url/i);
+    await user.clear(urlField);
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+    await waitFor(() => expect(screen.getByText(/url is required/i)).toBeInTheDocument());
+
+    await user.type(urlField, "https://example.com");
+    expect(screen.queryByText(/url is required/i)).not.toBeInTheDocument();
+  });
+
+  it("flags a scheme/host pasted into the Path field", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const pathField = screen.getByLabelText(/^path/i);
+    await user.type(pathField, "https://evil.com/health");
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/path shouldn't include a scheme or host/i)).toBeInTheDocument();
+    });
+  });
+
+  it("accepts a plain path without a scheme", async () => {
+    const user = userEvent.setup();
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    const pathField = screen.getByLabelText(/^path/i);
+    await user.type(pathField, "/health");
+    await user.tab();
+
+    expect(screen.queryByText(/path shouldn't include a scheme or host/i)).not.toBeInTheDocument();
+  });
+
   it("does not auto-focus the pre-filled URL field on open", () => {
     render(<TestConnectionDialog {...defaultProps} />);
 

--- a/client/src/components/servers/TestConnectionDialog.test.tsx
+++ b/client/src/components/servers/TestConnectionDialog.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
 import { TestConnectionDialog } from "./TestConnectionDialog";
+
+const TEST_ENDPOINT = "*/v1/mcp-servers/test";
 
 describe("TestConnectionDialog", () => {
   const mockOnOpenChange = vi.fn();
@@ -55,15 +59,189 @@ describe("TestConnectionDialog", () => {
     expect(screen.getByLabelText(/body/i)).toBeInTheDocument();
   });
 
-  it("shows a pending message until the test endpoint is available", async () => {
+  it("calls the connectivity endpoint and shows a successful response", async () => {
     const user = userEvent.setup();
+    let requestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        // Response uses camelCase — FastAPI serializes with by_alias=True.
+        return HttpResponse.json({ statusCode: 200, latencyMs: 42, body: { ok: true } });
+      }),
+    );
     render(<TestConnectionDialog {...defaultProps} />);
 
     await user.click(screen.getByRole("button", { name: /^test connection$/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/api endpoint is pending/i)).toBeInTheDocument();
+      expect(screen.getByText(/status: 200 ok/i)).toBeInTheDocument();
     });
+    expect(screen.getByText(/latency: 42 ms/i)).toBeInTheDocument();
+    // The wire request must use the backend's camelCase field names.
+    expect(requestBody).toEqual(
+      expect.objectContaining({
+        method: "GET",
+        baseUrl: "https://example.com",
+        path: "",
+        contentType: "application/json",
+      }),
+    );
+  });
+
+  it("renders a non-2xx response as an error", async () => {
+    const user = userEvent.setup();
+    // The endpoint returns HTTP 200 with a semantic error status in the body.
+    server.use(
+      http.post(TEST_ENDPOINT, () =>
+        HttpResponse.json({ statusCode: 502, latencyMs: 10, body: { error: "Request failed" } }),
+      ),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/status: 502 error/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces a thrown API error", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post(TEST_ENDPOINT, () =>
+        HttpResponse.json({ detail: "Access denied" }, { status: 403 }),
+      ),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+    });
+  });
+
+  it("parses a JSON body into an object before sending", async () => {
+    const user = userEvent.setup();
+    let requestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ statusCode: 200, latencyMs: 5, body: {} });
+      }),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("radio", { name: "Post" }));
+    await user.type(screen.getByLabelText(/body/i), '{{"hello":"world"}');
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/status: 200 ok/i)).toBeInTheDocument();
+    });
+    expect(requestBody).toEqual(
+      expect.objectContaining({ method: "POST", body: { hello: "world" } }),
+    );
+  });
+
+  it("forwards valid headers as a JSON object", async () => {
+    const user = userEvent.setup();
+    let requestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ statusCode: 200, latencyMs: 3, body: {} });
+      }),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.type(
+      screen.getByLabelText(/headers/i),
+      '{{"Authorization":"Bearer tok","X-Trace":"1"}',
+    );
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/status: 200 ok/i)).toBeInTheDocument();
+    });
+    expect(requestBody).toEqual(
+      expect.objectContaining({ headers: { Authorization: "Bearer tok", "X-Trace": "1" } }),
+    );
+  });
+
+  it("forwards a non-empty path", async () => {
+    const user = userEvent.setup();
+    let requestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ statusCode: 200, latencyMs: 3, body: {} });
+      }),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.type(screen.getByLabelText(/^path/i), "/health");
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/status: 200 ok/i)).toBeInTheDocument();
+    });
+    expect(requestBody).toEqual(expect.objectContaining({ path: "/health" }));
+  });
+
+  it("sends a non-JSON body as a raw string without JSON validation", async () => {
+    const user = userEvent.setup();
+    let requestBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ statusCode: 200, latencyMs: 3, body: {} });
+      }),
+    );
+    render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("radio", { name: "Post" }));
+    // Switch content type away from JSON so the body is sent verbatim.
+    await user.click(screen.getByRole("combobox", { name: /content type/i }));
+    await user.click(screen.getByRole("option", { name: /x-www-form-urlencoded/i }));
+    // A non-JSON body must NOT trigger the "Invalid body JSON" validation.
+    await user.type(screen.getByLabelText(/body/i), "name=subway&line=A");
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/status: 200 ok/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/invalid body json/i)).not.toBeInTheDocument();
+    expect(requestBody).toEqual(
+      expect.objectContaining({
+        contentType: "application/x-www-form-urlencoded",
+        body: "name=subway&line=A",
+      }),
+    );
+  });
+
+  it("cancels the in-flight request when the dialog closes", async () => {
+    const user = userEvent.setup();
+    let aborted = false;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        // Resolve only once the client aborts, so the test can observe cancellation.
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+        return HttpResponse.json({ statusCode: 200, latencyMs: 1, body: {} });
+      }),
+    );
+    const { rerender } = render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+    // Close the dialog while the request is still in flight.
+    rerender(<TestConnectionDialog {...defaultProps} open={false} />);
+
+    await waitFor(() => expect(aborted).toBe(true));
   });
 
   it("requires a URL before running", async () => {

--- a/client/src/components/servers/TestConnectionDialog.test.tsx
+++ b/client/src/components/servers/TestConnectionDialog.test.tsx
@@ -244,6 +244,38 @@ describe("TestConnectionDialog", () => {
     await waitFor(() => expect(aborted).toBe(true));
   });
 
+  it("relabels the footer button to Cancel during a test and cancels on click", async () => {
+    const user = userEvent.setup();
+    let aborted = false;
+    server.use(
+      http.post(TEST_ENDPOINT, async ({ request }) => {
+        // Resolve only once the client aborts, so the test can observe cancellation.
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+        return HttpResponse.json({ statusCode: 200, latencyMs: 1, body: {} });
+      }),
+    );
+    const { rerender } = render(<TestConnectionDialog {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /^test connection$/i }));
+
+    // While in flight the footer button stays enabled and reads "Cancel".
+    const cancelButton = await screen.findByRole("button", { name: /^cancel$/i });
+    expect(cancelButton).toBeEnabled();
+
+    await user.click(cancelButton);
+    // The button requests the close; the parent honors it by flipping `open`,
+    // which aborts the in-flight request via the open→false effect.
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false);
+    rerender(<TestConnectionDialog {...defaultProps} open={false} />);
+
+    await waitFor(() => expect(aborted).toBe(true));
+  });
+
   it("requires a URL before running", async () => {
     const user = userEvent.setup();
     render(<TestConnectionDialog {...defaultProps} />);

--- a/client/src/components/servers/TestConnectionDialog.tsx
+++ b/client/src/components/servers/TestConnectionDialog.tsx
@@ -18,6 +18,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 import { Textarea } from "../ui/textarea";
 import { JsonHighlighter } from "../ui/json-highlighter";
 import { copyToClipboard } from "@/lib/clipboard";
+import { serversApi } from "@/api/servers";
+import type { GatewayTestRequest, GatewayTestResponse } from "@/generated/types";
+import { parseApiError } from "@/lib/errorUtils";
 import { cn } from "@/lib/utils";
 
 interface TestConnectionDialogProps {
@@ -28,12 +31,6 @@ interface TestConnectionDialogProps {
 }
 
 type TestStatus = "idle" | "testing" | "success" | "error";
-
-interface TestResponse {
-  status_code: number;
-  latency_ms: number;
-  body?: string | Record<string, unknown>;
-}
 
 const HTTP_METHODS = ["Get", "Post", "Put", "Delete", "Patch"] as const;
 
@@ -89,26 +86,36 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
   const [headers, setHeaders] = useState<string>("");
   const [contentType, setContentType] = useState<string>("application/json");
   const [body, setBody] = useState<string>("");
-  const [response, setResponse] = useState<TestResponse | null>(null);
+  const [response, setResponse] = useState<GatewayTestResponse>(null);
   const [error, setError] = useState<string>("");
   const titleRef = useRef<HTMLHeadingElement>(null);
+  // Tracks the in-flight test request so it can be cancelled when the dialog is
+  // closed, reopened, or unmounted (prevents state updates on a stale request).
+  const abortRef = useRef<AbortController | null>(null);
 
-  // Reset state when dialog opens
+  // Cancel any in-flight request whenever the dialog opens or closes (covers the
+  // footer Close button, Escape, and overlay-dismiss uniformly), then reset state
+  // on open.
   useEffect(() => {
-    if (open) {
-      setStatus("idle");
-      setMethod("Get");
-      setUrl(serverUrl);
-      setPath("");
-      setHeaders("");
-      setContentType("application/json");
-      setBody("");
-      setResponse(null);
-      setError("");
+    abortRef.current?.abort();
+    if (!open) {
+      return;
     }
+    setStatus("idle");
+    setMethod("Get");
+    setUrl(serverUrl);
+    setPath("");
+    setHeaders("");
+    setContentType("application/json");
+    setBody("");
+    setResponse(null);
+    setError("");
   }, [open, serverUrl]);
 
-  const handleTest = useCallback(() => {
+  // Cancel any in-flight request on unmount.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const handleTest = useCallback(async () => {
     setResponse(null);
     setError("");
 
@@ -120,13 +127,15 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
       return;
     }
 
-    // Validate JSON fields before they would be sent.
+    // Validate and capture the headers JSON before it would be sent.
+    let parsedHeaders: Record<string, string> | undefined;
     if (headers.trim()) {
       try {
         const parsed = JSON.parse(headers);
-        if (typeof parsed !== "object" || Array.isArray(parsed)) {
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
           throw new Error("Headers must be a JSON object");
         }
+        parsedHeaders = parsed as Record<string, string>;
       } catch (e) {
         setStatus("error");
         setError(`Invalid headers JSON: ${e instanceof Error ? e.message : "Parse error"}`);
@@ -134,26 +143,60 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
       }
     }
 
-    if (body.trim() && method !== "Get" && method !== "HEAD") {
-      try {
-        JSON.parse(body);
-      } catch (e) {
-        setStatus("error");
-        setError(`Invalid body JSON: ${e instanceof Error ? e.message : "Parse error"}`);
-        return;
+    // Validate and capture the request body. JSON bodies are parsed to an object
+    // so the backend forwards them as JSON; form-encoded bodies are sent as-is.
+    const sendsBody = method !== "Get" && method !== "HEAD";
+    let parsedBody: string | Record<string, unknown> | undefined;
+    if (sendsBody && body.trim()) {
+      if (contentType === "application/json") {
+        try {
+          parsedBody = JSON.parse(body);
+        } catch (e) {
+          setStatus("error");
+          setError(`Invalid body JSON: ${e instanceof Error ? e.message : "Parse error"}`);
+          return;
+        }
+      } else {
+        parsedBody = body;
       }
     }
 
-    // TODO(#5326): Send the request to `POST /v1/mcp-servers/test` once that
-    // endpoint exists. The React UI must not call the legacy `/admin/**` routes
-    // (reserved for the HTMX admin UI), so live connection testing is disabled
-    // until the v1 endpoint is implemented.
-    // https://github.com/IBM/mcp-context-forge/issues/5326
-    setStatus("error");
-    setError("Connection testing isn't available yet — the API endpoint is pending (#5326).");
-  }, [url, headers, body, method]);
+    const payload: GatewayTestRequest = {
+      method: method.toUpperCase(),
+      baseUrl: urlResult.data,
+      path: path.trim(),
+      contentType,
+      ...(parsedHeaders ? { headers: parsedHeaders } : {}),
+      ...(parsedBody !== undefined ? { body: parsedBody } : {}),
+    };
+
+    // Cancel any previous in-flight request before starting a new one.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus("testing");
+    try {
+      const result = await serversApi.testConnectivity(payload, controller.signal);
+      if (controller.signal.aborted) {
+        return;
+      }
+      const statusCode = result?.statusCode ?? 0;
+      const succeeded = statusCode >= 200 && statusCode < 300;
+      setResponse(result);
+      setStatus(succeeded ? "success" : "error");
+    } catch (e) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      setResponse(null);
+      setStatus("error");
+      setError(parseApiError(e, "Connection test failed. Please try again."));
+    }
+  }, [url, headers, body, method, path, contentType]);
 
   const handleClose = useCallback(() => {
+    // The open→false effect cancels any in-flight request; just close here.
     onOpenChange(false);
   }, [onOpenChange]);
 
@@ -165,7 +208,7 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
   }, [response]);
 
   const headline = response
-    ? `Status: ${response.status_code} ${status === "success" ? "OK" : "error"}`
+    ? `Status: ${response.statusCode} ${status === "success" ? "OK" : "error"}`
     : error || "Connection failed";
 
   const isTesting = status === "testing";
@@ -358,7 +401,7 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
 
                 {response && (
                   <p className="pl-6 text-[13px] text-muted-foreground">
-                    Latency: {response.latency_ms} ms
+                    Latency: {response.latencyMs} ms
                   </p>
                 )}
 

--- a/client/src/components/servers/TestConnectionDialog.tsx
+++ b/client/src/components/servers/TestConnectionDialog.tsx
@@ -52,6 +52,61 @@ const testUrlSchema = z
     { message: "URL must start with http:// or https://." },
   );
 
+type FieldErrors = {
+  url?: string;
+  path?: string;
+  headers?: string;
+  body?: string;
+};
+
+// Field-level validators. Each returns an error message, or undefined when the
+// value is acceptable. Shared by the on-blur checks and the pre-submit sweep so
+// the two never drift.
+function validateUrl(value: string): string | undefined {
+  const result = testUrlSchema.safeParse(value);
+  return result.success ? undefined : result.error.issues[0].message;
+}
+
+// Path is a suffix appended to the base URL; the backend normalizes leading and
+// trailing slashes, so we don't police those. This is a soft guard against the
+// common fat-finger of pasting a full URL (scheme + host) into the Path field.
+function validatePath(value: string): string | undefined {
+  return value.includes("://")
+    ? "Path shouldn't include a scheme or host (e.g. https://…)."
+    : undefined;
+}
+
+function validateHeaders(value: string): string | undefined {
+  if (!value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return "Headers must be a JSON object.";
+    }
+  } catch (e) {
+    return `Invalid headers JSON: ${e instanceof Error ? e.message : "Parse error"}`;
+  }
+  return undefined;
+}
+
+function sendsBodyFor(method: string): boolean {
+  return method !== "Get" && method !== "HEAD";
+}
+
+// Only JSON bodies are validated; form-encoded (and other) content types are
+// sent verbatim, so there is nothing to parse.
+function validateBody(value: string, method: string, contentType: string): string | undefined {
+  if (!sendsBodyFor(method) || !value.trim() || contentType !== "application/json") {
+    return undefined;
+  }
+  try {
+    JSON.parse(value);
+  } catch (e) {
+    return `Invalid body JSON: ${e instanceof Error ? e.message : "Parse error"}`;
+  }
+  return undefined;
+}
+
 function FieldLabel({
   htmlFor,
   children,
@@ -88,6 +143,7 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
   const [body, setBody] = useState<string>("");
   const [response, setResponse] = useState<GatewayTestResponse>(null);
   const [error, setError] = useState<string>("");
+  const [errors, setErrors] = useState<FieldErrors>({});
   const titleRef = useRef<HTMLHeadingElement>(null);
   // Tracks the in-flight test request so it can be cancelled when the dialog is
   // closed, reopened, or unmounted (prevents state updates on a stale request).
@@ -110,7 +166,14 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
     setBody("");
     setResponse(null);
     setError("");
+    setErrors({});
   }, [open, serverUrl]);
+
+  // Drop a field's inline error as soon as the user edits it; validation runs
+  // again on blur and on submit.
+  const clearError = useCallback((field: keyof FieldErrors) => {
+    setErrors((prev) => (prev[field] ? { ...prev, [field]: undefined } : prev));
+  }, []);
 
   // Cancel any in-flight request on unmount.
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -119,51 +182,35 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
     setResponse(null);
     setError("");
 
-    // URL is required and must be an http/https URL before sending.
-    const urlResult = testUrlSchema.safeParse(url);
-    if (!urlResult.success) {
-      setStatus("error");
-      setError(urlResult.error.issues[0].message);
+    // Validate every field up front and surface problems inline; don't send a
+    // request while anything is invalid.
+    const nextErrors: FieldErrors = {
+      url: validateUrl(url),
+      path: validatePath(path),
+      headers: validateHeaders(headers),
+      body: validateBody(body, method, contentType),
+    };
+    setErrors(nextErrors);
+    if (nextErrors.url || nextErrors.path || nextErrors.headers || nextErrors.body) {
       return;
     }
 
-    // Validate and capture the headers JSON before it would be sent.
-    let parsedHeaders: Record<string, string> | undefined;
-    if (headers.trim()) {
-      try {
-        const parsed = JSON.parse(headers);
-        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-          throw new Error("Headers must be a JSON object");
-        }
-        parsedHeaders = parsed as Record<string, string>;
-      } catch (e) {
-        setStatus("error");
-        setError(`Invalid headers JSON: ${e instanceof Error ? e.message : "Parse error"}`);
-        return;
-      }
-    }
+    // Fields are valid — parse the JSON payloads for sending. JSON bodies are
+    // parsed to an object so the backend forwards them as JSON; form-encoded
+    // bodies are sent as-is.
+    const parsedHeaders: Record<string, string> | undefined = headers.trim()
+      ? (JSON.parse(headers) as Record<string, string>)
+      : undefined;
 
-    // Validate and capture the request body. JSON bodies are parsed to an object
-    // so the backend forwards them as JSON; form-encoded bodies are sent as-is.
-    const sendsBody = method !== "Get" && method !== "HEAD";
     let parsedBody: string | Record<string, unknown> | undefined;
-    if (sendsBody && body.trim()) {
-      if (contentType === "application/json") {
-        try {
-          parsedBody = JSON.parse(body);
-        } catch (e) {
-          setStatus("error");
-          setError(`Invalid body JSON: ${e instanceof Error ? e.message : "Parse error"}`);
-          return;
-        }
-      } else {
-        parsedBody = body;
-      }
+    if (sendsBodyFor(method) && body.trim()) {
+      parsedBody =
+        contentType === "application/json" ? (JSON.parse(body) as Record<string, unknown>) : body;
     }
 
     const payload: GatewayTestRequest = {
       method: method.toUpperCase(),
-      baseUrl: urlResult.data,
+      baseUrl: url.trim(),
       path: path.trim(),
       contentType,
       ...(parsedHeaders ? { headers: parsedHeaders } : {}),
@@ -250,11 +297,22 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
               <Input
                 id="url"
                 value={url}
-                onChange={(e) => setUrl(e.target.value)}
+                onChange={(e) => {
+                  setUrl(e.target.value);
+                  clearError("url");
+                }}
+                onBlur={() => setErrors((prev) => ({ ...prev, url: validateUrl(url) }))}
                 placeholder="https://mcp.github.com/mcp"
                 disabled={isTesting}
+                aria-invalid={!!errors.url}
+                aria-describedby={errors.url ? "url-error" : undefined}
                 className="bg-transparent dark:bg-transparent"
               />
+              {errors.url && (
+                <p id="url-error" className="text-sm text-red-500">
+                  {errors.url}
+                </p>
+              )}
             </div>
 
             {/* Method */}
@@ -293,11 +351,22 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
               <Input
                 id="path"
                 value={path}
-                onChange={(e) => setPath(e.target.value)}
+                onChange={(e) => {
+                  setPath(e.target.value);
+                  clearError("path");
+                }}
+                onBlur={() => setErrors((prev) => ({ ...prev, path: validatePath(path) }))}
                 placeholder="/health"
                 disabled={isTesting}
+                aria-invalid={!!errors.path}
+                aria-describedby={errors.path ? "path-error" : undefined}
                 className="bg-transparent dark:bg-transparent"
               />
+              {errors.path && (
+                <p id="path-error" className="text-sm text-red-500">
+                  {errors.path}
+                </p>
+              )}
             </div>
 
             {/* Content type */}
@@ -327,11 +396,22 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
               <Textarea
                 id="headers"
                 value={headers}
-                onChange={(e) => setHeaders(e.target.value)}
+                onChange={(e) => {
+                  setHeaders(e.target.value);
+                  clearError("headers");
+                }}
+                onBlur={() => setErrors((prev) => ({ ...prev, headers: validateHeaders(headers) }))}
                 placeholder="Add request headers as JSON..."
                 className="min-h-[96px] bg-transparent font-mono text-sm focus-visible:ring-1 focus-visible:ring-offset-0"
                 disabled={isTesting}
+                aria-invalid={!!errors.headers}
+                aria-describedby={errors.headers ? "headers-error" : undefined}
               />
+              {errors.headers && (
+                <p id="headers-error" className="text-sm text-red-500">
+                  {errors.headers}
+                </p>
+              )}
             </div>
 
             {/* Body — not applicable to GET requests */}
@@ -343,11 +423,27 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
                 <Textarea
                   id="body"
                   value={body}
-                  onChange={(e) => setBody(e.target.value)}
+                  onChange={(e) => {
+                    setBody(e.target.value);
+                    clearError("body");
+                  }}
+                  onBlur={() =>
+                    setErrors((prev) => ({
+                      ...prev,
+                      body: validateBody(body, method, contentType),
+                    }))
+                  }
                   placeholder="Add request body as JSON..."
                   className="min-h-[116px] bg-transparent font-mono text-sm focus-visible:ring-1 focus-visible:ring-offset-0"
                   disabled={isTesting}
+                  aria-invalid={!!errors.body}
+                  aria-describedby={errors.body ? "body-error" : undefined}
                 />
+                {errors.body && (
+                  <p id="body-error" className="text-sm text-red-500">
+                    {errors.body}
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/client/src/components/servers/TestConnectionDialog.tsx
+++ b/client/src/components/servers/TestConnectionDialog.tsx
@@ -432,8 +432,11 @@ export function TestConnectionDialog({ open, onOpenChange, serverUrl }: TestConn
             )}
           </Button>
 
-          <Button variant="ghost" onClick={handleClose} disabled={isTesting}>
-            Close
+          {/* Stays enabled during a test so it can cancel the in-flight request
+              (closing the dialog aborts it via the open→false effect); relabels
+              to "Cancel" to signal that action. */}
+          <Button variant="ghost" onClick={handleClose}>
+            {isTesting ? "Cancel" : "Close"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
### Summary

Completes the frontend for the MCP server "Test Connection" dialog.
The backend endpoint `POST /v1/mcp-servers/test` landed earlier (#5443), but the React dialog was still a stub that only showed a "pending" message. This wires the dialog to the real endpoint so users can test MCP server / gateway connectivity from the new UI, without touching the legacy `/admin/**` routes.

Relates to #5326
Closes #5040

https://github.com/user-attachments/assets/2fe8c6ba-2351-46d7-908a-80e3b85874b3

### Changes

- **`api/servers.ts`** — new `serversApi.testConnectivity(request, signal)` that POSTs to `/v1/mcp-servers/test`, typed with the orval-generated `GatewayTestRequest` / `GatewayTestResponse` from `@/generated/types`. Kept distinct from the existing `testConnection(id)` (which pings a registered server by ID via `/gateways/{id}/test`).
- **`TestConnectionDialog.tsx`** — replaced the placeholder stub with a real request:
    - Builds the payload from the form (uppercased method, trimmed base URL/path, optional headers, content type, body).
    - JSON bodies are parsed to an object; non-JSON content types (e.g. `x-www-form-urlencoded`) send the body verbatim and skip JSON validation.
    - Consumes the response in the backend's canonical camelCase shape (`statusCode` / `latencyMs`); a non-2xx `statusCode` renders as an error while still surfacing the response body.
    - Cancels any in-flight request on close, reopen, or unmount via `AbortController`.
    - Surfaces thrown API errors through the shared `parseApiError` helper.
    
- **`TestConnectionDialog.test.tsx`** — converted to MSW (consistent with the other servers-domain tests) and expanded coverage: success, non-2xx-as-error, thrown API error, JSON-body parsing, header forwarding, non-empty path, raw non-JSON body pass-through, and in-flight cancellation on close.